### PR TITLE
implements PR 6

### DIFF
--- a/django/api/tests/test_visibility_rss.py
+++ b/django/api/tests/test_visibility_rss.py
@@ -1,0 +1,400 @@
+"""
+Tests for RSS feed visibility enforcement (PR 6).
+
+Covers:
+  - ArticlesByAuthorFeed (/feed/author/<orcid>/):
+      - 404 when author has no articles in any visible org
+      - 200 and items filtered to visible articles when author is visible
+      - ?include_public=true extends visibility for identified callers
+  - TrialsBySubjectFeed (/feed/trials/subject/<slug>/):
+      - 404 when subject belongs to a hidden org
+      - 200 and items filtered to visible trials when subject is visible
+      - ?include_public=true extends visibility for identified callers
+  - Four caller archetypes: anonymous, authenticated member, API-key, null-org key
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_rss
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+
+from api.models import APIAccessScheme
+from gregory.models import Articles, Authors, OrganizationApiSettings, Subject, Team, Trials
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	slug = slugify(name)
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slug)
+
+
+def _make_author(given, family, orcid):
+	full = f'{given} {family}'
+	return Authors.objects.create(given_name=given, family_name=family, full_name=full, ORCID=orcid)
+
+
+def _make_article(title, link, teams=(), authors=()):
+	art = Articles.objects.create(title=title, link=link)
+	for t in teams:
+		art.teams.add(t)
+	for a in authors:
+		art.authors.add(a)
+	return art
+
+
+def _make_trial(title, link, teams=(), subjects=()):
+	trial = Trials.objects.create(title=title, link=link)
+	for t in teams:
+		trial.teams.add(t)
+	for s in subjects:
+		trial.subjects.add(s)
+	return trial
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp for author feed tests
+# ---------------------------------------------------------------------------
+
+ORCID_MINE  = '0000-0001-0001-0001'
+ORCID_PUB   = '0000-0001-0002-0002'
+ORCID_PRIV  = '0000-0001-0003-0003'
+
+
+class AuthorFeedBase(TestCase):
+	def setUp(self):
+		self.my_org   = _make_org('My Org',      'my-org-rss-auth',   public=False)
+		self.pub_org  = _make_org('Public Org',   'pub-org-rss-auth',  public=True)
+		self.priv_org = _make_org('Private Org',  'priv-org-rss-auth', public=False)
+
+		self.my_team   = _make_team(self.my_org,   'My Team RSS Auth')
+		self.pub_team  = _make_team(self.pub_org,  'Pub Team RSS Auth')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team RSS Auth')
+
+		# Authors
+		self.author_mine  = _make_author('Alice', 'Mine',    ORCID_MINE)
+		self.author_pub   = _make_author('Bob',   'Public',  ORCID_PUB)
+		self.author_priv  = _make_author('Carol', 'Private', ORCID_PRIV)
+
+		# Articles
+		_make_article('Mine Art',   'https://rss.ex/a1', teams=[self.my_team],   authors=[self.author_mine])
+		_make_article('Pub Art',    'https://rss.ex/a2', teams=[self.pub_team],  authors=[self.author_pub])
+		_make_article('Priv Art',   'https://rss.ex/a3', teams=[self.priv_team], authors=[self.author_priv])
+		# author_mine also has a public article
+		_make_article('Mine+Pub Art', 'https://rss.ex/a4', teams=[self.pub_team], authors=[self.author_mine])
+
+
+# ---------------------------------------------------------------------------
+# Anonymous: author feed
+# ---------------------------------------------------------------------------
+
+class AnonymousAuthorFeedTest(AuthorFeedBase):
+	"""Anonymous → only public org articles visible."""
+
+	def test_public_author_returns_200(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PUB}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_author_returns_404(self):
+		"""author_priv only has articles in private org → 404 for anonymous."""
+		resp = self.client.get(f'/feed/author/{ORCID_PRIV}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_private_author_feed_with_mine_and_pub_returns_200(self):
+		"""author_mine has both a private and a public article → visible because of pub article."""
+		resp = self.client.get(f'/feed/author/{ORCID_MINE}/')
+		self.assertEqual(resp.status_code, 200)
+		# The mine-only article should NOT appear; only the pub article
+		content = resp.content.decode()
+		self.assertIn('Mine+Pub Art', content)
+		self.assertNotIn('Mine Art', content)
+
+	def test_nonexistent_orcid_returns_404(self):
+		resp = self.client.get('/feed/author/0000-0000-0000-9999/')
+		self.assertEqual(resp.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org): author feed
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserAuthorFeedTest(AuthorFeedBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='rss-auth-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_own_author_returns_200(self):
+		resp = self.client.get(f'/feed/author/{ORCID_MINE}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_other_org_author_returns_404(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PRIV}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_author_hidden_without_flag(self):
+		"""author_pub only has articles in pub_org; not visible without include_public."""
+		resp = self.client.get(f'/feed/author/{ORCID_PUB}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_author_visible_with_include_public(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PUB}/?include_public=true')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_own_feed_items_excludes_pub_articles_without_flag(self):
+		"""author_mine items should only include the mine-team article (not pub-team)."""
+		resp = self.client.get(f'/feed/author/{ORCID_MINE}/')
+		self.assertEqual(resp.status_code, 200)
+		content = resp.content.decode()
+		self.assertIn('Mine Art', content)
+		self.assertNotIn('Mine+Pub Art', content)
+
+	def test_own_feed_items_includes_pub_articles_with_flag(self):
+		resp = self.client.get(f'/feed/author/{ORCID_MINE}/?include_public=true')
+		self.assertEqual(resp.status_code, 200)
+		content = resp.content.decode()
+		self.assertIn('Mine Art', content)
+		self.assertIn('Mine+Pub Art', content)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org): author feed
+# ---------------------------------------------------------------------------
+
+class APIKeyAuthorFeedTest(AuthorFeedBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'rss-author-key')
+		self.client.defaults['HTTP_AUTHORIZATION'] = self.scheme.api_key
+
+	def test_own_author_returns_200(self):
+		resp = self.client.get(f'/feed/author/{ORCID_MINE}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_other_org_author_returns_404(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PRIV}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_author_hidden_without_flag(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PUB}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_author_visible_with_include_public(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PUB}/?include_public=true')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org key: author feed
+# ---------------------------------------------------------------------------
+
+class NullOrgKeyAuthorFeedTest(AuthorFeedBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-rss-auth',
+			client_contacts='null-rss-auth@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.defaults['HTTP_AUTHORIZATION'] = self.scheme.api_key
+
+	def test_public_author_returns_200(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PUB}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_author_returns_404(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PRIV}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_mine_author_with_pub_article_returns_200(self):
+		"""author_mine has a public article → visible even to null-org key."""
+		resp = self.client.get(f'/feed/author/{ORCID_MINE}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp for trials feed tests
+# ---------------------------------------------------------------------------
+
+class TrialsFeedBase(TestCase):
+	def setUp(self):
+		self.my_org   = _make_org('My Org',      'my-org-rss-trial',   public=False)
+		self.pub_org  = _make_org('Public Org',   'pub-org-rss-trial',  public=True)
+		self.priv_org = _make_org('Private Org',  'priv-org-rss-trial', public=False)
+
+		self.my_team   = _make_team(self.my_org,   'My Team RSS Trial')
+		self.pub_team  = _make_team(self.pub_org,  'Pub Team RSS Trial')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team RSS Trial')
+
+		self.my_subj   = _make_subject(self.my_team,   'my-subj-rss')
+		self.pub_subj  = _make_subject(self.pub_team,  'pub-subj-rss')
+		self.priv_subj = _make_subject(self.priv_team, 'priv-subj-rss')
+
+		# Trials
+		_make_trial('Mine Trial',   'https://rss.ex/t1', teams=[self.my_team],   subjects=[self.my_subj])
+		_make_trial('Pub Trial',    'https://rss.ex/t2', teams=[self.pub_team],  subjects=[self.pub_subj])
+		_make_trial('Priv Trial',   'https://rss.ex/t3', teams=[self.priv_team], subjects=[self.priv_subj])
+
+
+# ---------------------------------------------------------------------------
+# Anonymous: trials feed
+# ---------------------------------------------------------------------------
+
+class AnonymousTrialsFeedTest(TrialsFeedBase):
+
+	def test_public_subject_returns_200(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_subject_returns_404(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.priv_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_mine_subject_returns_404_for_anon(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.my_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_nonexistent_slug_returns_404(self):
+		resp = self.client.get('/feed/trials/subject/does-not-exist/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_feed_contains_public_trial(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/')
+		self.assertIn('Pub Trial', resp.content.decode())
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user: trials feed
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserTrialsFeedTest(TrialsFeedBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='rss-trial-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_own_subject_returns_200(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.my_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_other_org_subject_returns_404(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.priv_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_subject_hidden_without_flag(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_subject_visible_with_include_public(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/?include_public=true')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_own_feed_contains_own_trial(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.my_subj.subject_slug}/')
+		self.assertIn('Mine Trial', resp.content.decode())
+
+	def test_own_feed_excludes_pub_trial_without_flag(self):
+		"""pub trial is not in my_team → filtered out from own-subject feed."""
+		# Add pub trial to my_subj to test filtering
+		pub_trial_in_my_subj = _make_trial(
+			'Pub Trial In My Subj', 'https://rss.ex/t99',
+			teams=[self.pub_team], subjects=[self.my_subj],
+		)
+		resp = self.client.get(f'/feed/trials/subject/{self.my_subj.subject_slug}/')
+		content = resp.content.decode()
+		# Mine Trial visible, pub-team trial not visible
+		self.assertIn('Mine Trial', content)
+		self.assertNotIn('Pub Trial In My Subj', content)
+
+
+# ---------------------------------------------------------------------------
+# API key: trials feed
+# ---------------------------------------------------------------------------
+
+class APIKeyTrialsFeedTest(TrialsFeedBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'rss-trials-key')
+		self.client.defaults['HTTP_AUTHORIZATION'] = self.scheme.api_key
+
+	def test_own_subject_returns_200(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.my_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_other_org_subject_returns_404(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.priv_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_subject_hidden_without_flag(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_subject_visible_with_include_public(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/?include_public=true')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org key: trials feed
+# ---------------------------------------------------------------------------
+
+class NullOrgKeyTrialsFeedTest(TrialsFeedBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-rss-trial',
+			client_contacts='null-rss-trial@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.defaults['HTTP_AUTHORIZATION'] = self.scheme.api_key
+
+	def test_public_subject_returns_200(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_subject_returns_404(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.priv_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_mine_subject_returns_404(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.my_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_stats.py
+++ b/django/api/tests/test_visibility_stats.py
@@ -1,0 +1,245 @@
+"""
+Tests for StatsView visibility enforcement (PR 6).
+
+Covers:
+  - Anonymous caller: counts reflect public orgs only
+  - Authenticated user (member of org): counts reflect own org
+  - API key caller: counts reflect key's org
+  - ?team=<id> for a hidden team → 404
+  - ?team=<id> for a visible team → counts scoped to that team
+  - ?include_public=true adds public org data for identified callers
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_stats
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import Articles, OrganizationApiSettings, Subject, Team, Trials
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_article(title, link, teams=()):
+	art = Articles.objects.create(title=title, link=link)
+	for t in teams:
+		art.teams.add(t)
+	return art
+
+
+def _make_trial(title, link, teams=(), subjects=()):
+	from gregory.models import Trials
+	trial = Trials.objects.create(title=title, link=link)
+	for t in teams:
+		trial.teams.add(t)
+	for s in subjects:
+		trial.subjects.add(s)
+	return trial
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class StatsVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org  = _make_org('My Org',      'my-org-stats',   public=False)
+		self.pub_org = _make_org('Public Org',   'pub-org-stats',  public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-stats', public=False)
+
+		self.my_team   = _make_team(self.my_org,   'My Team Stats')
+		self.pub_team  = _make_team(self.pub_org,  'Pub Team Stats')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team Stats')
+
+		# Articles
+		self.art_mine  = _make_article('Mine Art',   'https://st.ex/a1', teams=[self.my_team])
+		self.art_pub   = _make_article('Pub Art',    'https://st.ex/a2', teams=[self.pub_team])
+		self.art_priv  = _make_article('Priv Art',   'https://st.ex/a3', teams=[self.priv_team])
+
+		# Trials
+		self.trial_mine  = _make_trial('Mine Trial',   'https://st.ex/t1', teams=[self.my_team])
+		self.trial_pub   = _make_trial('Pub Trial',    'https://st.ex/t2', teams=[self.pub_team])
+		self.trial_priv  = _make_trial('Priv Trial',   'https://st.ex/t3', teams=[self.priv_team])
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousStatsVisibilityTest(StatsVisibilityBase):
+	"""Anonymous request → only public org data counted."""
+
+	def test_articles_count_only_public(self):
+		resp = self.client.get('/stats/')
+		self.assertEqual(resp.status_code, 200)
+		# Only pub article visible; mine and priv are hidden
+		self.assertGreaterEqual(resp.data['articles'], 1)
+		# The private article should not inflate the count beyond what pub provides
+		# Verify by checking counts with team scope
+		resp_pub = self.client.get('/stats/', {'team': self.pub_team.id})
+		resp_priv = self.client.get('/stats/', {'team': self.priv_team.id})
+		self.assertEqual(resp_pub.status_code, 200)
+		# Hidden team → 404
+		self.assertEqual(resp_priv.status_code, 404)
+
+	def test_hidden_team_param_returns_404(self):
+		resp = self.client.get('/stats/', {'team': self.priv_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_own_team_param_returns_404_for_anon(self):
+		"""my_team belongs to a private org → anonymous can't see it."""
+		resp = self.client.get('/stats/', {'team': self.my_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_team_param_returns_200(self):
+		resp = self.client.get('/stats/', {'team': self.pub_team.id})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 1)
+		self.assertEqual(resp.data['trials'], 1)
+
+	def test_invalid_team_param_returns_400(self):
+		resp = self.client.get('/stats/', {'team': 'abc'})
+		self.assertEqual(resp.status_code, 400)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserStatsVisibilityTest(StatsVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='stats-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_articles_count_only_own_org(self):
+		"""Authenticated user without include_public sees only own org."""
+		resp = self.client.get('/stats/')
+		self.assertEqual(resp.status_code, 200)
+		# Scope to own team for a precise count
+		resp_mine = self.client.get('/stats/', {'team': self.my_team.id})
+		self.assertEqual(resp_mine.status_code, 200)
+		self.assertEqual(resp_mine.data['articles'], 1)
+		self.assertEqual(resp_mine.data['trials'], 1)
+
+	def test_hidden_team_param_returns_404(self):
+		resp = self.client.get('/stats/', {'team': self.priv_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_team_hidden_without_flag(self):
+		"""pub_team is not visible without ?include_public=true."""
+		resp = self.client.get('/stats/', {'team': self.pub_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_team_visible_with_include_public(self):
+		resp = self.client.get('/stats/', {'team': self.pub_team.id, 'include_public': 'true'})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 1)
+
+	def test_include_public_expands_global_count(self):
+		resp_no_flag = self.client.get('/stats/')
+		resp_with_flag = self.client.get('/stats/?include_public=true')
+		# With flag → pub articles also counted
+		self.assertGreaterEqual(resp_with_flag.data['articles'], resp_no_flag.data['articles'])
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyStatsVisibilityTest(StatsVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'stats-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_own_team_visible(self):
+		resp = self.client.get('/stats/', {'team': self.my_team.id})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 1)
+		self.assertEqual(resp.data['trials'], 1)
+
+	def test_hidden_team_returns_404(self):
+		resp = self.client.get('/stats/', {'team': self.priv_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_team_hidden_without_flag(self):
+		resp = self.client.get('/stats/', {'team': self.pub_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_team_visible_with_include_public(self):
+		resp = self.client.get('/stats/', {'team': self.pub_team.id, 'include_public': 'true'})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 1)
+
+	def test_include_public_expands_global_count(self):
+		resp_no_flag = self.client.get('/stats/')
+		resp_with_flag = self.client.get('/stats/?include_public=true')
+		self.assertGreaterEqual(resp_with_flag.data['articles'], resp_no_flag.data['articles'])
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyStatsVisibilityTest(StatsVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-stats-key',
+			client_contacts='null-stats@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_own_team_not_visible(self):
+		resp = self.client.get('/stats/', {'team': self.my_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_team_visible(self):
+		resp = self.client.get('/stats/', {'team': self.pub_team.id})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 1)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1774,15 +1774,17 @@ class StatsView(APIView):
 
 		# Base querysets scoped to visible orgs (no-op when middleware absent)
 		if visible_org_ids is not None:
-			articles_base = Articles.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
-			trials_base   = Trials.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
-			authors_base  = Authors.objects.filter(articles__teams__organization_id__in=visible_org_ids).distinct()
-			sources_base  = Sources.objects.filter(team__organization_id__in=visible_org_ids)
+			articles_base     = Articles.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
+			trials_base       = Trials.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
+			authors_base      = Authors.objects.filter(articles__teams__organization_id__in=visible_org_ids).distinct()
+			sources_base      = Sources.objects.filter(team__organization_id__in=visible_org_ids)
+			subscribers_base  = Subscribers.objects.filter(subscriptions__team__organization_id__in=visible_org_ids)
 		else:
-			articles_base = Articles.objects.all()
-			trials_base   = Trials.objects.all()
-			authors_base  = Authors.objects.all()
-			sources_base  = Sources.objects.all()
+			articles_base     = Articles.objects.all()
+			trials_base       = Trials.objects.all()
+			authors_base      = Authors.objects.all()
+			sources_base      = Sources.objects.all()
+			subscribers_base  = Subscribers.objects.all()
 
 		# Articles count
 		if team_ids:
@@ -1798,12 +1800,12 @@ class StatsView(APIView):
 
 		# Subscribers count (active only)
 		if team_ids:
-			subscribers_count = Subscribers.objects.filter(
+			subscribers_count = subscribers_base.filter(
 				active=True,
 				subscriptions__team__in=team_ids
 			).distinct().count()
 		else:
-			subscribers_count = Subscribers.objects.filter(active=True).count()
+			subscribers_count = subscribers_base.filter(active=True).distinct().count()
 
 		# Authors count (distinct authors linked to articles in scope)
 		if team_ids:

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1744,12 +1744,16 @@ class StatsView(APIView):
 	"""
 	Returns aggregate statistics about the data in the system.
 	All counts can be optionally scoped to one or more teams via ?team=1 or ?team=1,2,3.
+	Counts are always filtered to organisations visible to the caller (see §4.1 of the spec).
 	"""
 	permission_classes = [permissions.AllowAny]
 
 	def get(self, request):
 		from urllib.parse import urlparse
 		from subscriptions.models import Subscribers
+
+		# --- Org visibility ------------------------------------------------
+		visible_org_ids = getattr(request, 'visible_org_ids', None)
 
 		# Parse team IDs from query params
 		team_param = request.query_params.get('team', None)
@@ -1762,18 +1766,35 @@ class StatsView(APIView):
 					{'error': 'Invalid team parameter. Expected integer or comma-separated integers.'},
 					status=status.HTTP_400_BAD_REQUEST
 				)
+			# 404 if any requested team is not in a visible org
+			if visible_org_ids is not None:
+				visible = Team.objects.filter(id__in=team_ids, organization_id__in=visible_org_ids)
+				if visible.count() != len(set(team_ids)):
+					raise Http404
+
+		# Base querysets scoped to visible orgs (no-op when middleware absent)
+		if visible_org_ids is not None:
+			articles_base = Articles.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
+			trials_base   = Trials.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
+			authors_base  = Authors.objects.filter(articles__teams__organization_id__in=visible_org_ids).distinct()
+			sources_base  = Sources.objects.filter(team__organization_id__in=visible_org_ids)
+		else:
+			articles_base = Articles.objects.all()
+			trials_base   = Trials.objects.all()
+			authors_base  = Authors.objects.all()
+			sources_base  = Sources.objects.all()
 
 		# Articles count
 		if team_ids:
-			articles_count = Articles.objects.filter(teams__in=team_ids).distinct().count()
+			articles_count = articles_base.filter(teams__in=team_ids).distinct().count()
 		else:
-			articles_count = Articles.objects.count()
+			articles_count = articles_base.count()
 
 		# Trials count
 		if team_ids:
-			trials_count = Trials.objects.filter(teams__in=team_ids).distinct().count()
+			trials_count = trials_base.filter(teams__in=team_ids).distinct().count()
 		else:
-			trials_count = Trials.objects.count()
+			trials_count = trials_base.count()
 
 		# Subscribers count (active only)
 		if team_ids:
@@ -1786,17 +1807,17 @@ class StatsView(APIView):
 
 		# Authors count (distinct authors linked to articles in scope)
 		if team_ids:
-			authors_count = Authors.objects.filter(
+			authors_count = authors_base.filter(
 				articles__teams__in=team_ids
 			).distinct().count()
 		else:
-			authors_count = Authors.objects.count()
+			authors_count = authors_base.count()
 
 		# Sources queryset scoped to team(s)
 		if team_ids:
-			sources_qs = Sources.objects.filter(team__in=team_ids)
+			sources_qs = sources_base.filter(team__in=team_ids)
 		else:
-			sources_qs = Sources.objects.all()
+			sources_qs = sources_base
 
 		def extract_domain(url):
 			if not url:

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1744,7 +1744,13 @@ class StatsView(APIView):
 	"""
 	Returns aggregate statistics about the data in the system.
 	All counts can be optionally scoped to one or more teams via ?team=1 or ?team=1,2,3.
-	Counts are always filtered to organisations visible to the caller (see §4.1 of the spec).
+
+	Counts are filtered to organisations visible to the caller when
+	``request.visible_org_ids`` is present (set by VisibleOrgMiddleware).
+	If the attribute is absent — e.g. in management commands or tests that
+	bypass middleware — the fallback is unscoped querysets that span all
+	organisations.  In production the middleware is always active, so callers
+	will always receive org-filtered results.
 	"""
 	permission_classes = [permissions.AllowAny]
 

--- a/django/rss/views.py
+++ b/django/rss/views.py
@@ -1,11 +1,13 @@
 from django.shortcuts import render
 from django.contrib.syndication.views import Feed
 from django.contrib.sites.models import Site
+from django.http import Http404
 from gregory.models import Articles, Authors, Trials, Subject
 from django.urls import reverse
 from django.contrib.sites.models import Site
 from sitesettings.models import CustomSetting
 from gregory.functions import normalize_orcid
+from gregory.visibility import visible_org_ids as _visible_org_ids
 
 def get_website_domain():
 	current_site = Site.objects.get_current()
@@ -19,7 +21,18 @@ class ArticlesByAuthorFeed(Feed):
 		normalized = normalize_orcid(orcid)
 		if not normalized:
 			raise Authors.DoesNotExist
-		return Authors.objects.get(ORCID=normalized)
+		author = Authors.objects.get(ORCID=normalized)
+
+		# Compute visibility and attach to self for use in items()
+		self._visible_org_ids = _visible_org_ids(request)
+
+		# 404 if author has no articles in any visible org
+		if not author.articles_set.filter(
+			teams__organization_id__in=self._visible_org_ids
+		).exists():
+			raise Http404
+
+		return author
 
 	# Feed metadata (dynamic per author)
 	def title(self, obj):
@@ -32,7 +45,14 @@ class ArticlesByAuthorFeed(Feed):
 	description = "RSS feed for articles by a specific author."
 
 	def items(self, obj):
-		return Articles.objects.filter(authors=obj).order_by('-published_date')[:50]
+		return (
+			Articles.objects.filter(
+				authors=obj,
+				teams__organization_id__in=self._visible_org_ids,
+			)
+			.distinct()
+			.order_by('-published_date')[:50]
+		)
 
 	def item_title(self, item):
 		return item.title
@@ -54,15 +74,29 @@ class ArticlesByAuthorFeed(Feed):
 		return item.published_date
 
 	def item_updateddate(self, item):
-		return item.last_updated
+		return item.discovery_date
 
 
 class TrialsBySubjectFeed(Feed):
 	"""RSS feed for clinical trials filtered by subject slug."""
 
 	def get_object(self, request, subject_slug):
-		# Look up subject by slug
-		return Subject.objects.get(subject_slug=subject_slug)
+		subject = Subject.objects.get(subject_slug=subject_slug)
+
+		# Compute visibility and attach to self for use in items()
+		self._visible_org_ids = _visible_org_ids(request)
+
+		# 404 if subject belongs to an org that isn't visible
+		if subject.team_id is not None:
+			from gregory.models import Team as _Team
+			try:
+				team = _Team.objects.get(id=subject.team_id)
+				if team.organization_id not in self._visible_org_ids:
+					raise Http404
+			except _Team.DoesNotExist:
+				raise Http404
+
+		return subject
 
 	# Feed metadata (dynamic per subject)
 	def title(self, obj):
@@ -75,7 +109,14 @@ class TrialsBySubjectFeed(Feed):
 		return f"RSS feed for clinical trials related to {obj.subject_name}."
 
 	def items(self, obj):
-		return Trials.objects.filter(subjects=obj).order_by('-discovery_date')[:50]
+		return (
+			Trials.objects.filter(
+				subjects=obj,
+				teams__organization_id__in=self._visible_org_ids,
+			)
+			.distinct()
+			.order_by('-discovery_date')[:50]
+		)
 
 	def item_title(self, item):
 		return item.title

--- a/django/rss/views.py
+++ b/django/rss/views.py
@@ -19,12 +19,13 @@ class ArticlesByAuthorFeed(Feed):
 			raise Authors.DoesNotExist
 		author = Authors.objects.get(ORCID=normalized)
 
-		# Compute visibility and attach to self for use in items()
-		self._visible_org_ids = _visible_org_ids(request)
+		# Compute visibility and attach to the per-request obj (not self)
+		# so concurrent requests on the shared Feed instance don't interfere.
+		author._visible_org_ids = _visible_org_ids(request)
 
 		# 404 if author has no articles in any visible org
 		if not author.articles_set.filter(
-			teams__organization_id__in=self._visible_org_ids
+			teams__organization_id__in=author._visible_org_ids
 		).exists():
 			raise Http404
 
@@ -44,7 +45,7 @@ class ArticlesByAuthorFeed(Feed):
 		return (
 			Articles.objects.filter(
 				authors=obj,
-				teams__organization_id__in=self._visible_org_ids,
+				teams__organization_id__in=obj._visible_org_ids,
 			)
 			.distinct()
 			.order_by('-published_date')[:50]
@@ -79,15 +80,16 @@ class TrialsBySubjectFeed(Feed):
 	def get_object(self, request, subject_slug):
 		subject = Subject.objects.get(subject_slug=subject_slug)
 
-		# Compute visibility and attach to self for use in items()
-		self._visible_org_ids = _visible_org_ids(request)
+		# Compute visibility and attach to the per-request obj (not self)
+		# so concurrent requests on the shared Feed instance don't interfere.
+		subject._visible_org_ids = _visible_org_ids(request)
 
 		# 404 if subject belongs to an org that isn't visible
 		if subject.team_id is not None:
 			from gregory.models import Team as _Team
 			try:
 				team = _Team.objects.get(id=subject.team_id)
-				if team.organization_id not in self._visible_org_ids:
+				if team.organization_id not in subject._visible_org_ids:
 					raise Http404
 			except _Team.DoesNotExist:
 				raise Http404
@@ -108,7 +110,7 @@ class TrialsBySubjectFeed(Feed):
 		return (
 			Trials.objects.filter(
 				subjects=obj,
-				teams__organization_id__in=self._visible_org_ids,
+				teams__organization_id__in=obj._visible_org_ids,
 			)
 			.distinct()
 			.order_by('-discovery_date')[:50]

--- a/django/rss/views.py
+++ b/django/rss/views.py
@@ -1,4 +1,3 @@
-from django.shortcuts import render
 from django.contrib.syndication.views import Feed
 from django.contrib.sites.models import Site
 from django.http import Http404

--- a/django/rss/views.py
+++ b/django/rss/views.py
@@ -3,9 +3,6 @@ from django.contrib.syndication.views import Feed
 from django.contrib.sites.models import Site
 from django.http import Http404
 from gregory.models import Articles, Authors, Trials, Subject
-from django.urls import reverse
-from django.contrib.sites.models import Site
-from sitesettings.models import CustomSetting
 from gregory.functions import normalize_orcid
 from gregory.visibility import visible_org_ids as _visible_org_ids
 


### PR DESCRIPTION
## PR 6 — Stats, search, and RSS

### Goal

Cover the remaining read surfaces.

### Scope

In:

- `StatsView`: filter aggregates over visible orgs; `?team=<id>` for a hidden team → 404.
- Any remaining search endpoints not covered in PR 4 or PR 5.
- RSS feeds (`ArticlesByAuthorFeed`, `TrialsBySubjectFeed`): items filtered to visible orgs, parent 404 if author/subject is not visible. `?include_public=true` honoured.

Out:

- `post_article` (PR 7).

### Files touched

- `django/api/views.py` — `StatsView`
- `django/rss/views.py` — feed classes
- `django/api/tests/test_visibility_stats.py` (new)
- `django/api/tests/test_visibility_rss.py` (new)

### Tests

- Stats with default scope and with `include_public=true` returns the right counts for each archetype.
- RSS feed for a visible author returns only visible articles.
- RSS feed for a hidden author returns 404.

### Risk and rollback

Low. Same default-open mitigation.

### Acceptance criteria

- New tests pass.
- Stats numbers for the production database remain unchanged when all orgs are `make_api_public=True`.
