### PR TITLE
Make DOI optional when adding content from the API

### DIFF
--- a/django/api/utils/exceptions.py
+++ b/django/api/utils/exceptions.py
@@ -40,3 +40,6 @@ class ArticleExistsError(APIError):
 class ArticleNotSavedError(APIError):
 	def __init__(self, message):
 		super().__init__(message)
+class DoiNotFound(APIError):
+	def __init__(self, message):
+		super().__init__(message)

--- a/django/api/utils/responses.py
+++ b/django/api/utils/responses.py
@@ -12,6 +12,7 @@ SOURCE_NOT_FOUND = 5
 FIELD_NOT_FOUND = 6
 ARTICLE_EXISTS = 7
 ARTICLE_NOT_SAVED = 8
+DOI_NOT_FOUND = 9
 
 ERRORS = {
     UNEXPECTED: 'Unexpected error. Please contact the support team.',
@@ -23,6 +24,7 @@ ERRORS = {
     FIELD_NOT_FOUND: 'One or more fields wasn\'t found in the payload',
     ARTICLE_EXISTS: 'An article already exists with one of these fields: title, doi.',
     ARTICLE_NOT_SAVED: 'Could not save the article that was received',
+    DOI_NOT_FOUND: 'Tried query on Crossref.org for articles with a matching title, got no results.'
 }
 
 def returnData(data):

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -147,13 +147,17 @@ def post_article(request):
 			data = {
 				'name': site.title + '| API',
 				'version': '0.1b',
-				# "data_received": json.loads(request.body),
+				"data_received": json.loads(request.body),
 				'data_processed_from_doi': new_article,
 				'article_id': save_article.article_id,
 			}
-
+			log_data = {
+				'name': site.title + '| API',
+				'version': '0.1b',
+				"data_received": json.loads(request.body),
+			}
 			# This creates an access log for this client in the DB
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 200, data)
+			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 201, log_data)
 			# Actually return the data to the API client
 			return returnData(data)
 		except APINoAPIKeyError as exception:

--- a/django/gregory/classes.py
+++ b/django/gregory/classes.py
@@ -105,6 +105,8 @@ class SciencePaper:
 				pass
 
 	def find_doi(self,title=None):
+		if title == None:
+			return 'Missing required title field'
 		import re
 		import os
 		from sitesettings.models import CustomSetting
@@ -128,9 +130,8 @@ class SciencePaper:
 					crossref_title = re.sub(r' ','',crossref_title).lower()
 					if crossref_title == article_title:
 						self.doi = w['DOI']
-						print(f'found DOI: {self.doi}\nfrom title: {self.title}\n\nrun .refresh(var.doi) to populate metadata')
 						return self.doi
 					i += 1
 					if i == 5:
-						return f'Did not find a match in the the first {i} results'
+						return None
 


### PR DESCRIPTION
The article gets saved to the database but the API returns an erro:

```
curl -X POST -g -H "Authorization: XYZ" -H "Content-Type: application/json" http://localhost:8000/articles/post/ -d '{ "kind": "science paper", "title":"Management of Trigeminal Neuralgia with Botulinum Toxin Type A: Report of Two Cases", "source_id":2, "doi":"", "link":"google.com"}'
{"code": 0, "error_msg": "Unexpected error. Please contact the support team.", "extra_data": "value too long for type character varying(500)\n"}%
```

Also, the reasoning for this change comes from the fact that some websites do not provide a DOI number when listing search results.