### PR TITLE
Filter admin relevancies by auto_predict

### DIFF
--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -14,21 +14,21 @@ from django.utils.html import format_html
 from django.urls import reverse
 # @admin.register(PredictionRunLog)
 class PredictionRunLogAdmin(admin.ModelAdmin):
-    list_display = ['id', 'team', 'subject', 'run_type', 'algorithm', 'model_version', 'run_started', 'run_finished', 'status_label', 'triggered_by']
-    list_filter = [DateRangeFilter, 'team', 'subject', 'run_type', 'algorithm', 'success', 'model_version']
-    search_fields = ['team__organization__name', 'subject__subject_name', 'model_version', 'triggered_by', 'algorithm']
-    readonly_fields = ['run_started']  # Auto-populated field
-    date_hierarchy = 'run_started'
-    actions = ['mark_as_failed', 'mark_as_successful', 'export_as_csv']
-    
-    fieldsets = (
-        ('Run Information', {
-            'fields': ('team', 'subject', 'run_type', 'algorithm', 'model_version', 'triggered_by'),
-        }),
-        ('Status', {
-            'fields': ('run_started', 'run_finished', 'success', 'error_message'),
-        }),
-    )
+		list_display = ['id', 'team', 'subject', 'run_type', 'algorithm', 'model_version', 'run_started', 'run_finished', 'status_label', 'triggered_by']
+		list_filter = [DateRangeFilter, 'team', 'subject', 'run_type', 'algorithm', 'success', 'model_version']
+		search_fields = ['team__organization__name', 'subject__subject_name', 'model_version', 'triggered_by', 'algorithm']
+		readonly_fields = ['run_started']  # Auto-populated field
+		date_hierarchy = 'run_started'
+		actions = ['mark_as_failed', 'mark_as_successful', 'export_as_csv']
+		
+		fieldsets = (
+				('Run Information', {
+						'fields': ('team', 'subject', 'run_type', 'algorithm', 'model_version', 'triggered_by'),
+				}),
+				('Status', {
+						'fields': ('run_started', 'run_finished', 'success', 'error_message'),
+				}),
+		)
 
 
 class RelevanceRadioWidget(forms.RadioSelect):
@@ -113,31 +113,30 @@ class ArticleSubjectRelevanceInline(admin.TabularInline):
 		return str(obj.subject) if obj.subject else ''
 	subject_name.short_description = 'Subject'
 	
-        def get_formset(self, request, obj=None, **kwargs):
-                """Pre-populate with all subjects for the article's teams"""
-                if obj and obj.pk:  # If editing existing article
-                        # Get subjects for the teams this article belongs to that
-                        # have auto_predict enabled
-                        team_subjects = Subject.objects.filter(
-                                team__in=obj.teams.all(),
-                                auto_predict=True
-                        ).distinct().order_by('subject_name')
+	def get_formset(self, request, obj=None, **kwargs):
+		"""Pre-populate with all subjects for the article's teams"""
+		if obj and obj.pk:  # If editing existing article
+			# Get subjects for the teams this article belongs to that
+			# have auto_predict enabled
+			team_subjects = Subject.objects.filter(
+				team__in=obj.teams.all(),
+				auto_predict=True
+			).distinct().order_by('subject_name')
 
-                        # Create ArticleSubjectRelevance instances for any missing subjects
-                        for subject in team_subjects:
-                                ArticleSubjectRelevance.objects.get_or_create(
-                                        article=obj,
-                                        subject=subject,
-                                        defaults={'is_relevant': None}
-                                )
-		
+			# Create ArticleSubjectRelevance instances for any missing subjects
+			for subject in team_subjects:
+				ArticleSubjectRelevance.objects.get_or_create(
+					article=obj,
+					subject=subject,
+					defaults={'is_relevant': None}
+				)
 		return super().get_formset(request, obj, **kwargs)
-	
-        def get_queryset(self, request):
-                """Order by subject name for consistency and filter auto_predict subjects"""
-                return super().get_queryset(request).select_related('subject').filter(
-                        subject__auto_predict=True
-                ).order_by('subject__subject_name')
+
+	def get_queryset(self, request):
+		"""Order by subject name for consistency and filter auto_predict subjects"""
+		return super().get_queryset(request).select_related('subject').filter(
+			subject__auto_predict=True
+		).order_by('subject__subject_name')
 
 class ArticleAdminForm(forms.ModelForm):
 	ml_predictions_display = MLPredictionsField(required=False)
@@ -238,21 +237,21 @@ class SourceAdmin(admin.ModelAdmin):
 	has_keyword_filter.short_description = 'Has Filter'
 
 class SubjectAdminForm(forms.ModelForm):
-    """Custom form for Subject admin with superuser-only team access"""
-    
-    class Meta:
-        model = Subject
-        fields = '__all__'
-    
-    def __init__(self, *args, **kwargs):
-        # Get the request from kwargs if passed
-        self.request = kwargs.pop('request', None)
-        super().__init__(*args, **kwargs)
-        
-        # If user is superuser, show all teams
-        # Otherwise, keep the default filtering (user's teams only)
-        if self.request and hasattr(self.request, 'user') and self.request.user.is_superuser:
-            self.fields['team'].queryset = Team.objects.all()
+		"""Custom form for Subject admin with superuser-only team access"""
+		
+		class Meta:
+				model = Subject
+				fields = '__all__'
+		
+		def __init__(self, *args, **kwargs):
+				# Get the request from kwargs if passed
+				self.request = kwargs.pop('request', None)
+				super().__init__(*args, **kwargs)
+				
+				# If user is superuser, show all teams
+				# Otherwise, keep the default filtering (user's teams only)
+				if self.request and hasattr(self.request, 'user') and self.request.user.is_superuser:
+						self.fields['team'].queryset = Team.objects.all()
 
 @admin.register(Subject)
 class SubjectAdmin(admin.ModelAdmin):
@@ -436,170 +435,170 @@ class TeamCredentialsAdmin(admin.ModelAdmin):
 		return self.readonly_fields
 @admin.register(PredictionRunLog)
 class PredictionRunLogAdmin(admin.ModelAdmin):
-    list_display = ['id', 'team', 'subject', 'run_type', 'algorithm', 'model_version', 'run_started', 'run_finished', 'status_label', 'triggered_by']
-    list_filter = [DateRangeFilter, 'team', 'subject', 'run_type', 'algorithm', 'success', 'model_version']
-    search_fields = ['team__organization__name', 'subject__subject_name', 'model_version', 'triggered_by', 'algorithm']
-    readonly_fields = ['run_started']  # Auto-populated field
-    date_hierarchy = 'run_started'
-    actions = ['mark_as_failed', 'mark_as_successful', 'export_as_csv']
-    
-    fieldsets = (
-        ('Run Information', {
-            'fields': ('team', 'subject', 'run_type', 'algorithm', 'model_version', 'triggered_by'),
-        }),
-        ('Status', {
-            'fields': ('run_started', 'run_finished', 'success', 'error_message'),
-        }),
-    )
-    
-    def status_label(self, obj):
-        if obj.success is True:
-            return format_html('<span style="color: green; font-weight: bold;">Success</span>')
-        elif obj.success is False:
-            return format_html('<span style="color: red; font-weight: bold;">Failed</span>')
-        else:
-            return format_html('<span style="color: orange; font-weight: bold;">Running</span>')
-    status_label.short_description = "Status"
-    
-    def get_queryset(self, request):
-        # Order by most recent runs first
-        return super().get_queryset(request).order_by('-run_started')
-    
-    def has_change_permission(self, request, obj=None):
-        # Logs should generally not be modified after creation
-        # But admins might need to update status or error messages
-        return True
-    
-    def has_delete_permission(self, request, obj=None):
-        # Allow deletion for admins
-        return True
-    
-    def mark_as_failed(self, request, queryset):
-        """Mark selected unfinished runs as failed"""
-        from django.utils import timezone
-        
-        # Only update runs that are still in progress (success is None)
-        updated = queryset.filter(success__isnull=True).update(
-            success=False,
-            run_finished=timezone.now(),
-            error_message="Manually marked as failed by admin."
-        )
-        
-        if updated == 0:
-            self.message_user(request, "No unfinished runs were selected.")
-        else:
-            self.message_user(request, f"Successfully marked {updated} run(s) as failed.")
-    mark_as_failed.short_description = "Mark selected unfinished runs as failed"
-    
-    def mark_as_successful(self, request, queryset):
-        """Mark selected unfinished runs as successful"""
-        from django.utils import timezone
-        
-        # Only update runs that are still in progress (success is None)
-        updated = queryset.filter(success__isnull=True).update(
-            success=True,
-            run_finished=timezone.now()
-        )
-        
-        if updated == 0:
-            self.message_user(request, "No unfinished runs were selected.")
-        else:
-            self.message_user(request, f"Successfully marked {updated} run(s) as successful.")
-    mark_as_successful.short_description = "Mark selected unfinished runs as successful"
-    
-    def export_as_csv(self, request, queryset):
-        """Export selected logs to CSV file"""
-        meta = self.model._meta
-        field_names = [
-            'id', 'team', 'subject', 'run_type', 'algorithm', 'model_version', 
-            'run_started', 'run_finished', 'success', 'triggered_by', 'error_message'
-        ]
-        
-        response = HttpResponse(content_type='text/csv')
-        response['Content-Disposition'] = f'attachment; filename={meta.verbose_name_plural}.csv'
-        
-        writer = csv.writer(response)
-        writer.writerow([field for field in field_names])
-        
-        for obj in queryset:
-            row = []
-            for field in field_names:
-                if field == 'team':
-                    value = str(getattr(obj, field))
-                elif field == 'subject':
-                    value = str(getattr(obj, field))
-                elif field == 'run_type':
-                    value = obj.get_run_type_display()
-                else:
-                    value = getattr(obj, field)
-                row.append(value)
-            writer.writerow(row)
-            
-        return response
-    export_as_csv.short_description = "Export selected logs to CSV"
-        
-    def changelist_view(self, request, extra_context=None):
-        # Add dashboard statistics to the context
-        extra_context = extra_context or {}
-        
-        # Training runs statistics
-        extra_context['training_success_count'] = PredictionRunLog.objects.filter(run_type='train', success=True).count()
-        extra_context['training_failed_count'] = PredictionRunLog.objects.filter(run_type='train', success=False).count()
-        extra_context['training_running_count'] = PredictionRunLog.objects.filter(run_type='train', success__isnull=True).count()
-        
-        # Prediction runs statistics
-        extra_context['prediction_success_count'] = PredictionRunLog.objects.filter(run_type='predict', success=True).count()
-        extra_context['prediction_failed_count'] = PredictionRunLog.objects.filter(run_type='predict', success=False).count()
-        extra_context['prediction_running_count'] = PredictionRunLog.objects.filter(run_type='predict', success__isnull=True).count()
-        
-        # Recent runs (last 10)
-        extra_context['recent_runs'] = PredictionRunLog.objects.all().order_by('-run_started')[:10]
-        
-        return super().changelist_view(request, extra_context=extra_context)
-    
-    def get_urls(self):
-        urls = super().get_urls()
-        custom_urls = [
-            path(
-                'ml-coverage/',
-                self.admin_site.admin_view(self.ml_coverage_view),
-                name='predictionrunlog_ml_coverage',
-            ),
-        ]
-        return custom_urls + urls
-    
-    def ml_coverage_view(self, request):
-        """View to show ML coverage across teams and subjects"""
-        # Get all teams
-        teams = Team.objects.prefetch_related('subjects').all()
-        
-        # Create dictionaries to store the latest runs per subject
-        training_data = {}
-        prediction_data = {}
-        
-        # Get all subjects
-        all_subjects = Subject.objects.all()
-        
-        # For each subject, get its latest training and prediction runs
-        for subject in all_subjects:
-            latest_training = PredictionRunLog.get_latest_run(subject.team, subject, run_type='train')
-            latest_prediction = PredictionRunLog.get_latest_run(subject.team, subject, run_type='predict')
-            
-            if latest_training:
-                training_data[subject.id] = latest_training
-                
-            if latest_prediction:
-                prediction_data[subject.id] = latest_prediction
-        
-        context = {
-            'title': 'ML Coverage Report',
-            'teams': teams,
-            'training_data': training_data,
-            'prediction_data': prediction_data,
-        }
-        
-        # Render the template
-        return render(request, 'admin/gregory/predictionrunlog/ml_coverage.html', context)
+		list_display = ['id', 'team', 'subject', 'run_type', 'algorithm', 'model_version', 'run_started', 'run_finished', 'status_label', 'triggered_by']
+		list_filter = [DateRangeFilter, 'team', 'subject', 'run_type', 'algorithm', 'success', 'model_version']
+		search_fields = ['team__organization__name', 'subject__subject_name', 'model_version', 'triggered_by', 'algorithm']
+		readonly_fields = ['run_started']  # Auto-populated field
+		date_hierarchy = 'run_started'
+		actions = ['mark_as_failed', 'mark_as_successful', 'export_as_csv']
+		
+		fieldsets = (
+				('Run Information', {
+						'fields': ('team', 'subject', 'run_type', 'algorithm', 'model_version', 'triggered_by'),
+				}),
+				('Status', {
+						'fields': ('run_started', 'run_finished', 'success', 'error_message'),
+				}),
+		)
+		
+		def status_label(self, obj):
+				if obj.success is True:
+						return format_html('<span style="color: green; font-weight: bold;">Success</span>')
+				elif obj.success is False:
+						return format_html('<span style="color: red; font-weight: bold;">Failed</span>')
+				else:
+						return format_html('<span style="color: orange; font-weight: bold;">Running</span>')
+		status_label.short_description = "Status"
+		
+		def get_queryset(self, request):
+				# Order by most recent runs first
+				return super().get_queryset(request).order_by('-run_started')
+		
+		def has_change_permission(self, request, obj=None):
+				# Logs should generally not be modified after creation
+				# But admins might need to update status or error messages
+				return True
+		
+		def has_delete_permission(self, request, obj=None):
+				# Allow deletion for admins
+				return True
+		
+		def mark_as_failed(self, request, queryset):
+				"""Mark selected unfinished runs as failed"""
+				from django.utils import timezone
+				
+				# Only update runs that are still in progress (success is None)
+				updated = queryset.filter(success__isnull=True).update(
+						success=False,
+						run_finished=timezone.now(),
+						error_message="Manually marked as failed by admin."
+				)
+				
+				if updated == 0:
+						self.message_user(request, "No unfinished runs were selected.")
+				else:
+						self.message_user(request, f"Successfully marked {updated} run(s) as failed.")
+		mark_as_failed.short_description = "Mark selected unfinished runs as failed"
+		
+		def mark_as_successful(self, request, queryset):
+				"""Mark selected unfinished runs as successful"""
+				from django.utils import timezone
+				
+				# Only update runs that are still in progress (success is None)
+				updated = queryset.filter(success__isnull=True).update(
+						success=True,
+						run_finished=timezone.now()
+				)
+				
+				if updated == 0:
+						self.message_user(request, "No unfinished runs were selected.")
+				else:
+						self.message_user(request, f"Successfully marked {updated} run(s) as successful.")
+		mark_as_successful.short_description = "Mark selected unfinished runs as successful"
+		
+		def export_as_csv(self, request, queryset):
+				"""Export selected logs to CSV file"""
+				meta = self.model._meta
+				field_names = [
+						'id', 'team', 'subject', 'run_type', 'algorithm', 'model_version', 
+						'run_started', 'run_finished', 'success', 'triggered_by', 'error_message'
+				]
+				
+				response = HttpResponse(content_type='text/csv')
+				response['Content-Disposition'] = f'attachment; filename={meta.verbose_name_plural}.csv'
+				
+				writer = csv.writer(response)
+				writer.writerow([field for field in field_names])
+				
+				for obj in queryset:
+						row = []
+						for field in field_names:
+								if field == 'team':
+										value = str(getattr(obj, field))
+								elif field == 'subject':
+										value = str(getattr(obj, field))
+								elif field == 'run_type':
+										value = obj.get_run_type_display()
+								else:
+										value = getattr(obj, field)
+								row.append(value)
+						writer.writerow(row)
+						
+				return response
+		export_as_csv.short_description = "Export selected logs to CSV"
+				
+		def changelist_view(self, request, extra_context=None):
+				# Add dashboard statistics to the context
+				extra_context = extra_context or {}
+				
+				# Training runs statistics
+				extra_context['training_success_count'] = PredictionRunLog.objects.filter(run_type='train', success=True).count()
+				extra_context['training_failed_count'] = PredictionRunLog.objects.filter(run_type='train', success=False).count()
+				extra_context['training_running_count'] = PredictionRunLog.objects.filter(run_type='train', success__isnull=True).count()
+				
+				# Prediction runs statistics
+				extra_context['prediction_success_count'] = PredictionRunLog.objects.filter(run_type='predict', success=True).count()
+				extra_context['prediction_failed_count'] = PredictionRunLog.objects.filter(run_type='predict', success=False).count()
+				extra_context['prediction_running_count'] = PredictionRunLog.objects.filter(run_type='predict', success__isnull=True).count()
+				
+				# Recent runs (last 10)
+				extra_context['recent_runs'] = PredictionRunLog.objects.all().order_by('-run_started')[:10]
+				
+				return super().changelist_view(request, extra_context=extra_context)
+		
+		def get_urls(self):
+				urls = super().get_urls()
+				custom_urls = [
+						path(
+								'ml-coverage/',
+								self.admin_site.admin_view(self.ml_coverage_view),
+								name='predictionrunlog_ml_coverage',
+						),
+				]
+				return custom_urls + urls
+		
+		def ml_coverage_view(self, request):
+				"""View to show ML coverage across teams and subjects"""
+				# Get all teams
+				teams = Team.objects.prefetch_related('subjects').all()
+				
+				# Create dictionaries to store the latest runs per subject
+				training_data = {}
+				prediction_data = {}
+				
+				# Get all subjects
+				all_subjects = Subject.objects.all()
+				
+				# For each subject, get its latest training and prediction runs
+				for subject in all_subjects:
+						latest_training = PredictionRunLog.get_latest_run(subject.team, subject, run_type='train')
+						latest_prediction = PredictionRunLog.get_latest_run(subject.team, subject, run_type='predict')
+						
+						if latest_training:
+								training_data[subject.id] = latest_training
+								
+						if latest_prediction:
+								prediction_data[subject.id] = latest_prediction
+				
+				context = {
+						'title': 'ML Coverage Report',
+						'teams': teams,
+						'training_data': training_data,
+						'prediction_data': prediction_data,
+				}
+				
+				# Render the template
+				return render(request, 'admin/gregory/predictionrunlog/ml_coverage.html', context)
 
 admin.site.register(Articles, ArticleAdmin)
 admin.site.register(Authors, AuthorsAdmin)


### PR DESCRIPTION
## Summary
- filter ArticleSubjectRelevance inlines so that only subjects with `auto_predict` enabled are pre-populated and displayed in Django admin

## Testing
- `pytest -k "" -q` *(fails: AttributeError: module 'django' ...)*

------
https://chatgpt.com/codex/tasks/task_e_684c9927f5d88324b26720abe4d792dd