### PR TITLE
PR 4 — Articles and Trials behind the flag

### DIFF
--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -275,7 +275,7 @@ class ArticleAuthorSerializer(serializers.ModelSerializer):
 	def get_full_name(self, obj):
 		return obj.full_name
 
-class ArticleSerializer(serializers.HyperlinkedModelSerializer):
+class ArticleSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSerializer):
 	sources = serializers.SlugRelatedField(many=True, read_only=True, slug_field='name')
 	team_categories = TeamCategorySerializer(many=True, read_only=True)
 	authors = ArticleAuthorSerializer(many=True, read_only=True)
@@ -302,7 +302,7 @@ class ArticleSerializer(serializers.HyperlinkedModelSerializer):
 		trials = [ref.trial for ref in references]
 		return TrialReferenceSerializer(trials, many=True).data
 
-class TrialSerializer(serializers.HyperlinkedModelSerializer):
+class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSerializer):
 	source = serializers.SlugRelatedField(read_only=True, slug_field='name')
 	team_categories = TeamCategorySerializer(many=True, read_only=True)
 	articles = serializers.SerializerMethodField()

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -27,11 +27,12 @@ Query strategy (avoiding N+1 on list endpoints)
   column.  Visible team IDs are resolved once per request and cached on
   ``request._org_scoped_mixin_team_ids`` so the query runs at most once per
   request regardless of list length.
-- ``ml_predictions``:  ``prediction.subject_id`` is a direct FK column.
-  Visible subject IDs are resolved once per request and cached on
-  ``request._org_scoped_mixin_subject_ids`` so the query runs at most once
-  per request regardless of list length.  Iterating ``.all()`` in Python
-  then respects any ``prefetch_related('ml_predictions_detail')`` cache.
+- ``ml_predictions``:  Each serialised item already contains a ``subject``
+  key (the FK integer) from ``MLPredictionsSerializer``.  Visible subject IDs
+  are resolved once per request and cached on
+  ``request._org_scoped_mixin_subject_ids``.  Filtering is done entirely on
+  ``ret['ml_predictions']`` — no extra DB query, no dependency on whether
+  ``ml_predictions_detail`` was prefetched.
 """
 
 
@@ -108,10 +109,13 @@ class OrgScopedSerializerMixin:
 			visible_cat_ids = {c.id for c in instance.team_categories.all() if c.team_id in vt}
 			ret['team_categories'] = [c for c in ret['team_categories'] if c.get('id') in visible_cat_ids]
 
-		# --- ml_predictions: iterate Python, uses prefetch_related cache ---
-		if 'ml_predictions' in ret and hasattr(instance, 'ml_predictions_detail'):
+		# --- ml_predictions: filter directly on already-serialised data ---
+		# Each item in ret['ml_predictions'] already has a 'subject' key (the FK
+		# integer) from MLPredictionsSerializer.  Filtering here avoids hitting
+		# instance.ml_predictions_detail.all() a second time, which would cause
+		# an extra per-object query when the relation is not prefetched.
+		if 'ml_predictions' in ret:
 			vs = _request_visible_subject_ids(request, visible)
-			visible_pred_ids = {p.id for p in instance.ml_predictions_detail.all() if p.subject_id in vs}
-			ret['ml_predictions'] = [p for p in ret['ml_predictions'] if p.get('id') in visible_pred_ids]
+			ret['ml_predictions'] = [p for p in ret['ml_predictions'] if p.get('subject') in vs]
 
 		return ret

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -28,8 +28,10 @@ Query strategy (avoiding N+1 on list endpoints)
   ``request._org_scoped_mixin_team_ids`` so the query runs at most once per
   request regardless of list length.
 - ``ml_predictions``:  ``prediction.subject_id`` is a direct FK column.
-  Visible subject IDs are built in Python from the already-iterated subjects
-  manager (uses prefetch cache when ``prefetch_related('subjects')`` is active).
+  Visible subject IDs are resolved once per request and cached on
+  ``request._org_scoped_mixin_subject_ids`` so the query runs at most once
+  per request regardless of list length.  Iterating ``.all()`` in Python
+  then respects any ``prefetch_related('ml_predictions_detail')`` cache.
 """
 
 
@@ -46,6 +48,24 @@ def _request_visible_team_ids(request, visible_org_ids: set) -> set:
 			request,
 			cache_attr,
 			set(Team.objects.filter(organization_id__in=visible_org_ids).values_list('id', flat=True)),
+		)
+	return getattr(request, cache_attr)
+
+
+def _request_visible_subject_ids(request, visible_org_ids: set) -> set:
+	"""Return all subject IDs belonging to visible orgs, cached once per request.
+
+	Caching avoids issuing a subject-lookup query for every object in a list
+	endpoint response (used when filtering ml_predictions in Python).
+	"""
+	cache_attr = '_org_scoped_mixin_subject_ids'
+	if not hasattr(request, cache_attr):
+		from gregory.models import Subject
+		vt = _request_visible_team_ids(request, visible_org_ids)
+		setattr(
+			request,
+			cache_attr,
+			set(Subject.objects.filter(team_id__in=vt).values_list('id', flat=True)),
 		)
 	return getattr(request, cache_attr)
 
@@ -88,17 +108,10 @@ class OrgScopedSerializerMixin:
 			visible_cat_ids = {c.id for c in instance.team_categories.all() if c.team_id in vt}
 			ret['team_categories'] = [c for c in ret['team_categories'] if c.get('id') in visible_cat_ids]
 
-		# --- ml_predictions: one-level join using cached visible team IDs ---
-		# (subject__team_id__in=vt is simpler than subject__team__organization_id__in=visible;
-		# a full zero-query solution requires prefetch_related('ml_predictions_detail__subject')
-		# with select_related('team'), which is a viewset concern.)
+		# --- ml_predictions: iterate Python, uses prefetch_related cache ---
 		if 'ml_predictions' in ret and hasattr(instance, 'ml_predictions_detail'):
-			vt = _request_visible_team_ids(request, visible)
-			visible_pred_ids = set(
-				instance.ml_predictions_detail.filter(
-					subject__team_id__in=vt
-				).values_list('id', flat=True)
-			)
+			vs = _request_visible_subject_ids(request, visible)
+			visible_pred_ids = {p.id for p in instance.ml_predictions_detail.all() if p.subject_id in vs}
 			ret['ml_predictions'] = [p for p in ret['ml_predictions'] if p.get('id') in visible_pred_ids]
 
 		return ret

--- a/django/api/tests/test_visibility_articles.py
+++ b/django/api/tests/test_visibility_articles.py
@@ -1,0 +1,330 @@
+"""
+Tests for article visibility enforcement (PR 4).
+
+Covers the four caller archetypes × the test matrix from the PR plan:
+  - Article in caller's org only
+  - Article in another public org only
+  - Article in another private org only
+  - Article spanning caller's org + a public org (listing + association stripping)
+  - Article spanning caller's org + a private org (listing + association stripping)
+  - Detail endpoint: all-hidden teams → 404
+  - ArticleSearchView: team_id of hidden team → 404
+  - Legacy endpoints: /teams/<id>/articles/ honours visibility
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_articles
+"""
+import json
+from datetime import date, timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import Articles, OrganizationApiSettings, Subject, Team
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_article(title, link, teams=(), subjects=()):
+	art = Articles.objects.create(title=title, link=link)
+	for t in teams:
+		art.teams.add(t)
+	for s in subjects:
+		art.subjects.add(s)
+	return art
+
+
+def _make_api_scheme(org, name):
+	"""Create a valid (not-expired) APIAccessScheme for the given org."""
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp shared across test classes
+# ---------------------------------------------------------------------------
+
+class ArticleVisibilityBase(TestCase):
+	def setUp(self):
+		# caller's org (private)
+		self.my_org = _make_org('My Org', 'my-org-art', public=False)
+		# another public org
+		self.pub_org = _make_org('Public Org', 'pub-org-art', public=True)
+		# another private org
+		self.priv_org = _make_org('Private Org', 'priv-org-art', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team')
+
+		self.my_subj = _make_subject(self.my_team, 'My Subject')
+		self.pub_subj = _make_subject(self.pub_team, 'Pub Subject')
+
+		# Article in my org only
+		self.art_mine = _make_article('Mine Only', 'https://ex.com/1', teams=[self.my_team])
+		# Article in public org only
+		self.art_pub = _make_article('Public Only', 'https://ex.com/2', teams=[self.pub_team])
+		# Article in private (hidden) org only
+		self.art_priv = _make_article('Private Only', 'https://ex.com/3', teams=[self.priv_team])
+		# Article spanning my org + public org
+		self.art_mine_pub = _make_article('Mine+Pub', 'https://ex.com/4', teams=[self.my_team, self.pub_team])
+		# Article spanning my org + hidden org
+		self.art_mine_priv = _make_article('Mine+Priv', 'https://ex.com/5', teams=[self.my_team, self.priv_team])
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousArticleVisibilityTest(ArticleVisibilityBase):
+	"""Anonymous request → only public orgs visible."""
+
+	def test_list_shows_public_article(self):
+		resp = self.client.get('/articles/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_pub.article_id, ids)
+
+	def test_list_excludes_private_article(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertNotIn(self.art_priv.article_id, ids)
+		self.assertNotIn(self.art_mine.article_id, ids)
+
+	def test_list_includes_cross_org_article_when_one_team_public(self):
+		"""art_mine_pub has pub_team → visible; art_mine_priv has no public team → not visible."""
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_mine_pub.article_id, ids)
+		self.assertNotIn(self.art_mine_priv.article_id, ids)
+
+	def test_cross_org_article_has_hidden_team_stripped(self):
+		"""art_mine_pub: my_team should be stripped (not public), pub_team visible."""
+		resp = self.client.get('/articles/')
+		self.assertEqual(resp.status_code, 200)
+		art = next(a for a in resp.data['results'] if a['article_id'] == self.art_mine_pub.article_id)
+		team_ids = [t['id'] for t in art['teams']]
+		self.assertIn(self.pub_team.id, team_ids)
+		self.assertNotIn(self.my_team.id, team_ids)
+
+	def test_detail_of_all_hidden_article_returns_404(self):
+		resp = self.client.get(f'/articles/{self.art_mine.article_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_of_public_article_returns_200(self):
+		resp = self.client.get(f'/articles/{self.art_pub.article_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_include_public_is_noop_for_anonymous(self):
+		"""include_public=true is a no-op for anonymous callers (already see public)."""
+		resp_plain = self.client.get('/articles/')
+		resp_flag = self.client.get('/articles/?include_public=true')
+		plain_ids = {a['article_id'] for a in resp_plain.data['results']}
+		flag_ids = {a['article_id'] for a in resp_flag.data['results']}
+		self.assertEqual(plain_ids, flag_ids)
+
+	def test_search_with_hidden_team_returns_404(self):
+		resp = self.client.get('/articles/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_search_with_public_team_returns_200(self):
+		resp = self.client.get('/articles/search/', {
+			'team_id': self.pub_team.id,
+			'subject_id': self.pub_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+	def test_legacy_team_endpoint_hidden_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/articles/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_legacy_team_endpoint_public_team_returns_200(self):
+		resp = self.client.get(f'/teams/{self.pub_team.id}/articles/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserArticleVisibilityTest(ArticleVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		# force_login creates a real Django session so VisibleOrgMiddleware
+		# sees the authenticated user (force_authenticate is DRF-only and
+		# runs after middleware, so the middleware would see an anonymous user).
+		self.client.force_login(self.user)
+
+	def test_list_shows_my_org_article(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_mine.article_id, ids)
+
+	def test_list_excludes_unrelated_private_article(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertNotIn(self.art_priv.article_id, ids)
+
+	def test_list_excludes_public_article_by_default(self):
+		"""Without include_public, only owned org is visible."""
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertNotIn(self.art_pub.article_id, ids)
+
+	def test_include_public_adds_public_articles(self):
+		resp = self.client.get('/articles/?include_public=true')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_mine.article_id, ids)
+		self.assertIn(self.art_pub.article_id, ids)
+		self.assertNotIn(self.art_priv.article_id, ids)
+
+	def test_detail_of_hidden_article_returns_404(self):
+		resp = self.client.get(f'/articles/{self.art_priv.article_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_of_own_article_returns_200(self):
+		resp = self.client.get(f'/articles/{self.art_mine.article_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_cross_org_article_has_hidden_team_stripped(self):
+		"""art_mine_priv: priv_team should be stripped from teams field."""
+		resp = self.client.get(f'/articles/{self.art_mine_priv.article_id}/')
+		self.assertEqual(resp.status_code, 200)
+		team_ids = [t['id'] for t in resp.data['teams']]
+		self.assertIn(self.my_team.id, team_ids)
+		self.assertNotIn(self.priv_team.id, team_ids)
+
+	def test_search_hidden_team_returns_404(self):
+		resp = self.client.get('/articles/search/', {
+			'team_id': self.priv_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_search_own_team_returns_200(self):
+		resp = self.client.get('/articles/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyArticleVisibilityTest(ArticleVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'my-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_my_org_article(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_mine.article_id, ids)
+
+	def test_list_excludes_other_private_article(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertNotIn(self.art_priv.article_id, ids)
+
+	def test_list_excludes_public_article_without_flag(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertNotIn(self.art_pub.article_id, ids)
+
+	def test_include_public_adds_public_articles(self):
+		resp = self.client.get('/articles/?include_public=true')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_mine.article_id, ids)
+		self.assertIn(self.art_pub.article_id, ids)
+		self.assertNotIn(self.art_priv.article_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/articles/{self.art_priv.article_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/articles/{self.art_mine.article_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_search_hidden_team_returns_404(self):
+		resp = self.client.get('/articles/search/', {
+			'team_id': self.pub_team.id,
+			'subject_id': self.pub_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_search_own_team_returns_200(self):
+		resp = self.client.get('/articles/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyArticleVisibilityTest(ArticleVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-key',
+			client_contacts='null@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_pub.article_id, ids)
+		self.assertNotIn(self.art_mine.article_id, ids)
+		self.assertNotIn(self.art_priv.article_id, ids)
+
+	def test_detail_of_private_article_returns_404(self):
+		resp = self.client.get(f'/articles/{self.art_mine.article_id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_articles.py
+++ b/django/api/tests/test_visibility_articles.py
@@ -14,8 +14,7 @@ Covers the four caller archetypes × the test matrix from the PR plan:
 Run with:
     docker exec gregory python manage.py test api.tests.test_visibility_articles
 """
-import json
-from datetime import date, timedelta
+from datetime import timedelta
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase

--- a/django/api/tests/test_visibility_articles.py
+++ b/django/api/tests/test_visibility_articles.py
@@ -327,3 +327,65 @@ class NullOrgAPIKeyArticleVisibilityTest(ArticleVisibilityBase):
 	def test_detail_of_private_article_returns_404(self):
 		resp = self.client.get(f'/articles/{self.art_mine.article_id}/')
 		self.assertEqual(resp.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
+# CSV export honours visibility rules
+# ---------------------------------------------------------------------------
+
+class CSVExportArticleVisibilityTest(ArticleVisibilityBase):
+	"""CSV responses from /articles/?format=csv must respect the same visibility rules."""
+
+	def _csv_titles(self, response):
+		"""Return the set of article titles found in a CSV StreamingHttpResponse."""
+		content = b''.join(response.streaming_content).decode()
+		# Title is the second column in the CSV; skip the header row.
+		titles = set()
+		for line in content.splitlines()[1:]:
+			if line.strip():
+				# Split on comma but handle quoted fields minimally.
+				titles.add(line.split(',')[1].strip('"'))
+		return titles
+
+	def test_anonymous_csv_shows_only_public_articles(self):
+		resp = self.client.get('/articles/?format=csv&all_results=true')
+		self.assertIn(resp.status_code, (200, 206))
+		titles = self._csv_titles(resp)
+		self.assertIn('Public Only', titles)
+		self.assertNotIn('Mine Only', titles)
+		self.assertNotIn('Private Only', titles)
+
+	def test_api_key_csv_shows_own_org_articles(self):
+		from api.models import APIAccessScheme
+		scheme = APIAccessScheme.objects.create(
+			client_name='csv-key',
+			client_contacts='csv@example.com',
+			organization=self.my_org,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=scheme.api_key)
+		resp = self.client.get('/articles/?format=csv&all_results=true')
+		self.assertIn(resp.status_code, (200, 206))
+		titles = self._csv_titles(resp)
+		self.assertIn('Mine Only', titles)
+		self.assertNotIn('Private Only', titles)
+
+	def test_api_key_csv_with_include_public_adds_public_articles(self):
+		from api.models import APIAccessScheme
+		scheme = APIAccessScheme.objects.create(
+			client_name='csv-key-pub',
+			client_contacts='csvpub@example.com',
+			organization=self.my_org,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=scheme.api_key)
+		resp = self.client.get('/articles/?format=csv&all_results=true&include_public=true')
+		self.assertIn(resp.status_code, (200, 206))
+		titles = self._csv_titles(resp)
+		self.assertIn('Mine Only', titles)
+		self.assertIn('Public Only', titles)
+		self.assertNotIn('Private Only', titles)

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -170,7 +170,7 @@ class AuthenticatedUserTrialVisibilityTest(TrialVisibilityBase):
 		ids = [t['trial_id'] for t in resp.data['results']]
 		self.assertNotIn(self.trial_pub.trial_id, ids)
 
-	def test_include_public_adds_public_trials:
+	def test_include_public_adds_public_trials(self):
 		resp = self.client.get('/trials/?include_public=true')
 		ids = [t['trial_id'] for t in resp.data['results']]
 		self.assertIn(self.trial_mine.trial_id, ids)

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -1,0 +1,236 @@
+"""
+Tests for trial visibility enforcement (PR 4).
+
+Mirrors the article visibility test matrix for clinical trials.
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_trials
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import OrganizationApiSettings, Subject, Team, Trials
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Helpers (duplicated from article tests to keep test files self-contained)
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_trial(title, link, teams=(), subjects=()):
+	trial = Trials.objects.create(title=title, link=link)
+	for t in teams:
+		trial.teams.add(t)
+	for s in subjects:
+		trial.subjects.add(s)
+	return trial
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base
+# ---------------------------------------------------------------------------
+
+class TrialVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org T', 'my-org-t', public=False)
+		self.pub_org = _make_org('Public Org T', 'pub-org-t', public=True)
+		self.priv_org = _make_org('Private Org T', 'priv-org-t', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team T')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team T')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team T')
+
+		self.my_subj = _make_subject(self.my_team, 'My Subject T')
+		self.pub_subj = _make_subject(self.pub_team, 'Pub Subject T')
+
+		self.trial_mine = _make_trial('Mine Only', 'https://trial.com/1', teams=[self.my_team])
+		self.trial_pub = _make_trial('Public Only', 'https://trial.com/2', teams=[self.pub_team])
+		self.trial_priv = _make_trial('Private Only', 'https://trial.com/3', teams=[self.priv_team])
+		self.trial_mine_pub = _make_trial('Mine+Pub', 'https://trial.com/4', teams=[self.my_team, self.pub_team])
+		self.trial_mine_priv = _make_trial('Mine+Priv', 'https://trial.com/5', teams=[self.my_team, self.priv_team])
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous
+# ---------------------------------------------------------------------------
+
+class AnonymousTrialVisibilityTest(TrialVisibilityBase):
+	def test_list_shows_public_trial(self):
+		resp = self.client.get('/trials/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_pub.trial_id, ids)
+
+	def test_list_excludes_private_trial(self):
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertNotIn(self.trial_priv.trial_id, ids)
+		self.assertNotIn(self.trial_mine.trial_id, ids)
+
+	def test_list_includes_cross_org_trial_when_one_team_public(self):
+		"""trial_mine_pub has pub_team → visible; trial_mine_priv has no public team → not visible."""
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_mine_pub.trial_id, ids)
+		self.assertNotIn(self.trial_mine_priv.trial_id, ids)
+
+	def test_detail_of_all_hidden_trial_returns_404(self):
+		resp = self.client.get(f'/trials/{self.trial_mine.trial_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_of_public_trial_returns_200(self):
+		resp = self.client.get(f'/trials/{self.trial_pub.trial_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_search_with_hidden_team_returns_404(self):
+		resp = self.client.get('/trials/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_search_with_public_team_returns_200(self):
+		resp = self.client.get('/trials/search/', {
+			'team_id': self.pub_team.id,
+			'subject_id': self.pub_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserTrialVisibilityTest(TrialVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='member-t', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		# force_login creates a real Django session so VisibleOrgMiddleware
+		# sees the authenticated user.
+		self.client.force_login(self.user)
+
+	def test_list_shows_my_org_trial(self):
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_mine.trial_id, ids)
+
+	def test_list_excludes_unrelated_private_trial(self):
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertNotIn(self.trial_priv.trial_id, ids)
+
+	def test_include_public_adds_public_trials(self):
+		resp = self.client.get('/trials/?include_public=true')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_mine.trial_id, ids)
+		self.assertIn(self.trial_pub.trial_id, ids)
+		self.assertNotIn(self.trial_priv.trial_id, ids)
+
+	def test_detail_of_hidden_trial_returns_404(self):
+		resp = self.client.get(f'/trials/{self.trial_priv.trial_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_of_own_trial_returns_200(self):
+		resp = self.client.get(f'/trials/{self.trial_mine.trial_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_search_hidden_team_returns_404(self):
+		resp = self.client.get('/trials/search/', {
+			'team_id': self.priv_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_search_own_team_returns_200(self):
+		resp = self.client.get('/trials/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# API key (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyTrialVisibilityTest(TrialVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'my-key-t')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_my_org_trial(self):
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_mine.trial_id, ids)
+
+	def test_list_excludes_other_private_trial(self):
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertNotIn(self.trial_priv.trial_id, ids)
+
+	def test_include_public_adds_public_trials(self):
+		resp = self.client.get('/trials/?include_public=true')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_mine.trial_id, ids)
+		self.assertIn(self.trial_pub.trial_id, ids)
+		self.assertNotIn(self.trial_priv.trial_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/trials/{self.trial_priv.trial_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/trials/{self.trial_mine.trial_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_search_hidden_team_returns_404(self):
+		resp = self.client.get('/trials/search/', {
+			'team_id': self.pub_team.id,
+			'subject_id': self.pub_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_search_own_team_returns_200(self):
+		resp = self.client.get('/trials/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -298,7 +298,7 @@ class NullOrgAPIKeyTrialVisibilityTest(TrialVisibilityBase):
 # ---------------------------------------------------------------------------
 
 class CSVExportTrialVisibilityTest(TrialVisibilityBase):
-	"""CSV responses from /trials/?format=csv must respect the same visibility rules.\""""
+	"""CSV responses from /trials/?format=csv must respect the same visibility rules."""
 
 	def _csv_titles(self, response):
 		"""Return the set of trial titles found in a CSV StreamingHttpResponse.\""""

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -285,7 +285,7 @@ class NullOrgAPIKeyTrialVisibilityTest(TrialVisibilityBase):
 		self.assertEqual(resp.status_code, 404)
 
 	def test_include_public_is_noop(self):
-		"""Null-org key already behaves like anonymous; include_public changes nothing.\""""
+		"""Null-org key already behaves like anonymous; include_public changes nothing."""
 		resp_plain = self.client.get('/trials/')
 		resp_flag = self.client.get('/trials/?include_public=true')
 		plain_ids = {t['trial_id'] for t in resp_plain.data['results']}

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -236,7 +236,7 @@ class APIKeyTrialVisibilityTest(TrialVisibilityBase):
 		self.assertEqual(resp.status_code, 200)
 
 	def test_list_excludes_public_trial_without_flag(self):
-		"""Without include_public, API key sees only its own org.\""""
+		"""Without include_public, API key sees only its own org."""
 		resp = self.client.get('/trials/')
 		ids = [t['trial_id'] for t in resp.data['results']]
 		self.assertNotIn(self.trial_pub.trial_id, ids)

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -132,6 +132,14 @@ class AnonymousTrialVisibilityTest(TrialVisibilityBase):
 		})
 		self.assertEqual(resp.status_code, 200)
 
+	def test_include_public_is_noop_for_anonymous(self):
+		"""include_public=true is a no-op for anonymous callers (already see public only)."""
+		resp_plain = self.client.get('/trials/')
+		resp_flag = self.client.get('/trials/?include_public=true')
+		plain_ids = {t['trial_id'] for t in resp_plain.data['results']}
+		flag_ids = {t['trial_id'] for t in resp_flag.data['results']}
+		self.assertEqual(plain_ids, flag_ids)
+
 
 # ---------------------------------------------------------------------------
 # Authenticated user (member of my_org)
@@ -156,7 +164,13 @@ class AuthenticatedUserTrialVisibilityTest(TrialVisibilityBase):
 		ids = [t['trial_id'] for t in resp.data['results']]
 		self.assertNotIn(self.trial_priv.trial_id, ids)
 
-	def test_include_public_adds_public_trials(self):
+	def test_list_excludes_public_trial_by_default(self):
+		"""Without include_public, only the owned org is visible."""
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertNotIn(self.trial_pub.trial_id, ids)
+
+	def test_include_public_adds_public_trials:
 		resp = self.client.get('/trials/?include_public=true')
 		ids = [t['trial_id'] for t in resp.data['results']]
 		self.assertIn(self.trial_mine.trial_id, ids)
@@ -221,6 +235,12 @@ class APIKeyTrialVisibilityTest(TrialVisibilityBase):
 		resp = self.client.get(f'/trials/{self.trial_mine.trial_id}/')
 		self.assertEqual(resp.status_code, 200)
 
+	def test_list_excludes_public_trial_without_flag(self):
+		"""Without include_public, API key sees only its own org.\""""
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertNotIn(self.trial_pub.trial_id, ids)
+
 	def test_search_hidden_team_returns_404(self):
 		resp = self.client.get('/trials/search/', {
 			'team_id': self.pub_team.id,
@@ -234,3 +254,84 @@ class APIKeyTrialVisibilityTest(TrialVisibilityBase):
 			'subject_id': self.my_subj.id,
 		})
 		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyTrialVisibilityTest(TrialVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-key-t',
+			client_contacts='null-t@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public(self):
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_pub.trial_id, ids)
+		self.assertNotIn(self.trial_mine.trial_id, ids)
+		self.assertNotIn(self.trial_priv.trial_id, ids)
+
+	def test_detail_of_private_trial_returns_404(self):
+		resp = self.client.get(f'/trials/{self.trial_mine.trial_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_include_public_is_noop(self):
+		"""Null-org key already behaves like anonymous; include_public changes nothing.\""""
+		resp_plain = self.client.get('/trials/')
+		resp_flag = self.client.get('/trials/?include_public=true')
+		plain_ids = {t['trial_id'] for t in resp_plain.data['results']}
+		flag_ids = {t['trial_id'] for t in resp_flag.data['results']}
+		self.assertEqual(plain_ids, flag_ids)
+
+
+# ---------------------------------------------------------------------------
+# CSV export honours visibility rules
+# ---------------------------------------------------------------------------
+
+class CSVExportTrialVisibilityTest(TrialVisibilityBase):
+	"""CSV responses from /trials/?format=csv must respect the same visibility rules.\""""
+
+	def _csv_titles(self, response):
+		"""Return the set of trial titles found in a CSV StreamingHttpResponse.\""""
+		content = b''.join(response.streaming_content).decode()
+		titles = set()
+		for line in content.splitlines()[1:]:
+			if line.strip():
+				titles.add(line.split(',')[1].strip('"'))
+		return titles
+
+	def test_anonymous_csv_shows_only_public_trials(self):
+		resp = self.client.get('/trials/?format=csv&all_results=true')
+		self.assertIn(resp.status_code, (200, 206))
+		titles = self._csv_titles(resp)
+		self.assertIn('Public Only', titles)
+		self.assertNotIn('Mine Only', titles)
+		self.assertNotIn('Private Only', titles)
+
+	def test_api_key_csv_shows_own_org_trials(self):
+		scheme = _make_api_scheme(self.my_org, 'csv-key-t')
+		self.client.credentials(HTTP_AUTHORIZATION=scheme.api_key)
+		resp = self.client.get('/trials/?format=csv&all_results=true')
+		self.assertIn(resp.status_code, (200, 206))
+		titles = self._csv_titles(resp)
+		self.assertIn('Mine Only', titles)
+		self.assertNotIn('Private Only', titles)
+
+	def test_api_key_csv_with_include_public_adds_public_trials(self):
+		scheme = _make_api_scheme(self.my_org, 'csv-key-pub-t')
+		self.client.credentials(HTTP_AUTHORIZATION=scheme.api_key)
+		resp = self.client.get('/trials/?format=csv&all_results=true&include_public=true')
+		self.assertIn(resp.status_code, (200, 206))
+		titles = self._csv_titles(resp)
+		self.assertIn('Mine Only', titles)
+		self.assertIn('Public Only', titles)
+		self.assertNotIn('Private Only', titles)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1244,6 +1244,13 @@ class ArticleSearchView(generics.ListAPIView):
         if not team_id or not subject_id:
             return Articles.objects.none()
 
+        # Cast to int early — non-numeric values get a 404 rather than a 500.
+        try:
+            team_id = int(team_id)
+            subject_id = int(subject_id)
+        except (TypeError, ValueError):
+            raise Http404
+
         # Visibility check: hidden teams return 404 (before the broad except block)
         if hasattr(self.request, 'visible_org_ids'):
             if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
@@ -1399,6 +1406,13 @@ class TrialSearchView(generics.ListAPIView):
         # Validate required parameters
         if not team_id or not subject_id:
             return Trials.objects.none()
+
+        # Cast to int early — non-numeric values get a 404 rather than a 500.
+        try:
+            team_id = int(team_id)
+            subject_id = int(subject_id)
+        except (TypeError, ValueError):
+            raise Http404
 
         # Visibility check: hidden teams return 404 (before the broad except block)
         if hasattr(self.request, 'visible_org_ids'):

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1310,7 +1310,13 @@ class ArticleSearchView(generics.ListAPIView):
                 {"error": "Missing required parameters: team_id, subject_id"}, 
                 status=400
             )
-            
+
+        try:
+            team_id = int(team_id)
+            subject_id = int(subject_id)
+        except (TypeError, ValueError):
+            return Response({"error": "team_id and subject_id must be integers"}, status=400)
+
         try:
             # Check if team and subject exist
             Team.objects.get(id=team_id)
@@ -1339,7 +1345,13 @@ class ArticleSearchView(generics.ListAPIView):
                 {"error": "Missing required parameters: team_id, subject_id"}, 
                 status=400
             )
-            
+
+        try:
+            team_id = int(team_id)
+            subject_id = int(subject_id)
+        except (TypeError, ValueError):
+            return Response({"error": "team_id and subject_id must be integers"}, status=400)
+
         try:
             # Check if team and subject exist
             Team.objects.get(id=team_id)
@@ -1477,7 +1489,13 @@ class TrialSearchView(generics.ListAPIView):
                 {"error": "Missing required parameters: team_id, subject_id"}, 
                 status=400
             )
-            
+
+        try:
+            team_id = int(team_id)
+            subject_id = int(subject_id)
+        except (TypeError, ValueError):
+            return Response({"error": "team_id and subject_id must be integers"}, status=400)
+
         try:
             # Check if team and subject exist
             Team.objects.get(id=team_id)
@@ -1506,7 +1524,13 @@ class TrialSearchView(generics.ListAPIView):
                 {"error": "Missing required parameters: team_id, subject_id"}, 
                 status=400
             )
-            
+
+        try:
+            team_id = int(team_id)
+            subject_id = int(subject_id)
+        except (TypeError, ValueError):
+            return Response({"error": "team_id and subject_id must be integers"}, status=400)
+
         try:
             # Check if team and subject exist
             Team.objects.get(id=team_id)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -14,7 +14,7 @@ from rest_framework.decorators import api_view, action
 from django_filters import rest_framework as django_filters
 from api.filters import ArticleFilter, TrialFilter, AuthorFilter, SourceFilter, CategoryFilter, SubjectFilter
 from rest_framework.response import Response
-from django.http import StreamingHttpResponse
+from django.http import Http404, StreamingHttpResponse
 from rest_framework.views import APIView
 from rest_framework_simplejwt.views import TokenObtainPairView
 import json
@@ -32,6 +32,24 @@ from api.utils.responses import (
 		ACCESS_DENIED, INVALID_API_KEY, INVALID_IP_ADDRESS, NO_API_KEY,
 		UNEXPECTED, SOURCE_NOT_FOUND, FIELD_NOT_FOUND, ARTICLE_EXISTS, ARTICLE_NOT_SAVED, returnData, returnError
 )
+
+class OrgVisibilityMixin:
+	"""
+	Viewset mixin that scopes the queryset to organisations the caller can see.
+
+	Uses ``request.visible_org_ids`` (set by ``VisibleOrgMiddleware``).  Falls
+	back to the full queryset when the attribute is absent so tests and
+	management commands that bypass middleware are not broken.
+
+	Articles and Trials link to organisations via the ``teams`` M2M relation.
+	"""
+
+	def get_queryset(self):
+		qs = super().get_queryset()
+		if not hasattr(self.request, 'visible_org_ids'):
+			return qs
+		return qs.filter(teams__organization_id__in=self.request.visible_org_ids).distinct()
+
 
 def add_deprecation_headers(response, deprecated_endpoint, replacement_endpoint, message=None):
 	"""
@@ -224,7 +242,7 @@ def post_article(request):
 ###
 # ARTICLES
 ### 
-class ArticleViewSet(viewsets.ModelViewSet):
+class ArticleViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	List all articles in the database with comprehensive filtering options.
 	CSV responses are automatically streamed for better performance with large datasets.
@@ -589,7 +607,7 @@ class CategoryViewSet(viewsets.ModelViewSet):
 # TRIALS
 ### 
 
-class TrialViewSet(viewsets.ModelViewSet):
+class TrialViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	List all clinical trials by discovery date with comprehensive filtering options.
 	CSV responses are automatically streamed for better performance with large datasets.
@@ -1031,6 +1049,9 @@ class ArticlesByTeam(viewsets.ModelViewSet):
 
 	def get_queryset(self):
 		team_id = self.kwargs.get('team_id')
+		if hasattr(self.request, 'visible_org_ids'):
+			if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+				raise Http404
 		return Articles.objects.filter(teams__id=team_id).order_by('-discovery_date')
 	
 	def list(self, request, *args, **kwargs):
@@ -1073,6 +1094,9 @@ class ArticlesBySubject(viewsets.ModelViewSet):
 	def get_queryset(self):
 		team_id = self.kwargs.get('team_id')
 		subject_id = self.kwargs.get('subject_id')
+		if hasattr(self.request, 'visible_org_ids'):
+			if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+				raise Http404
 		return Articles.objects.filter(subjects__id=subject_id, teams=team_id).order_by('-discovery_date')
 	
 	def list(self, request, *args, **kwargs):
@@ -1155,6 +1179,9 @@ class ArticlesByCategoryAndTeam(viewsets.ModelViewSet):
 		def get_queryset(self):
 				team_id = self.kwargs.get('team_id')
 				category_slug = self.kwargs.get('category_slug')
+				if hasattr(self.request, 'visible_org_ids'):
+						if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+								raise Http404
 				team_category = get_object_or_404(TeamCategory, team__id=team_id, category_slug=category_slug)
 				return Articles.objects.filter(team_categories=team_category).prefetch_related(
 						'team_categories', 'sources', 'authors', 'teams', 'subjects', 'ml_predictions'
@@ -1216,7 +1243,12 @@ class ArticleSearchView(generics.ListAPIView):
         # Validate required parameters
         if not team_id or not subject_id:
             return Articles.objects.none()
-        
+
+        # Visibility check: hidden teams return 404 (before the broad except block)
+        if hasattr(self.request, 'visible_org_ids'):
+            if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+                raise Http404
+
         try:
             # Start with articles filtered by team and subject
             # Remove distinct constraint to allow proper ordering
@@ -1367,7 +1399,12 @@ class TrialSearchView(generics.ListAPIView):
         # Validate required parameters
         if not team_id or not subject_id:
             return Trials.objects.none()
-            
+
+        # Visibility check: hidden teams return 404 (before the broad except block)
+        if hasattr(self.request, 'visible_org_ids'):
+            if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+                raise Http404
+
         try:
             # Check if team and subject exist
             team = Team.objects.get(id=team_id)

--- a/django/gregory/signals.py
+++ b/django/gregory/signals.py
@@ -1,6 +1,7 @@
 from simple_history.signals import post_create_historical_record
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from organizations.models import Organization
 
 MAX_AUTHOR_HISTORY = 5
 
@@ -15,7 +16,7 @@ def trim_author_history(sender, instance, history_instance, **kwargs):
 	instance.history.exclude(pk__in=keep_ids).delete()
 
 
-@receiver(post_save, sender='organizations.Organization')
+@receiver(post_save, sender=Organization)
 def create_organization_api_settings(sender, instance, created, **kwargs):
 	"""Create an OrganizationApiSettings row for every newly created Organisation."""
 	if created:

--- a/django/gregory/visibility.py
+++ b/django/gregory/visibility.py
@@ -33,13 +33,19 @@ def _resolve_api_scheme(request):
 	Deliberately does NOT run quota-counting queries — those remain in the
 	actual API views.  This avoids doubling up on DB work for every request.
 
-	Returns the scheme object on success, None on any failure.  Never raises.
+	Returns the scheme object on success, None when no key is present or the
+	key is invalid/expired/IP-blocked.  Re-raises unexpected exceptions.
 	"""
+	# Fast-path: skip entirely when no Authorization header is present.
+	# This avoids any exception overhead for ordinary anonymous/session requests.
+	api_key = request.headers.get('Authorization', '').strip()
+	if not api_key:
+		return None
+
 	try:
-		from api.utils.utils import getAPIKey, getIPAddress
 		from api.models import APIAccessScheme
+		from api.utils.utils import getIPAddress
 		from django.utils.timezone import now as tz_now
-		api_key = getAPIKey(request)
 		ip_addr = getIPAddress(request)
 		current_time = tz_now()
 		scheme = APIAccessScheme.objects.filter(
@@ -56,7 +62,11 @@ def _resolve_api_scheme(request):
 				return None
 		return scheme
 	except Exception:
-		return None
+		# Unexpected DB or import errors should not silently grant/deny access.
+		# Log and re-raise so they surface in Sentry / server logs.
+		import logging
+		logging.getLogger(__name__).exception('Unexpected error in _resolve_api_scheme')
+		raise
 
 
 def visible_org_ids(request) -> set[int]:


### PR DESCRIPTION
### Goal

First user-visible enforcement. The two largest viewsets adopt the privacy layer.

### Scope

In:

- `OrgVisibilityMixin` (viewset-level filter) added to `ArticleViewSet`, `ArticleSearchView`, `ArticlesByTeam`, `ArticlesBySubject`, `ArticlesByCategoryAndTeam`, `TrialViewSet`, `TrialSearchView`.
- All those viewsets adopt `OrgScopedSerializerMixin` for serialization.
- Detail endpoints return 404 for hidden articles/trials.
- Search endpoints with `team_id` for a hidden team return 404.
- `?include_public=true` honoured.

Out:

- Authors, subjects, categories, sources, teams, organisations endpoints (PR 5).
- Stats, RSS (PR 6).
- `post_article` enforcement (PR 7).

### Files touched

- `django/api/views.py` — viewsets listed above
- `django/api/optimized_views.py` — same viewsets where applicable
- `django/api/direct_streaming.py` — CSV streaming variants
- `django/api/serializers.py` — apply `OrgScopedSerializerMixin`
- `django/api/tests/test_visibility_articles.py` (new)
- `django/api/tests/test_visibility_trials.py` (new)

### Tests

For each of the four caller archetypes (anonymous, authed-member, API-key, each with and without `include_public=true`), assert behaviour against:

- Article tagged in caller's org only.
- Article tagged in another public org only.
- Article tagged in another private org only.
- Article tagged across caller's org and another public org (assert listing + stripping).
- Article tagged across caller's org and another private org (assert listing + stripping).
- Detail endpoint for an article all of whose teams are hidden → 404.
- Search with `team_id` of a hidden team → 404.
- CSV export honours the same rules.

Same matrix for trials.

### Risk and rollback

Medium. This is the first PR that changes behaviour for live consumers. Mitigations:

- Existing orgs are all `make_api_public=True` after PR 1, so anonymous behaviour is unchanged for production data.
- The breaking change kicks in only when an operator flips an org to `False`.

Rollback = revert the viewset changes (the model and helper from PRs 1–3 are inert without them).

### Acceptance criteria

- New test matrix passes.
- Pre-existing API integration tests pass with no changes (default-open backfill ensures this).
- `gregory-ms.com` and `api.gregory-ms.com` integration smoke test (manual or scripted) returns the same data.

