### PR TITLE
Move allowed_domains from Lists to CustomSetting

### DIFF
--- a/django/sitesettings/admin.py
+++ b/django/sitesettings/admin.py
@@ -16,6 +16,7 @@ class CustomSettingInline(admin.StackedInline):
 		'bluesky_url', 'github_url', 'mastodon_url',
 		'postmark_api_token', 'postmark_api_url',
 		'privacy_policy_url', 'terms_url',
+		'allowed_domains',
 	]
 
 

--- a/django/sitesettings/admin.py
+++ b/django/sitesettings/admin.py
@@ -10,13 +10,26 @@ class CustomSettingInline(admin.StackedInline):
 	model = CustomSetting
 	extra = 1
 	max_num = 1
-	fields = [
-		'title', 'sender_email_prefix', 'admin_email', 'api_domain',
-		'website_url', 'support_url', 'about_url', 'contact_url',
-		'bluesky_url', 'github_url', 'mastodon_url',
-		'postmark_api_token', 'postmark_api_url',
-		'privacy_policy_url', 'terms_url',
-		'allowed_domains',
+	fieldsets = [
+		(None, {
+			'fields': ['title'],
+		}),
+		('Email', {
+			'fields': ['admin_email', 'sender_email_prefix'],
+		}),
+		('API & Domain', {
+			'fields': ['api_domain', 'allowed_domains'],
+		}),
+		('Postmark Integration', {
+			'fields': ['postmark_api_token', 'postmark_api_url'],
+		}),
+		('Website URLs', {
+			'fields': ['website_url', 'support_url', 'about_url', 'contact_url', 'privacy_policy_url', 'terms_url'],
+		}),
+		('Social Links', {
+			'classes': ['collapse'],
+			'fields': ['bluesky_url', 'github_url', 'mastodon_url'],
+		}),
 	]
 
 

--- a/django/sitesettings/migrations/0009_customsetting_allowed_domains.py
+++ b/django/sitesettings/migrations/0009_customsetting_allowed_domains.py
@@ -1,0 +1,23 @@
+# Generated manually on 2026-04-24
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		('sitesettings', '0008_remove_customsetting_email_footer'),
+	]
+
+	operations = [
+		migrations.AddField(
+			model_name='customsetting',
+			name='allowed_domains',
+			field=models.TextField(
+				blank=True,
+				default='',
+				help_text='Comma-separated list of domains (e.g. example.com, other-site.org) allowed to submit subscribers for any list on this site. The origin domain is used for post-subscription redirects. The site\'s own domain is always accepted.',
+				verbose_name='Allowed Domains',
+			),
+		),
+	]

--- a/django/sitesettings/migrations/0010_copy_allowed_domains_from_lists.py
+++ b/django/sitesettings/migrations/0010_copy_allowed_domains_from_lists.py
@@ -1,0 +1,61 @@
+# Generated manually on 2026-04-24
+#
+# Copies allowed_domains values from subscriptions.Lists to the site-level
+# sitesettings.CustomSetting model. Domains from all Lists sharing the same
+# Site are merged and deduplicated into a single comma-separated string on
+# the first CustomSetting for that Site. If a Site has no CustomSetting, a
+# minimal one is created so the values are not lost.
+#
+# Existing CustomSetting.allowed_domains values are preserved: per-list
+# domains are merged into the existing set rather than overwriting it.
+
+from django.db import migrations
+
+
+def _split_domains(value):
+	return {d.strip().lower() for d in (value or '').split(',') if d.strip()}
+
+
+def _join_domains(domains):
+	return ', '.join(sorted(domains))
+
+
+def copy_allowed_domains_forward(apps, schema_editor):
+	Lists = apps.get_model('subscriptions', 'Lists')
+	CustomSetting = apps.get_model('sitesettings', 'CustomSetting')
+	Site = apps.get_model('sites', 'Site')
+
+	domains_by_site = {}
+	for lst in Lists.objects.exclude(site_id=None).exclude(allowed_domains='').only('site_id', 'allowed_domains'):
+		domains_by_site.setdefault(lst.site_id, set()).update(_split_domains(lst.allowed_domains))
+
+	for site_id, new_domains in domains_by_site.items():
+		if not new_domains:
+			continue
+		custom = CustomSetting.objects.filter(site_id=site_id).order_by('pk').first()
+		if custom is None:
+			try:
+				site = Site.objects.get(pk=site_id)
+			except Site.DoesNotExist:
+				continue
+			custom = CustomSetting.objects.create(
+				site_id=site_id,
+				title=f'Settings for {site.domain}',
+				allowed_domains=_join_domains(new_domains),
+			)
+			continue
+		merged = _split_domains(custom.allowed_domains) | new_domains
+		custom.allowed_domains = _join_domains(merged)
+		custom.save(update_fields=['allowed_domains'])
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		('sitesettings', '0009_customsetting_allowed_domains'),
+		('subscriptions', '0019_announcement_show_tagline_preheader_text'),
+	]
+
+	operations = [
+		migrations.RunPython(copy_allowed_domains_forward, migrations.RunPython.noop),
+	]

--- a/django/sitesettings/models.py
+++ b/django/sitesettings/models.py
@@ -76,3 +76,9 @@ class CustomSetting(models.Model):
 		default='',
 		help_text="Terms of service page URL for the email footer."
 	)
+	allowed_domains = models.TextField(
+		blank=True,
+		default='',
+		help_text="Comma-separated list of domains (e.g. example.com, other-site.org) allowed to submit subscribers for any list on this site. The origin domain is used for post-subscription redirects. The site's own domain is always accepted.",
+		verbose_name="Allowed Domains"
+	)

--- a/django/subscriptions/admin.py
+++ b/django/subscriptions/admin.py
@@ -402,9 +402,7 @@ class ListsAdmin(admin.ModelAdmin):
 	filter_horizontal = ['subjects', 'latest_research_categories']
 	actions = ['reassign_to_team_action']
 	fieldsets = [
-		(None, {'fields': ['list_name', 'list_description', 'list_email_subject', 'team', 'site', 'allowed_domains']}),
-					# allowed_domains: comma-separated domains (e.g. example.com) whose subscription
-					# forms are permitted to add subscribers to this list and receive redirects.
+		(None, {'fields': ['list_name', 'list_description', 'list_email_subject', 'team', 'site']}),
 		('Email Types', {'fields': ['admin_summary', 'weekly_digest', 'clinical_trials_notifications']}),
 		('Content Settings', {
 			'fields': ['article_limit', 'ml_threshold'],

--- a/django/subscriptions/migrations/0020_remove_lists_allowed_domains.py
+++ b/django/subscriptions/migrations/0020_remove_lists_allowed_domains.py
@@ -1,0 +1,18 @@
+# Generated manually on 2026-04-24
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		('subscriptions', '0019_announcement_show_tagline_preheader_text'),
+		('sitesettings', '0010_copy_allowed_domains_from_lists'),
+	]
+
+	operations = [
+		migrations.RemoveField(
+			model_name='lists',
+			name='allowed_domains',
+		),
+	]

--- a/django/subscriptions/models.py
+++ b/django/subscriptions/models.py
@@ -35,13 +35,6 @@ class Lists(models.Model):
 		help_text="ML prediction confidence threshold (0.0-1.0). Only articles with ML predictions above this threshold will be considered relevant.",
 		verbose_name="ML Threshold for Relevance"
 	)
-	# Allowed domains for the subscription form
-	allowed_domains = models.TextField(
-		blank=True,
-		default='',
-		help_text="Comma-separated list of domains allowed to submit subscribers to this list (e.g. example.com, other-site.org). The origin domain is used for post-subscription redirects.",
-		verbose_name="Allowed Domains"
-	)
 	# Latest research categories
 	latest_research_categories = models.ManyToManyField(
 		'gregory.TeamCategory', 

--- a/django/subscriptions/tests/test_views.py
+++ b/django/subscriptions/tests/test_views.py
@@ -9,6 +9,7 @@ from django.contrib.sites.models import Site
 from django.conf import settings
 from organizations.models import Organization
 from gregory.models import Team
+from sitesettings.models import CustomSetting
 from subscriptions.models import Lists, Subscribers
 from subscriptions.views import (
 	subscribe_view,
@@ -16,6 +17,7 @@ from subscriptions.views import (
 	_origin_matches_allowed,
 	_check_origin_allowed,
 	_resolve_site_from_request,
+	_site_allowed_domains,
 )
 
 class SubscribeViewTest(TestCase):
@@ -228,19 +230,18 @@ class OriginValidationTest(TestCase):
 		self.team = Team.objects.create(
 			organization=self.org, name='OriginTeam', slug='origin-team',
 		)
-		Site.objects.update_or_create(
+		self.site, _ = Site.objects.update_or_create(
 			id=settings.SITE_ID,
 			defaults={'domain': 'example.com', 'name': 'example'},
 		)
-		self.restricted_list = Lists.objects.create(
-			list_name='Restricted',
-			team=self.team,
-			allowed_domains='example.com',
+		self.custom = CustomSetting.objects.create(
+			site=self.site,
+			title='example settings',
+			allowed_domains='partner.org',
 		)
-		self.open_list = Lists.objects.create(
-			list_name='Open',
+		self.lst = Lists.objects.create(
+			list_name='Daily',
 			team=self.team,
-			# allowed_domains left blank — no restriction
 		)
 
 	def _post(self, list_obj, email, origin=None, accept=None, ajax=False):
@@ -257,17 +258,21 @@ class OriginValidationTest(TestCase):
 			**headers,
 		)
 
-	def test_exact_allowed_origin_succeeds(self):
-		request = self._post(self.restricted_list, 'ok@example.com', 'https://example.com')
+	def test_exact_site_domain_origin_succeeds(self):
+		request = self._post(self.lst, 'ok@example.com', 'https://example.com')
 		self.assertNotEqual(subscribe_view(request).status_code, 403)
 
-	def test_www_subdomain_of_allowed_origin_succeeds(self):
-		request = self._post(self.restricted_list, 'www@example.com', 'https://www.example.com')
+	def test_www_subdomain_of_site_domain_succeeds(self):
+		request = self._post(self.lst, 'www@example.com', 'https://www.example.com')
+		self.assertNotEqual(subscribe_view(request).status_code, 403)
+
+	def test_configured_allowed_domain_origin_succeeds(self):
+		request = self._post(self.lst, 'ok@partner.org', 'https://partner.org')
 		self.assertNotEqual(subscribe_view(request).status_code, 403)
 
 	def test_malicious_origin_redirects_browser_to_error(self):
 		"""A plain browser form POST from an unauthorized origin redirects to /error/."""
-		request = self._post(self.restricted_list, 'hax@evil.com', 'https://evil.com')
+		request = self._post(self.lst, 'hax@evil.com', 'https://evil.com')
 		with self.assertLogs('subscriptions.views', level='WARNING') as log:
 			response = subscribe_view(request)
 		self.assertEqual(response.status_code, 302)
@@ -278,7 +283,7 @@ class OriginValidationTest(TestCase):
 	def test_malicious_origin_returns_json_403_for_ajax(self):
 		"""An XHR from an unauthorized origin gets a JSON 403."""
 		request = self._post(
-			self.restricted_list, 'hax2@evil.com', 'https://evil.com', ajax=True,
+			self.lst, 'hax2@evil.com', 'https://evil.com', ajax=True,
 		)
 		with self.assertLogs('subscriptions.views', level='WARNING'):
 			response = subscribe_view(request)
@@ -288,7 +293,7 @@ class OriginValidationTest(TestCase):
 	def test_malicious_origin_returns_json_403_for_json_accept(self):
 		"""A fetch() client sending Accept: application/json gets a JSON 403."""
 		request = self._post(
-			self.restricted_list, 'hax3@evil.com', 'https://evil.com',
+			self.lst, 'hax3@evil.com', 'https://evil.com',
 			accept='application/json',
 		)
 		with self.assertLogs('subscriptions.views', level='WARNING'):
@@ -297,16 +302,28 @@ class OriginValidationTest(TestCase):
 
 	def test_no_origin_header_allowed_through_with_warning(self):
 		"""Server-side / API requests without Origin are allowed (with a warning log)."""
-		request = self._post(self.restricted_list, 'noorigin@example.com', origin=None)
+		request = self._post(self.lst, 'noorigin@example.com', origin=None)
 		with self.assertLogs('subscriptions.views', level='WARNING') as log:
 			response = subscribe_view(request)
 		self.assertNotEqual(response.status_code, 403)
 		self.assertTrue(any('no Origin or Referer header' in msg for msg in log.output))
 
-	def test_unrestricted_list_allows_any_origin(self):
-		"""A list with empty allowed_domains imposes no origin restriction."""
-		request = self._post(self.open_list, 'any@evil.com', 'https://evil.com')
+	def test_blank_custom_setting_still_accepts_site_domain(self):
+		"""With no configured allowed_domains, the site's own domain is still accepted."""
+		self.custom.allowed_domains = ''
+		self.custom.save(update_fields=['allowed_domains'])
+		request = self._post(self.lst, 'bare@example.com', 'https://example.com')
 		self.assertNotEqual(subscribe_view(request).status_code, 403)
+
+	def test_blank_custom_setting_rejects_foreign_origin(self):
+		"""With no configured allowed_domains, a foreign origin is rejected."""
+		self.custom.allowed_domains = ''
+		self.custom.save(update_fields=['allowed_domains'])
+		request = self._post(self.lst, 'hax@evil.com', 'https://evil.com')
+		with self.assertLogs('subscriptions.views', level='WARNING'):
+			response = subscribe_view(request)
+		self.assertEqual(response.status_code, 302)
+		self.assertIn('/error/', response['Location'])
 
 	def test_site_profile_recorded_from_origin_not_host(self):
 		"""SubscriberSiteProfile.site must match the Origin header domain, not the API host."""
@@ -317,7 +334,7 @@ class OriginValidationTest(TestCase):
 				'first_name': 'Origin',
 				'email': 'originsite@example.com',
 				'profile': 'patient',
-				'list': [str(self.restricted_list.pk)],
+				'list': [str(self.lst.pk)],
 			},
 			HTTP_ORIGIN='https://example.com',
 		)
@@ -328,3 +345,60 @@ class OriginValidationTest(TestCase):
 		).first()
 		self.assertIsNotNone(profile)
 		self.assertEqual(profile.site.domain, 'example.com')
+
+
+# ---------------------------------------------------------------------------
+# _site_allowed_domains / _check_origin_allowed
+# ---------------------------------------------------------------------------
+
+class SiteAllowedDomainsTest(TestCase):
+	def setUp(self):
+		self.site, _ = Site.objects.update_or_create(
+			id=settings.SITE_ID,
+			defaults={'domain': 'example.com', 'name': 'example'},
+		)
+
+	def test_returns_site_domain_when_no_custom_setting(self):
+		self.assertEqual(_site_allowed_domains(self.site), 'example.com')
+
+	def test_returns_site_domain_when_custom_setting_blank(self):
+		CustomSetting.objects.create(site=self.site, title='bare', allowed_domains='')
+		self.assertEqual(_site_allowed_domains(self.site), 'example.com')
+
+	def test_combines_site_domain_with_configured_domains(self):
+		CustomSetting.objects.create(
+			site=self.site, title='combined', allowed_domains='partner.org, friend.net',
+		)
+		combined = _site_allowed_domains(self.site)
+		self.assertIn('example.com', combined)
+		self.assertIn('partner.org', combined)
+		self.assertIn('friend.net', combined)
+
+
+class CheckOriginAllowedTest(TestCase):
+	def setUp(self):
+		self.site, _ = Site.objects.update_or_create(
+			id=settings.SITE_ID,
+			defaults={'domain': 'example.com', 'name': 'example'},
+		)
+
+	def test_site_domain_is_always_allowed(self):
+		self.assertTrue(_check_origin_allowed('example.com', self.site))
+
+	def test_site_subdomain_is_allowed(self):
+		self.assertTrue(_check_origin_allowed('www.example.com', self.site))
+
+	def test_foreign_origin_rejected_without_custom_setting(self):
+		self.assertFalse(_check_origin_allowed('evil.com', self.site))
+
+	def test_configured_domain_is_allowed(self):
+		CustomSetting.objects.create(
+			site=self.site, title='cfg', allowed_domains='partner.org',
+		)
+		self.assertTrue(_check_origin_allowed('partner.org', self.site))
+
+	def test_non_configured_domain_is_rejected(self):
+		CustomSetting.objects.create(
+			site=self.site, title='cfg', allowed_domains='partner.org',
+		)
+		self.assertFalse(_check_origin_allowed('evil.com', self.site))

--- a/django/subscriptions/views.py
+++ b/django/subscriptions/views.py
@@ -1,5 +1,6 @@
 from subscriptions.forms import SubscribersForm
 from subscriptions.models import Subscribers, Lists, ListSubscription, SubscriberSiteProfile
+from sitesettings.models import CustomSetting
 from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpResponseRedirect, HttpResponseBadRequest, JsonResponse
 from django.shortcuts import render, get_object_or_404
@@ -12,26 +13,43 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _site_allowed_domains(site):
+	"""
+	Return the effective allowed_domains string for a Site.
+
+	Combines the site's ``CustomSetting.allowed_domains`` with the Site's own
+	domain so that requests from the canonical site host are always accepted,
+	even when no allowed_domains are configured.
+	"""
+	configured = ''
+	if site is not None:
+		custom = CustomSetting.objects.filter(site=site).order_by('pk').first()
+		if custom and custom.allowed_domains:
+			configured = custom.allowed_domains
+	own = (site.domain or '').strip() if site is not None else ''
+	if own and configured:
+		return f"{own},{configured}"
+	return own or configured
+
+
 def _get_redirect_base(request, subscription_lists):
 	"""
 	Return a validated base URL (scheme + netloc) for post-subscription redirects.
 
-	The request Origin (or Referer) must match a domain listed in
-	``allowed_domains`` on at least one of the selected lists, using
+	The request Origin (or Referer) must match a domain in the current site's
+	``CustomSetting.allowed_domains`` (or the site's own domain), using
 	subdomain-aware matching. If no match is found the current Site domain is
 	used as a safe fallback.
 	"""
+	site = Site.objects.get_current()
 	origin = request.META.get('HTTP_ORIGIN') or request.META.get('HTTP_REFERER', '')
 	if origin:
 		parsed = urlparse(origin)
 		origin_hostname = parsed.hostname  # IPv6-safe, no port
-		if origin_hostname:
-			for lst in subscription_lists:
-				if _origin_matches_allowed(origin_hostname, lst.allowed_domains or ''):
-					return f"{parsed.scheme}://{parsed.netloc}"
+		if origin_hostname and _origin_matches_allowed(origin_hostname, _site_allowed_domains(site)):
+			return f"{parsed.scheme}://{parsed.netloc}"
 	scheme = 'https' if request.is_secure() else 'http'
-	domain = Site.objects.get_current().domain
-	return f"{scheme}://{domain}"
+	return f"{scheme}://{site.domain}"
 
 
 def _get_client_ip(request):
@@ -99,19 +117,15 @@ def _origin_matches_allowed(origin_host, allowed_domains_str):
 	return False
 
 
-def _check_origin_allowed(origin_host, subscription_lists):
+def _check_origin_allowed(origin_host, site):
 	"""
-	Return True if origin_host is permitted to submit to all requested lists
-	that have allowed_domains configured.
+	Return True if origin_host is permitted to submit subscribers on this site.
 
-	A list with no allowed_domains configured imposes no origin restriction.
-	A list with allowed_domains configured requires the origin to match at
-	least one of those domains (subdomain-aware).
+	The origin must match either the site's own domain or a domain listed in
+	the site's ``CustomSetting.allowed_domains`` (subdomain-aware). When no
+	allowed_domains are configured, only the site's own domain is accepted.
 	"""
-	for lst in subscription_lists:
-		if lst.allowed_domains and not _origin_matches_allowed(origin_host, lst.allowed_domains):
-			return False
-	return True
+	return _origin_matches_allowed(origin_host, _site_allowed_domains(site))
 
 
 def _resolve_site_from_request(request):
@@ -170,16 +184,16 @@ def subscribe_view(request):
 		)
 		return HttpResponseRedirect(f'{redirect_base}/error/')
 
-	# Origin validation: reject requests unless the origin is authorised by
-	# every requested list that has allowed_domains configured. A list with
-	# no allowed_domains configured imposes no restriction. If no
-	# Origin/Referer header is present (e.g. server-side or API usage) the
-	# request is allowed through with a warning.
+	# Origin validation: reject requests unless the origin matches the
+	# current site's CustomSetting.allowed_domains (or the site's own domain).
+	# If no Origin/Referer header is present (e.g. server-side or API usage)
+	# the request is allowed through with a warning.
+	current_site = Site.objects.get_current()
 	origin_header = request.META.get('HTTP_ORIGIN') or request.META.get('HTTP_REFERER', '')
 	if origin_header:
 		parsed_origin = urlparse(origin_header)
 		origin_host = parsed_origin.hostname  # IPv6-safe, no port
-		if origin_host and not _check_origin_allowed(origin_host, subscription_lists):
+		if origin_host and not _check_origin_allowed(origin_host, current_site):
 			logger.warning(
 				"subscribe_view: request from unauthorized origin '%s' rejected.",
 				origin_host,

--- a/django/subscriptions/views.py
+++ b/django/subscriptions/views.py
@@ -32,16 +32,15 @@ def _site_allowed_domains(site):
 	return own or configured
 
 
-def _get_redirect_base(request, subscription_lists):
+def _get_redirect_base(request, site):
 	"""
 	Return a validated base URL (scheme + netloc) for post-subscription redirects.
 
-	The request Origin (or Referer) must match a domain in the current site's
+	The request Origin (or Referer) must match a domain in ``site``'s
 	``CustomSetting.allowed_domains`` (or the site's own domain), using
-	subdomain-aware matching. If no match is found the current Site domain is
+	subdomain-aware matching. If no match is found the site's own domain is
 	used as a safe fallback.
 	"""
-	site = Site.objects.get_current()
 	origin = request.META.get('HTTP_ORIGIN') or request.META.get('HTTP_REFERER', '')
 	if origin:
 		parsed = urlparse(origin)
@@ -161,9 +160,25 @@ def subscribe_view(request):
 	list_ids = request.POST.getlist('list')
 	subscription_lists = list(Lists.objects.filter(pk__in=list_ids)) if list_ids else []
 
+	# Derive the target site from the submitted lists so that origin validation
+	# and redirect-base calculation use the correct site's allowed_domains in
+	# multi-site deployments. Fall back to the global default when lists span
+	# multiple sites or no lists have been resolved yet.
+	site_ids = {lst.site_id for lst in subscription_lists}
+	if len(site_ids) == 1:
+		target_site = Site.objects.get(pk=next(iter(site_ids)))
+	else:
+		if len(site_ids) > 1:
+			logger.warning(
+				"subscribe_view: lists span multiple sites (%s); "
+				"falling back to default site for origin validation.",
+				site_ids,
+			)
+		target_site = Site.objects.get_current()
+
 	# Determine redirect base before processing the form so we can redirect
 	# to the correct domain even when the form is invalid.
-	redirect_base = _get_redirect_base(request, subscription_lists)
+	redirect_base = _get_redirect_base(request, target_site)
 
 	# Validate that every requested list ID resolved to a real List.
 	if list_ids:
@@ -185,15 +200,14 @@ def subscribe_view(request):
 		return HttpResponseRedirect(f'{redirect_base}/error/')
 
 	# Origin validation: reject requests unless the origin matches the
-	# current site's CustomSetting.allowed_domains (or the site's own domain).
+	# target site's CustomSetting.allowed_domains (or the site's own domain).
 	# If no Origin/Referer header is present (e.g. server-side or API usage)
 	# the request is allowed through with a warning.
-	current_site = Site.objects.get_current()
 	origin_header = request.META.get('HTTP_ORIGIN') or request.META.get('HTTP_REFERER', '')
 	if origin_header:
 		parsed_origin = urlparse(origin_header)
 		origin_host = parsed_origin.hostname  # IPv6-safe, no port
-		if origin_host and not _check_origin_allowed(origin_host, current_site):
+		if origin_host and not _check_origin_allowed(origin_host, target_site):
 			logger.warning(
 				"subscribe_view: request from unauthorized origin '%s' rejected.",
 				origin_host,

--- a/docs/subscription-system.md
+++ b/docs/subscription-system.md
@@ -99,7 +99,7 @@ Subscribes a visitor to one or more lists.
 - On success: redirect to `{origin}/thank-you/`
 - On error: redirect to `{origin}/error/`
 
-The request origin is validated against the `allowed_domains` field on the current site's `CustomSetting`. The site's own `Site.domain` is always accepted; additional domains can be added (comma-separated) in the **Sites → [site] → Custom Setting** inline. If the origin doesn't match, the request is rejected and the redirect falls back to the current site's domain.
+The request origin is validated against the `allowed_domains` field on the current site's `CustomSetting`. The site's own `Site.domain` is always accepted; additional domains can be added (comma-separated) in the **Sites → [site] → Custom Setting** inline. If the origin doesn't match, the request is rejected. For standard non-AJAX browser form submissions, any redirect fallback uses the current site's domain. AJAX or JSON-oriented clients may instead receive a `403` JSON response and should not assume the request will be redirected.
 
 ---
 

--- a/docs/subscription-system.md
+++ b/docs/subscription-system.md
@@ -99,7 +99,7 @@ Subscribes a visitor to one or more lists.
 - On success: redirect to `{origin}/thank-you/`
 - On error: redirect to `{origin}/error/`
 
-The redirect origin is validated against the `allowed_domains` field on each list. If the origin doesn't match any allowed domain, the redirect falls back to the current site's domain. Configure `allowed_domains` on each `Lists` record in the admin.
+The request origin is validated against the `allowed_domains` field on the current site's `CustomSetting`. The site's own `Site.domain` is always accepted; additional domains can be added (comma-separated) in the **Sites → [site] → Custom Setting** inline. If the origin doesn't match, the request is rejected and the redirect falls back to the current site's domain.
 
 ---
 
@@ -167,7 +167,7 @@ Post to `POST /subscriptions/new/` with `Content-Type: application/x-www-form-ur
 
 **Key points:**
 - The `list` field must appear **once per list ID** — use `name="list"` repeated, not `name="list[]"`.
-- The form's `Origin` header (set automatically by the browser) must match a domain in the list's `allowed_domains` setting, otherwise the post-subscribe redirect falls back to the API domain. Ask your backend team to add your frontend domain to `allowed_domains` for each relevant list.
+- The form's `Origin` header (set automatically by the browser) must match a domain in the site's `CustomSetting.allowed_domains` (or the site's own domain), otherwise the request is rejected and the redirect falls back to the API domain. Ask your backend team to add your frontend domain to the site's `allowed_domains` in the admin (one site-level setting covers every list on that site).
 - The endpoint redirects on both success and failure (no JSON response). Handle the destination pages:
   - `/thank-you/` — shown after a successful subscription
   - `/error/` — shown when the form is invalid


### PR DESCRIPTION
Consolidate the subscription origin allow-list from per-list configuration to a single site-level setting on sitesettings.CustomSetting. Domains on existing Lists are merged and copied over by a data migration.

Origin validation now always accepts the Site's own domain and, optionally, any domain listed in CustomSetting.allowed_domains. Requests from unlisted origins are rejected.

https://claude.ai/code/session_019recRsTzFhgXpwsYfnD2oT