### PR TITLE
fix reverse relation when adding and listing sources

### DIFF
--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -337,7 +337,7 @@ class SourceAdmin(admin.ModelAdmin):
 			return qs
 			
 		# Regular users only see sources from their teams
-		user_teams = request.user.teammember_set.values_list('organization__teams__id', flat=True)
+		user_teams = request.user.organizations_organizationuser.values_list('organization__teams__id', flat=True)
 		return qs.filter(team__id__in=user_teams)
 	
 	def activate_sources(self, request, queryset):


### PR DESCRIPTION
Avoids an error when non-admin users try to create or list sources
```
AttributeError at /admin/gregory/sources/

'User' object has no attribute 'teammember_set'

Request Method: 	GET
Request URL: 	http://api.clinicaltrialupdates.com/admin/gregory/sources/
Django Version: 	5.2.3
Exception Type: 	AttributeError
Exception Value: 	

'User' object has no attribute 'teammember_set'
```