### PR TITLE
adds missing query argument

### DIFF
--- a/django/api/views.py
+++ b/django/api/views.py
@@ -291,11 +291,12 @@ class RelevantList(generics.ListAPIView):
 
 	def get_queryset(self):
 		return Articles.objects.filter(
-				Q(relevant=True) | 
-				Q(ml_predictions__gnb=True) | 
-				Q(ml_predictions__lr=True) |
-				Q(ml_predictions__lsvc=True) |
-				Q(ml_predictions__mnb=True)
+			Q(relevant=True) | 
+			Q(ml_predictions__gnb=True) | 
+			Q(ml_predictions__lr=True) |
+			Q(ml_predictions__lsvc=True) |
+			Q(ml_predictions__mnb=True) |
+			Q(article_subject_relevances__is_relevant=True)
 		).distinct().order_by('-discovery_date')
 
 class UnsentList(generics.ListAPIView):


### PR DESCRIPTION
We are using a new relevance model, where each article can be relevant to one or more subjects. This wasn't reflected in the API yet.