### PR TITLE
remove node-red from docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,23 +16,6 @@ services:
     networks:
       - gregory_network
 
-  node-red:
-    image: nodered/node-red:latest
-    restart: always
-    container_name: node-red 
-    environment:
-      - TZ=Europe/Lisbon
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_DB=${POSTGRES_DB}
-      - DB_HOST=${DB_HOST}
-    ports:
-      - "1880:1880"
-    networks:
-      - gregory_network
-    volumes:
-      - ./nodered-data:/data
-
   admin:
     container_name: admin
     restart: always


### PR DESCRIPTION
@Node-RED is an amazing tool. Right now it is not a requirement to be able to run Gregory, and that's why we are removing it.