### PR TITLE
implement PR 5 in the api visibility plan

### DIFF
--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -25,7 +25,7 @@ from api.views import (
 	post_article, CategoryViewSet, LoginView, ProtectedEndpointView,
 	ArticlesByTeam, ArticlesBySubject, TeamsViewSet, SubjectsViewSet, SubjectsByTeam,
     ArticlesByCategoryAndTeam, ArticleSearchView, TrialSearchView, AuthorSearchView, CategoriesByTeamAndSubject,
-    StatsView
+    StatsView, OrganizationsViewSet
 )
 from rss.views import	ArticlesByAuthorFeed, TrialsBySubjectFeed
 from subscriptions.views import subscribe_view, unsubscribe_list, unsubscribe_site, unsubscribe_all
@@ -45,6 +45,7 @@ router = routers.DefaultRouter()
 router.register(r'articles', ArticleViewSet)
 router.register(r'authors', AuthorsViewSet, basename='authors')
 router.register(r'categories', CategoryViewSet, basename='categories')
+router.register(r'organizations', OrganizationsViewSet, basename='organizations')
 router.register(r'sources', SourceViewSet)
 router.register(r'trials', TrialViewSet)
 router.register(r'subjects', SubjectsViewSet)

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -349,6 +349,10 @@ class AuthorSerializer(serializers.ModelSerializer):
 		# If the queryset has annotated article_count, use it for efficiency
 		if hasattr(obj, 'article_count'):
 			return obj.article_count
+		# Filter by visible orgs when request context is available
+		request = self.context.get('request')
+		if request is not None and hasattr(request, 'visible_org_ids'):
+			return obj.articles_set.filter(teams__organization_id__in=request.visible_org_ids).distinct().count()
 		# Fallback to counting all articles
 		return obj.articles_set.count()
 
@@ -392,3 +396,10 @@ class ArticlesByCategoryAndTeamSerializer(serializers.ModelSerializer):
 	class Meta:
 		model = TeamCategory
 		fields = ['id', 'team', 'category', 'articles']
+
+
+class OrganizationSerializer(serializers.ModelSerializer):
+	"""Minimal serializer for the Organizations list/detail endpoints."""
+	class Meta:
+		model = Organization
+		fields = ['id', 'name', 'slug', 'is_active']

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -346,14 +346,17 @@ class AuthorSerializer(serializers.ModelSerializer):
 		fields = ['author_id', 'given_name', 'family_name', 'full_name', 'ORCID', 'country', 'articles_count', 'articles_list']
 
 	def get_articles_count(self, obj):
-		# If the queryset has annotated article_count, use it for efficiency
+		request = self.context.get('request')
+		# When org-visibility is active, always compute the scoped count so the
+		# value is correct even if an un-scoped article_count was annotated by
+		# an earlier queryset stage (e.g. a cached queryset without visibility).
+		if request is not None and hasattr(request, 'visible_org_ids'):
+			return obj.articles_set.filter(
+				teams__organization_id__in=request.visible_org_ids
+			).distinct().count()
+		# No visibility active — use the pre-annotated count for efficiency.
 		if hasattr(obj, 'article_count'):
 			return obj.article_count
-		# Filter by visible orgs when request context is available
-		request = self.context.get('request')
-		if request is not None and hasattr(request, 'visible_org_ids'):
-			return obj.articles_set.filter(teams__organization_id__in=request.visible_org_ids).distinct().count()
-		# Fallback to counting all articles
 		return obj.articles_set.count()
 
 	def get_country(self, obj):

--- a/django/api/tests/test_visibility_authors.py
+++ b/django/api/tests/test_visibility_authors.py
@@ -1,0 +1,311 @@
+"""
+Tests for author visibility enforcement (PR 5).
+
+Covers:
+  - Authors list: only authors with at least one article in a visible org
+  - articles_count reflects only visible articles
+  - Detail endpoint 404s when author has no visible articles
+  - Author search: team_id of hidden team returns 404
+  - Four caller archetypes × the standard test matrix
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_authors
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import Articles, Authors, OrganizationApiSettings, Subject, Team
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_author(given, family):
+	full = f'{given} {family}'
+	return Authors.objects.create(
+		given_name=given,
+		family_name=family,
+		full_name=full,
+	)
+
+
+def _make_article(title, link, teams=(), subjects=(), authors=()):
+	art = Articles.objects.create(title=title, link=link)
+	for t in teams:
+		art.teams.add(t)
+	for s in subjects:
+		art.subjects.add(s)
+	for a in authors:
+		art.authors.add(a)
+	return art
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class AuthorVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org', 'my-org-auth', public=False)
+		self.pub_org = _make_org('Public Org', 'pub-org-auth', public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-auth', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team Auth')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team Auth')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team Auth')
+
+		self.my_subj = _make_subject(self.my_team, 'My Subject Auth')
+		self.pub_subj = _make_subject(self.pub_team, 'Pub Subject Auth')
+
+		# Authors
+		self.author_mine = _make_author('Alice', 'Mine')
+		self.author_pub = _make_author('Bob', 'Public')
+		self.author_priv = _make_author('Carol', 'Private')
+		self.author_cross = _make_author('Dave', 'Cross')  # articles in my + priv org
+
+		# Articles
+		_make_article('Mine Art', 'https://ex.com/a1', teams=[self.my_team], authors=[self.author_mine])
+		_make_article('Pub Art', 'https://ex.com/a2', teams=[self.pub_team], authors=[self.author_pub])
+		_make_article('Priv Art', 'https://ex.com/a3', teams=[self.priv_team], authors=[self.author_priv])
+		# author_cross has articles in both my_team and priv_team
+		_make_article('Cross Mine Art', 'https://ex.com/a4', teams=[self.my_team], authors=[self.author_cross])
+		_make_article('Cross Priv Art', 'https://ex.com/a5', teams=[self.priv_team], authors=[self.author_cross])
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousAuthorVisibilityTest(AuthorVisibilityBase):
+	"""Anonymous → only public org data visible."""
+
+	def test_list_includes_public_author(self):
+		resp = self.client.get('/authors/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_pub.author_id, ids)
+
+	def test_list_excludes_private_authors(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertNotIn(self.author_mine.author_id, ids)
+		self.assertNotIn(self.author_priv.author_id, ids)
+
+	def test_list_excludes_cross_org_author_with_no_public_article(self):
+		"""author_cross has mine+priv articles, neither is public → not listed."""
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertNotIn(self.author_cross.author_id, ids)
+
+	def test_detail_of_hidden_author_returns_404(self):
+		resp = self.client.get(f'/authors/{self.author_mine.author_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_of_public_author_returns_200(self):
+		resp = self.client.get(f'/authors/{self.author_pub.author_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_author_search_hidden_team_returns_404(self):
+		resp = self.client.get('/authors/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_author_search_public_team_returns_200(self):
+		resp = self.client.get('/authors/search/', {
+			'team_id': self.pub_team.id,
+			'subject_id': self.pub_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserAuthorVisibilityTest(AuthorVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='author-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_list_shows_own_org_author(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_mine.author_id, ids)
+
+	def test_list_excludes_unrelated_private_author(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertNotIn(self.author_priv.author_id, ids)
+
+	def test_list_excludes_public_author_without_flag(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertNotIn(self.author_pub.author_id, ids)
+
+	def test_list_includes_cross_org_author_when_has_own_article(self):
+		"""author_cross has article in my_team → visible."""
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_cross.author_id, ids)
+
+	def test_include_public_adds_public_authors(self):
+		resp = self.client.get('/authors/?include_public=true')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_mine.author_id, ids)
+		self.assertIn(self.author_pub.author_id, ids)
+		self.assertNotIn(self.author_priv.author_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/authors/{self.author_priv.author_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/authors/{self.author_mine.author_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_articles_count_excludes_hidden_org_articles(self):
+		"""author_cross: articles_count must count only the article in my_team."""
+		resp = self.client.get(f'/authors/{self.author_cross.author_id}/')
+		self.assertEqual(resp.status_code, 200)
+		# author_cross has 1 visible article (in my_team) and 1 hidden (in priv_team)
+		self.assertEqual(resp.data['articles_count'], 1)
+
+	def test_author_search_hidden_team_returns_404(self):
+		resp = self.client.get('/authors/search/', {
+			'team_id': self.priv_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_author_search_own_team_returns_200(self):
+		resp = self.client.get('/authors/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyAuthorVisibilityTest(AuthorVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'author-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_own_org_author(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_mine.author_id, ids)
+
+	def test_list_excludes_private_author(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertNotIn(self.author_priv.author_id, ids)
+
+	def test_list_excludes_public_author_without_flag(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertNotIn(self.author_pub.author_id, ids)
+
+	def test_include_public_adds_public_authors(self):
+		resp = self.client.get('/authors/?include_public=true')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_mine.author_id, ids)
+		self.assertIn(self.author_pub.author_id, ids)
+		self.assertNotIn(self.author_priv.author_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/authors/{self.author_priv.author_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/authors/{self.author_mine.author_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_author_search_hidden_team_returns_404(self):
+		resp = self.client.get('/authors/search/', {
+			'team_id': self.pub_team.id,
+			'subject_id': self.pub_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_author_search_own_team_returns_200(self):
+		resp = self.client.get('/authors/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyAuthorVisibilityTest(AuthorVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-author-key',
+			client_contacts='null-author@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public_authors(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_pub.author_id, ids)
+		self.assertNotIn(self.author_mine.author_id, ids)
+		self.assertNotIn(self.author_priv.author_id, ids)
+
+	def test_detail_of_private_author_returns_404(self):
+		resp = self.client.get(f'/authors/{self.author_mine.author_id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_categories.py
+++ b/django/api/tests/test_visibility_categories.py
@@ -1,0 +1,240 @@
+"""
+Tests for category (TeamCategory) visibility enforcement (PR 5).
+
+Covers:
+  - CategoryViewSet list/detail: only categories whose team.org is visible
+  - Detail endpoint 404s when category belongs to a hidden org
+  - CategoriesByTeamAndSubject: hidden parent team → 404
+  - Four caller archetypes × the standard test matrix
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_categories
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import OrganizationApiSettings, Subject, Team, TeamCategory
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_category(team, subject, name):
+	from django.utils.text import slugify
+	cat = TeamCategory.objects.create(
+		team=team,
+		category_name=name,
+		category_slug=f'{team.slug}-{slugify(name)}',
+	)
+	cat.subjects.add(subject)
+	return cat
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class CategoryVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org', 'my-org-cat', public=False)
+		self.pub_org = _make_org('Public Org', 'pub-org-cat', public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-cat', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team Cat')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team Cat')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team Cat')
+
+		self.my_subj = _make_subject(self.my_team, 'My Subj Cat')
+		self.pub_subj = _make_subject(self.pub_team, 'Pub Subj Cat')
+		self.priv_subj = _make_subject(self.priv_team, 'Priv Subj Cat')
+
+		self.cat_mine = _make_category(self.my_team, self.my_subj, 'Mine Category')
+		self.cat_pub = _make_category(self.pub_team, self.pub_subj, 'Public Category')
+		self.cat_priv = _make_category(self.priv_team, self.priv_subj, 'Private Category')
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousCategoryVisibilityTest(CategoryVisibilityBase):
+	def test_list_includes_public_category(self):
+		resp = self.client.get('/categories/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertIn(self.cat_pub.id, ids)
+
+	def test_list_excludes_private_categories(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertNotIn(self.cat_mine.id, ids)
+		self.assertNotIn(self.cat_priv.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/categories/{self.cat_mine.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_public_returns_200(self):
+		resp = self.client.get(f'/categories/{self.cat_pub.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_categories_by_team_hidden_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/subjects/{self.my_subj.id}/categories/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_categories_by_team_public_team_returns_200(self):
+		resp = self.client.get(f'/teams/{self.pub_team.id}/subjects/{self.pub_subj.id}/categories/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserCategoryVisibilityTest(CategoryVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='cat-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_list_shows_own_org_category(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertIn(self.cat_mine.id, ids)
+
+	def test_list_excludes_unrelated_private_category(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertNotIn(self.cat_priv.id, ids)
+
+	def test_list_excludes_public_category_without_flag(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertNotIn(self.cat_pub.id, ids)
+
+	def test_include_public_adds_public_categories(self):
+		resp = self.client.get('/categories/?include_public=true')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertIn(self.cat_mine.id, ids)
+		self.assertIn(self.cat_pub.id, ids)
+		self.assertNotIn(self.cat_priv.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/categories/{self.cat_priv.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/categories/{self.cat_mine.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_categories_by_team_own_team_returns_200(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/subjects/{self.my_subj.id}/categories/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_categories_by_team_hidden_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.priv_team.id}/subjects/{self.priv_subj.id}/categories/')
+		self.assertEqual(resp.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyCategoryVisibilityTest(CategoryVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'cat-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_own_category(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertIn(self.cat_mine.id, ids)
+
+	def test_list_excludes_private_category(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertNotIn(self.cat_priv.id, ids)
+
+	def test_include_public_adds_public_categories(self):
+		resp = self.client.get('/categories/?include_public=true')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertIn(self.cat_mine.id, ids)
+		self.assertIn(self.cat_pub.id, ids)
+		self.assertNotIn(self.cat_priv.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/categories/{self.cat_priv.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/categories/{self.cat_mine.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyCategoryVisibilityTest(CategoryVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-cat-key',
+			client_contacts='null-cat@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public_categories(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertIn(self.cat_pub.id, ids)
+		self.assertNotIn(self.cat_mine.id, ids)
+		self.assertNotIn(self.cat_priv.id, ids)
+
+	def test_detail_of_private_category_returns_404(self):
+		resp = self.client.get(f'/categories/{self.cat_mine.id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_organisations.py
+++ b/django/api/tests/test_visibility_organisations.py
@@ -1,0 +1,212 @@
+"""
+Tests for organisation visibility enforcement (PR 5).
+
+Covers:
+  - OrganizationsViewSet list/detail: only orgs in visible_org_ids
+  - Detail endpoint 404s when org is not visible (hide-existence rule)
+  - Four caller archetypes × the standard test matrix
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_organisations
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import OrganizationApiSettings, Team
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class OrganizationVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org', 'my-org-orgs', public=False)
+		self.pub_org = _make_org('Public Org', 'pub-org-orgs', public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-orgs', public=False)
+
+		# Teams are needed so visible_org_ids works via OrganizationUser membership
+		_make_team(self.my_org, 'My Team Orgs')
+		_make_team(self.pub_org, 'Pub Team Orgs')
+		_make_team(self.priv_org, 'Priv Team Orgs')
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousOrganizationVisibilityTest(OrganizationVisibilityBase):
+	def test_list_includes_public_org(self):
+		resp = self.client.get('/organizations/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertIn(self.pub_org.id, ids)
+
+	def test_list_excludes_private_orgs(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertNotIn(self.my_org.id, ids)
+		self.assertNotIn(self.priv_org.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/organizations/{self.my_org.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_public_returns_200(self):
+		resp = self.client.get(f'/organizations/{self.pub_org.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_include_public_is_noop_for_anonymous(self):
+		resp_plain = self.client.get('/organizations/')
+		resp_flag = self.client.get('/organizations/?include_public=true')
+		plain_ids = {o['id'] for o in resp_plain.data['results']}
+		flag_ids = {o['id'] for o in resp_flag.data['results']}
+		self.assertEqual(plain_ids, flag_ids)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserOrganizationVisibilityTest(OrganizationVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='org-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_list_shows_own_org(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertIn(self.my_org.id, ids)
+
+	def test_list_excludes_unrelated_private_org(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertNotIn(self.priv_org.id, ids)
+
+	def test_list_excludes_public_org_without_flag(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertNotIn(self.pub_org.id, ids)
+
+	def test_include_public_adds_public_org(self):
+		resp = self.client.get('/organizations/?include_public=true')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertIn(self.my_org.id, ids)
+		self.assertIn(self.pub_org.id, ids)
+		self.assertNotIn(self.priv_org.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/organizations/{self.priv_org.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/organizations/{self.my_org.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyOrganizationVisibilityTest(OrganizationVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'org-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_own_org(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertIn(self.my_org.id, ids)
+
+	def test_list_excludes_other_private_org(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertNotIn(self.priv_org.id, ids)
+
+	def test_list_excludes_public_org_without_flag(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertNotIn(self.pub_org.id, ids)
+
+	def test_include_public_adds_public_org(self):
+		resp = self.client.get('/organizations/?include_public=true')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertIn(self.my_org.id, ids)
+		self.assertIn(self.pub_org.id, ids)
+		self.assertNotIn(self.priv_org.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/organizations/{self.priv_org.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/organizations/{self.my_org.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyOrganizationVisibilityTest(OrganizationVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-org-key',
+			client_contacts='null-org@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public_orgs(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertIn(self.pub_org.id, ids)
+		self.assertNotIn(self.my_org.id, ids)
+		self.assertNotIn(self.priv_org.id, ids)
+
+	def test_detail_of_private_org_returns_404(self):
+		resp = self.client.get(f'/organizations/{self.my_org.id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_sources.py
+++ b/django/api/tests/test_visibility_sources.py
@@ -1,0 +1,222 @@
+"""
+Tests for source visibility enforcement (PR 5).
+
+Covers:
+  - SourceViewSet list/detail: only sources whose team.org is visible
+  - Detail endpoint 404s when source belongs to a hidden org
+  - Four caller archetypes × the standard test matrix
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_sources
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import OrganizationApiSettings, Sources, Subject, Team
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_source(team, subject, name):
+	return Sources.objects.create(
+		name=name,
+		team=team,
+		subject=subject,
+		source_for='science paper',
+		method='rss',
+	)
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class SourceVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org', 'my-org-src', public=False)
+		self.pub_org = _make_org('Public Org', 'pub-org-src', public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-src', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team Src')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team Src')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team Src')
+
+		self.my_subj = _make_subject(self.my_team, 'My Subj Src')
+		self.pub_subj = _make_subject(self.pub_team, 'Pub Subj Src')
+		self.priv_subj = _make_subject(self.priv_team, 'Priv Subj Src')
+
+		self.src_mine = _make_source(self.my_team, self.my_subj, 'Mine Source')
+		self.src_pub = _make_source(self.pub_team, self.pub_subj, 'Public Source')
+		self.src_priv = _make_source(self.priv_team, self.priv_subj, 'Private Source')
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousSourceVisibilityTest(SourceVisibilityBase):
+	def test_list_includes_public_source(self):
+		resp = self.client.get('/sources/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertIn(self.src_pub.source_id, ids)
+
+	def test_list_excludes_private_sources(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertNotIn(self.src_mine.source_id, ids)
+		self.assertNotIn(self.src_priv.source_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/sources/{self.src_mine.source_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_public_returns_200(self):
+		resp = self.client.get(f'/sources/{self.src_pub.source_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserSourceVisibilityTest(SourceVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='src-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_list_shows_own_org_source(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertIn(self.src_mine.source_id, ids)
+
+	def test_list_excludes_unrelated_private_source(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertNotIn(self.src_priv.source_id, ids)
+
+	def test_list_excludes_public_source_without_flag(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertNotIn(self.src_pub.source_id, ids)
+
+	def test_include_public_adds_public_sources(self):
+		resp = self.client.get('/sources/?include_public=true')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertIn(self.src_mine.source_id, ids)
+		self.assertIn(self.src_pub.source_id, ids)
+		self.assertNotIn(self.src_priv.source_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/sources/{self.src_priv.source_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/sources/{self.src_mine.source_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeySourceVisibilityTest(SourceVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'src-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_own_source(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertIn(self.src_mine.source_id, ids)
+
+	def test_list_excludes_private_source(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertNotIn(self.src_priv.source_id, ids)
+
+	def test_include_public_adds_public_sources(self):
+		resp = self.client.get('/sources/?include_public=true')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertIn(self.src_mine.source_id, ids)
+		self.assertIn(self.src_pub.source_id, ids)
+		self.assertNotIn(self.src_priv.source_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/sources/{self.src_priv.source_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/sources/{self.src_mine.source_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeySourceVisibilityTest(SourceVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-src-key',
+			client_contacts='null-src@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public_sources(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertIn(self.src_pub.source_id, ids)
+		self.assertNotIn(self.src_mine.source_id, ids)
+		self.assertNotIn(self.src_priv.source_id, ids)
+
+	def test_detail_of_private_source_returns_404(self):
+		resp = self.client.get(f'/sources/{self.src_mine.source_id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_subjects.py
+++ b/django/api/tests/test_visibility_subjects.py
@@ -1,0 +1,238 @@
+"""
+Tests for subject visibility enforcement (PR 5).
+
+Covers:
+  - SubjectsViewSet list/detail: only subjects whose team.organization is visible
+  - Detail endpoint 404s when subject belongs to a hidden org
+  - SubjectsByTeam: parent team hidden → 404 on the parent path
+  - Four caller archetypes × the standard test matrix
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_subjects
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import OrganizationApiSettings, Subject, Team
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class SubjectVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org', 'my-org-subj', public=False)
+		self.pub_org = _make_org('Public Org', 'pub-org-subj', public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-subj', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team Subj')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team Subj')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team Subj')
+
+		self.subj_mine = _make_subject(self.my_team, 'Mine Subj')
+		self.subj_pub = _make_subject(self.pub_team, 'Public Subj')
+		self.subj_priv = _make_subject(self.priv_team, 'Private Subj')
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousSubjectVisibilityTest(SubjectVisibilityBase):
+	def test_list_includes_public_subject(self):
+		resp = self.client.get('/subjects/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertIn(self.subj_pub.id, ids)
+
+	def test_list_excludes_private_subjects(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertNotIn(self.subj_mine.id, ids)
+		self.assertNotIn(self.subj_priv.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/subjects/{self.subj_mine.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_public_returns_200(self):
+		resp = self.client.get(f'/subjects/{self.subj_pub.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_subjects_by_team_hidden_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/subjects/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_subjects_by_team_public_team_returns_200(self):
+		resp = self.client.get(f'/teams/{self.pub_team.id}/subjects/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserSubjectVisibilityTest(SubjectVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='subj-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_list_shows_own_org_subject(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertIn(self.subj_mine.id, ids)
+
+	def test_list_excludes_unrelated_private_subject(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertNotIn(self.subj_priv.id, ids)
+
+	def test_list_excludes_public_subject_without_flag(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertNotIn(self.subj_pub.id, ids)
+
+	def test_include_public_adds_public_subjects(self):
+		resp = self.client.get('/subjects/?include_public=true')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertIn(self.subj_mine.id, ids)
+		self.assertIn(self.subj_pub.id, ids)
+		self.assertNotIn(self.subj_priv.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/subjects/{self.subj_priv.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/subjects/{self.subj_mine.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_subjects_by_team_own_team_returns_200(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/subjects/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_subjects_by_team_hidden_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.priv_team.id}/subjects/')
+		self.assertEqual(resp.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeySubjectVisibilityTest(SubjectVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'subj-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_own_subject(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertIn(self.subj_mine.id, ids)
+
+	def test_list_excludes_private_subject(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertNotIn(self.subj_priv.id, ids)
+
+	def test_list_excludes_public_subject_without_flag(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertNotIn(self.subj_pub.id, ids)
+
+	def test_include_public_adds_public_subjects(self):
+		resp = self.client.get('/subjects/?include_public=true')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertIn(self.subj_mine.id, ids)
+		self.assertIn(self.subj_pub.id, ids)
+		self.assertNotIn(self.subj_priv.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/subjects/{self.subj_priv.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/subjects/{self.subj_mine.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_subjects_by_team_hidden_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.pub_team.id}/subjects/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_subjects_by_team_own_team_returns_200(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/subjects/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeySubjectVisibilityTest(SubjectVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-subj-key',
+			client_contacts='null-subj@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public_subjects(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertIn(self.subj_pub.id, ids)
+		self.assertNotIn(self.subj_mine.id, ids)
+		self.assertNotIn(self.subj_priv.id, ids)
+
+	def test_detail_of_private_subject_returns_404(self):
+		resp = self.client.get(f'/subjects/{self.subj_mine.id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_teams.py
+++ b/django/api/tests/test_visibility_teams.py
@@ -1,0 +1,210 @@
+"""
+Tests for team visibility enforcement (PR 5).
+
+Covers:
+  - TeamsViewSet list/detail: only teams in visible orgs
+  - Detail endpoint 404s when team belongs to a hidden org
+  - Permission changed from IsAuthenticated → IsAuthenticatedOrReadOnly
+    (anonymous users can now see public orgs' teams without authentication)
+  - Four caller archetypes × the standard test matrix
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_teams
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import OrganizationApiSettings, Team
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class TeamVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org', 'my-org-team', public=False)
+		self.pub_org = _make_org('Public Org', 'pub-org-team', public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-team', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team Teams')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team Teams')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team Teams')
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousTeamVisibilityTest(TeamVisibilityBase):
+	def test_list_does_not_require_auth(self):
+		"""TeamsViewSet is now IsAuthenticatedOrReadOnly — anonymous read is allowed."""
+		resp = self.client.get('/teams/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_list_includes_public_team(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertIn(self.pub_team.id, ids)
+
+	def test_list_excludes_private_teams(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertNotIn(self.my_team.id, ids)
+		self.assertNotIn(self.priv_team.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_public_returns_200(self):
+		resp = self.client.get(f'/teams/{self.pub_team.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserTeamVisibilityTest(TeamVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='team-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_list_shows_own_team(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertIn(self.my_team.id, ids)
+
+	def test_list_excludes_unrelated_private_team(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertNotIn(self.priv_team.id, ids)
+
+	def test_list_excludes_public_team_without_flag(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertNotIn(self.pub_team.id, ids)
+
+	def test_include_public_adds_public_teams(self):
+		resp = self.client.get('/teams/?include_public=true')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertIn(self.my_team.id, ids)
+		self.assertIn(self.pub_team.id, ids)
+		self.assertNotIn(self.priv_team.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/teams/{self.priv_team.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyTeamVisibilityTest(TeamVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'team-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_own_team(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertIn(self.my_team.id, ids)
+
+	def test_list_excludes_other_private_team(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertNotIn(self.priv_team.id, ids)
+
+	def test_list_excludes_public_team_without_flag(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertNotIn(self.pub_team.id, ids)
+
+	def test_include_public_adds_public_teams(self):
+		resp = self.client.get('/teams/?include_public=true')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertIn(self.my_team.id, ids)
+		self.assertIn(self.pub_team.id, ids)
+		self.assertNotIn(self.priv_team.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/teams/{self.priv_team.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyTeamVisibilityTest(TeamVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-team-key',
+			client_contacts='null-team@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public_teams(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertIn(self.pub_team.id, ids)
+		self.assertNotIn(self.my_team.id, ids)
+		self.assertNotIn(self.priv_team.id, ids)
+
+	def test_detail_of_private_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -9,6 +9,7 @@ from django.db.models.functions import Length, TruncMonth
 from django.shortcuts import get_object_or_404
 from gregory.classes import SciencePaper
 from gregory.models import Articles, Trials, Sources, Authors, Team, Subject, TeamCategory
+from organizations.models import Organization
 from rest_framework import permissions, viewsets, generics, filters, status
 from rest_framework.decorators import api_view, action
 from django_filters import rest_framework as django_filters
@@ -41,14 +42,22 @@ class OrgVisibilityMixin:
 	back to the full queryset when the attribute is absent so tests and
 	management commands that bypass middleware are not broken.
 
-	Articles and Trials link to organisations via the ``teams`` M2M relation.
+	Override ``_org_filter_path`` in the subclass to set the ORM lookup path
+	from the model to the Organisation PK.  Defaults to
+	``teams__organization_id`` (Articles and Trials via M2M teams relation).
+
+	Examples:
+	  - Team:          _org_filter_path = 'organization_id'
+	  - Subject/Source/Category:  _org_filter_path = 'team__organization_id'
 	"""
+
+	_org_filter_path = 'teams__organization_id'
 
 	def get_queryset(self):
 		qs = super().get_queryset()
 		if not hasattr(self.request, 'visible_org_ids'):
 			return qs
-		return qs.filter(teams__organization_id__in=self.request.visible_org_ids).distinct()
+		return qs.filter(**{f'{self._org_filter_path}__in': self.request.visible_org_ids}).distinct()
 
 
 def add_deprecation_headers(response, deprecated_endpoint, replacement_endpoint, message=None):
@@ -410,6 +419,10 @@ class CategoryViewSet(viewsets.ModelViewSet):
 		3. Use select_related for foreign keys
 		"""
 		queryset = TeamCategory.objects.all()
+
+		# --- Org visibility: only categories whose team's org is visible ---
+		if hasattr(self.request, 'visible_org_ids'):
+			queryset = queryset.filter(team__organization_id__in=self.request.visible_org_ids)
 		
 		# Apply filters without expensive annotations
 		team_id = self.request.query_params.get('team_id')
@@ -699,7 +712,7 @@ class AllTrialViewSet(generics.ListAPIView):
 # SOURCES
 ### 
 
-class SourceViewSet(viewsets.ModelViewSet):
+class SourceViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	List all sources of data with optional filters for team and subject.
 	
@@ -707,6 +720,7 @@ class SourceViewSet(viewsets.ModelViewSet):
 	- **team_id** - filter by team ID
 	- **subject_id** - filter by subject ID
 	"""
+	_org_filter_path = 'team__organization_id'
 	queryset = Sources.objects.all().order_by('name')
 	serializer_class = SourceSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -768,6 +782,12 @@ class AuthorsViewSet(viewsets.ModelViewSet):
 	
 	def get_queryset(self):
 		queryset = Authors.objects.all()
+
+		# --- Org visibility: only authors with at least one article in a visible org ---
+		if hasattr(self.request, 'visible_org_ids'):
+			queryset = queryset.filter(
+				articles__teams__organization_id__in=self.request.visible_org_ids
+			).distinct()
 		
 		# Get query parameters
 		author_id = self.request.query_params.get('author_id')
@@ -980,19 +1000,49 @@ class ProtectedEndpointView(APIView):
 # TEAMS
 ###
 
-class TeamsViewSet(viewsets.ModelViewSet):
+class TeamsViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	List all teams
 	"""
+	_org_filter_path = 'organization_id'
 	queryset = Team.objects.all().order_by('id')
 	serializer_class = TeamSerializer
-	permission_classes  = [permissions.IsAuthenticated]
+	permission_classes  = [permissions.IsAuthenticatedOrReadOnly]
+
+###
+# ORGANISATIONS
+###
+
+class OrganizationsViewSet(viewsets.ReadOnlyModelViewSet):
+	"""
+	List organisations visible to the caller.
+
+	Anonymous callers see only organisations where ``make_api_public=True``.
+	Authenticated users and API-key holders see their own org; add
+	``?include_public=true`` to also see public orgs.
+
+	Detail endpoint (``/organizations/<id>/``) returns 404 rather than 403
+	when the organisation is not visible (hide-existence rule).
+	"""
+	from api.serializers import OrganizationSerializer
+	serializer_class = None  # set in get_serializer_class
+	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+	def get_serializer_class(self):
+		from api.serializers import OrganizationSerializer
+		return OrganizationSerializer
+
+	def get_queryset(self):
+		qs = Organization.objects.all().order_by('id')
+		if not hasattr(self.request, 'visible_org_ids'):
+			return qs
+		return qs.filter(id__in=self.request.visible_org_ids)
 
 ###
 # SUBJECTS
 ###
 
-class SubjectsViewSet(viewsets.ModelViewSet):
+class SubjectsViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	✅ **PREFERRED ENDPOINT**: This is the main subjects endpoint that supports filtering options.
 	
@@ -1009,6 +1059,7 @@ class SubjectsViewSet(viewsets.ModelViewSet):
 	- Team filter with search: `/subjects/?team_id=1&search=sclerosis`
 	- Order by name: `/subjects/?ordering=subject_name`
 	"""
+	_org_filter_path = 'team__organization_id'
 	queryset = Subject.objects.all().order_by('id')
 	serializer_class = SubjectsSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -1134,6 +1185,9 @@ class SubjectsByTeam(viewsets.ModelViewSet):
 
 	def get_queryset(self):
 		team_id = self.kwargs.get('team_id')
+		if hasattr(self.request, 'visible_org_ids'):
+			if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+				raise Http404
 		return Subject.objects.filter(team__id=team_id).order_by('-id')
 	
 	def list(self, request, *args, **kwargs):
@@ -1154,6 +1208,9 @@ class CategoriesByTeamAndSubject(viewsets.ModelViewSet):
 	def get_queryset(self):
 		team_id = self.kwargs.get('team_id')
 		subject_id = self.kwargs.get('subject_id')
+		if hasattr(self.request, 'visible_org_ids'):
+			if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+				raise Http404
 		return TeamCategory.objects.filter(
 			team__id=team_id,
 			subjects__id=subject_id
@@ -1566,6 +1623,12 @@ class AuthorSearchView(generics.ListAPIView):
     pagination_class = FlexiblePagination
     http_method_names = ['get', 'post']
 
+    def _check_team_visibility(self, team_id):
+        """Raise Http404 if team_id is not in the caller's visible orgs."""
+        if hasattr(self.request, 'visible_org_ids'):
+            if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+                raise Http404
+
     def get_queryset(self):
         params = self.request.query_params if self.request.method == 'GET' else self.request.data
 
@@ -1624,7 +1687,8 @@ class AuthorSearchView(generics.ListAPIView):
                 {"error": f"Subject with ID {subject_id} not found or does not belong to team {team_id}"}, 
                 status=404
             )
-            
+
+        self._check_team_visibility(team_id)
         return self.list(request, *args, **kwargs)
         
     def get(self, request, *args, **kwargs):
@@ -1652,7 +1716,8 @@ class AuthorSearchView(generics.ListAPIView):
                 {"error": f"Subject with ID {subject_id} not found or does not belong to team {team_id}"}, 
                 status=404
             )
-            
+
+        self._check_team_visibility(team_id)
         # Delegate to the list method
         return self.list(request, *args, **kwargs)
 

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1,6 +1,7 @@
 from api.serializers import (
-		ArticleSerializer, TrialSerializer, SourceSerializer, AuthorSerializer, 
-		CategorySerializer, CategoryTopAuthorSerializer, TeamSerializer, SubjectsSerializer, ArticlesByCategoryAndTeamSerializer
+		ArticleSerializer, TrialSerializer, SourceSerializer, AuthorSerializer,
+		CategorySerializer, CategoryTopAuthorSerializer, TeamSerializer, SubjectsSerializer,
+		ArticlesByCategoryAndTeamSerializer, OrganizationSerializer
 )
 from api.pagination import FlexiblePagination
 from datetime import datetime, timedelta
@@ -52,12 +53,16 @@ class OrgVisibilityMixin:
 	"""
 
 	_org_filter_path = 'teams__organization_id'
+	# Set to False for viewsets that reach orgs via a simple FK (not M2M) to
+	# avoid unnecessary DISTINCT overhead on those queries.
+	_org_filter_distinct = True
 
 	def get_queryset(self):
 		qs = super().get_queryset()
 		if not hasattr(self.request, 'visible_org_ids'):
 			return qs
-		return qs.filter(**{f'{self._org_filter_path}__in': self.request.visible_org_ids}).distinct()
+		qs = qs.filter(**{f'{self._org_filter_path}__in': self.request.visible_org_ids})
+		return qs.distinct() if self._org_filter_distinct else qs
 
 
 def add_deprecation_headers(response, deprecated_endpoint, replacement_endpoint, message=None):
@@ -721,6 +726,7 @@ class SourceViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	- **subject_id** - filter by subject ID
 	"""
 	_org_filter_path = 'team__organization_id'
+	_org_filter_distinct = False
 	queryset = Sources.objects.all().order_by('name')
 	serializer_class = SourceSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -890,23 +896,34 @@ class AuthorsViewSet(viewsets.ModelViewSet):
 		
 		# Add date filters to count filters
 		count_filters.update(date_filters)
-		
+
+		# Build an org-visibility filter for the Count annotation so that
+		# article_count always reflects only visible articles (fixes sorting/
+		# filtering by article_count leaking hidden-org data).
+		has_org_scope = hasattr(self.request, 'visible_org_ids')
+		org_q = Q(articles__teams__organization_id__in=self.request.visible_org_ids) if has_org_scope else Q()
+
 		# Add article count annotation for sorting
 		if sort_by == 'article_count':
 			if count_filters:
-				# Annotate with count and filter to only include authors with articles matching criteria
+				combined_q = Q(**count_filters) & org_q if has_org_scope else Q(**count_filters)
 				queryset = queryset.annotate(
-					article_count=Count('articles', filter=Q(**count_filters), distinct=True)
+					article_count=Count('articles', filter=combined_q, distinct=True)
 				).filter(article_count__gt=0)
+			elif has_org_scope:
+				queryset = queryset.annotate(
+					article_count=Count('articles', filter=org_q, distinct=True)
+				)
 			else:
 				queryset = queryset.annotate(
 					article_count=Count('articles', distinct=True)
 				)
 		elif count_filters:
-			# Even if not sorting by article_count, we still need to filter authors 
+			# Even if not sorting by article_count, we still need to filter authors
 			# to only those who have articles matching the criteria
+			combined_q = Q(**count_filters) & org_q if has_org_scope else Q(**count_filters)
 			queryset = queryset.annotate(
-				article_count=Count('articles', filter=Q(**count_filters), distinct=True)
+				article_count=Count('articles', filter=combined_q, distinct=True)
 			).filter(article_count__gt=0)
 		
 		# Apply sorting
@@ -1005,6 +1022,7 @@ class TeamsViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	List all teams
 	"""
 	_org_filter_path = 'organization_id'
+	_org_filter_distinct = False
 	queryset = Team.objects.all().order_by('id')
 	serializer_class = TeamSerializer
 	permission_classes  = [permissions.IsAuthenticatedOrReadOnly]
@@ -1024,13 +1042,8 @@ class OrganizationsViewSet(viewsets.ReadOnlyModelViewSet):
 	Detail endpoint (``/organizations/<id>/``) returns 404 rather than 403
 	when the organisation is not visible (hide-existence rule).
 	"""
-	from api.serializers import OrganizationSerializer
-	serializer_class = None  # set in get_serializer_class
+	serializer_class = OrganizationSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
-
-	def get_serializer_class(self):
-		from api.serializers import OrganizationSerializer
-		return OrganizationSerializer
 
 	def get_queryset(self):
 		qs = Organization.objects.all().order_by('id')
@@ -1060,6 +1073,7 @@ class SubjectsViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	- Order by name: `/subjects/?ordering=subject_name`
 	"""
 	_org_filter_path = 'team__organization_id'
+	_org_filter_distinct = False
 	queryset = Subject.objects.all().order_by('id')
 	serializer_class = SubjectsSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]


### PR DESCRIPTION
## PR 5 — Authors, Subjects, Categories, Sources, Teams, Organisations

### Goal

Apply the same enforcement to the remaining resource viewsets.

### Scope

In:

- `AuthorsViewSet`, `AuthorSearchView`: only authors with at least one article in a visible org. `articles_count` and nested article lists reflect only visible articles. Detail endpoint 404s when the author has no visible articles.
- `SubjectsViewSet`, `SubjectsByTeam`: only subjects whose `team.organization` is visible. Detail 404s otherwise.
- `CategoryViewSet`, `CategoriesByTeamAndSubject`: only `TeamCategory` whose team's org is visible.
- `SourceViewSet`: only sources whose team's org is visible.
- `TeamsViewSet`: only teams in visible orgs.
- New `OrganizationsViewSet` (or update if one exists): only visible orgs.

Out:

- Stats, search (PR 6).
- RSS (PR 6).

### Files touched

- `django/api/views.py`
- `django/api/serializers.py`
- `django/api/tests/test_visibility_authors.py` (new)
- `django/api/tests/test_visibility_subjects.py` (new)
- `django/api/tests/test_visibility_categories.py` (new)
- `django/api/tests/test_visibility_sources.py` (new)
- `django/api/tests/test_visibility_teams.py` (new)
- `django/api/tests/test_visibility_organisations.py` (new)

### Tests

Run the four-caller matrix against each resource. Specific cases worth calling out:

- Author with articles in both a visible and a hidden org → visible, hidden articles stripped from nested lists, `articles_count` reflects only visible articles.
- Author whose only articles are in hidden orgs → 404 on detail, absent from list.
- Subject in a hidden team's org → 404 on detail, absent from list.
- `/teams/<id>/subjects/` for a hidden team → 404 on the parent path.

### Risk and rollback

Low–medium. Same mitigation as PR 4 (default-open backfill keeps live data behaviour unchanged).

### Acceptance criteria

- New tests pass.
- Pre-existing tests pass.
- Smoke test of `/authors/<orcid>/` for a known public author returns the same shape (with the new stripped-association rule applied if applicable).

### Depends on

PR 4.
