### PR TITLE
Add CSV export to admin lists

### DIFF
--- a/django/api/direct_streaming.py
+++ b/django/api/direct_streaming.py
@@ -105,10 +105,18 @@ class DirectStreamingCSVRenderer(CSVRenderer):
         # Check if this is paginated data but ONLY for CSV requests
         if renderer_context and 'request' in renderer_context:
             request = renderer_context['request']
+            
+            # Helper function to get query params from both Django and DRF requests
+            def get_query_params(request):
+                # DRF request has query_params, Django request has GET
+                return getattr(request, 'query_params', request.GET)
+            
+            query_params = get_query_params(request)
+            
             # For CSV requests, check if we need to use paginated data or get all results
-            if request.query_params.get('format', '').lower() == 'csv':
+            if query_params.get('format', '').lower() == 'csv':
                 # Check if this is explicitly paginated or if we should fetch all results
-                all_results = request.query_params.get('all_results', '').lower() in ('true', '1', 'yes')
+                all_results = query_params.get('all_results', '').lower() in ('true', '1', 'yes')
                 
                 # Check if we have paginated data
                 if isinstance(data, dict) and 'results' in data:

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -213,19 +213,21 @@ class ArticleAdmin(SimpleHistoryAdmin):
 	
 	def get_urls(self):
 		from django.urls import path
-		from .admin_views import article_review_status_view
+		from .admin_views import article_review_status_view, export_articles_csv
 		
-		urls = super().get_urls()
-		custom_urls = [
-			path('review-status/', self.admin_site.admin_view(article_review_status_view), name='article_review_status'),
+				urls = super().get_urls()
+					custom_urls = [
+								path('review-status/', self.admin_site.admin_view(article_review_status_view), name='article_review_status'),
+								path('export-csv/', self.admin_site.admin_view(export_articles_csv), name='articles_export_csv'),
 		]
 		return custom_urls + urls
 	
 	def changelist_view(self, request, extra_context=None):
 		"""Override changelist view to add a button to access review status page"""
 		extra_context = extra_context or {}
-		extra_context['review_status_url'] = reverse('admin:article_review_status')
-		return super().changelist_view(request, extra_context=extra_context)
+extra_context['review_status_url'] = reverse('admin:article_review_status')
+extra_context['csv_export_url'] = reverse('admin:articles_export_csv')
+return super().changelist_view(request, extra_context=extra_context)
 	
 	class Media:
 		css = {
@@ -246,7 +248,22 @@ class TrialAdmin(SimpleHistoryAdmin):
 		'therapeutic_areas', 'sponsor_type', 'internal_number', 'secondary_id',
 		'identifiers'
 	]
-	list_filter = ['teams', 'subjects', 'sources']
+list_filter = ['teams', 'subjects', 'sources']
+
+	def get_urls(self):
+	from django.urls import path
+	from .admin_views import export_trials_csv
+	
+	urls = super().get_urls()
+	custom_urls = [
+	path('export-csv/', self.admin_site.admin_view(export_trials_csv), name='trials_export_csv'),
+	]
+	return custom_urls + urls
+	
+	def changelist_view(self, request, extra_context=None):
+	extra_context = extra_context or {}
+	extra_context['csv_export_url'] = reverse('admin:trials_export_csv')
+	return super().changelist_view(request, extra_context=extra_context)
 
 	def display_identifiers(self, obj):
 		# Customize this depending on how you want to display the JSON

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -215,19 +215,19 @@ class ArticleAdmin(SimpleHistoryAdmin):
 		from django.urls import path
 		from .admin_views import article_review_status_view, export_articles_csv
 		
-				urls = super().get_urls()
-					custom_urls = [
-								path('review-status/', self.admin_site.admin_view(article_review_status_view), name='article_review_status'),
-								path('export-csv/', self.admin_site.admin_view(export_articles_csv), name='articles_export_csv'),
+		urls = super().get_urls()
+		custom_urls = [
+			path('review-status/', self.admin_site.admin_view(article_review_status_view), name='article_review_status'),
+			path('export-csv/', self.admin_site.admin_view(export_articles_csv), name='articles_export_csv'),
 		]
 		return custom_urls + urls
-	
+
 	def changelist_view(self, request, extra_context=None):
 		"""Override changelist view to add a button to access review status page"""
 		extra_context = extra_context or {}
-extra_context['review_status_url'] = reverse('admin:article_review_status')
-extra_context['csv_export_url'] = reverse('admin:articles_export_csv')
-return super().changelist_view(request, extra_context=extra_context)
+		extra_context['review_status_url'] = reverse('admin:article_review_status')
+		extra_context['csv_export_url'] = reverse('admin:articles_export_csv')
+		return super().changelist_view(request, extra_context=extra_context)
 	
 	class Media:
 		css = {
@@ -235,43 +235,43 @@ return super().changelist_view(request, extra_context=extra_context)
 		}
 
 class TrialAdmin(SimpleHistoryAdmin):
-	list_display = ['trial_id', 'title', 'display_identifiers', 'discovery_date', 'last_updated']
-	exclude = ['ml_predictions','relevant']
-	readonly_fields = ['last_updated', 'team_categories']
-	inlines = [TrialArticleReferenceInline]
-	search_fields = [
-		'trial_id', 'title', 'summary', 'summary_plain_english', 'scientific_title',
-		'primary_sponsor', 'source_register', 'recruitment_status', 'condition',
-		'intervention', 'primary_outcome', 'secondary_outcome', 'inclusion_criteria',
-		'exclusion_criteria', 'study_type', 'study_design', 'phase', 'countries',
-		'contact_firstname', 'contact_lastname', 'contact_affiliation',
-		'therapeutic_areas', 'sponsor_type', 'internal_number', 'secondary_id',
-		'identifiers'
-	]
-list_filter = ['teams', 'subjects', 'sources']
+    list_display = ['trial_id', 'title', 'display_identifiers', 'discovery_date', 'last_updated']
+    exclude = ['ml_predictions','relevant']
+    readonly_fields = ['last_updated', 'team_categories']
+    inlines = [TrialArticleReferenceInline]
+    search_fields = [
+        'trial_id', 'title', 'summary', 'summary_plain_english', 'scientific_title',
+        'primary_sponsor', 'source_register', 'recruitment_status', 'condition',
+        'intervention', 'primary_outcome', 'secondary_outcome', 'inclusion_criteria',
+        'exclusion_criteria', 'study_type', 'study_design', 'phase', 'countries',
+        'contact_firstname', 'contact_lastname', 'contact_affiliation',
+        'therapeutic_areas', 'sponsor_type', 'internal_number', 'secondary_id',
+        'identifiers'
+    ]
+    list_filter = ['teams', 'subjects', 'sources']
 
-	def get_urls(self):
-	from django.urls import path
-	from .admin_views import export_trials_csv
-	
-	urls = super().get_urls()
-	custom_urls = [
-	path('export-csv/', self.admin_site.admin_view(export_trials_csv), name='trials_export_csv'),
-	]
-	return custom_urls + urls
-	
-	def changelist_view(self, request, extra_context=None):
-	extra_context = extra_context or {}
-	extra_context['csv_export_url'] = reverse('admin:trials_export_csv')
-	return super().changelist_view(request, extra_context=extra_context)
+    def get_urls(self):
+        from django.urls import path
+        from .admin_views import export_trials_csv
+        
+        urls = super().get_urls()
+        custom_urls = [
+            path('export-csv/', self.admin_site.admin_view(export_trials_csv), name='trials_export_csv'),
+        ]
+        return custom_urls + urls
 
-	def display_identifiers(self, obj):
-		# Customize this depending on how you want to display the JSON
-		if obj.identifiers:
-			return ", ".join([f"{k}: {v}" for k, v in obj.identifiers.items()])
-		return "No Identifiers"
+    def changelist_view(self, request, extra_context=None):
+        extra_context = extra_context or {}
+        extra_context['csv_export_url'] = reverse('admin:trials_export_csv')
+        return super().changelist_view(request, extra_context=extra_context)
 
-	display_identifiers.short_description = "Identifiers"
+    def display_identifiers(self, obj):
+        # Customize this depending on how you want to display the JSON
+        if obj.identifiers:
+            return ", ".join([f"{k}: {v}" for k, v in obj.identifiers.items()])
+        return "No Identifiers"
+
+    display_identifiers.short_description = "Identifiers"
 class SourceInline(admin.StackedInline):
 	model = Sources
 	extra = 1
@@ -520,7 +520,8 @@ class ArticleCountFilter(admin.SimpleListFilter):
 
 class AuthorsAdmin(admin.ModelAdmin):
 	search_fields = ['family_name', 'given_name', 'ORCID']
-	list_display = ['given_name', 'family_name', 'display_orcid', 'country', 'article_count']
+	list_display = ['given_name', 'family_name', 'display_orcid', 'country', 'article_count'
+]
 	list_filter = ['country', ArticleCountFilter]
 	inlines = [AuthorArticlesInline]
 	

--- a/django/gregory/admin_views.py
+++ b/django/gregory/admin_views.py
@@ -223,31 +223,31 @@ def mark_articles_for_review(article_ids, subject):
 
 @staff_member_required
 def export_model_csv(request, model, serializer_class):
-"""Generic CSV export for admin list views."""
-	admin_class = admin.site._registry[model]
-	cl = admin_class.get_changelist_instance(request)
-	queryset = cl.get_queryset(request)
-	all_fields = list(serializer_class.Meta.fields)
-	if request.method == "POST":
-	selected = request.POST.getlist("fields") or all_fields
-	serializer = serializer_class(queryset, many=True)
-	data = [
-	{k: v for k, v in item.items() if k in selected}
-	for item in serializer.data
-	]
-	renderer = DirectStreamingCSVRenderer()
-	return renderer.render(data, "text/csv", {"request": request})
-	context = {
-	"title": f"Export {model._meta.verbose_name_plural.title()} as CSV",
-	"fields": all_fields,
-	"query_string": request.GET.urlencode(),
-	}
-	return render(request, "admin/export_csv_form.html", context)
+    """Generic CSV export for admin list views."""
+    admin_class = admin.site._registry[model]
+    cl = admin_class.get_changelist_instance(request)
+    queryset = cl.get_queryset(request)
+    all_fields = list(serializer_class.Meta.fields)
+    if request.method == "POST":
+        selected = request.POST.getlist("fields") or all_fields
+        serializer = serializer_class(queryset, many=True)
+        data = [
+            {k: v for k, v in item.items() if k in selected}
+            for item in serializer.data
+        ]
+        renderer = DirectStreamingCSVRenderer()
+        return renderer.render(data, "text/csv", {"request": request})
+    context = {
+        "title": f"Export {model._meta.verbose_name_plural.title()} as CSV",
+        "fields": all_fields,
+        "query_string": request.GET.urlencode(),
+    }
+    return render(request, "admin/export_csv_form.html", context)
 
 
 def export_articles_csv(request):
-	return export_model_csv(request, Articles, ArticleSerializer)
+    return export_model_csv(request, Articles, ArticleSerializer)
 
 
 def export_trials_csv(request):
-	return export_model_csv(request, Trials, TrialSerializer)
+    return export_model_csv(request, Trials, TrialSerializer)

--- a/django/gregory/admin_views.py
+++ b/django/gregory/admin_views.py
@@ -7,7 +7,10 @@ from django.db.models import Q, Case, When, Value, BooleanField, Count
 from django.contrib import messages
 from django.utils.dateparse import parse_date
 from django.utils import timezone
-from .models import Articles, Subject, ArticleSubjectRelevance
+from django.contrib import admin
+from api.serializers import ArticleSerializer, TrialSerializer
+from api.direct_streaming import DirectStreamingCSVRenderer
+from .models import Articles, Trials, Subject, ArticleSubjectRelevance
 import json
 from datetime import datetime, timedelta
 
@@ -216,3 +219,35 @@ def mark_articles_for_review(article_ids, subject):
             # No need to do anything if the relevance object doesn't exist
             # since no relevance means it's already marked for review
             pass
+
+
+@staff_member_required
+def export_model_csv(request, model, serializer_class):
+"""Generic CSV export for admin list views."""
+	admin_class = admin.site._registry[model]
+	cl = admin_class.get_changelist_instance(request)
+	queryset = cl.get_queryset(request)
+	all_fields = list(serializer_class.Meta.fields)
+	if request.method == "POST":
+	selected = request.POST.getlist("fields") or all_fields
+	serializer = serializer_class(queryset, many=True)
+	data = [
+	{k: v for k, v in item.items() if k in selected}
+	for item in serializer.data
+	]
+	renderer = DirectStreamingCSVRenderer()
+	return renderer.render(data, "text/csv", {"request": request})
+	context = {
+	"title": f"Export {model._meta.verbose_name_plural.title()} as CSV",
+	"fields": all_fields,
+	"query_string": request.GET.urlencode(),
+	}
+	return render(request, "admin/export_csv_form.html", context)
+
+
+def export_articles_csv(request):
+	return export_model_csv(request, Articles, ArticleSerializer)
+
+
+def export_trials_csv(request):
+	return export_model_csv(request, Trials, TrialSerializer)

--- a/django/gregory/templates/admin/export_csv_form.html
+++ b/django/gregory/templates/admin/export_csv_form.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-<h1>{{ title }}</h1>
 <form method="post" action="?{{ query_string }}">
   {% csrf_token %}
   <p>Select columns to include:</p>

--- a/django/gregory/templates/admin/export_csv_form.html
+++ b/django/gregory/templates/admin/export_csv_form.html
@@ -1,0 +1,18 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{{ title }}</h1>
+<form method="post" action="?{{ query_string }}">
+  {% csrf_token %}
+  <p>Select columns to include:</p>
+  {% for field in fields %}
+  <div>
+    <label>
+      <input type="checkbox" name="fields" value="{{ field }}" checked> {{ field }}
+    </label>
+  </div>
+  {% endfor %}
+  <button type="submit" class="button default">Download CSV</button>
+</form>
+{% endblock %}

--- a/django/gregory/templates/admin/gregory/trials/change_list.html
+++ b/django/gregory/templates/admin/gregory/trials/change_list.html
@@ -3,11 +3,6 @@
 
 {% block object-tools-items %}
   <li>
-    <a href="{{ review_status_url }}" class="addlink" style="background-color: #417690;">
-      Review Status by Subject
-    </a>
-  </li>
-  <li>
     <a href="{{ csv_export_url }}?{{ request.GET.urlencode }}" class="button">
       Download CSV
     </a>


### PR DESCRIPTION
## Summary
- support exporting filtered admin lists as CSV
- allow column selection via new admin view
- add CSV download buttons for Articles and Trials

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68619241f75c8324ac3b8109169715fd