### PR TITLE
Improves the way subscription lists work

### DIFF
--- a/django/subscriptions/management/commands/send_trials_notification.py
+++ b/django/subscriptions/management/commands/send_trials_notification.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
         site = Site.objects.get_current()
 
         # Step 1: Find all lists that have subjects.
-        subject_lists = Lists.objects.filter(subjects__isnull=False).distinct()
+        subject_lists = Lists.objects.filter(subjects__isnull=False,weekly_digest=False).distinct()
 
         if not subject_lists.exists():
             self.stdout.write(self.style.WARNING('No lists found with subjects.'))

--- a/django/subscriptions/management/commands/send_trials_notification.py
+++ b/django/subscriptions/management/commands/send_trials_notification.py
@@ -1,59 +1,81 @@
 from django.core.management.base import BaseCommand
-from django.db.models import Q
 from django.template.loader import get_template
 from django.utils.html import strip_tags
-from gregory.models import Trials
-from sitesettings.models import CustomSetting
-from subscriptions.models import Subscribers
-import requests
 from django.contrib.sites.models import Site
 from django.conf import settings
+from gregory.models import Trials, Subject
+from sitesettings.models import CustomSetting
+from subscriptions.models import Subscribers, SentTrialNotification
+import requests
 
 class Command(BaseCommand):
-    help = 'Sends real-time notifications for new clinical trials to subscribers.'
+    help = 'Sends real-time notifications for new clinical trials to subscribers, filtered by subjects, without relying on a sent flag on Trials.'
 
     def handle(self, *args, **options):
         customsettings = CustomSetting.objects.get(site=Site.objects.get_current().id)
         site = Site.objects.get_current()
-        
-        subscribers_email_list = Subscribers.objects.filter(
-            subscriptions__list_name='Clinical Trials',
-            active=True
-        ).values_list('email', flat=True)
 
-        trials = Trials.objects.filter(sent_real_time_notification=False)
-        if trials and subscribers_email_list:
-            summary_context = {
-                "trials": trials,
-                "title": customsettings.title,
-                "email_footer": customsettings.email_footer,
-                "site": site,
-            }
+        # Get subscribers who have lists with subjects
+        subscribers = Subscribers.objects.filter(
+            active=True,
+            subscriptions__subjects__isnull=False
+        ).distinct()
 
-            html_content = get_template('emails/trial_notification.html').render(summary_context)
-            text_content = strip_tags(html_content)
+        if not subscribers.exists():
+            self.stdout.write(self.style.WARNING('No subscribers found with subject-based subscriptions.'))
+            return
 
-            # Send an email notification to each subscriber individually
-            for subscriber_email in subscribers_email_list:
+        for subscriber in subscribers:
+            subscriber_lists = subscriber.subscriptions.all()
+
+            # Gather all subjects related to this subscriber's lists
+            subscriber_subjects = Subject.objects.filter(lists__in=subscriber_lists).distinct()
+
+            # Fetch trials matching these subjects
+            matching_trials = Trials.objects.filter(
+                subjects__in=subscriber_subjects
+            ).distinct()
+
+            # Determine which have already been sent to these lists
+            already_sent_ids = SentTrialNotification.objects.filter(
+                trial__in=matching_trials,
+                list__in=subscriber_lists
+            ).values_list('trial_id', flat=True)
+
+            # Filter out already sent trials
+            new_trials = matching_trials.exclude(pk__in=already_sent_ids)
+
+            if new_trials.exists():
+                summary_context = {
+                    "trials": new_trials,
+                    "title": customsettings.title,
+                    "email_footer": customsettings.email_footer,
+                    "site": site,
+                }
+
+                html_content = get_template('emails/trial_notification.html').render(summary_context)
+                text_content = strip_tags(html_content)
+
                 result = self.send_simple_message(
-                    to=subscriber_email,
-                    subject='There is a new clinical trial',
+                    to=subscriber.email,
+                    subject='There are new clinical trials',
                     html=html_content,
                     text=text_content,
                     site=site,
                     customsettings=customsettings
                 )
 
-                # Check if the email was successfully sent
                 if result.status_code == 200:
-                    self.stdout.write(self.style.SUCCESS(f'Email sent to {subscriber_email}.'))
-                else:
-                    self.stdout.write(self.style.ERROR(f'Failed to send email to {subscriber_email}. Status: {result.status_code}'))
+                    self.stdout.write(self.style.SUCCESS(f'Email sent to {subscriber.email}.'))
 
-            # Mark trials as notified only after all emails are sent
-            trials.update(sent_real_time_notification=True)
-        else:
-            self.stdout.write(self.style.WARNING('No new trials or subscribers found for notifications.'))
+                    # Record that these trials have been sent for each of the subscriber's lists
+                    for trial in new_trials:
+                        for lst in subscriber_lists:
+                            SentTrialNotification.objects.get_or_create(trial=trial, list=lst)
+                else:
+                    self.stdout.write(self.style.ERROR(f'Failed to send email to {subscriber.email}. Status: {result.status_code}'))
+            else:
+                self.stdout.write(self.style.WARNING(f'No new trials found for {subscriber.email}.'))
 
     def send_simple_message(self, to, subject, html, text, site, customsettings):
         sender = 'GregoryAI <gregory@' + site.domain + '>'
@@ -69,7 +91,6 @@ class Command(BaseCommand):
             "HtmlBody": html
         }
 
-        # Send the request to Postmark
         response = requests.post(
             email_postmark_api_url,
             headers={
@@ -80,8 +101,7 @@ class Command(BaseCommand):
             json=payload
         )
 
-        # Output the response for debugging
         print("Status Code:", response.status_code)
         print("Response:", response.json())
-        
+
         return response

--- a/django/subscriptions/management/commands/send_weekly_summary.py
+++ b/django/subscriptions/management/commands/send_weekly_summary.py
@@ -1,73 +1,128 @@
 from django.core.management.base import BaseCommand
-from django.db.models import Q
 from django.template.loader import get_template
 from django.utils.html import strip_tags
-from gregory.models import Articles, Trials
-from sitesettings.models import CustomSetting
-from subscriptions.models import Subscribers
-import requests
 from django.contrib.sites.models import Site
 from django.conf import settings
+from gregory.models import Articles, Trials, Subject
+from sitesettings.models import CustomSetting
+from subscriptions.models import (
+	Lists,
+	Subscribers,
+	SentArticleNotification,
+	SentTrialNotification
+)
+import requests
 
 class Command(BaseCommand):
-	help = 'Sends a weekly summary email to all subscribers every Tuesday.'
+	help = 'Sends a weekly digest email for all weekly digest lists.'
 
 	def handle(self, *args, **options):
-		customsettings = CustomSetting.objects.get(site__domain=Site.objects.get_current().domain)
 		site = Site.objects.get_current()
+		customsettings = CustomSetting.objects.get(site=site)
 
+		# Step 1: Find all lists that are a weekly digest
+		weekly_digest_lists = Lists.objects.filter(weekly_digest=True, subjects__isnull=False).distinct()
 
-		subscribers_email_list = Subscribers.objects.filter(
-			subscriptions__list_name='Weekly Summary',
-			active=True
-		).values_list('email', flat=True)
+		if not weekly_digest_lists.exists():
+			self.stdout.write(self.style.WARNING('No lists marked as weekly digest with subjects found.'))
+			return
 
-		if subscribers_email_list:
-			articles = Articles.objects.filter(
-				Q(ml_predictions__gnb=True) |
-				Q(ml_predictions__lr=True) |
-				Q(ml_predictions__lsvc=True) |
-				Q(ml_predictions__mnb=True) |
-				Q(article_subject_relevances__is_relevant=True)
-			).exclude(sent_to_subscribers=True).distinct()
-			
-			trials = Trials.objects.exclude(sent_to_subscribers=True)
+		for digest_list in weekly_digest_lists:
+			# Step 2: Get the subjects for this list
+			list_subjects = digest_list.subjects.all()
 
-			summary_context = {
-				"articles": articles,
-				"trials": trials,
-				"title": customsettings.title,
-				"email_footer": customsettings.email_footer,
-				"site": site,
-			}
+			if not list_subjects.exists():
+				self.stdout.write(self.style.WARNING(f'The list "{digest_list.list_name}" is marked as weekly digest but has no subjects.'))
+				continue
 
-			html_content = get_template('emails/weekly_summary.html').render(summary_context)
-			text_content = strip_tags(html_content)
+			# Step 3: Gather clinical trials and articles for the subjects of this list
+			articles = Articles.objects.filter(subjects__in=list_subjects).distinct()
+			trials = Trials.objects.filter(subjects__in=list_subjects).distinct()
 
-			# Send an email to each subscriber individually
-			for subscriber_email in subscribers_email_list:
+			# Step 4: Send the digest to the subscribers of this list
+			subscribers = Subscribers.objects.filter(
+				active=True,
+				subscriptions=digest_list
+			).distinct()
+
+			if not subscribers.exists():
+				self.stdout.write(self.style.WARNING(f'No active subscribers found for the weekly digest list "{digest_list.list_name}".'))
+				continue
+
+			for subscriber in subscribers:
+				# Filter out articles already sent to this subscriber for this list
+				sent_article_ids = SentArticleNotification.objects.filter(
+					article__in=articles,
+					list=digest_list,
+					subscriber=subscriber
+				).values_list('article_id', flat=True)
+
+				unsent_articles = articles.exclude(pk__in=sent_article_ids)
+
+				# Filter out trials already sent to this subscriber for this list
+				sent_trial_ids = SentTrialNotification.objects.filter(
+					trial__in=trials,
+					list=digest_list,
+					subscriber=subscriber
+				).values_list('trial_id', flat=True)
+
+				unsent_trials = trials.exclude(pk__in=sent_trial_ids)
+
+				# If there's nothing new, skip this subscriber
+				if not unsent_articles.exists() and not unsent_trials.exists():
+					self.stdout.write(
+						self.style.WARNING(f'No new articles or trials for {subscriber.email} in list "{digest_list.list_name}".')
+					)
+					continue
+
+				# Prepare and send the email
+				summary_context = {
+					"articles": unsent_articles,
+					"trials": unsent_trials,
+					"title": customsettings.title,
+					"email_footer": customsettings.email_footer,
+					"site": site,
+				}
+
+				html_content = get_template('emails/weekly_summary.html').render(summary_context)
+				text_content = strip_tags(html_content)
+
 				result = self.send_simple_message(
-					to=subscriber_email,
-					subject='Weekly Summary',
+					to=subscriber.email,
+					subject=f'Your Weekly Digest: {digest_list.list_name}',
 					html=html_content,
 					text=text_content,
 					site=site,
 					customsettings=customsettings
 				)
-			
-			# Mark articles and trials as sent
-			articles.update(sent_to_subscribers=True)
-			trials.update(sent_to_subscribers=True)
-		else:
-			self.stdout.write(self.style.WARNING('No subscribers found for the Weekly Summary.'))
+
+				if result.status_code == 200:
+					self.stdout.write(
+						self.style.SUCCESS(f'Weekly digest email sent to {subscriber.email} for list "{digest_list.list_name}".')
+					)
+					# Step 5: Record that these emails were already sent
+					for article in unsent_articles:
+						SentArticleNotification.objects.get_or_create(
+							article=article,
+							list=digest_list,
+							subscriber=subscriber
+						)
+					for trial in unsent_trials:
+						SentTrialNotification.objects.get_or_create(
+							trial=trial,
+							list=digest_list,
+							subscriber=subscriber
+						)
+				else:
+					self.stdout.write(
+						self.style.ERROR(f'Failed to send weekly digest email to {subscriber.email} for list "{digest_list.list_name}". Status: {result.status_code}')
+					)
 
 	def send_simple_message(self, to, subject, html, text, site, customsettings):
-		# Prepare sender email and Postmark API credentials
 		sender = f'GregoryAI <gregory@{site.domain}>'
 		email_postmark_api_url = settings.EMAIL_POSTMARK_API_URL
 		email_postmark_api = settings.EMAIL_POSTMARK_API
 
-		# Set up the payload for the Postmark API
 		payload = {
 			"MessageStream": "broadcast",
 			"From": sender,
@@ -77,7 +132,6 @@ class Command(BaseCommand):
 			"HtmlBody": html
 		}
 
-		# Make the POST request to send the email
 		response = requests.post(
 			email_postmark_api_url,
 			headers={
@@ -88,8 +142,7 @@ class Command(BaseCommand):
 			json=payload
 		)
 
-		# Output response status for debugging
 		print("Status Code:", response.status_code)
 		print("Response:", response.json())
-		
+
 		return response

--- a/django/subscriptions/management/mark_all_as_sent.py
+++ b/django/subscriptions/management/mark_all_as_sent.py
@@ -1,0 +1,52 @@
+from django.core.management.base import BaseCommand
+from gregory.models import Articles, Trials
+from subscriptions.models import Subscribers, SentArticleNotification, SentTrialNotification
+
+class Command(BaseCommand):
+	help = 'Marks all articles and trials as already sent to all subscribers for all their subscribed lists.'
+
+	def handle(self, *args, **options):
+		subscribers = Subscribers.objects.filter(active=True).prefetch_related('subscriptions')
+		articles = list(Articles.objects.all())
+		trials = list(Trials.objects.all())
+
+		if not subscribers:
+			self.stdout.write(self.style.WARNING('No active subscribers found.'))
+			return
+
+		if not articles and not trials:
+			self.stdout.write(self.style.WARNING('No articles or trials found.'))
+			return
+
+		for subscriber in subscribers:
+			lists_subscribed = subscriber.subscriptions.all()
+			if not lists_subscribed.exists():
+				self.stdout.write(self.style.WARNING(f'Subscriber {subscriber.email} has no subscriptions.'))
+				continue
+
+			for lst in lists_subscribed:
+				# Mark all articles as sent
+				for article in articles:
+					_, created = SentArticleNotification.objects.get_or_create(
+						article=article,
+						list=lst,
+						subscriber=subscriber
+					)
+					if created:
+						self.stdout.write(self.style.SUCCESS(
+							f'Article {article.pk} marked as sent to {subscriber.email} for list "{lst.list_name}".'
+						))
+
+				# Mark all trials as sent
+				for trial in trials:
+					_, created = SentTrialNotification.objects.get_or_create(
+						trial=trial,
+						list=lst,
+						subscriber=subscriber
+					)
+					if created:
+						self.stdout.write(self.style.SUCCESS(
+							f'Trial {trial.pk} marked as sent to {subscriber.email} for list "{lst.list_name}".'
+						))
+
+		self.stdout.write(self.style.SUCCESS('All articles and trials have been marked as sent to all subscribers.'))

--- a/django/subscriptions/models.py
+++ b/django/subscriptions/models.py
@@ -2,18 +2,19 @@ from django.db import models
 from django.db.models import UniqueConstraint
 from django.db.models.functions import Lower
 
-# Create your models here.
 class Lists(models.Model):
 	list_id = models.AutoField(primary_key=True)
 	list_name = models.CharField(max_length=150, null=False, blank=False)
 	list_description = models.CharField(max_length=150, null=True, blank=True)
+	subjects = models.ManyToManyField('gregory.Subject', blank=True)
+
 	class Meta:
 		managed = True
 		verbose_name_plural = 'lists'
-		# db_table = 'lists'
+
 	def __str__(self):
 		return str(self.list_name)
-			
+
 class Subscribers(models.Model):
 	PROFILEOPTIONS = [
 		('patient', 'Patient'),
@@ -38,13 +39,22 @@ class Subscribers(models.Model):
 		constraints = [
 			UniqueConstraint(Lower('email'), name='unique_lower_email')
 		]
+
 	def __str__(self):
 		return str(self.email)
 
 	def save(self, *args, **kwargs):
-		# Normalize the email to lowercase before saving
 		self.email = self.email.lower()
 		super(Subscribers, self).save(*args, **kwargs)
 
+class SentTrialNotification(models.Model):
+	trial = models.ForeignKey('gregory.Trials', on_delete=models.CASCADE)
+	list = models.ForeignKey('subscriptions.Lists', on_delete=models.CASCADE)
+	sent_at = models.DateTimeField(auto_now_add=True)
 
+	class Meta:
+		unique_together = ('trial', 'list')
+		verbose_name_plural = 'sent trial notifications'
 
+	def __str__(self):
+		return f"Trial {self.trial_id} sent to {self.list_id} at {self.sent_at}"

--- a/django/subscriptions/models.py
+++ b/django/subscriptions/models.py
@@ -8,6 +8,7 @@ class Lists(models.Model):
 	list_name = models.CharField(max_length=150, null=False, blank=False)
 	list_description = models.CharField(max_length=150, null=True, blank=True)
 	subjects = models.ManyToManyField('gregory.Subject', blank=True)
+	weekly_digest = models.BooleanField(default=False) # If True, send a weekly digest email
 
 	class Meta:
 		managed = True

--- a/django/subscriptions/models.py
+++ b/django/subscriptions/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.db.models import UniqueConstraint
 from django.db.models.functions import Lower
+from gregory.models import Subject, Articles, Trials
 
 class Lists(models.Model):
 	list_id = models.AutoField(primary_key=True)
@@ -47,14 +48,29 @@ class Subscribers(models.Model):
 		self.email = self.email.lower()
 		super(Subscribers, self).save(*args, **kwargs)
 
-class SentTrialNotification(models.Model):
-	trial = models.ForeignKey('gregory.Trials', on_delete=models.CASCADE)
-	list = models.ForeignKey('subscriptions.Lists', on_delete=models.CASCADE)
+
+class SentArticleNotification(models.Model):
+	article = models.ForeignKey(Articles, on_delete=models.CASCADE)
+	list = models.ForeignKey(Lists, on_delete=models.CASCADE)
+	subscriber = models.ForeignKey(Subscribers, on_delete=models.CASCADE)
 	sent_at = models.DateTimeField(auto_now_add=True)
 
 	class Meta:
-		unique_together = ('trial', 'list')
+		unique_together = ('article', 'list', 'subscriber')
+		verbose_name_plural = 'sent article notifications'
+
+	def __str__(self):
+		return f"Article {self.article_id} sent to {self.list_id}, subscriber {self.subscriber_id}"
+
+class SentTrialNotification(models.Model):
+	trial = models.ForeignKey(Trials, on_delete=models.CASCADE)
+	list = models.ForeignKey(Lists, on_delete=models.CASCADE)
+	subscriber = models.ForeignKey(Subscribers, on_delete=models.CASCADE)
+	sent_at = models.DateTimeField(auto_now_add=True)
+
+	class Meta:
+		unique_together = ('trial', 'list', 'subscriber')
 		verbose_name_plural = 'sent trial notifications'
 
 	def __str__(self):
-		return f"Trial {self.trial_id} sent to {self.list_id} at {self.sent_at}"
+		return f"Trial {self.trial_id} sent to {self.list_id}, subscriber {self.subscriber_id}"


### PR DESCRIPTION
1. add option to link a subscription list to one or more subjects
2. add option to set a subscription list as a weekly digest
3. changes the weekly_summary command to send all a summary for each distribution list that is a weekly_digest
4. changes the send_trials_notification to use the existing lists not marked as a weekly_digest and allow notifications per subject(s)