### PR TITLE
adds a new endpoint to list articles by journal name

### DIFF
--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -18,7 +18,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import include, path, re_path
 from rest_framework import routers
-from api.views import ArticleViewSet,ArticlesByAuthorList,ArticlesByCategory,ArticlesBySourceList,ArticlesBySubject,AuthorsViewSet,OpenAccessArticles,RelevantList,UnsentList,TrialsBySourceList,SourceViewSet,TrialViewSet,post_article
+from api.views import ArticleViewSet,ArticlesByAuthorList,ArticlesByCategory,ArticlesBySourceList,ArticlesByJournal,ArticlesBySubject,AuthorsViewSet,OpenAccessArticles,RelevantList,UnsentList,TrialsBySourceList,SourceViewSet,TrialViewSet,post_article
 from rss.views import *
 from subscriptions.views import subscribe_view
 
@@ -52,6 +52,7 @@ urlpatterns = [
 	re_path('^articles/category/(?P<category>.+)/$', ArticlesByCategory.as_view({'get':'list'})),
 	re_path('^articles/source/(?P<source>.+)/$', ArticlesBySourceList.as_view()),
 	re_path('^articles/subject/(?P<subject>.+)/$', ArticlesBySubject.as_view({'get':'list'})),
+	re_path('^articles/journal/(?P<journal>.+)/$', ArticlesByJournal.as_view({'get':'list'})),
 	re_path('^articles/open/$', OpenAccessArticles.as_view()),
 	re_path('^articles/unsent/$', UnsentList.as_view()),
 	re_path('^trials/source/(?P<source>.+)/$', TrialsBySourceList.as_view()),

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -238,7 +238,7 @@ class ArticlesBySubject(viewsets.ModelViewSet):
 
 class ArticlesByJournal(viewsets.ModelViewSet):
 	"""
-	Search articles by the subject field. Usage /articles/journal/{{journal}}/.
+	Search articles by the journal field. Usage /articles/journal/{{journal}}/.
 	Journal should be lower case and spaces should be replaced by dashes, for example: 	"The Lancet Neurology" becomes the-lancet-neurology.
 	"""
 	def get_queryset(self):

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -236,13 +236,25 @@ class ArticlesBySubject(viewsets.ModelViewSet):
 	serializer_class = ArticleSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
+class ArticlesByJournal(viewsets.ModelViewSet):
+	"""
+	Search articles by the subject field. Usage /articles/journal/{{journal}}/.
+	Journal should be lower case and spaces should be replaced by dashes, for example: 	"The Lancet Neurology" becomes the-lancet-neurology.
+	"""
+	def get_queryset(self):
+		journal = self.kwargs.get('journal', None)
+		journal = journal.replace('-', ' ')
+		return Articles.objects.filter(container_title__iregex=journal).order_by('-article_id')
+
+	serializer_class = ArticleSerializer
+	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
 class AllArticleViewSet(generics.ListAPIView):
 	"""
 	List all articles 
 	"""
 	pagination_class = None
-	queryset = Articles.objects.all().order_by('-published_date')
+	queryset = Articles.objects.all().order_by('-article_id')
 	serializer_class = ArticleSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 


### PR DESCRIPTION
Search articles by the journal field. Usage `/articles/journal/{{journal}}/`.

Journal should be lower case and spaces should be replaced by dashes, for example: 	"The Lancet Neurology" becomes the-lancet-neurology.
