### PR TITLE
Handle multi-list subscription

### DIFF
--- a/django/subscriptions/forms.py
+++ b/django/subscriptions/forms.py
@@ -4,11 +4,13 @@ from django.forms import ModelForm
 from .models import Subscribers
 
 class SubscribersForm(ModelForm):
-	first_name = forms.CharField(max_length=100  )
-	last_name = forms.CharField(max_length=100  )
-	email = forms.EmailField(max_length=120)
-	list = forms.IntegerField()
-	class Meta:
+        first_name = forms.CharField(max_length=100)
+        last_name = forms.CharField(max_length=100)
+        email = forms.EmailField(max_length=120)
+        # ``list`` was previously an ``IntegerField`` which only captured a
+        # single checkbox value.  It has been removed so the view can obtain all
+        # selected list IDs using ``request.POST.getlist('list')``.
+        class Meta:
 		model = Subscribers
 		fields = [
 			'first_name',

--- a/django/subscriptions/views.py
+++ b/django/subscriptions/views.py
@@ -11,18 +11,21 @@ def subscribe_view(request):
 	logger = logging.getLogger('__name__')
 	
 	# Process the form data
-	subscriber_form = SubscribersForm(request.POST)
+        subscriber_form = SubscribersForm(request.POST)
 	
 	if subscriber_form.is_valid():
 		first_name = subscriber_form.cleaned_data['first_name']
 		last_name = subscriber_form.cleaned_data['last_name']
 		email = subscriber_form.cleaned_data['email']
 		profile = subscriber_form.cleaned_data['profile']
-		list_id = subscriber_form.cleaned_data['list']
+                # ``request.POST`` may contain multiple ``list`` values when the
+                # user checks more than one subscription option. ``getlist``
+                # returns all of them as a list of strings.
+                list_ids = request.POST.getlist('list')
 		
-		try:
-			# Fetch the list object
-			subscription_list = Lists.objects.get(pk=list_id)
+                try:
+                        # Fetch all subscription lists selected by the user
+                        subscription_lists = Lists.objects.filter(pk__in=list_ids)
 
 			# Check if the subscriber already exists
 			subscriber, created = Subscribers.objects.get_or_create(
@@ -40,15 +43,15 @@ def subscribe_view(request):
 				subscriber.last_name = last_name
 				subscriber.profile = profile
 
-			# Add the list to the subscriber's subscriptions
-			subscriber.subscriptions.add(subscription_list)
+                        # Add the lists to the subscriber's subscriptions
+                        subscriber.subscriptions.add(*subscription_lists)
 			subscriber.save()
 
 			return HttpResponseRedirect('https://gregory-ms.com/thank-you/')
 
-		except Lists.DoesNotExist:
-			logger.error(f"List with ID {list_id} does not exist.")
-			return HttpResponseRedirect('https://gregory-ms.com/error/')
+                except Exception as e:
+                        logger.error(f"Subscription error: {e}")
+                        return HttpResponseRedirect('https://gregory-ms.com/error/')
 
 	else:
 		# Log errors for debugging


### PR DESCRIPTION
## Summary
- update form to stop forcing a single list value
- handle multiple `list` values in subscribe view

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6847051fffd08324a7ee34d3edd1dc75