### PR TITLE
Allow ordering trials by last_updated

### DIFF
--- a/django/api/tests/test_search_ordering.py
+++ b/django/api/tests/test_search_ordering.py
@@ -222,20 +222,72 @@ class SearchOrderingTestCase(TestCase):
     def test_trial_search_ordering_with_post(self):
         """Test that POST requests also support ordering for trials"""
         url = reverse('trial-search')
-        
+
         data = {
             'team_id': self.team.id,
             'subject_id': self.subject.id,
             'search': 'Test Search',
             'ordering': 'trial_id'  # Order by ID
         }
-        
+
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        
+
         results = response.data['results']
         self.assertEqual(len(results), 3)
-        
+
         # Check that trials are ordered by trial_id (ascending)
         trial_ids = [result['trial_id'] for result in results]
         self.assertEqual(trial_ids, sorted(trial_ids))
+
+    def test_trial_search_ordering_by_last_updated(self):
+        """Test that trial search supports ordering by last_updated"""
+        now = timezone.now()
+        # Override auto_now via queryset update so we control the timestamps
+        Trials.objects.filter(pk=self.trial1.pk).update(last_updated=now - timedelta(days=8))
+        Trials.objects.filter(pk=self.trial2.pk).update(last_updated=now - timedelta(days=4))
+        Trials.objects.filter(pk=self.trial3.pk).update(last_updated=now - timedelta(days=1))
+
+        url = reverse('trial-search')
+        params = {
+            'team_id': self.team.id,
+            'subject_id': self.subject.id,
+            'search': 'Test Search',
+            'ordering': '-last_updated',
+        }
+
+        response = self.client.get(url, params)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.data['results']
+        self.assertEqual(len(results), 3)
+
+        # trial3 most recently updated, trial1 least recently updated
+        self.assertEqual(results[0]['trial_id'], self.trial3.trial_id)
+        self.assertEqual(results[1]['trial_id'], self.trial2.trial_id)
+        self.assertEqual(results[2]['trial_id'], self.trial1.trial_id)
+
+    def test_trial_list_ordering_by_last_updated(self):
+        """Test that the /trials/ endpoint supports ordering by last_updated"""
+        now = timezone.now()
+        Trials.objects.filter(pk=self.trial1.pk).update(last_updated=now - timedelta(days=8))
+        Trials.objects.filter(pk=self.trial2.pk).update(last_updated=now - timedelta(days=4))
+        Trials.objects.filter(pk=self.trial3.pk).update(last_updated=now - timedelta(days=1))
+
+        url = reverse('trials-list')
+        params = {
+            'team_id': self.team.id,
+            'ordering': '-last_updated',
+        }
+
+        response = self.client.get(url, params)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.data['results']
+        self.assertGreaterEqual(len(results), 3)
+
+        # The three test trials should appear at the top in last_updated desc order
+        top_ids = [r['trial_id'] for r in results[:3]]
+        self.assertEqual(top_ids[0], self.trial3.trial_id)
+        self.assertEqual(top_ids[1], self.trial2.trial_id)
+        self.assertEqual(top_ids[2], self.trial1.trial_id)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -631,7 +631,7 @@ class TrialViewSet(viewsets.ModelViewSet):
 	filter_backends = [django_filters.DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
 	filterset_class = TrialFilter
 	search_fields = ['title', 'summary']
-	ordering_fields = ['discovery_date', 'published_date', 'title', 'trial_id']
+	ordering_fields = ['discovery_date', 'published_date', 'title', 'trial_id', 'last_updated']
 	ordering = ['-discovery_date']
 
 	def list(self, request, *args, **kwargs):
@@ -1333,7 +1333,7 @@ class TrialSearchView(generics.ListAPIView):
     - page: Page number for pagination (default: 1)
     - page_size: Number of results per page (default: 10, max: 100)
     - all_results: Set to 'true' to retrieve all results without pagination (useful for CSV export)
-    - ordering: Order results by field (e.g., -discovery_date, -published_date, title, trial_id)
+    - ordering: Order results by field (e.g., -discovery_date, -published_date, title, trial_id, -last_updated)
     
     Results are ordered by discovery date (newest first) by default.
 	
@@ -1345,7 +1345,7 @@ class TrialSearchView(generics.ListAPIView):
     filter_backends = [filters.SearchFilter, django_filters.DjangoFilterBackend, filters.OrderingFilter]
     filterset_class = TrialFilter
     search_fields = ['title', 'summary']
-    ordering_fields = ['discovery_date', 'published_date', 'title', 'trial_id']
+    ordering_fields = ['discovery_date', 'published_date', 'title', 'trial_id', 'last_updated']
     ordering = ['-discovery_date']  # Default ordering by newest first
     pagination_class = FlexiblePagination
     http_method_names = ['get', 'post']  # Support both GET and POST


### PR DESCRIPTION
## Summary

- Add `last_updated` to `ordering_fields` in `TrialViewSet` (`/trials/`) and `TrialSearchView` (`/trials/search/`)
- Update `TrialSearchView` docstring to list `-last_updated` as a valid `ordering` value
- Add two tests covering `?ordering=-last_updated` on both endpoints; use `queryset.update()` to control `auto_now` timestamps in fixtures

## Why not Meta.ordering

`Meta.ordering` was considered and deliberately left unset. Setting it would silently inject `ORDER BY discovery_date` into every queryset — including aggregations — which would pollute `GROUP BY` clauses and break the status-count logic in `TrialViewSet.list`. The existing viewset-level `ordering = ['-discovery_date']` is the right place for defaults.

## Test plan

- [ ] `python manage.py test api.tests.test_search_ordering` — all existing tests still pass, two new tests pass
- [ ] Manual: `GET /trials/?ordering=-last_updated` returns results ordered newest-updated first
- [ ] Manual: `GET /trials/search/?team_id=1&subject_id=1&search=covid&ordering=-last_updated` returns results ordered newest-updated first

https://claude.ai/code/session_01QnyAVkstg1cUeeiKLwXMf1