### PR TITLE
bypass SSL check to parse the European Clinical Trial Register feed

### DIFF
--- a/python-ml/feedreader.py
+++ b/python-ml/feedreader.py
@@ -2,6 +2,7 @@ import feedparser
 import psycopg2
 from dotenv import load_dotenv
 import os
+import ssl
 
 load_dotenv()
 ## GET ENV
@@ -70,6 +71,10 @@ for i in sources:
 cur = conn.cursor()
 cur.execute("SELECT source_id,name,link,subject FROM sources WHERE method = 'rss' and source_for = 'trials';")
 sources = cur.fetchall()
+
+# This disables the SSL verification. The only reason why we are doing this is because of issue #55 <https://github.com/brunoamaral/gregory/issues/55> 
+if hasattr(ssl, '_create_unverified_context'):
+	ssl._create_default_https_context = ssl._create_unverified_context
 
 for i in sources:
 	link = i[2]


### PR DESCRIPTION
This workaround fixes #55 

A better alternative would be with the new context option for feedparser and a flag on the database entry for this source.

https://github.com/kurtmckee/feedparser/pull/290

This will have to do meanwhile.