### PR TITLE
Add Codex workflow to auto assign labeled issues

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,30 @@
+name: Codex Issue Runner
+
+on:
+    issues:
+        types: [opened, edited, reopened, labeled]
+
+permissions:
+    issues: write
+    pull-requests: write
+
+jobs:
+    codex:
+        if: contains(github.event.issue.labels.*.name, 'codex')
+        runs-on: ubuntu-latest
+        steps:
+            - name: Assign issue to Codex
+              uses: actions/github-script@v7
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      await github.issues.addAssignees({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.issue.number,
+                          assignees: ['openai-codex']
+                      })
+            - name: Run Codex
+              uses: openai/codex-action@v1
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ For other integrations, the Django app provides RSS feeds with a live update of 
 
 #### Rest API: <https://api.gregory-ms.com>
 
+## Codex Automation
+
+Issues labeled `codex` are automatically assigned to the **openai-codex** user.
+The workflow then invokes the Codex GitHub App, which proposes a pull request
+with changes that address the issue.
+
 ## Running in Production
 
 ### Server Requirements


### PR DESCRIPTION
## Summary
- add a GitHub workflow to run Codex on issues
- document Codex automation in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6846fb0466008324a72805b3383ba1ee