### PR TITLE
Update LICENSE to require attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,121 +1,117 @@
-Creative Commons Legal Code
+# Creative Commons — Attribution 4.0 International — CC BY 4.0
 
-CC0 1.0 Universal
+Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
 
-    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
-    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
-    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
-    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
-    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
-    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
-    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
-    HEREUNDER.
+**Using Creative Commons Public Licenses**
 
-Statement of Purpose
+Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
 
-The laws of most jurisdictions throughout the world automatically confer
-exclusive Copyright and Related Rights (defined below) upon the creator
-and subsequent owner(s) (each and all, an "owner") of an original work of
-authorship and/or a database (each, a "Work").
+**Considerations for licensors:** Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. [More considerations for licensors.](https://wiki.creativecommons.org/Considerations_for_licensors_and_licensees#Considerations_for_licensors)[![](https://creativecommons.org/images/deed/svg/deed_arrow_orange.svg)](https://creativecommons.org/licenses/by/4.0/legalcode#)
 
-Certain owners wish to permanently relinquish those rights to a Work for
-the purpose of contributing to a commons of creative, cultural and
-scientific works ("Commons") that the public can reliably and without fear
-of later claims of infringement build upon, modify, incorporate in other
-works, reuse and redistribute as freely as possible in any form whatsoever
-and for any purposes, including without limitation commercial purposes.
-These owners may contribute to the Commons to promote the ideal of a free
-culture and the further production of creative, cultural and scientific
-works, or to gain reputation or greater distribution for their Work in
-part through the use and efforts of others.
+**Considerations for the public:** By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. [More considerations for the public.](https://wiki.creativecommons.org/Considerations_for_licensors_and_licensees#Considerations_for_licensees)[![](https://creativecommons.org/images/deed/svg/deed_arrow_orange.svg)](https://creativecommons.org/licenses/by/4.0/legalcode#)
 
-For these and/or other purposes and motivations, and without any
-expectation of additional consideration or compensation, the person
-associating CC0 with a Work (the "Affirmer"), to the extent that he or she
-is an owner of Copyright and Related Rights in the Work, voluntarily
-elects to apply CC0 to the Work and publicly distribute the Work under its
-terms, with knowledge of his or her Copyright and Related Rights in the
-Work and the meaning and intended legal effect of CC0 on those rights.
+### Creative Commons Attribution 4.0 International Public License
 
-1. Copyright and Related Rights. A Work made available under CC0 may be
-protected by copyright and related or neighboring rights ("Copyright and
-Related Rights"). Copyright and Related Rights include, but are not
-limited to, the following:
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
 
-  i. the right to reproduce, adapt, distribute, perform, display,
-     communicate, and translate a Work;
- ii. moral rights retained by the original author(s) and/or performer(s);
-iii. publicity and privacy rights pertaining to a person's image or
-     likeness depicted in a Work;
- iv. rights protecting against unfair competition in regards to a Work,
-     subject to the limitations in paragraph 4(a), below;
-  v. rights protecting the extraction, dissemination, use and reuse of data
-     in a Work;
- vi. database rights (such as those arising under Directive 96/9/EC of the
-     European Parliament and of the Council of 11 March 1996 on the legal
-     protection of databases, and under any national implementation
-     thereof, including any amended or successor version of such
-     directive); and
-vii. other similar, equivalent or corresponding rights throughout the
-     world based on applicable law or treaty, and any national
-     implementations thereof.
+**Section 1 – Definitions.**
 
-2. Waiver. To the greatest extent permitted by, but not in contravention
-of, applicable law, Affirmer hereby overtly, fully, permanently,
-irrevocably and unconditionally waives, abandons, and surrenders all of
-Affirmer's Copyright and Related Rights and associated claims and causes
-of action, whether now known or unknown (including existing as well as
-future claims and causes of action), in the Work (i) in all territories
-worldwide, (ii) for the maximum duration provided by applicable law or
-treaty (including future time extensions), (iii) in any current or future
-medium and for any number of copies, and (iv) for any purpose whatsoever,
-including without limitation commercial, advertising or promotional
-purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
-member of the public at large and to the detriment of Affirmer's heirs and
-successors, fully intending that such Waiver shall not be subject to
-revocation, rescission, cancellation, termination, or any other legal or
-equitable action to disrupt the quiet enjoyment of the Work by the public
-as contemplated by Affirmer's express Statement of Purpose.
+1.  **Adapted Material** means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+2.  **Adapter's License** means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+3.  **Copyright and Similar Rights** means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section [2(b)(1)-(2)](https://creativecommons.org/licenses/by/4.0/legalcode#s2b) are not Copyright and Similar Rights.
+4.  **Effective Technological Measures** means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+5.  **Exceptions and Limitations** means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+6.  **Licensed Material** means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+7.  **Licensed Rights** means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+8.  **Licensor** means the individual(s) or entity(ies) granting rights under this Public License.
+9.  **Share** means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+10.  **Sui Generis Database Rights** means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+11.  **You** means the individual or entity exercising the Licensed Rights under this Public License. **Your** has a corresponding meaning.
 
-3. Public License Fallback. Should any part of the Waiver for any reason
-be judged legally invalid or ineffective under applicable law, then the
-Waiver shall be preserved to the maximum extent permitted taking into
-account Affirmer's express Statement of Purpose. In addition, to the
-extent the Waiver is so judged Affirmer hereby grants to each affected
-person a royalty-free, non transferable, non sublicensable, non exclusive,
-irrevocable and unconditional license to exercise Affirmer's Copyright and
-Related Rights in the Work (i) in all territories worldwide, (ii) for the
-maximum duration provided by applicable law or treaty (including future
-time extensions), (iii) in any current or future medium and for any number
-of copies, and (iv) for any purpose whatsoever, including without
-limitation commercial, advertising or promotional purposes (the
-"License"). The License shall be deemed effective as of the date CC0 was
-applied by Affirmer to the Work. Should any part of the License for any
-reason be judged legally invalid or ineffective under applicable law, such
-partial invalidity or ineffectiveness shall not invalidate the remainder
-of the License, and in such case Affirmer hereby affirms that he or she
-will not (i) exercise any of his or her remaining Copyright and Related
-Rights in the Work or (ii) assert any associated claims and causes of
-action with respect to the Work, in either case contrary to Affirmer's
-express Statement of Purpose.
+**Section 2 – Scope.**
 
-4. Limitations and Disclaimers.
+1.  **License grant**.
+    1.  Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+        1.  reproduce and Share the Licensed Material, in whole or in part; and
+        2.  produce, reproduce, and Share Adapted Material.
+    2.  Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+    3.  Term. The term of this Public License is specified in Section [6(a)](https://creativecommons.org/licenses/by/4.0/legalcode#s6a).
+    4.  Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section [2(a)(4)](https://creativecommons.org/licenses/by/4.0/legalcode#s2a4) never produces Adapted Material.
+    5.  Downstream recipients.
+        
+        1.  Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+        2.  No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+        
+    6.  No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section [3(a)(1)(A)(i)](https://creativecommons.org/licenses/by/4.0/legalcode#s3a1Ai).
+2.  **Other rights**.
+    
+    1.  Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+    2.  Patent and trademark rights are not licensed under this Public License.
+    3.  To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
 
- a. No trademark or patent rights held by Affirmer are waived, abandoned,
-    surrendered, licensed or otherwise affected by this document.
- b. Affirmer offers the Work as-is and makes no representations or
-    warranties of any kind concerning the Work, express, implied,
-    statutory or otherwise, including without limitation warranties of
-    title, merchantability, fitness for a particular purpose, non
-    infringement, or the absence of latent or other defects, accuracy, or
-    the present or absence of errors, whether or not discoverable, all to
-    the greatest extent permissible under applicable law.
- c. Affirmer disclaims responsibility for clearing rights of other persons
-    that may apply to the Work or any use thereof, including without
-    limitation any person's Copyright and Related Rights in the Work.
-    Further, Affirmer disclaims responsibility for obtaining any necessary
-    consents, permissions or other rights required for any use of the
-    Work.
- d. Affirmer understands and acknowledges that Creative Commons is not a
-    party to this document and has no duty or obligation with respect to
-    this CC0 or use of the Work.
+**Section 3 – License Conditions.**
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+1.  **Attribution**.
+    
+    1.  If You Share the Licensed Material (including in modified form), You must:
+        
+        1.  retain the following if it is supplied by the Licensor with the Licensed Material:
+            1.  identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+            2.  a copyright notice;
+            3.  a notice that refers to this Public License;
+            4.  a notice that refers to the disclaimer of warranties;
+            5.  a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+        2.  indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+        3.  indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+    2.  You may satisfy the conditions in Section [3(a)(1)](https://creativecommons.org/licenses/by/4.0/legalcode#s3a1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+    3.  If requested by the Licensor, You must remove any of the information required by Section [3(a)(1)(A)](https://creativecommons.org/licenses/by/4.0/legalcode#s3a1A) to the extent reasonably practicable.
+    4.  If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+
+**Section 4 – Sui Generis Database Rights.**
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+1.  for the avoidance of doubt, Section [2(a)(1)](https://creativecommons.org/licenses/by/4.0/legalcode#s2a1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+2.  if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+3.  You must comply with the conditions in Section [3(a)](https://creativecommons.org/licenses/by/4.0/legalcode#s3a) if You Share all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section [4](https://creativecommons.org/licenses/by/4.0/legalcode#s4) supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+**Section 5 – Disclaimer of Warranties and Limitation of Liability.**
+
+1.  **Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.**
+2.  **To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.**
+
+3.  The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+**Section 6 – Term and Termination.**
+
+1.  This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+2.  Where Your right to use the Licensed Material has terminated under Section [6(a)](https://creativecommons.org/licenses/by/4.0/legalcode#s6a), it reinstates:
+    
+    1.  automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+    2.  upon express reinstatement by the Licensor.
+    
+    For the avoidance of doubt, this Section [6(b)](https://creativecommons.org/licenses/by/4.0/legalcode#s6b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+3.  For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+4.  Sections [1](https://creativecommons.org/licenses/by/4.0/legalcode#s1), [5](https://creativecommons.org/licenses/by/4.0/legalcode#s5), [6](https://creativecommons.org/licenses/by/4.0/legalcode#s6), [7](https://creativecommons.org/licenses/by/4.0/legalcode#s7), and [8](https://creativecommons.org/licenses/by/4.0/legalcode#s8) survive termination of this Public License.
+
+**Section 7 – Other Terms and Conditions.**
+
+1.  The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+2.  Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+**Section 8 – Interpretation.**
+
+1.  For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+2.  To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+3.  No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+4.  Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public domain under the [CC0 Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/legalcode). Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at [creativecommons.org/policies](https://creativecommons.org/policies), Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at [creativecommons.org](https://creativecommons.org/).
+
+Additional languages available: [العربية](https://creativecommons.org/licenses/by/4.0/legalcode.ar), [čeština](https://creativecommons.org/licenses/by/4.0/legalcode.cs), [Dansk](https://creativecommons.org/licenses/by/4.0/legalcode.da), [Deutsch](https://creativecommons.org/licenses/by/4.0/legalcode.de), [Ελληνικά](https://creativecommons.org/licenses/by/4.0/legalcode.el), [Español](https://creativecommons.org/licenses/by/4.0/legalcode.es), [euskara](https://creativecommons.org/licenses/by/4.0/legalcode.eu), [suomeksi](https://creativecommons.org/licenses/by/4.0/legalcode.fi), [français](https://creativecommons.org/licenses/by/4.0/legalcode.fr), [Frysk](https://creativecommons.org/licenses/by/4.0/legalcode.fy), [hrvatski](https://creativecommons.org/licenses/by/4.0/legalcode.hr), [Bahasa Indonesia](https://creativecommons.org/licenses/by/4.0/legalcode.id), [italiano](https://creativecommons.org/licenses/by/4.0/legalcode.it), [日本語](https://creativecommons.org/licenses/by/4.0/legalcode.ja), [한국어](https://creativecommons.org/licenses/by/4.0/legalcode.ko), [Lietuvių](https://creativecommons.org/licenses/by/4.0/legalcode.lt), [latviski](https://creativecommons.org/licenses/by/4.0/legalcode.lv), [te reo Māori](https://creativecommons.org/licenses/by/4.0/legalcode.mi), [Nederlands](https://creativecommons.org/licenses/by/4.0/legalcode.nl), [norsk](https://creativecommons.org/licenses/by/4.0/legalcode.no), [polski](https://creativecommons.org/licenses/by/4.0/legalcode.pl), [português](https://creativecommons.org/licenses/by/4.0/legalcode.pt), [română](https://creativecommons.org/licenses/by/4.0/legalcode.ro), [русский](https://creativecommons.org/licenses/by/4.0/legalcode.ru), [Slovenščina](https://creativecommons.org/licenses/by/4.0/legalcode.sl), [svenska](https://creativecommons.org/licenses/by/4.0/legalcode.sv), [Türkçe](https://creativecommons.org/licenses/by/4.0/legalcode.tr), [українська](https://creativecommons.org/licenses/by/4.0/legalcode.uk), [中文](https://creativecommons.org/licenses/by/4.0/legalcode.zh-Hans), [華語](https://creativecommons.org/licenses/by/4.0/legalcode.zh-Hant). Please read the [FAQ](https://creativecommons.org/faq/#officialtranslations) for more information about official translations.


### PR DESCRIPTION
Gregory is meant to be accessible by as many people as possible. And lately some have stepped forward with a desire to help. 

For that reason, we are making an update to the license that requires anyone using it to mention where the work is coming from.

And in all fairness, this change is long overdue. @antoniolopes has been one of the driving forces to develop new features and make Gregory smarter, and On/Offline others have also contributed a great deal. 

To everyone, I thank you from my heart.