### PR TITLE
Fix docs for ML training and team endpoints

### DIFF
--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -87,6 +87,13 @@ Gregory's API is open and doesn't require authentication unless you need to use 
 | Teams                   | GET /teams/{id}/subjects                 | List all subjects for specific team by ID           | ✅                                       |
 | Teams                   | GET /teams/{id}/sources                  | List all sources for specific team by ID            | ✅                                       |
 | Teams                   | GET /teams/{id}/categories               | List all categories for specific team by ID         | ✅                                       |
+| Teams                   | GET /teams/{id}/articles/subject/{subject_id}/     | List all articles for a team filtered by subject    | ✅              |
+| Teams                   | GET /teams/{id}/articles/category/{category_slug}/ | List all articles for a team filtered by category   | ✅              |
+| Teams                   | GET /teams/{id}/articles/source/{source_id}/       | List all articles for a team filtered by source     | ✅              |
+| Teams                   | GET /teams/{id}/trials/category/{category_slug}/   | List clinical trials for a team filtered by category | ✅              |
+| Teams                   | GET /teams/{id}/trials/subject/{subject_id}/       | List clinical trials for a team filtered by subject | ✅              |
+| Teams                   | GET /teams/{id}/trials/source/{source_id}/         | List clinical trials for a team filtered by source  | ✅              |
+| Teams                   | GET /teams/{id}/categories/{category_slug}/monthly-counts/ | Monthly article and trial counts for a team category | ✅              |
 | MLPredictions           | GET /ml-predictions/                     | List all ML predictions                             | 🛑                                              |
 | MLPredictions           | POST /ml-predictions/                    | Create a new ML prediction                          | 🛑                                              |
 | MLPredictions           | GET /ml-predictions/{id}/                | Retrieve a specific ML prediction by ID             | 🛑                                              |
@@ -97,5 +104,3 @@ Gregory's API is open and doesn't require authentication unless you need to use 
 | ArticleSubjectRelevance | GET /article-subject-relevances/{id}/    | Retrieve a specific article subject relevance by ID | 🛑                                              |
 | ArticleSubjectRelevance | PUT /article-subject-relevances/{id}/    | Update a specific article subject relevance by ID   | 🛑                                              |
 | ArticleSubjectRelevance | DELETE /article-subject-relevances/{id}/ | Delete a specific article subject relevance by ID   | 🛑                                              |
-
-This table now includes the additional endpoints defined in your `urls.py` file, ensuring that all your API endpoints are accurately tracked.

--- a/docs/04-machine-learning.md
+++ b/docs/04-machine-learning.md
@@ -18,5 +18,4 @@ In the email, click the **Edit** link, and you'll be taken to the API page of th
 It's useful to re-train the machine learning models once you have a good number of articles flagged as relevant.
 
 1. `cd django; source venv/bin/activate`
-2. `sudo docker exec -it admin ./manage.py 1_data_processor` the source.csv file will show up here `django/gregory/data/source.csv`
-3. `python3 2_train_models.py`
+2. `sudo docker exec -it admin ./manage.py train_models`

--- a/docs/04-machine-learning.md
+++ b/docs/04-machine-learning.md
@@ -18,4 +18,4 @@ In the email, click the **Edit** link, and you'll be taken to the API page of th
 It's useful to re-train the machine learning models once you have a good number of articles flagged as relevant.
 
 1. `cd django; source venv/bin/activate`
-2. `sudo docker exec -it admin ./manage.py train_models`
+2. `docker exec -it admin ./manage.py train_models`

--- a/docs/API EndPoints.md
+++ b/docs/API EndPoints.md
@@ -52,6 +52,13 @@
 | Teams                   | GET /teams/{id}/subjects                 | List all subjects for specific team by ID           | :white_check_mark:                                       |
 | Teams                   | GET /teams/{id}/sources                  | List all sources for specific team by ID            | :white_check_mark:                                       |
 | Teams                   | GET /teams/{id}/categories               | List all categories for specific team by ID         | :white_check_mark:                                       |
+| Teams                   | GET /teams/{id}/articles/subject/{subject_id}/     | List all articles for a team filtered by subject    | :white_check_mark:              |
+| Teams                   | GET /teams/{id}/articles/category/{category_slug}/ | List all articles for a team filtered by category   | :white_check_mark:              |
+| Teams                   | GET /teams/{id}/articles/source/{source_id}/       | List all articles for a team filtered by source     | :white_check_mark:              |
+| Teams                   | GET /teams/{id}/trials/category/{category_slug}/   | List clinical trials for a team filtered by category| :white_check_mark:              |
+| Teams                   | GET /teams/{id}/trials/subject/{subject_id}/       | List clinical trials for a team filtered by subject | :white_check_mark:              |
+| Teams                   | GET /teams/{id}/trials/source/{source_id}/         | List clinical trials for a team filtered by source  | :white_check_mark:              |
+| Teams                   | GET /teams/{id}/categories/{category_slug}/monthly-counts/ | Monthly article and trial counts for a team category | :white_check_mark:              |
 | MLPredictions           | GET /ml-predictions/                     | List all ML predictions                             | :stop_sign:                                              |
 | MLPredictions           | POST /ml-predictions/                    | Create a new ML prediction                          | :stop_sign:                                              |
 | MLPredictions           | GET /ml-predictions/{id}/                | Retrieve a specific ML prediction by ID             | :stop_sign:                                              |


### PR DESCRIPTION
## Summary
- update machine learning documentation to use `train_models`
- document missing team endpoints for API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `ruff check .` *(fails: 421 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845b57762e48324957a8b0036d41fcd