### PR TITLE
Add API endpoints to filter content by teams

### DIFF
--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -27,7 +27,7 @@ from api.views import (
 	ArticlesByJournal, ArticlesBySubject, AuthorsViewSet, OpenAccessArticles, 
 	RelevantList, UnsentList, TrialsBySourceList, SourceViewSet, TrialViewSet, 
 	post_article, newsletterByWeek, lastXdays, CategoryViewSet, TrialsByCategory, MonthlyCountsView, LoginView, ProtectedEndpointView,
-	ArticlesByTeam, ArticlesBySubject
+	ArticlesByTeam, ArticlesBySubject, TeamsViewSet
 )
 from rss.views import (
 	ArticlesByAuthorFeed, ArticlesByCategoryFeed, ArticlesBySubjectFeed, OpenAccessFeed,
@@ -42,6 +42,7 @@ router.register(r'authors', AuthorsViewSet)
 router.register(r'categories', CategoryViewSet)
 router.register(r'sources', SourceViewSet)
 router.register(r'trials', TrialViewSet)
+router.register(r'teams', TeamsViewSet)
 
 # Define URL patterns
 urlpatterns = [
@@ -100,6 +101,9 @@ urlpatterns = [
 
 	# Protected endpoint route
 	path('protected_endpoint/', ProtectedEndpointView.as_view(), name='protected_endpoint'),
+
+	# Team Routes
+	path('teams/', TeamsViewSet.as_view({'get':'list'})),
 
 	# Include router routes
 	path('', include(router.urls)),

--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -27,7 +27,7 @@ from api.views import (
 	ArticlesByJournal, ArticlesBySubject, AuthorsViewSet, OpenAccessArticles, 
 	RelevantList, UnsentList, TrialsBySourceList, SourceViewSet, TrialViewSet, 
 	post_article, newsletterByWeek, lastXdays, CategoryViewSet, TrialsByCategory, MonthlyCountsView, LoginView, ProtectedEndpointView,
-	ArticlesByTeam, ArticlesBySubject, TeamsViewSet, SubjectsViewSet, TrialsByTeam, SubjectsByTeam, SourcesByTeam
+	ArticlesByTeam, ArticlesBySubject, TeamsViewSet, SubjectsViewSet, TrialsByTeam, SubjectsByTeam, SourcesByTeam,CategoriesByTeam,
 )
 from rss.views import (
 	ArticlesByAuthorFeed, ArticlesByCategoryFeed, ArticlesBySubjectFeed, OpenAccessFeed,
@@ -66,6 +66,8 @@ urlpatterns = [
 	path('teams/<int:team_id>/subjects/', SubjectsByTeam.as_view({'get': 'list'}), name='subjects-by-team'),
 	# Sources by team
 	path('teams/<int:team_id>/sources/', SourcesByTeam.as_view({'get': 'list'}), name='sources-by-team'),
+	# Category by team
+	path('teams/<int:team_id>/categories/', CategoriesByTeam.as_view({'get': 'list'}), name='categories-by-team'),
 	# Articles by team and subject
 	path('articles/team/<int:team_id>/', ArticlesByTeam.as_view({'get': 'list'}), name='articles-by-team'),
 	path('articles/subject/<int:subject_id>/', ArticlesBySubject.as_view({'get': 'list'}), name='articles-by-subject'),

--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -27,7 +27,7 @@ from api.views import (
 	ArticlesByJournal, ArticlesBySubject, AuthorsViewSet, OpenAccessArticles, 
 	RelevantList, UnsentList, TrialsBySourceList, SourceViewSet, TrialViewSet, 
 	post_article, newsletterByWeek, lastXdays, CategoryViewSet, TrialsByCategory, MonthlyCountsView, LoginView, ProtectedEndpointView,
-	ArticlesByTeam, ArticlesBySubject, TeamsViewSet, SubjectsViewSet
+	ArticlesByTeam, ArticlesBySubject, TeamsViewSet, SubjectsViewSet, TrialsByTeam
 )
 from rss.views import (
 	ArticlesByAuthorFeed, ArticlesByCategoryFeed, ArticlesBySubjectFeed, OpenAccessFeed,
@@ -60,6 +60,8 @@ urlpatterns = [
 	path('articles/post/', post_article),
 	# Articles by team
 	path('teams/<int:team_id>/articles/', ArticlesByTeam.as_view({'get': 'list'}), name='articles-by-team'),
+	# Clinical Trials by team
+	path('teams/<int:team_id>/trials/', TrialsByTeam.as_view({'get': 'list'}), name='trials-by-team'),
 	# Articles by team and subject
 	path('articles/team/<int:team_id>/', ArticlesByTeam.as_view({'get': 'list'}), name='articles-by-team'),
 	path('articles/subject/<int:subject_id>/', ArticlesBySubject.as_view({'get': 'list'}), name='articles-by-subject'),

--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -27,7 +27,7 @@ from api.views import (
 	ArticlesByJournal, ArticlesBySubject, AuthorsViewSet, OpenAccessArticles, 
 	RelevantList, UnsentList, TrialsBySourceList, SourceViewSet, TrialViewSet, 
 	post_article, newsletterByWeek, lastXdays, CategoryViewSet, TrialsByCategory, MonthlyCountsView, LoginView, ProtectedEndpointView,
-	ArticlesByTeam, ArticlesBySubject, TeamsViewSet
+	ArticlesByTeam, ArticlesBySubject, TeamsViewSet, SubjectsViewSet
 )
 from rss.views import (
 	ArticlesByAuthorFeed, ArticlesByCategoryFeed, ArticlesBySubjectFeed, OpenAccessFeed,
@@ -43,6 +43,7 @@ router.register(r'categories', CategoryViewSet)
 router.register(r'sources', SourceViewSet)
 router.register(r'trials', TrialViewSet)
 router.register(r'teams', TeamsViewSet)
+router.register(r'subjects', SubjectsViewSet)
 
 # Define URL patterns
 urlpatterns = [
@@ -57,6 +58,11 @@ urlpatterns = [
 	# Article routes
 	path('articles/relevant/', RelevantList.as_view()),
 	path('articles/post/', post_article),
+	# Articles by team
+	path('teams/<int:team_id>/articles/', ArticlesByTeam.as_view({'get': 'list'}), name='articles-by-team'),
+	# Articles by team and subject
+	path('articles/team/<int:team_id>/', ArticlesByTeam.as_view({'get': 'list'}), name='articles-by-team'),
+	path('articles/subject/<int:subject_id>/', ArticlesBySubject.as_view({'get': 'list'}), name='articles-by-subject'),
 
 	# Feed routes
 	path('feed/articles/author/<int:author_id>/', ArticlesByAuthorFeed(), name='articles_by_author_feed'),

--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -27,7 +27,7 @@ from api.views import (
 	ArticlesByJournal, ArticlesBySubject, AuthorsViewSet, OpenAccessArticles, 
 	RelevantList, UnsentList, TrialsBySourceList, SourceViewSet, TrialViewSet, 
 	post_article, newsletterByWeek, lastXdays, CategoryViewSet, TrialsByCategory, MonthlyCountsView, LoginView, ProtectedEndpointView,
-	ArticlesByTeam, ArticlesBySubject, TeamsViewSet, SubjectsViewSet, TrialsByTeam
+	ArticlesByTeam, ArticlesBySubject, TeamsViewSet, SubjectsViewSet, TrialsByTeam, SubjectsByTeam
 )
 from rss.views import (
 	ArticlesByAuthorFeed, ArticlesByCategoryFeed, ArticlesBySubjectFeed, OpenAccessFeed,
@@ -62,6 +62,8 @@ urlpatterns = [
 	path('teams/<int:team_id>/articles/', ArticlesByTeam.as_view({'get': 'list'}), name='articles-by-team'),
 	# Clinical Trials by team
 	path('teams/<int:team_id>/trials/', TrialsByTeam.as_view({'get': 'list'}), name='trials-by-team'),
+	# Subjects by team
+	path('teams/<int:team_id>/subjects/', SubjectsByTeam.as_view({'get': 'list'}), name='subjects-by-team'),
 	# Articles by team and subject
 	path('articles/team/<int:team_id>/', ArticlesByTeam.as_view({'get': 'list'}), name='articles-by-team'),
 	path('articles/subject/<int:subject_id>/', ArticlesBySubject.as_view({'get': 'list'}), name='articles-by-subject'),

--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -27,7 +27,7 @@ from api.views import (
 	ArticlesByJournal, ArticlesBySubject, AuthorsViewSet, OpenAccessArticles, 
 	RelevantList, UnsentList, TrialsBySourceList, SourceViewSet, TrialViewSet, 
 	post_article, newsletterByWeek, lastXdays, CategoryViewSet, TrialsByCategory, MonthlyCountsView, LoginView, ProtectedEndpointView,
-	ArticlesByTeam, ArticlesBySubject, TeamsViewSet, SubjectsViewSet, TrialsByTeam, SubjectsByTeam
+	ArticlesByTeam, ArticlesBySubject, TeamsViewSet, SubjectsViewSet, TrialsByTeam, SubjectsByTeam, SourcesByTeam
 )
 from rss.views import (
 	ArticlesByAuthorFeed, ArticlesByCategoryFeed, ArticlesBySubjectFeed, OpenAccessFeed,
@@ -64,6 +64,8 @@ urlpatterns = [
 	path('teams/<int:team_id>/trials/', TrialsByTeam.as_view({'get': 'list'}), name='trials-by-team'),
 	# Subjects by team
 	path('teams/<int:team_id>/subjects/', SubjectsByTeam.as_view({'get': 'list'}), name='subjects-by-team'),
+	# Sources by team
+	path('teams/<int:team_id>/sources/', SourcesByTeam.as_view({'get': 'list'}), name='sources-by-team'),
 	# Articles by team and subject
 	path('articles/team/<int:team_id>/', ArticlesByTeam.as_view({'get': 'list'}), name='articles-by-team'),
 	path('articles/subject/<int:subject_id>/', ArticlesBySubject.as_view({'get': 'list'}), name='articles-by-subject'),

--- a/django/api/serializers.py
+++ b/django/api/serializers.py
@@ -82,7 +82,7 @@ class TrialSerializer(serializers.HyperlinkedModelSerializer):
 		model = Trials
 		fields = [
 			'trial_id', 'title', 'summary', 'published_date', 'discovery_date', 'link', 'source', 'relevant', 
-			'identifiers', 'categories', 'export_date', 'internal_number', 'last_refreshed_on', 
+			'identifiers', 'categories', 'team_categories', 'export_date', 'internal_number', 'last_refreshed_on', 
 			'scientific_title', 'primary_sponsor', 'retrospective_flag', 'date_registration', 
 			'source_register', 'recruitment_status', 'other_records', 'inclusion_agemin', 
 			'inclusion_agemax', 'inclusion_gender', 'date_enrollement', 'target_size', 

--- a/django/api/serializers.py
+++ b/django/api/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from gregory.models import Articles, Trials, Sources, Authors, Categories, Subject, Team, MLPredictions, ArticleSubjectRelevance,TeamCategory
+from gregory.models import Articles, Trials, Sources, Authors, Categories, Subject, Team, MLPredictions, ArticleSubjectRelevance,TeamCategory,Subject
 from organizations.models import Organization
 from sitesettings.models import CustomSetting
 from django.contrib.sites.models import Site
@@ -13,126 +13,123 @@ class SubjectsSerializer(serializers.ModelSerializer):
 		model = Subject
 		fields = ['id','subject_name', 'description', 'team_id']
 class TeamCategorySerializer(serializers.ModelSerializer):
-    class Meta:
-        model = TeamCategory
-        fields = ['id', 'category_name', 'category_description', 'category_slug', 'category_terms']
-class SubjectSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Subject
-        fields = ['id', 'subject_name', 'description']
+	class Meta:
+		model = TeamCategory
+		fields = ['id', 'category_name', 'category_description', 'category_slug', 'category_terms']
 
 class ArticleSubjectRelevanceSerializer(serializers.ModelSerializer):
-    subject = SubjectSerializer(read_only=True)
-    subject_id = serializers.PrimaryKeyRelatedField(queryset=Subject.objects.all(), source='subject', write_only=True)
+	subject = SubjectsSerializer(read_only=True)
+	subject_id = serializers.PrimaryKeyRelatedField(queryset=Subject.objects.all(), source='subject', write_only=True)
 
-    class Meta:
-        model = ArticleSubjectRelevance
-        fields = ['subject', 'subject_id', 'is_relevant']
+	class Meta:
+		model = ArticleSubjectRelevance
+		fields = ['subject', 'subject_id', 'is_relevant']
 
 class MLPredictionsSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = MLPredictions
-        fields = ['gnb', 'lr', 'lsvc', 'mnb', 'created_date', 'subject']
+	class Meta:
+		model = MLPredictions
+		fields = ['gnb', 'lr', 'lsvc', 'mnb', 'created_date', 'subject']
 
 class TeamSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Team
-        fields = ['id', 'name']
+	class Meta:
+		model = Team
+		fields = ['id', 'name']
 
 class CategorySerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Categories
-        fields = ['category_id', 'category_description', 'category_name', 'category_slug', 'category_terms', 'article_count']
+	class Meta:
+		model = Categories
+		fields = ['category_id', 'category_description', 'category_name', 'category_slug', 'category_terms', 'article_count']
 
 class ArticleAuthorSerializer(serializers.ModelSerializer):
-    country = serializers.SerializerMethodField()
+	country = serializers.SerializerMethodField()
 
-    class Meta:
-        model = Authors
-        fields = ['author_id', 'given_name', 'family_name', 'ORCID', 'country']
+	class Meta:
+		model = Authors
+		fields = ['author_id', 'given_name', 'family_name', 'ORCID', 'country']
 
-    def get_country(self, obj):
-        # Return the country code or name
-        return obj.country.code if obj.country else None
+	def get_country(self, obj):
+		# Return the country code or name
+		return obj.country.code if obj.country else None
 
 class ArticleSerializer(serializers.HyperlinkedModelSerializer):
-    sources = serializers.SlugRelatedField(many=True, read_only=True, slug_field='name')
-    categories = CategorySerializer(many=True, read_only=True)
-    team_categories = TeamCategorySerializer(many=True, read_only=True)
-    authors = ArticleAuthorSerializer(many=True, read_only=True)
-    teams = TeamSerializer(many=True, read_only=True)
-    subjects = SubjectSerializer(many=True, read_only=True,)
-    ml_predictions = MLPredictionsSerializer(many=True, read_only=True, source='ml_predictions.all')
-    article_subject_relevances = ArticleSubjectRelevanceSerializer(many=True, read_only=True)
+	sources = serializers.SlugRelatedField(many=True, read_only=True, slug_field='name')
+	categories = CategorySerializer(many=True, read_only=True)
+	team_categories = TeamCategorySerializer(many=True, read_only=True)
+	authors = ArticleAuthorSerializer(many=True, read_only=True)
+	teams = TeamSerializer(many=True, read_only=True)
+	subjects = SubjectsSerializer(many=True, read_only=True,)
+	ml_predictions = MLPredictionsSerializer(many=True, read_only=True, source='ml_predictions.all')
+	article_subject_relevances = ArticleSubjectRelevanceSerializer(many=True, read_only=True)
 
-    class Meta:
-        model = Articles
-        depth = 1
-        fields = [
-            'article_id', 'title', 'summary', 'link', 'published_date', 'sources', 'teams', 
-            'subjects', 'publisher', 'container_title', 'authors', 'relevant', 
-            'ml_prediction_gnb', 'ml_prediction_lr', 'ml_prediction_lsvc', 'discovery_date',
-            'article_subject_relevances', 
-            'noun_phrases', 'doi', 'access', 'takeaways', 'categories', 'team_categories', 'ml_predictions',
-        ]
-        read_only_fields = ('discovery_date', 'ml_predictions', 'ml_prediction_gnb', 'ml_prediction_lr', 'ml_prediction_lsvc', 'noun_phrases', 'takeaways')
+	class Meta:
+		model = Articles
+		depth = 1
+		fields = [
+			'article_id', 'title', 'summary', 'link', 'published_date', 'sources', 'teams', 
+			'subjects', 'publisher', 'container_title', 'authors', 'relevant', 
+			'ml_prediction_gnb', 'ml_prediction_lr', 'ml_prediction_lsvc', 'discovery_date',
+			'article_subject_relevances', 
+			'noun_phrases', 'doi', 'access', 'takeaways', 'categories', 'team_categories', 'ml_predictions',
+		]
+		read_only_fields = ('discovery_date', 'ml_predictions', 'ml_prediction_gnb', 'ml_prediction_lr', 'ml_prediction_lsvc', 'noun_phrases', 'takeaways')
 
 class TrialSerializer(serializers.HyperlinkedModelSerializer):
-    source = serializers.SlugRelatedField(read_only=True, slug_field='name')
-    categories = CategorySerializer(many=True, read_only=True)
-    team_categories = TeamCategorySerializer(many=True, read_only=True)
+	source = serializers.SlugRelatedField(read_only=True, slug_field='name')
+	categories = CategorySerializer(many=True, read_only=True)
+	team_categories = TeamCategorySerializer(many=True, read_only=True)
 
-    class Meta:
-        model = Trials
-        fields = [
-            'trial_id', 'title', 'summary', 'published_date', 'discovery_date', 'link', 'source', 'relevant', 
-            'identifiers', 'categories', 'export_date', 'internal_number', 'last_refreshed_on', 
-            'scientific_title', 'primary_sponsor', 'retrospective_flag', 'date_registration', 
-            'source_register', 'recruitment_status', 'other_records', 'inclusion_agemin', 
-            'inclusion_agemax', 'inclusion_gender', 'date_enrollement', 'target_size', 
-            'study_type', 'study_design', 'phase', 'countries', 'contact_firstname', 
-            'contact_lastname', 'contact_address', 'contact_email', 'contact_tel', 
-            'contact_affiliation', 'inclusion_criteria', 'exclusion_criteria', 'condition', 
-            'intervention', 'primary_outcome', 'secondary_outcome', 'secondary_id', 
-            'source_support', 'ethics_review_status', 'ethics_review_approval_date', 
-            'ethics_review_contact_name', 'ethics_review_contact_address', 'ethics_review_contact_phone', 
-            'ethics_review_contact_email', 'results_date_completed', 'results_url_link'
-        ]
-        read_only_fields = ('discovery_date',)
+	class Meta:
+		model = Trials
+		fields = [
+			'trial_id', 'title', 'summary', 'published_date', 'discovery_date', 'link', 'source', 'relevant', 
+			'identifiers', 'categories', 'export_date', 'internal_number', 'last_refreshed_on', 
+			'scientific_title', 'primary_sponsor', 'retrospective_flag', 'date_registration', 
+			'source_register', 'recruitment_status', 'other_records', 'inclusion_agemin', 
+			'inclusion_agemax', 'inclusion_gender', 'date_enrollement', 'target_size', 
+			'study_type', 'study_design', 'phase', 'countries', 'contact_firstname', 
+			'contact_lastname', 'contact_address', 'contact_email', 'contact_tel', 
+			'contact_affiliation', 'inclusion_criteria', 'exclusion_criteria', 'condition', 
+			'intervention', 'primary_outcome', 'secondary_outcome', 'secondary_id', 
+			'source_support', 'ethics_review_status', 'ethics_review_approval_date', 
+			'ethics_review_contact_name', 'ethics_review_contact_address', 'ethics_review_contact_phone', 
+			'ethics_review_contact_email', 'results_date_completed', 'results_url_link'
+		]
+		read_only_fields = ('discovery_date',)
 
 class SourceSerializer(serializers.HyperlinkedModelSerializer):
-    class Meta:
-        model = Sources
-        fields = ['source_id', 'source_for', 'name', 'description', 'link', 'language', 'subject_id', 'team_id']
+	class Meta:
+		model = Sources
+		fields = ['source_id', 'source_for', 'name', 'description', 'link', 'language', 'subject_id', 'team_id']
 
 class AuthorSerializer(serializers.ModelSerializer):
-    articles_count = serializers.SerializerMethodField()
-    country = serializers.SerializerMethodField()
-    articles_list = serializers.SerializerMethodField()
+	articles_count = serializers.SerializerMethodField()
+	country = serializers.SerializerMethodField()
+	articles_list = serializers.SerializerMethodField()
 
-    class Meta:
-        model = Authors
-        fields = ['author_id', 'given_name', 'family_name', 'ORCID', 'country', 'articles_count', 'articles_list']
+	class Meta:
+		model = Authors
+		fields = ['author_id', 'given_name', 'family_name', 'ORCID', 'country', 'articles_count', 'articles_list']
 
-    def get_articles_count(self, obj):
-        return obj.articles_set.count()
-    def get_country(self, obj):
-        # Return the country code or name
-        return obj.country.code if obj.country else None
-    def get_articles_list(self, obj):
-        base_url = f"https://api.{site.domain}/articles/author/"
-        return base_url + str(obj.author_id)
+	def get_articles_count(self, obj):
+		return obj.articles_set.count()
+	def get_country(self, obj):
+		# Return the country code or name
+		return obj.country.code if obj.country else None
+	def get_articles_list(self, obj):
+		base_url = f"https://api.{site.domain}/articles/author/"
+		return base_url + str(obj.author_id)
 
 class CountArticlesSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Articles
-        fields = ('articles_count',)
+	class Meta:
+		model = Articles
+		fields = ('articles_count',)
 
-    def get_articles_count(self, obj):
-        return Articles.objects.count()
+	def get_articles_count(self, obj):
+		return Articles.objects.count()
 
 
 class TeamSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Team
-        fields = '__all__'
+	class Meta:
+		model = Team
+		fields = '__all__'
+

--- a/django/api/serializers.py
+++ b/django/api/serializers.py
@@ -99,7 +99,7 @@ class TrialSerializer(serializers.HyperlinkedModelSerializer):
 class SourceSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Sources
-        fields = ['source_id', 'source_for', 'name', 'description', 'link', 'language']
+        fields = ['source_id', 'source_for', 'name', 'description', 'link', 'language', 'subject_id', 'team_id']
 
 class AuthorSerializer(serializers.ModelSerializer):
     articles_count = serializers.SerializerMethodField()

--- a/django/api/serializers.py
+++ b/django/api/serializers.py
@@ -126,3 +126,9 @@ class CountArticlesSerializer(serializers.ModelSerializer):
 
     def get_articles_count(self, obj):
         return Articles.objects.count()
+
+
+class TeamSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Team
+        fields = '__all__'

--- a/django/api/serializers.py
+++ b/django/api/serializers.py
@@ -7,7 +7,11 @@ from django.conf import settings
 
 customsettings = CustomSetting.objects.get(site=settings.SITE_ID)
 site = Site.objects.get(pk=settings.SITE_ID)
-
+class SubjectsSerializer(serializers.ModelSerializer):
+	team_id = serializers.IntegerField(source='team.id', read_only=True)
+	class Meta:
+		model = Subject
+		fields = ['id','subject_name', 'description', 'team_id']
 class TeamCategorySerializer(serializers.ModelSerializer):
     class Meta:
         model = TeamCategory

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1,11 +1,11 @@
-from api.serializers import ArticleSerializer, TrialSerializer, SourceSerializer, CountArticlesSerializer, AuthorSerializer, CategorySerializer
+from api.serializers import ArticleSerializer, TrialSerializer, SourceSerializer, CountArticlesSerializer, AuthorSerializer, CategorySerializer, TeamSerializer
 from datetime import datetime, timedelta
 from django.db.models import Count
 from django.db.models import Q
 from django.db.models.functions import Length, TruncMonth
 from django.shortcuts import get_object_or_404
 from gregory.classes import SciencePaper
-from gregory.models import Articles, Trials, Sources, Authors, Categories
+from gregory.models import Articles, Trials, Sources, Authors, Categories,Team
 from rest_framework import permissions
 from rest_framework import viewsets, permissions, generics, filters
 from rest_framework_simplejwt.views import TokenObtainPairView
@@ -543,3 +543,15 @@ class ProtectedEndpointView(APIView):
 
 	def get(self, request):
 		return Response({"message": "You have accessed the protected endpoint!"})
+
+###
+# TEAMS
+###
+
+class TeamsViewSet(viewsets.ModelViewSet):
+	"""
+	List all teams
+	"""
+	queryset = Team.objects.all().order_by('id')
+	serializer_class = TeamSerializer
+	permission_classes  = [permissions.IsAuthenticatedOrReadOnly]

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -569,12 +569,22 @@ class SubjectsViewSet(viewsets.ModelViewSet):
 	permission_classes  = [permissions.IsAuthenticatedOrReadOnly]
 
 class ArticlesByTeam(viewsets.ModelViewSet):
-    """
-    List all articles for a specific team by ID
-    """
-    serializer_class = ArticleSerializer
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+		"""
+		List all articles for a specific team by ID
+		"""
+		serializer_class = ArticleSerializer
+		permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
-    def get_queryset(self):
-        team_id = self.kwargs.get('team_id')
-        return Articles.objects.filter(teams__id=team_id).order_by('-discovery_date')
+		def get_queryset(self):
+				team_id = self.kwargs.get('team_id')
+				return Articles.objects.filter(teams__id=team_id).order_by('-discovery_date')
+class TrialsByTeam(viewsets.ModelViewSet):
+	"""
+	List all clinical trials for a specific team by ID
+	"""
+	serializer_class = TrialSerializer
+	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+	def get_queryset(self):
+		team_id = self.kwargs.get('team_id')
+		return Articles.objects.filter(teams__id=team_id).order_by('-discovery_date')

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -584,10 +584,18 @@ class TrialsByTeam(viewsets.ModelViewSet):
 	"""
 	serializer_class = TrialSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
 	def get_queryset(self):
 		team_id = self.kwargs.get('team_id')
 		return Trials.objects.filter(teams__id=team_id).order_by('-discovery_date')
 
+class SubjectsByTeam(viewsets.ModelViewSet):
+	"""
+	List all research subjects for a specific team by ID
+	"""
+	serializer_class = SubjectsSerializer
+	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
 	def get_queryset(self):
 		team_id = self.kwargs.get('team_id')
-		return Articles.objects.filter(teams__id=team_id).order_by('-discovery_date')
+		return Subject.objects.filter(team__id=team_id).order_by('-id')

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -584,6 +584,9 @@ class TrialsByTeam(viewsets.ModelViewSet):
 	"""
 	serializer_class = TrialSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+	def get_queryset(self):
+		team_id = self.kwargs.get('team_id')
+		return Trials.objects.filter(teams__id=team_id).order_by('-discovery_date')
 
 	def get_queryset(self):
 		team_id = self.kwargs.get('team_id')

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -599,3 +599,14 @@ class SubjectsByTeam(viewsets.ModelViewSet):
 	def get_queryset(self):
 		team_id = self.kwargs.get('team_id')
 		return Subject.objects.filter(team__id=team_id).order_by('-id')
+
+class SourcesByTeam(viewsets.ModelViewSet):
+	"""
+	List all sources for a specific team by ID
+	"""
+	serializer_class = SourceSerializer
+	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+	def get_queryset(self):
+		team_id = self.kwargs.get('team_id')
+		return Sources.objects.filter(team__id=team_id).order_by('-source_id')

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -610,3 +610,15 @@ class SourcesByTeam(viewsets.ModelViewSet):
 	def get_queryset(self):
 		team_id = self.kwargs.get('team_id')
 		return Sources.objects.filter(team__id=team_id).order_by('-source_id')
+
+
+class CategoriesByTeam(viewsets.ModelViewSet):
+	"""
+	List all categories for a specific team by ID
+	"""
+	serializer_class = CategorySerializer
+	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+	def get_queryset(self):
+		team_id = self.kwargs.get('team_id')
+		return Categories.objects.filter(team__id=team_id).order_by('-category_id')

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1,11 +1,11 @@
-from api.serializers import ArticleSerializer, TrialSerializer, SourceSerializer, CountArticlesSerializer, AuthorSerializer, CategorySerializer, TeamSerializer
+from api.serializers import ArticleSerializer, TrialSerializer, SourceSerializer, CountArticlesSerializer, AuthorSerializer, CategorySerializer, TeamSerializer,SubjectsSerializer
 from datetime import datetime, timedelta
 from django.db.models import Count
 from django.db.models import Q
 from django.db.models.functions import Length, TruncMonth
 from django.shortcuts import get_object_or_404
 from gregory.classes import SciencePaper
-from gregory.models import Articles, Trials, Sources, Authors, Categories,Team
+from gregory.models import Articles, Trials, Sources, Authors, Categories,Team,Subject
 from rest_framework import permissions
 from rest_framework import viewsets, permissions, generics, filters
 from rest_framework_simplejwt.views import TokenObtainPairView
@@ -555,3 +555,26 @@ class TeamsViewSet(viewsets.ModelViewSet):
 	queryset = Team.objects.all().order_by('id')
 	serializer_class = TeamSerializer
 	permission_classes  = [permissions.IsAuthenticatedOrReadOnly]
+
+###
+# SUBJECTS
+###
+
+class SubjectsViewSet(viewsets.ModelViewSet):
+	"""
+	List all subjects
+	"""
+	queryset = Subject.objects.all().order_by('id')
+	serializer_class = SubjectsSerializer
+	permission_classes  = [permissions.IsAuthenticatedOrReadOnly]
+
+class ArticlesByTeam(viewsets.ModelViewSet):
+    """
+    List all articles for a specific team by ID
+    """
+    serializer_class = ArticleSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+    def get_queryset(self):
+        team_id = self.kwargs.get('team_id')
+        return Articles.objects.filter(teams__id=team_id).order_by('-discovery_date')

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -1,4 +1,4 @@
-# API and RSS feeds
+# RSS feeds
 
 Gregory's API is open and doesn't require authentication unless you need to use it to add Articles or Clinical Trials.
 
@@ -19,34 +19,83 @@ Gregory's API is open and doesn't require authentication unless you need to use 
    - `feed/machine-learning/`: Feed for machine learning related articles.
 5. **Subscriptions Route:**
    - `subscriptions/new/`: Endpoint for new subscriptions.
-6. **More Articles Routes:**
-   - `articles/author/<int:author_id>/`: List articles by a specific author.
-   - `articles/category/<category_slug>/`: List articles in a specific category.
-   - `articles/source/<int:source_id>`: List articles from a specific source.
-   - `articles/subject/<subject>/`: List articles on a specific subject.
-   - `articles/journal/<journal_slug>/`: List articles from a specific journal.
-   - `articles/open-access/`: List open-access articles.
-   - `articles/unsent/`: List unsent articles.
-7. **Relevant Articles Routes:**
-   - `articles/relevant/week/<int:year>/<int:week>/`: Articles relevant for a specific week.
-   - `articles/relevant/last/<int:days>/`: Articles relevant in the last X days.
-8. **Category Routes:**
-   - `categories/`: List all categories.
-   - `categories/<category_slug>/monthly-counts/`: Monthly counts for a specific category.
-9. **Trial Routes:**
-   - `trials/category/<category_slug>/`: List trials in a specific category.
-   - `trials/source/<source>/`: List trials from a specific source.
-10. **Token Routes:**
-    - `api/token/`: Obtain a new token pair.
-    - `api/token/get/`: Obtain an authentication token.
-11. **Protected Endpoint Route:**
-    - `protected_endpoint/`: A protected endpoint.
-12. **Router Registered Routes:**
-    - `articles/`: Routes for `ArticleViewSet`.
-    - `authors/`: Routes for `AuthorsViewSet`.
-    - `categories/`: Routes for `CategoryViewSet`.
-    - `sources/`: Routes for `SourceViewSet`.
-    - `trials/`: Routes for `TrialViewSet`.
 
+# API EndPoints
 
-You might want to use tools such as Postman or similar to test these endpoints, ensuring they provide the expected functionality.
+| Model                   | API Endpoint                             | Description                                         | Status                                                   |
+| ----------------------- | ---------------------------------------- | --------------------------------------------------- | -------------------------------------------------------- |
+| Authors                 | GET /authors/                            | List all authors                                    | ✅                                       |
+| Authors                 | POST /authors/                           | Create a new author                                 | 🛑                                              |
+| Authors                 | GET /authors/{id}/                       | Retrieve a specific author by ID                    | ✅                                       |
+| Authors                 | PUT /authors/{id}/                       | Update a specific author by ID                      | 🛑                                              |
+| Authors                 | DELETE /authors/{id}/                    | Delete a specific author by ID                      | 🛑                                              |
+| Categories              | GET /categories/                         | List all categories                                 | ✅                                                        |
+| Categories              | POST /categories/                        | Create a new category                               | 🛑                                              |
+| Categories              | GET /categories/{id}/                    | Retrieve a specific category by ID                  | ✅                                                        |
+| Categories              | PUT /categories/{id}/                    | Update a specific category by ID                    | 🛑                                              |
+| Categories              | DELETE /categories/{id}/                 | Delete a specific category by ID                    | 🛑                                              |
+| Categories              | GET /categories/<str:category_slug>/monthly-counts/ | Get monthly counts of articles and trials for a specific category by slug | |
+| Team Categories         | GET /team-categories/                    | List all team categories                            |                                                          |
+| Team Categories         | POST /team-categories/                   | Create a new team category                          | 🛑                                              |
+| Team Categories         | GET /team-categories/{id}/               | Retrieve a specific team category by ID             |                                                          |
+| Team Categories         | PUT /team-categories/{id}/               | Update a specific team category by ID               | 🛑                                              |
+| Team Categories         | DELETE /team-categories/{id}/            | Delete a specific team category by ID               | 🛑                                              |
+| Entities                | GET /entities/                           | List all entities                                   | 🛑                                              |
+| Entities                | POST /entities/                          | Create a new entity                                 | 🛑                                              |
+| Entities                | GET /entities/{id}/                      | Retrieve a specific entity by ID                    | 🛑                                              |
+| Entities                | PUT /entities/{id}/                      | Update a specific entity by ID                      | 🛑                                              |
+| Entities                | DELETE /entities/{id}/                   | Delete a specific entity by ID                      | 🛑                                              |
+| Subjects                | GET /subjects/                           | List all subjects                                   | ✅                                       |
+| Subjects                | POST /subjects/                          | Create a new subject                                | 🛑                                              |
+| Subjects                | GET /subjects/{id}/                      | Retrieve a specific subject by ID                   | ✅                                       |
+| Subjects                | PUT /subjects/{id}/                      | Update a specific subject by ID                     | 🛑                                              |
+| Subjects                | DELETE /subjects/{id}/                   | Delete a specific subject by ID                     | 🛑                                              |
+| Sources                 | GET /sources/                            | List all sources                                    | ✅ needs to migrate to new sources model |
+| Sources                 | POST /sources/                           | Create a new source                                 | 🛑                                              |
+| Sources                 | GET /sources/{id}/                       | Retrieve a specific source by ID                    | ✅ needs to migrate to new sources model |
+| Sources                 | PUT /sources/{id}/                       | Update a specific source by ID                      | 🛑                                              |
+| Sources                 | DELETE /sources/{id}/                    | Delete a specific source by ID                      | 🛑                                              |
+| Articles                | GET /articles/                           | List all articles                                   | ✅                                       |
+| Articles                | POST /articles/                          | Create a new article                                | ✅                                       |
+| Articles                | GET /articles/{id}/                      | Retrieve a specific article by ID                   | ✅                                       |
+| Articles                | PUT /articles/{id}/                      | Update a specific article by ID                     | 🛑                                              |
+| Articles                | DELETE /articles/{id}/                   | Delete a specific article by ID                     | 🛑                                              |
+| Articles                | GET /articles/relevant/                  | List relevant articles                              |                                                          |
+| Articles                | POST /articles/post/                     | Post a new article                                  |                                                          |
+| Articles                | GET /articles/author/{author_id}/        | List articles by author                             |                                                          |
+| Articles                | GET /articles/category/{category_slug}/  | List articles by category                           |                                                          |
+| Articles                | GET /articles/source/{source_id}/        | List articles by source                             |                                                          |
+| Articles                | GET /articles/journal/{journal_slug}/    | List articles by journal                            |                                                          |
+| Articles                | GET /articles/open-access/               | List open access articles                           |                                                          |
+| Articles                | GET /articles/unsent/                    | List unsent articles                                |                                                          |
+| Articles                | GET /articles/relevant/week/{year}/{week}/| List relevant articles for a specific week          |                                                          |
+| Articles                | GET /articles/relevant/last/{days}/      | List relevant articles for the last number of days  |                                                          |
+| Trials                  | GET /trials/                             | List all trials                                     | ✅                                       |
+| Trials                  | POST /trials/                            | Create a new trial                                  | 🛑                                              |
+| Trials                  | GET /trials/{id}/                        | Retrieve a specific trial by ID                     | ✅                                       |
+| Trials                  | PUT /trials/{id}/                        | Update a specific trial by ID                       | 🛑                                              |
+| Trials                  | DELETE /trials/{id}/                     | Delete a specific trial by ID                       | 🛑                                              |
+| Trials                  | GET /trials/category/{category_slug}/    | List trials by category                             |                                                          |
+| Trials                  | GET /trials/source/{source}/             | List trials by source                               |                                                          |
+| Teams                   | GET /teams/                              | List all teams                                      | ✅                                       |
+| Teams                   | POST /teams/                             | Create a new team                                   |                                                          |
+| Teams                   | GET /teams/{id}/                         | Retrieve a specific team by ID                      | ✅                                       |
+| Teams                   | PUT /teams/{id}/                         | Update a specific team by ID                        |                                                          |
+| Teams                   | DELETE /teams/{id}/                      | Delete a specific team by ID                        |                                                          |
+| Teams                   | GET /teams/{id}/articles                 | List all articles for a specific team by ID         | ✅                                       |
+| Teams                   | GET /teams/{id}/trials                   | List all clinical trials for a specific team by ID  | ✅                                       |
+| Teams                   | GET /teams/{id}/subjects                 | List all subjects for specific team by ID           | ✅                                       |
+| Teams                   | GET /teams/{id}/sources                  | List all sources for specific team by ID            | ✅                                       |
+| Teams                   | GET /teams/{id}/categories               | List all categories for specific team by ID         | ✅                                       |
+| MLPredictions           | GET /ml-predictions/                     | List all ML predictions                             | 🛑                                              |
+| MLPredictions           | POST /ml-predictions/                    | Create a new ML prediction                          | 🛑                                              |
+| MLPredictions           | GET /ml-predictions/{id}/                | Retrieve a specific ML prediction by ID             | 🛑                                              |
+| MLPredictions           | PUT /ml-predictions/{id}/                | Update a specific ML prediction by ID               | 🛑                                              |
+| MLPredictions           | DELETE /ml-predictions/{id}/             | Delete a specific ML prediction by ID               | 🛑                                              |
+| ArticleSubjectRelevance | GET /article-subject-relevances/         | List all article subject relevances                 | 🛑                                              |
+| ArticleSubjectRelevance | POST /article-subject-relevances/        | Create a new article subject relevance              | 🛑                                              |
+| ArticleSubjectRelevance | GET /article-subject-relevances/{id}/    | Retrieve a specific article subject relevance by ID | 🛑                                              |
+| ArticleSubjectRelevance | PUT /article-subject-relevances/{id}/    | Update a specific article subject relevance by ID   | 🛑                                              |
+| ArticleSubjectRelevance | DELETE /article-subject-relevances/{id}/ | Delete a specific article subject relevance by ID   | 🛑                                              |
+
+This table now includes the additional endpoints defined in your `urls.py` file, ensuring that all your API endpoints are accurately tracked.


### PR DESCRIPTION
| Model                   | API Endpoint                             | Description                                         | Status                                                   |
| ----------------------- | ---------------------------------------- | --------------------------------------------------- | -------------------------------------------------------- |
Teams | GET /teams/{id}/articles | List all articles for a specific team by ID | ✅
Teams | GET /teams/{id}/trials | List all clinical trials for a specific team by ID | ✅
Teams | GET /teams/{id}/subjects | List all subjects for specific team by ID | ✅
Teams | GET /teams/{id}/sources | List all sources for specific team by ID | ✅
Teams | GET /teams/{id}/categories | List all categories for specific team by ID | ✅

