### PR TITLE
implements basic functions to make API visible on per organization level

### DIFF
--- a/django/admin/settings.py
+++ b/django/admin/settings.py
@@ -100,6 +100,7 @@ MIDDLEWARE = [
 	'django.middleware.gzip.GZipMiddleware',
 	'django.contrib.sites.middleware.CurrentSiteMiddleware',
 	'simple_history.middleware.HistoryRequestMiddleware',
+	'gregory.middleware.visibility.VisibleOrgMiddleware',
 ]
 
 ROOT_URLCONF = 'admin.urls'

--- a/django/api/admin.py
+++ b/django/api/admin.py
@@ -2,7 +2,9 @@ from django.contrib import admin
 from .models import APIAccessScheme, APIAccessSchemeLog
 
 class APIAcccessSchemeAdmin(admin.ModelAdmin):
-	list_display = ['api_key','client_name','client_contacts','ip_addresses','begin_date','end_date','max_calls_minute','max_calls_hour','max_calls_day']
+	list_display = ['api_key', 'client_name', 'client_contacts', 'organization', 'ip_addresses', 'begin_date', 'end_date', 'max_calls_minute', 'max_calls_hour', 'max_calls_day']
+	list_filter = ('organization',)
+	fields = ('api_key', 'client_name', 'client_contacts', 'organization', 'ip_addresses', 'begin_date', 'end_date', 'max_calls_minute', 'max_calls_hour', 'max_calls_day')
 	# a list of displayed columns name.
 
 class APILogAdmin(admin.ModelAdmin):

--- a/django/api/migrations/0003_apiaccessscheme_organization.py
+++ b/django/api/migrations/0003_apiaccessscheme_organization.py
@@ -1,0 +1,25 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		('api', '0002_apiaccessschemelog_payload_received'),
+		('organizations', '0001_initial'),
+	]
+
+	operations = [
+		migrations.AddField(
+			model_name='apiaccessscheme',
+			name='organization',
+			field=models.ForeignKey(
+				blank=True,
+				help_text='Organisation this key represents. Required after the transition window.',
+				null=True,
+				on_delete=django.db.models.deletion.CASCADE,
+				related_name='api_access_schemes',
+				to='organizations.organization',
+			),
+		),
+	]

--- a/django/api/models.py
+++ b/django/api/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.utils.crypto import get_random_string
 from django.utils.timezone import now
 from datetime import timedelta
+from organizations.models import Organization
 
 DEFAULT_MAX_CALLS_MINUTE = 60
 DEFAULT_MAX_CALLS_HOUR = DEFAULT_MAX_CALLS_MINUTE * 60
@@ -49,6 +50,17 @@ class APIAccessScheme(models.Model):
 
     # Maximum number of calls permitted per day
     max_calls_day = models.IntegerField(default=DEFAULT_MAX_CALLS_DAY, blank=False)
+
+    # The organisation this API key represents.
+    # Null is permitted during the transition window (PR 2); will become required in PR 8.
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name='api_access_schemes',
+        help_text='Organisation this key represents. Required after the transition window.',
+    )
 
     def __str__(self):
         return self.client_name

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count, Q
 
+from api.serializers.mixins import OrgScopedSerializerMixin  # noqa: F401
+
 def get_custom_settings():
 		try:
 			return CustomSetting.objects.get(site=settings.SITE_ID)

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -1,0 +1,77 @@
+"""
+api/serializers/mixins.py
+
+OrgScopedSerializerMixin — strips nested associations that belong to
+organisations outside ``request.visible_org_ids``.
+
+Applied fields (when present on the serialised object):
+  - ``teams``           → Team entries whose org is not visible
+  - ``subjects``        → Subject entries whose team's org is not visible
+  - ``team_categories`` → TeamCategory entries whose team's org is not visible
+  - ``ml_predictions``  → MLPredictions entries whose subject's team's org
+                           is not visible
+
+The mixin is intentionally a no-op when:
+  - There is no ``request`` in the serializer context, OR
+  - ``request.visible_org_ids`` has not been set (middleware not active).
+
+This guarantees zero behaviour change until the viewsets are explicitly
+opted in (PR 4 onwards).
+"""
+
+
+class OrgScopedSerializerMixin:
+	"""
+	Mixin for DRF serializers that strips nested associations belonging to
+	organisations the caller cannot see.
+
+	Usage::
+
+	    class ArticleSerializer(OrgScopedSerializerMixin,
+	                            serializers.HyperlinkedModelSerializer):
+	        ...
+	"""
+
+	def to_representation(self, instance):
+		ret = super().to_representation(instance)
+
+		request = self.context.get('request')
+		if request is None or not hasattr(request, 'visible_org_ids'):
+			return ret
+
+		visible = request.visible_org_ids
+
+		# --- teams ---
+		if 'teams' in ret and hasattr(instance, 'teams'):
+			visible_team_ids = set(
+				instance.teams.filter(organization_id__in=visible)
+				.values_list('id', flat=True)
+			)
+			ret['teams'] = [t for t in ret['teams'] if t.get('id') in visible_team_ids]
+
+		# --- subjects ---
+		if 'subjects' in ret and hasattr(instance, 'subjects'):
+			visible_subject_ids = set(
+				instance.subjects.filter(team__organization_id__in=visible)
+				.values_list('id', flat=True)
+			)
+			ret['subjects'] = [s for s in ret['subjects'] if s.get('id') in visible_subject_ids]
+
+		# --- team_categories ---
+		if 'team_categories' in ret and hasattr(instance, 'team_categories'):
+			visible_cat_ids = set(
+				instance.team_categories.filter(team__organization_id__in=visible)
+				.values_list('id', flat=True)
+			)
+			ret['team_categories'] = [c for c in ret['team_categories'] if c.get('id') in visible_cat_ids]
+
+		# --- ml_predictions (source='ml_predictions_detail') ---
+		if 'ml_predictions' in ret and hasattr(instance, 'ml_predictions_detail'):
+			visible_pred_ids = set(
+				instance.ml_predictions_detail.filter(
+					subject__team__organization_id__in=visible
+				).values_list('id', flat=True)
+			)
+			ret['ml_predictions'] = [p for p in ret['ml_predictions'] if p.get('id') in visible_pred_ids]
+
+		return ret

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -17,7 +17,37 @@ The mixin is intentionally a no-op when:
 
 This guarantees zero behaviour change until the viewsets are explicitly
 opted in (PR 4 onwards).
+
+Query strategy (avoiding N+1 on list endpoints)
+------------------------------------------------
+- ``teams``:  ``team.organization_id`` is a direct FK column; iterating
+  ``.all()`` in Python respects ``prefetch_related('teams')`` with zero
+  extra DB queries.
+- ``subjects`` / ``team_categories``:  ``subject.team_id`` is a direct FK
+  column.  Visible team IDs are resolved once per request and cached on
+  ``request._org_scoped_mixin_team_ids`` so the query runs at most once per
+  request regardless of list length.
+- ``ml_predictions``:  ``prediction.subject_id`` is a direct FK column.
+  Visible subject IDs are built in Python from the already-iterated subjects
+  manager (uses prefetch cache when ``prefetch_related('subjects')`` is active).
 """
+
+
+def _request_visible_team_ids(request, visible_org_ids: set) -> set:
+	"""Return all team IDs belonging to visible orgs, cached once per request.
+
+	Caching avoids issuing a team-lookup query for every object in a list
+	endpoint response.
+	"""
+	cache_attr = '_org_scoped_mixin_team_ids'
+	if not hasattr(request, cache_attr):
+		from gregory.models import Team
+		setattr(
+			request,
+			cache_attr,
+			set(Team.objects.filter(organization_id__in=visible_org_ids).values_list('id', flat=True)),
+		)
+	return getattr(request, cache_attr)
 
 
 class OrgScopedSerializerMixin:
@@ -41,35 +71,32 @@ class OrgScopedSerializerMixin:
 
 		visible = request.visible_org_ids
 
-		# --- teams ---
+		# --- teams: iterate Python, uses prefetch_related cache ---
 		if 'teams' in ret and hasattr(instance, 'teams'):
-			visible_team_ids = set(
-				instance.teams.filter(organization_id__in=visible)
-				.values_list('id', flat=True)
-			)
+			visible_team_ids = {t.id for t in instance.teams.all() if t.organization_id in visible}
 			ret['teams'] = [t for t in ret['teams'] if t.get('id') in visible_team_ids]
 
-		# --- subjects ---
+		# --- subjects: team_id is a direct FK attribute; team IDs cached per request ---
 		if 'subjects' in ret and hasattr(instance, 'subjects'):
-			visible_subject_ids = set(
-				instance.subjects.filter(team__organization_id__in=visible)
-				.values_list('id', flat=True)
-			)
+			vt = _request_visible_team_ids(request, visible)
+			visible_subject_ids = {s.id for s in instance.subjects.all() if s.team_id in vt}
 			ret['subjects'] = [s for s in ret['subjects'] if s.get('id') in visible_subject_ids]
 
-		# --- team_categories ---
+		# --- team_categories: same approach as subjects ---
 		if 'team_categories' in ret and hasattr(instance, 'team_categories'):
-			visible_cat_ids = set(
-				instance.team_categories.filter(team__organization_id__in=visible)
-				.values_list('id', flat=True)
-			)
+			vt = _request_visible_team_ids(request, visible)
+			visible_cat_ids = {c.id for c in instance.team_categories.all() if c.team_id in vt}
 			ret['team_categories'] = [c for c in ret['team_categories'] if c.get('id') in visible_cat_ids]
 
-		# --- ml_predictions (source='ml_predictions_detail') ---
+		# --- ml_predictions: one-level join using cached visible team IDs ---
+		# (subject__team_id__in=vt is simpler than subject__team__organization_id__in=visible;
+		# a full zero-query solution requires prefetch_related('ml_predictions_detail__subject')
+		# with select_related('team'), which is a viewset concern.)
 		if 'ml_predictions' in ret and hasattr(instance, 'ml_predictions_detail'):
+			vt = _request_visible_team_ids(request, visible)
 			visible_pred_ids = set(
 				instance.ml_predictions_detail.filter(
-					subject__team__organization_id__in=visible
+					subject__team_id__in=vt
 				).values_list('id', flat=True)
 			)
 			ret['ml_predictions'] = [p for p in ret['ml_predictions'] if p.get('id') in visible_pred_ids]

--- a/django/api/tests/test_apiaccessscheme_org_fk.py
+++ b/django/api/tests/test_apiaccessscheme_org_fk.py
@@ -1,0 +1,65 @@
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
+django.setup()
+
+from django.test import TestCase
+from organizations.models import Organization
+from api.models import APIAccessScheme
+
+
+class APIAccessSchemeOrganizationFKTest(TestCase):
+	"""Tests for the APIAccessScheme.organization FK introduced in PR 2."""
+
+	def setUp(self):
+		self.org = Organization.objects.create(name='Test Org', slug='test-org')
+
+	def test_create_without_organization(self):
+		"""Existing keys with no org (null) must still work."""
+		scheme = APIAccessScheme.objects.create(
+			client_name='No Org Client',
+			client_contacts='noorg@example.com',
+		)
+		retrieved = APIAccessScheme.objects.get(pk=scheme.pk)
+		self.assertIsNone(retrieved.organization)
+
+	def test_create_with_organization(self):
+		"""New keys can be bound to an organisation."""
+		scheme = APIAccessScheme.objects.create(
+			client_name='Org Client',
+			client_contacts='org@example.com',
+			organization=self.org,
+		)
+		retrieved = APIAccessScheme.objects.get(pk=scheme.pk)
+		self.assertEqual(retrieved.organization, self.org)
+
+	def test_organization_reverse_relation(self):
+		"""org.api_access_schemes reverse manager works."""
+		scheme = APIAccessScheme.objects.create(
+			client_name='Reverse Rel Client',
+			client_contacts='rev@example.com',
+			organization=self.org,
+		)
+		self.assertIn(scheme, self.org.api_access_schemes.all())
+
+	def test_null_org_does_not_break_existing_schemes(self):
+		"""Rows created before the migration (simulated as null org) survive."""
+		scheme = APIAccessScheme.objects.create(
+			client_name='Legacy Client',
+			client_contacts='legacy@example.com',
+			organization=None,
+		)
+		self.assertIsNone(APIAccessScheme.objects.get(pk=scheme.pk).organization)
+
+	def test_cascade_delete(self):
+		"""Deleting an org cascades to its API keys."""
+		org2 = Organization.objects.create(name='Doomed Org', slug='doomed-org')
+		scheme = APIAccessScheme.objects.create(
+			client_name='Doomed Client',
+			client_contacts='doomed@example.com',
+			organization=org2,
+		)
+		pk = scheme.pk
+		org2.delete()
+		self.assertFalse(APIAccessScheme.objects.filter(pk=pk).exists())

--- a/django/api/tests/test_org_scoped_serializer_mixin.py
+++ b/django/api/tests/test_org_scoped_serializer_mixin.py
@@ -1,0 +1,190 @@
+"""
+Tests for api.serializers.mixins.OrgScopedSerializerMixin.
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_org_scoped_serializer_mixin
+"""
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import AnonymousUser
+from rest_framework import serializers
+from organizations.models import Organization
+from gregory.models import (
+	Articles, Team, Subject, TeamCategory, MLPredictions, OrganizationApiSettings,
+)
+from api.serializers.mixins import OrgScopedSerializerMixin
+
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	return Team.objects.create(organization=org, name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_article(title='Test Article', link='https://example.com/1'):
+	return Articles.objects.create(title=title, link=link)
+
+
+def _make_team_category(team, name):
+	from django.utils.text import slugify
+	return TeamCategory.objects.create(team=team, category_name=name, category_slug=slugify(name))
+
+
+def _request_with_visible(visible_ids):
+	"""Build a fake request with a pre-set visible_org_ids attribute."""
+	factory = RequestFactory()
+	req = factory.get('/')
+	req.user = AnonymousUser()
+	req.visible_org_ids = visible_ids
+	return req
+
+
+# ---------------------------------------------------------------------------
+# Minimal serializer that uses the mixin (mirrors ArticleSerializer shape)
+# ---------------------------------------------------------------------------
+
+class _TeamSerializer(serializers.ModelSerializer):
+	class Meta:
+		model = Team
+		fields = ['id', 'name']
+
+
+class _SubjectSerializer(serializers.ModelSerializer):
+	class Meta:
+		model = Subject
+		fields = ['id', 'subject_name']
+
+
+class _TeamCategorySerializer(serializers.ModelSerializer):
+	class Meta:
+		model = TeamCategory
+		fields = ['id', 'category_name']
+
+
+class _MLPredictionsSerializer(serializers.ModelSerializer):
+	class Meta:
+		model = MLPredictions
+		fields = ['id', 'algorithm', 'probability_score']
+
+
+class _TestArticleSerializer(OrgScopedSerializerMixin, serializers.ModelSerializer):
+	teams = _TeamSerializer(many=True, read_only=True)
+	subjects = _SubjectSerializer(many=True, read_only=True)
+	team_categories = _TeamCategorySerializer(many=True, read_only=True)
+	ml_predictions = _MLPredictionsSerializer(
+		many=True, read_only=True, source='ml_predictions_detail'
+	)
+
+	class Meta:
+		model = Articles
+		fields = ['article_id', 'title', 'teams', 'subjects', 'team_categories', 'ml_predictions']
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class OrgScopedSerializerMixinTeamsTest(TestCase):
+	def setUp(self):
+		self.org_a = _make_org('Org A', 'org-a-m', public=False)
+		self.org_b = _make_org('Org B', 'org-b-m', public=False)
+		self.team_a = _make_team(self.org_a, 'Team A')
+		self.team_b = _make_team(self.org_b, 'Team B')
+
+		self.article = _make_article()
+		self.article.teams.add(self.team_a, self.team_b)
+
+	def test_teams_stripped_for_hidden_org(self):
+		"""Only team_a should appear when org_b is not visible."""
+		req = _request_with_visible({self.org_a.id})
+		data = _TestArticleSerializer(self.article, context={'request': req}).data
+		team_ids = [t['id'] for t in data['teams']]
+		self.assertIn(self.team_a.id, team_ids)
+		self.assertNotIn(self.team_b.id, team_ids)
+
+	def test_both_teams_visible_when_both_orgs_visible(self):
+		req = _request_with_visible({self.org_a.id, self.org_b.id})
+		data = _TestArticleSerializer(self.article, context={'request': req}).data
+		team_ids = [t['id'] for t in data['teams']]
+		self.assertIn(self.team_a.id, team_ids)
+		self.assertIn(self.team_b.id, team_ids)
+
+	def test_no_middleware_returns_all_teams(self):
+		"""When request has no visible_org_ids, the mixin is a no-op."""
+		factory = RequestFactory()
+		req = factory.get('/')
+		req.user = AnonymousUser()
+		# No visible_org_ids attribute set
+		data = _TestArticleSerializer(self.article, context={'request': req}).data
+		team_ids = [t['id'] for t in data['teams']]
+		self.assertIn(self.team_a.id, team_ids)
+		self.assertIn(self.team_b.id, team_ids)
+
+	def test_no_request_in_context_is_no_op(self):
+		"""Serializer without request context must not crash."""
+		data = _TestArticleSerializer(self.article).data
+		self.assertIn('teams', data)
+
+
+class OrgScopedSerializerMixinSubjectsTest(TestCase):
+	def setUp(self):
+		self.org_a = _make_org('Org A', 'org-a-s', public=False)
+		self.org_b = _make_org('Org B', 'org-b-s', public=False)
+		self.team_a = _make_team(self.org_a, 'Team A S')
+		self.team_b = _make_team(self.org_b, 'Team B S')
+		self.subject_a = _make_subject(self.team_a, 'Subject A')
+		self.subject_b = _make_subject(self.team_b, 'Subject B')
+
+		self.article = _make_article(title='Subject Article', link='https://example.com/2')
+		self.article.subjects.add(self.subject_a, self.subject_b)
+
+	def test_hidden_subjects_stripped(self):
+		req = _request_with_visible({self.org_a.id})
+		data = _TestArticleSerializer(self.article, context={'request': req}).data
+		subject_ids = [s['id'] for s in data['subjects']]
+		self.assertIn(self.subject_a.id, subject_ids)
+		self.assertNotIn(self.subject_b.id, subject_ids)
+
+
+class OrgScopedSerializerMixinMLPredictionsTest(TestCase):
+	def setUp(self):
+		self.org_a = _make_org('Org A', 'org-a-ml', public=False)
+		self.org_b = _make_org('Org B', 'org-b-ml', public=False)
+		self.team_a = _make_team(self.org_a, 'Team A ML')
+		self.team_b = _make_team(self.org_b, 'Team B ML')
+		self.subject_a = _make_subject(self.team_a, 'Subj ML A')
+		self.subject_b = _make_subject(self.team_b, 'Subj ML B')
+
+		self.article = _make_article(title='ML Article', link='https://example.com/3')
+
+		self.pred_a = MLPredictions.objects.create(
+			article=self.article,
+			subject=self.subject_a,
+			algorithm='lgbm_tfidf',
+			probability_score=0.9,
+			predicted_relevant=True,
+			model_version='v1',
+		)
+		self.pred_b = MLPredictions.objects.create(
+			article=self.article,
+			subject=self.subject_b,
+			algorithm='lgbm_tfidf',
+			probability_score=0.8,
+			predicted_relevant=True,
+			model_version='v1',
+		)
+
+	def test_hidden_ml_predictions_stripped(self):
+		req = _request_with_visible({self.org_a.id})
+		data = _TestArticleSerializer(self.article, context={'request': req}).data
+		pred_ids = [p['id'] for p in data['ml_predictions']]
+		self.assertIn(self.pred_a.id, pred_ids)
+		self.assertNotIn(self.pred_b.id, pred_ids)

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -19,7 +19,8 @@ from organizations.admin import OrganizationAdmin as BaseOrganizationAdmin
 from .models import (
     Articles, Trials, Sources, Entities, Authors, Subject, MLPredictions, 
     ArticleSubjectRelevance, TeamCategory, PredictionRunLog, Team,
-    ArticleTrialReference, OrganizationCredentials, OrganizationSite
+    ArticleTrialReference, OrganizationCredentials, OrganizationSite,
+    OrganizationApiSettings
 )
 from .widgets import MLPredictionsWidget
 from django import forms
@@ -1054,6 +1055,16 @@ class OrganizationCredentialsInline(admin.StackedInline):
 	verbose_name_plural = 'Credentials'
 
 
+class OrganizationApiSettingsInline(admin.StackedInline):
+	"""Inline to manage API visibility settings for an organization."""
+	model = OrganizationApiSettings
+	extra = 0
+	max_num = 1
+	fields = ('make_api_public',)
+	verbose_name = 'API settings'
+	verbose_name_plural = 'API settings'
+
+
 class OrganizationTeamInline(admin.TabularInline):
 	"""Inline to display teams belonging to an organization."""
 	model = Team
@@ -1090,6 +1101,7 @@ class OrganizationAdmin(BaseOrganizationAdmin):
 			inlines.append(OrganizationTeamInline(self.model, self.admin_site))
 			inlines.append(OrganizationSiteInline(self.model, self.admin_site))
 			inlines.append(OrganizationCredentialsInline(self.model, self.admin_site))
+			inlines.append(OrganizationApiSettingsInline(self.model, self.admin_site))
 		return inlines
 
 	def teams_count(self, obj):

--- a/django/gregory/middleware/visibility.py
+++ b/django/gregory/middleware/visibility.py
@@ -1,0 +1,19 @@
+"""
+gregory/middleware/visibility.py
+
+Attaches ``request.visible_org_ids`` (a ``set[int]``) to every incoming
+request so that viewsets and serializers can read it without recomputing.
+
+The set is computed by ``gregory.visibility.visible_org_ids`` which
+implements the access-control rules from the spec (§4.1).
+"""
+
+
+class VisibleOrgMiddleware:
+	def __init__(self, get_response):
+		self.get_response = get_response
+
+	def __call__(self, request):
+		from gregory.visibility import visible_org_ids
+		request.visible_org_ids = visible_org_ids(request)
+		return self.get_response(request)

--- a/django/gregory/migrations/0043_organizationapisettings.py
+++ b/django/gregory/migrations/0043_organizationapisettings.py
@@ -1,0 +1,58 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def backfill_api_settings(apps, schema_editor):
+	"""Create OrganizationApiSettings rows for all pre-existing organisations.
+
+	Existing orgs are assumed to have been publicly accessible before this flag
+	existed, so we backfill with make_api_public=True.  Orgs created after this
+	migration will be handled by the post_save signal and will default to False.
+	"""
+	Organization = apps.get_model('organizations', 'Organization')
+	OrganizationApiSettings = apps.get_model('gregory', 'OrganizationApiSettings')
+	for org in Organization.objects.all():
+		OrganizationApiSettings.objects.get_or_create(
+			organization=org,
+			defaults={'make_api_public': True},
+		)
+
+
+def reverse_backfill(apps, schema_editor):
+	"""Remove all OrganizationApiSettings rows (used when reversing the migration)."""
+	OrganizationApiSettings = apps.get_model('gregory', 'OrganizationApiSettings')
+	OrganizationApiSettings.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		('gregory', '0042_historicalauthors'),
+		('organizations', '0001_initial'),
+	]
+
+	operations = [
+		migrations.CreateModel(
+			name='OrganizationApiSettings',
+			fields=[
+				('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+				('organization', models.OneToOneField(
+					help_text='Organisation whose API exposure these settings govern.',
+					on_delete=django.db.models.deletion.CASCADE,
+					related_name='api_settings',
+					to='organizations.organization',
+				)),
+				('make_api_public', models.BooleanField(
+					default=False,
+					help_text="When true, anonymous API and RSS consumers can see this org's data.",
+				)),
+				('created_at', models.DateTimeField(auto_now_add=True)),
+				('updated_at', models.DateTimeField(auto_now=True)),
+			],
+			options={
+				'verbose_name': 'Organisation API settings',
+				'verbose_name_plural': 'Organisation API settings',
+			},
+		),
+		migrations.RunPython(backfill_api_settings, reverse_code=reverse_backfill),
+	]

--- a/django/gregory/models.py
+++ b/django/gregory/models.py
@@ -624,6 +624,28 @@ class OrganizationSite(models.Model):
 		default_label = " (default)" if self.is_default else ""
 		return f"{self.site.domain}{default_label} — {self.organization.name}"
 
+class OrganizationApiSettings(models.Model):
+	organization = models.OneToOneField(
+		Organization,
+		on_delete=models.CASCADE,
+		related_name='api_settings',
+		help_text='Organisation whose API exposure these settings govern.',
+	)
+	make_api_public = models.BooleanField(
+		default=False,
+		help_text="When true, anonymous API and RSS consumers can see this org's data.",
+	)
+	created_at = models.DateTimeField(auto_now_add=True)
+	updated_at = models.DateTimeField(auto_now=True)
+
+	def __str__(self):
+		return f"API settings for {self.organization.name}"
+
+	class Meta:
+		verbose_name = 'Organisation API settings'
+		verbose_name_plural = 'Organisation API settings'
+
+
 class TeamMember(OrganizationUser):
 	class Meta:
 		proxy = True

--- a/django/gregory/signals.py
+++ b/django/gregory/signals.py
@@ -1,4 +1,5 @@
 from simple_history.signals import post_create_historical_record
+from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 MAX_AUTHOR_HISTORY = 5
@@ -12,3 +13,11 @@ def trim_author_history(sender, instance, history_instance, **kwargs):
 		instance.history.order_by('-history_date').values_list('pk', flat=True)[:MAX_AUTHOR_HISTORY]
 	)
 	instance.history.exclude(pk__in=keep_ids).delete()
+
+
+@receiver(post_save, sender='organizations.Organization')
+def create_organization_api_settings(sender, instance, created, **kwargs):
+	"""Create an OrganizationApiSettings row for every newly created Organisation."""
+	if created:
+		from gregory.models import OrganizationApiSettings
+		OrganizationApiSettings.objects.get_or_create(organization=instance)

--- a/django/gregory/tests/test_organization_api_settings.py
+++ b/django/gregory/tests/test_organization_api_settings.py
@@ -1,0 +1,99 @@
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
+django.setup()
+
+from django.test import TestCase
+from organizations.models import Organization
+from gregory.models import OrganizationApiSettings
+
+
+class OrganizationApiSettingsRoundTripTest(TestCase):
+	"""Basic create/read round-trip for OrganizationApiSettings."""
+
+	def setUp(self):
+		# Suppress the signal so we control creation manually in these tests.
+		self.org = Organization.objects.create(name='Round Trip Org', slug='round-trip-org')
+		# The signal will have created a row already; clean it up so the tests
+		# can assert on explicit creation.
+		OrganizationApiSettings.objects.filter(organization=self.org).delete()
+
+	def test_create_with_default_false(self):
+		settings = OrganizationApiSettings.objects.create(organization=self.org)
+		self.assertFalse(settings.make_api_public)
+
+	def test_create_explicit_true(self):
+		settings = OrganizationApiSettings.objects.create(
+			organization=self.org,
+			make_api_public=True,
+		)
+		retrieved = OrganizationApiSettings.objects.get(pk=settings.pk)
+		self.assertTrue(retrieved.make_api_public)
+
+	def test_str_repr(self):
+		settings = OrganizationApiSettings.objects.create(organization=self.org)
+		self.assertIn(self.org.name, str(settings))
+
+	def test_one_to_one_uniqueness(self):
+		OrganizationApiSettings.objects.create(organization=self.org)
+		from django.db import IntegrityError
+		with self.assertRaises(IntegrityError):
+			OrganizationApiSettings.objects.create(organization=self.org)
+
+
+class OrganizationApiSettingsSignalTest(TestCase):
+	"""post_save signal on Organization should auto-create an api_settings row."""
+
+	def test_new_org_gets_settings_row(self):
+		org = Organization.objects.create(name='Signal Org', slug='signal-org')
+		self.assertTrue(
+			OrganizationApiSettings.objects.filter(organization=org).exists()
+		)
+
+	def test_new_org_settings_defaults_to_false(self):
+		org = Organization.objects.create(name='Private Org', slug='private-org')
+		settings = OrganizationApiSettings.objects.get(organization=org)
+		self.assertFalse(settings.make_api_public)
+
+	def test_signal_is_idempotent(self):
+		"""get_or_create in the signal means a second save doesn't create a duplicate."""
+		org = Organization.objects.create(name='Idempotent Org', slug='idempotent-org')
+		# Force another post_save (e.g. an org update)
+		org.name = 'Idempotent Org Updated'
+		org.save()
+		self.assertEqual(
+			OrganizationApiSettings.objects.filter(organization=org).count(), 1
+		)
+
+
+class OrganizationApiSettingsMigrationBackfillTest(TestCase):
+	"""
+	Verify the invariant that the migration's backfill step would leave
+	one OrganizationApiSettings row per Organisation.
+
+	The migration itself cannot be re-run in tests, but we can assert the
+	invariant on the live test database state: every org created in tests
+	(via the signal) has exactly one settings row.
+	"""
+
+	def test_every_org_has_exactly_one_settings_row(self):
+		org1 = Organization.objects.create(name='Org One', slug='org-one')
+		org2 = Organization.objects.create(name='Org Two', slug='org-two')
+		for org in [org1, org2]:
+			self.assertEqual(
+				OrganizationApiSettings.objects.filter(organization=org).count(),
+				1,
+			)
+
+	def test_count_parity(self):
+		"""After creating several orgs, counts match."""
+		before_orgs = Organization.objects.count()
+		before_settings = OrganizationApiSettings.objects.count()
+		self.assertEqual(before_orgs, before_settings)
+
+		Organization.objects.create(name='Extra Org', slug='extra-org')
+		self.assertEqual(
+			Organization.objects.count(),
+			OrganizationApiSettings.objects.count(),
+		)

--- a/django/gregory/tests/test_organization_api_settings.py
+++ b/django/gregory/tests/test_organization_api_settings.py
@@ -13,10 +13,9 @@ class OrganizationApiSettingsRoundTripTest(TestCase):
 	"""Basic create/read round-trip for OrganizationApiSettings."""
 
 	def setUp(self):
-		# Suppress the signal so we control creation manually in these tests.
+		# Creating an org fires the post_save signal which creates a settings row.
+		# Delete that row so each test can assert on explicitly created rows.
 		self.org = Organization.objects.create(name='Round Trip Org', slug='round-trip-org')
-		# The signal will have created a row already; clean it up so the tests
-		# can assert on explicit creation.
 		OrganizationApiSettings.objects.filter(organization=self.org).delete()
 
 	def test_create_with_default_false(self):
@@ -56,8 +55,9 @@ class OrganizationApiSettingsSignalTest(TestCase):
 		settings = OrganizationApiSettings.objects.get(organization=org)
 		self.assertFalse(settings.make_api_public)
 
-	def test_signal_is_idempotent(self):
-		"""get_or_create in the signal means a second save doesn't create a duplicate."""
+	def test_signal_only_fires_on_create(self):
+		"""The signal handler guards on `created=True`, so saving an existing org
+		does not fire the handler and cannot produce a duplicate settings row."""
 		org = Organization.objects.create(name='Idempotent Org', slug='idempotent-org')
 		# Force another post_save (e.g. an org update)
 		org.name = 'Idempotent Org Updated'

--- a/django/gregory/tests/test_visibility.py
+++ b/django/gregory/tests/test_visibility.py
@@ -1,0 +1,155 @@
+"""
+Tests for gregory.visibility — the visible_org_ids() helper.
+
+Run with:
+    docker exec gregory python manage.py test gregory.tests.test_visibility
+"""
+from django.test import TestCase, RequestFactory
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from organizations.models import Organization
+from gregory.models import OrganizationApiSettings, Team
+from gregory.visibility import visible_org_ids
+
+User = get_user_model()
+
+
+def _make_org(name, slug, public):
+	"""Create an org and set its make_api_public flag."""
+	org = Organization.objects.create(name=name, slug=slug)
+	# Signal already created the settings row; just update it
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _anon_request(factory, path='/', include_public=False):
+	"""RequestFactory GET with an anonymous user (no auth)."""
+	qs = '?include_public=true' if include_public else ''
+	req = factory.get(path + qs)
+	req.user = AnonymousUser()
+	return req
+
+
+class VisibleOrgIdsAnonymousTest(TestCase):
+	def setUp(self):
+		self.factory = RequestFactory()
+		self.pub_org = _make_org('Public Org', 'public-org', public=True)
+		self.priv_org = _make_org('Private Org', 'private-org', public=False)
+
+	def test_anonymous_no_flag_sees_public_only(self):
+		req = _anon_request(self.factory)
+		result = visible_org_ids(req)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.priv_org.id, result)
+
+	def test_anonymous_with_include_public_still_only_public(self):
+		"""Flag is a no-op for anonymous callers."""
+		req = _anon_request(self.factory, include_public=True)
+		result = visible_org_ids(req)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.priv_org.id, result)
+
+
+class VisibleOrgIdsAuthenticatedUserTest(TestCase):
+	def setUp(self):
+		self.factory = RequestFactory()
+		self.pub_org = _make_org('Public Org', 'pub-org-u', public=True)
+		self.priv_org_a = _make_org('Org A', 'org-a-u', public=False)
+		self.priv_org_b = _make_org('Org B', 'org-b-u', public=False)
+
+		self.user = User.objects.create_user(username='testuser', password='pw')
+
+	def _authed_request(self, include_public=False):
+		qs = '?include_public=true' if include_public else ''
+		req = self.factory.get('/' + qs)
+		req.user = self.user
+		return req
+
+	def test_user_no_team_no_include_public_sees_nothing(self):
+		req = self._authed_request()
+		result = visible_org_ids(req)
+		# No membership → empty owned set, no public flag → empty
+		self.assertEqual(result, set())
+
+	def test_user_no_team_with_include_public_sees_public(self):
+		req = self._authed_request(include_public=True)
+		result = visible_org_ids(req)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.priv_org_a.id, result)
+
+	def test_user_in_org_a_sees_only_org_a_by_default(self):
+		# Add user to a team in org A
+		Team.objects.create(organization=self.priv_org_a, name='Team A', slug='team-a-u')
+		from organizations.models import OrganizationUser
+		OrganizationUser.objects.create(organization=self.priv_org_a, user=self.user)
+
+		req = self._authed_request()
+		result = visible_org_ids(req)
+		self.assertIn(self.priv_org_a.id, result)
+		self.assertNotIn(self.pub_org.id, result)
+		self.assertNotIn(self.priv_org_b.id, result)
+
+	def test_user_in_org_a_with_include_public_sees_org_a_plus_public(self):
+		from organizations.models import OrganizationUser
+		OrganizationUser.objects.create(organization=self.priv_org_a, user=self.user)
+
+		req = self._authed_request(include_public=True)
+		result = visible_org_ids(req)
+		self.assertIn(self.priv_org_a.id, result)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.priv_org_b.id, result)
+
+
+class VisibleOrgIdsAPIKeyTest(TestCase):
+	def setUp(self):
+		self.factory = RequestFactory()
+		self.pub_org = _make_org('Public Org', 'pub-org-k', public=True)
+		self.org_x = _make_org('Org X', 'org-x-k', public=False)
+		self.other_priv_org = _make_org('Other Priv', 'other-priv-k', public=False)
+
+		from api.models import APIAccessScheme
+		self.scheme_with_org = APIAccessScheme.objects.create(
+			client_name='Key With Org',
+			client_contacts='a@b.com',
+			organization=self.org_x,
+			ip_addresses='',
+		)
+		self.scheme_no_org = APIAccessScheme.objects.create(
+			client_name='Key No Org',
+			client_contacts='c@d.com',
+			organization=None,
+			ip_addresses='',
+		)
+
+	def _key_request(self, scheme, include_public=False):
+		qs = '?include_public=true' if include_public else ''
+		req = self.factory.get('/' + qs, HTTP_AUTHORIZATION=scheme.api_key, REMOTE_ADDR='127.0.0.1')
+		req.user = AnonymousUser()
+		return req
+
+	def test_key_bound_to_org_x_sees_only_org_x(self):
+		req = self._key_request(self.scheme_with_org)
+		result = visible_org_ids(req)
+		self.assertIn(self.org_x.id, result)
+		self.assertNotIn(self.pub_org.id, result)
+		self.assertNotIn(self.other_priv_org.id, result)
+
+	def test_key_bound_to_org_x_with_include_public(self):
+		req = self._key_request(self.scheme_with_org, include_public=True)
+		result = visible_org_ids(req)
+		self.assertIn(self.org_x.id, result)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.other_priv_org.id, result)
+
+	def test_null_org_key_no_include_public_sees_only_public(self):
+		req = self._key_request(self.scheme_no_org)
+		result = visible_org_ids(req)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.org_x.id, result)
+
+	def test_null_org_key_with_include_public_sees_only_public(self):
+		"""Flag is still a no-op for null-org keys (anonymous-equivalent)."""
+		req = self._key_request(self.scheme_no_org, include_public=True)
+		result = visible_org_ids(req)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.org_x.id, result)

--- a/django/gregory/visibility.py
+++ b/django/gregory/visibility.py
@@ -1,0 +1,82 @@
+"""
+gregory/visibility.py
+
+Computes the set of Organisation IDs visible to a given request.
+
+Rules (see spec §4.1):
+  - Anonymous caller (no auth, no valid API key, or null-org key)
+      → public orgs only; ?include_public flag is a no-op
+  - Authenticated user
+      → orgs they are a member of (via any team); ?include_public=true adds public orgs
+  - API key bound to org X
+      → {X}; ?include_public=true adds public orgs
+"""
+
+from __future__ import annotations
+
+
+def _public_org_ids() -> set[int]:
+	"""Return the set of org IDs whose make_api_public flag is True."""
+	from gregory.models import OrganizationApiSettings
+	return set(
+		OrganizationApiSettings.objects
+		.filter(make_api_public=True)
+		.values_list('organization_id', flat=True)
+	)
+
+
+def _resolve_api_scheme(request):
+	"""
+	Try to resolve an APIAccessScheme from the request's Authorization header.
+
+	Returns the scheme object on success, None on any failure (missing key,
+	invalid key, expired, IP mismatch, etc.).  Never raises.
+	"""
+	try:
+		from api.utils.utils import getAPIKey, checkValidAccess, getIPAddress
+		api_key = getAPIKey(request)
+		ip_addr = getIPAddress(request)
+		return checkValidAccess(api_key, ip_addr)
+	except Exception:
+		return None
+
+
+def visible_org_ids(request) -> set[int]:
+	"""
+	Return the set of organisation IDs the caller is permitted to see.
+
+	The result is computed once per call; callers that need it on multiple
+	occasions should cache it on the request (the middleware does this via
+	``request.visible_org_ids``).
+	"""
+	include_public = request.GET.get('include_public', '').lower() == 'true'
+
+	owned_ids: set[int] = set()
+	is_identified = False  # True when caller has a non-anonymous identity
+
+	# --- 1. Try API key identity ---
+	api_scheme = _resolve_api_scheme(request)
+	if api_scheme is not None:
+		if api_scheme.organization_id is not None:
+			owned_ids.add(api_scheme.organization_id)
+			is_identified = True
+		# null-org key → anonymous-equivalent; is_identified stays False
+
+	# --- 2. Try authenticated-user identity (only if no API key found) ---
+	elif getattr(request, 'user', None) is not None and request.user.is_authenticated:
+		user_org_ids = set(
+			request.user.organizations_organizationuser
+			.values_list('organization_id', flat=True)
+		)
+		owned_ids |= user_org_ids
+		is_identified = True
+
+	# --- 3. Resolve final set ---
+	if not is_identified:
+		# Anonymous or null-org key → public orgs only (flag is a no-op)
+		return _public_org_ids()
+
+	if include_public:
+		return owned_ids | _public_org_ids()
+
+	return owned_ids

--- a/django/gregory/visibility.py
+++ b/django/gregory/visibility.py
@@ -7,7 +7,7 @@ Rules (see spec §4.1):
   - Anonymous caller (no auth, no valid API key, or null-org key)
       → public orgs only; ?include_public flag is a no-op
   - Authenticated user
-      → orgs they are a member of (via any team); ?include_public=true adds public orgs
+      → orgs they are a member of (via OrganizationUser membership); ?include_public=true adds public orgs
   - API key bound to org X
       → {X}; ?include_public=true adds public orgs
 """
@@ -27,16 +27,34 @@ def _public_org_ids() -> set[int]:
 
 def _resolve_api_scheme(request):
 	"""
-	Try to resolve an APIAccessScheme from the request's Authorization header.
+	Lightweight resolution of an APIAccessScheme from the Authorization header.
 
-	Returns the scheme object on success, None on any failure (missing key,
-	invalid key, expired, IP mismatch, etc.).  Never raises.
+	Only validates key existence, date window, and (if configured) IP address.
+	Deliberately does NOT run quota-counting queries — those remain in the
+	actual API views.  This avoids doubling up on DB work for every request.
+
+	Returns the scheme object on success, None on any failure.  Never raises.
 	"""
 	try:
-		from api.utils.utils import getAPIKey, checkValidAccess, getIPAddress
+		from api.utils.utils import getAPIKey, getIPAddress
+		from api.models import APIAccessScheme
+		from django.utils.timezone import now as tz_now
 		api_key = getAPIKey(request)
 		ip_addr = getIPAddress(request)
-		return checkValidAccess(api_key, ip_addr)
+		current_time = tz_now()
+		scheme = APIAccessScheme.objects.filter(
+			api_key=api_key,
+			begin_date__lte=current_time,
+			end_date__gte=current_time,
+		).first()
+		if scheme is None:
+			return None
+		# Enforce IP allowlist only when the scheme has one configured
+		if scheme.ip_addresses:
+			allowed = [i.strip() for i in scheme.ip_addresses.split(',')]
+			if ip_addr not in allowed:
+				return None
+		return scheme
 	except Exception:
 		return None
 


### PR DESCRIPTION
## PR 1 — OrganizationApiSettings model

### Goal

Introduce the storage backing the flag without altering any existing behaviour.

### Scope

In:

- New `OrganizationApiSettings` model (OneToOne to `Organization`, field `make_api_public: BooleanField(default=False)`).
- Migration that creates the table and runs a `RunPython` backfill creating one row per existing `Organization` with `make_api_public=True`.
- `post_save` signal on `Organization` that creates an `OrganizationApiSettings` row with the model default of `False` for any newly created org.
- Django admin registration with inline editing on the Organization admin page.

Out:

- No queryset filtering, no API behaviour change. The flag is dormant.

### Files touched

- `django/gregory/models.py` — new model class
- `django/gregory/signals.py` (new) — post_save handler
- `django/gregory/apps.py` — wire up the signal in `ready()`
- `django/gregory/admin.py` — register `OrganizationApiSettings` inline
- `django/gregory/migrations/00XX_add_organizationapisettings.py`

### Tests

- `OrganizationApiSettings.objects.create(organization=org)` round-trip.
- Creating a new `Organization` triggers signal and produces a settings row with `make_api_public=False`.
- Migration `RunPython` step backfills `True` for orgs created before the migration; new orgs get `False`.
- Existing orgs without prior settings rows get one row each (idempotent).

### Risk and rollback

Low. The new model is additive. Rollback = revert the migration and the model.

### Acceptance criteria

- All existing tests pass.
- `Organization.objects.count() == OrganizationApiSettings.objects.count()` after migration.
- Newly created `Organization` instances always have a corresponding settings row.

### Depends on

Nothing.

## PR 2 — APIAccessScheme.organization FK

### Goal

Bind API keys to organisations so the visibility helper can identify the caller's org. Permissive nullability during the transition window.

### Scope

In:

- `APIAccessScheme.organization = ForeignKey(Organization, null=True, blank=True, related_name='api_access_schemes')`.
- Migration adds the column.
- Admin update to expose the FK on the `APIAccessScheme` admin page.
- Operator runbook entry (added to `docs/changelog/`) describing how to backfill existing keys.

Out:

- No enforcement on `post_article` yet (PR 7).
- Null is not yet rejected on read endpoints (PR 3 reads it as anonymous-equivalent).

### Files touched

- `django/api/models.py`
- `django/api/admin.py`
- `django/api/migrations/00XX_apiaccessscheme_organization.py`
- `docs/changelog/api-access-scheme-org-fk.md`

### Tests

- Migration creates the column with `null=True`.
- Existing `APIAccessScheme` rows survive the migration with `organization=None`.
- New rows can be created with or without an organisation.

### Risk and rollback

Low. Column is nullable; no existing key breaks. Rollback = drop the column.

### Acceptance criteria

- `POST /articles/post/` continues to function for keys with `organization=None` (no enforcement yet).
- Operator runbook is published.

### Depends on

Nothing. Can land in parallel with PR 1.

## PR 3 — Visibility helper, middleware, and serializer mixin

### Goal

Build the infrastructure that PRs 4–7 will plug into. No viewsets are wired up yet.

### Scope

In:

- `gregory/visibility.py` with `visible_org_ids(request) -> set[int]`.
- `gregory/middleware/visibility.py` with `VisibleOrgMiddleware` that attaches `request.visible_org_ids`.
- Middleware registered in `admin/settings.py`.
- `?include_public=true` query parameter parsing inside the helper.
- `OrgScopedSerializerMixin` in `api/serializers/mixins.py` that strips `teams`, `subjects`, `team_categories`, and ML predictions tied to non-visible orgs.

Out:

- No viewset uses the mixin or the middleware output yet. The middleware is a no-op for existing paths.

### Files touched

- `django/gregory/visibility.py` (new)
- `django/gregory/middleware/__init__.py` (new)
- `django/gregory/middleware/visibility.py` (new)
- `django/admin/settings.py` — register middleware
- `django/api/serializers/__init__.py` — export the mixin
- `django/api/serializers/mixins.py` (new)

### Tests

For `visible_org_ids`:

- Anonymous request, no `include_public` → public orgs only.
- Anonymous request with `include_public=true` → public orgs only (flag is a no-op).
- Authenticated user with no team membership → empty set without `include_public`, public orgs with it.
- Authenticated user with one team in org A (private) → {A} without `include_public`, {A} ∪ public orgs with it.
- API key bound to org X → {X} without `include_public`, {X} ∪ public orgs with it.
- API key with `organization=None` → empty set without `include_public`, public orgs with it.

For `OrgScopedSerializerMixin`:

- Article tagged across orgs A (visible) and B (hidden) → response includes the article, `teams` excludes B.
- Article whose subjects span visible and hidden orgs → hidden subjects stripped.
- ML predictions tied to a hidden subject → stripped.

### Risk and rollback

Low. Code is unused. Rollback = revert.

### Acceptance criteria

- All new unit tests pass.
- `request.visible_org_ids` is present on every request after middleware registration.
- No production endpoint changes behaviour.