### PR TITLE
508 number of trials in title does not match total trials listed

### DIFF
--- a/django/templates/emails/components/content_organizer.py
+++ b/django/templates/emails/components/content_organizer.py
@@ -22,8 +22,8 @@ class EmailContentOrganizer:
     def __init__(self, email_type='weekly_summary'):
         self.email_type = email_type
         self.confidence_threshold = 0.8
-        self.max_articles_per_email = 10
-        self.max_trials_per_email = 5
+        self.max_articles_per_email = 99
+        self.max_trials_per_email = 99
     
     def organize_articles(self, articles, subscriber=None, list_obj=None):
         """

--- a/django/templates/emails/components/content_organizer.py
+++ b/django/templates/emails/components/content_organizer.py
@@ -168,8 +168,8 @@ class EmailContentOrganizer:
         sorted_articles = list(articles.order_by('-discovery_date'))
         
         return {
-            'featured_articles': sorted_articles[:self.max_articles_per_email//2],  # Use configured limits
-            'regular_articles': sorted_articles[self.max_articles_per_email//2:self.max_articles_per_email],
+            'featured_articles': sorted_articles,  # Include ALL articles - no limits
+            'regular_articles': [],  # No need to split when including all
             'total_count': len(sorted_articles),
             'high_confidence_count': 0
         }


### PR DESCRIPTION
fixes #508 

There were some limits to the number of articles added to the body of the email. This PR removes them.