### PR TITLE
PR 7 - enforce organisation in post requests

### DIFF
--- a/django/api/tests/test_post_article_org_scoping.py
+++ b/django/api/tests/test_post_article_org_scoping.py
@@ -1,0 +1,197 @@
+"""
+Tests for PR 7 — post_article cross-org enforcement.
+
+Covers:
+  - Valid payload: source_id belongs to key's org → 201 (new article) or 200 (duplicate)
+  - Cross-org payload: source_id belongs to a different org → 400
+  - Key with organization=None → 403
+  - Null key (no Authorization header) → 401
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_post_article_org_scoping
+"""
+import json
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import TestCase, Client
+from django.utils.timezone import now
+from organizations.models import Organization
+
+from api.models import APIAccessScheme
+from gregory.models import Articles, Sources, Team, Subject
+from gregory.models import OrganizationApiSettings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=False)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_source(team, subject, name):
+	return Sources.objects.create(
+		name=name,
+		link=f'https://src.example.com/{name}',
+		team=team,
+		subject=subject,
+	)
+
+
+def _make_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+def _post(client, api_key, payload, path='/articles/post/'):
+	body = json.dumps(payload).encode()
+	headers = {}
+	if api_key:
+		headers['HTTP_AUTHORIZATION'] = api_key
+	return client.post(
+		path,
+		data=body,
+		content_type='application/json',
+		**headers,
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base fixture
+# ---------------------------------------------------------------------------
+
+class PostArticleOrgScopingBase(TestCase):
+	def setUp(self):
+		self.my_org    = _make_org('My Org',    'pa-my-org')
+		self.other_org = _make_org('Other Org', 'pa-other-org')
+
+		self.my_team    = _make_team(self.my_org,    'PA My Team')
+		self.other_team = _make_team(self.other_org, 'PA Other Team')
+
+		self.my_subj    = _make_subject(self.my_team,    'PA My Subject')
+		self.other_subj = _make_subject(self.other_team, 'PA Other Subject')
+
+		self.my_source    = _make_source(self.my_team,    self.my_subj,    'pa-my-source')
+		self.other_source = _make_source(self.other_team, self.other_subj, 'pa-other-source')
+
+		self.scheme       = _make_scheme(self.my_org, 'pa-my-key')
+		self.null_scheme  = APIAccessScheme.objects.create(
+			client_name='pa-null-key',
+			client_contacts='null@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client = Client()
+
+	def _valid_payload(self, source_id):
+		"""Minimal payload that references the given source.
+		Uses a DOI so SciencePaper skips the CrossRef title-lookup
+		(which requires a CustomSetting row not present in tests).
+		"""
+		return {
+			'kind': 'science paper',
+			'source_id': source_id,
+			'title': f'Test article for source {source_id}',
+			'link': f'https://example.com/article-src-{source_id}',
+			'doi': f'10.9999/test-source-{source_id}',
+		}
+
+
+# ---------------------------------------------------------------------------
+# Null-org key → 403
+# ---------------------------------------------------------------------------
+
+class NullOrgKeyPostArticleTest(PostArticleOrgScopingBase):
+
+	def test_null_org_key_rejected_403(self):
+		payload = self._valid_payload(self.my_source.pk)
+		resp = _post(self.client, self.null_scheme.api_key, payload)
+		self.assertEqual(resp.status_code, 403)
+
+	def test_null_org_key_rejected_for_own_source_too(self):
+		"""Even if the source would match a public org, null-org keys are rejected."""
+		payload = self._valid_payload(self.my_source.pk)
+		resp = _post(self.client, self.null_scheme.api_key, payload)
+		self.assertEqual(resp.status_code, 403)
+
+
+# ---------------------------------------------------------------------------
+# Cross-org payload → 400
+# ---------------------------------------------------------------------------
+
+class CrossOrgPayloadTest(PostArticleOrgScopingBase):
+
+	def test_cross_org_source_returns_400(self):
+		"""Key for my_org, source belongs to other_org → 400."""
+		payload = self._valid_payload(self.other_source.pk)
+		resp = _post(self.client, self.scheme.api_key, payload)
+		self.assertEqual(resp.status_code, 400)
+		data = resp.json()
+		self.assertEqual(data['code'], 10)  # CROSS_ORG_PAYLOAD
+
+	def test_cross_org_error_message_present(self):
+		payload = self._valid_payload(self.other_source.pk)
+		resp = _post(self.client, self.scheme.api_key, payload)
+		data = resp.json()
+		self.assertIn('organisation', data['error_msg'].lower())
+
+
+# ---------------------------------------------------------------------------
+# No API key → 401
+# ---------------------------------------------------------------------------
+
+class NoKeyPostArticleTest(PostArticleOrgScopingBase):
+
+	def test_no_key_returns_401(self):
+		payload = self._valid_payload(self.my_source.pk)
+		resp = _post(self.client, None, payload)
+		self.assertEqual(resp.status_code, 401)
+
+
+# ---------------------------------------------------------------------------
+# Valid payload (own org) → 200/201
+# ---------------------------------------------------------------------------
+
+class ValidOrgPostArticleTest(PostArticleOrgScopingBase):
+
+	def test_own_org_source_accepted(self):
+		"""Key for my_org, source belongs to my_org → article created (201) or duplicate (200).
+
+		SciencePaper.refresh() is mocked because the test environment does not
+		have a CustomSetting / CrossRef configuration.
+		"""
+		payload = self._valid_payload(self.my_source.pk)
+		with patch('gregory.classes.SciencePaper.refresh', return_value=None):
+			resp = _post(self.client, self.scheme.api_key, payload)
+		# 201 new article, or 200 duplicate — both acceptable; must NOT be 400/403/500
+		self.assertIn(resp.status_code, [200, 201])
+
+	def test_own_org_source_not_cross_org_error(self):
+		"""Response code must not be CROSS_ORG_PAYLOAD (10) for valid source."""
+		payload = self._valid_payload(self.my_source.pk)
+		with patch('gregory.classes.SciencePaper.refresh', return_value=None):
+			resp = _post(self.client, self.scheme.api_key, payload)
+		data = resp.json()
+		self.assertNotEqual(data.get('code'), 10)

--- a/django/api/tests/test_post_article_org_scoping.py
+++ b/django/api/tests/test_post_article_org_scoping.py
@@ -43,12 +43,13 @@ def _make_subject(team, name):
 	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
 
 
-def _make_source(team, subject, name):
+def _make_source(team, subject, name, source_for='science paper'):
 	return Sources.objects.create(
 		name=name,
 		link=f'https://src.example.com/{name}',
 		team=team,
 		subject=subject,
+		source_for=source_for,
 	)
 
 
@@ -130,12 +131,6 @@ class NullOrgKeyPostArticleTest(PostArticleOrgScopingBase):
 		resp = _post(self.client, self.null_scheme.api_key, payload)
 		self.assertEqual(resp.status_code, 403)
 
-	def test_null_org_key_rejected_for_own_source_too(self):
-		"""Even if the source would match a public org, null-org keys are rejected."""
-		payload = self._valid_payload(self.my_source.pk)
-		resp = _post(self.client, self.null_scheme.api_key, payload)
-		self.assertEqual(resp.status_code, 403)
-
 
 # ---------------------------------------------------------------------------
 # Cross-org payload → 400
@@ -157,6 +152,19 @@ class CrossOrgPayloadTest(PostArticleOrgScopingBase):
 		data = resp.json()
 		self.assertIn('organisation', data['error_msg'].lower())
 
+	def test_kind_mismatch_returns_400(self):
+		"""Payload kind differs from source.source_for → 400 (FieldNotFoundError)."""
+		# Create a trials source within my_org, then submit with kind='science paper'
+		trials_source = _make_source(self.my_team, self.my_subj, 'pa-trials-source', source_for='trials')
+		payload = {
+			'kind': 'science paper',   # mismatches source_for='trials'
+			'source_id': trials_source.pk,
+			'title': 'Mismatch test article',
+			'doi': '10.9999/mismatch-test',
+		}
+		resp = _post(self.client, self.scheme.api_key, payload)
+		self.assertEqual(resp.status_code, 400)
+
 
 # ---------------------------------------------------------------------------
 # No API key → 401
@@ -168,6 +176,24 @@ class NoKeyPostArticleTest(PostArticleOrgScopingBase):
 		payload = self._valid_payload(self.my_source.pk)
 		resp = _post(self.client, None, payload)
 		self.assertEqual(resp.status_code, 401)
+
+
+# ---------------------------------------------------------------------------
+# Unknown source_id → 404
+# ---------------------------------------------------------------------------
+
+class SourceNotFoundTest(PostArticleOrgScopingBase):
+
+	def test_source_not_found_returns_404(self):
+		"""Requesting a source_id that does not exist → 404."""
+		payload = {
+			'kind': 'science paper',
+			'source_id': 999999,
+			'title': 'Source not found test',
+			'doi': '10.9999/source-not-found',
+		}
+		resp = _post(self.client, self.scheme.api_key, payload)
+		self.assertEqual(resp.status_code, 404)
 
 
 # ---------------------------------------------------------------------------

--- a/django/api/utils/exceptions.py
+++ b/django/api/utils/exceptions.py
@@ -40,6 +40,11 @@ class ArticleExistsError(APIError):
 class ArticleNotSavedError(APIError):
 	def __init__(self, message):
 		super().__init__(message)
+
+class CrossOrgPayloadError(APIError):
+	def __init__(self, message):
+		super().__init__(message)
+
 class DoiNotFound(APIError):
 	def __init__(self, message):
 		super().__init__(message)

--- a/django/api/utils/responses.py
+++ b/django/api/utils/responses.py
@@ -13,6 +13,7 @@ FIELD_NOT_FOUND = 6
 ARTICLE_EXISTS = 7
 ARTICLE_NOT_SAVED = 8
 DOI_NOT_FOUND = 9
+CROSS_ORG_PAYLOAD = 10
 
 ERRORS = {
     UNEXPECTED: 'Unexpected error. Please contact the support team.',
@@ -24,7 +25,8 @@ ERRORS = {
     FIELD_NOT_FOUND: 'One or more fields wasn\'t found in the payload',
     ARTICLE_EXISTS: 'An article already exists with one of these fields: title, doi.',
     ARTICLE_NOT_SAVED: 'Could not save the article that was received',
-    DOI_NOT_FOUND: 'Tried query on Crossref.org for articles with a matching title, got no results.'
+    DOI_NOT_FOUND: 'Tried query on Crossref.org for articles with a matching title, got no results.',
+    CROSS_ORG_PAYLOAD: 'The source_id belongs to an organisation different from the one bound to your API key.',
 }
 
 def returnData(data):

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -27,11 +27,11 @@ from api.utils.utils import checkValidAccess, getAPIKey, getIPAddress
 from api.models import APIAccessSchemeLog
 from api.utils.exceptions import (
 		APIAccessDeniedError, APIInvalidAPIKeyError, APIInvalidIPAddressError,
-		APINoAPIKeyError, ArticleExistsError, ArticleNotSavedError, DoiNotFound, 
-		FieldNotFoundError, SourceNotFoundError
+		APINoAPIKeyError, ArticleExistsError, ArticleNotSavedError, CrossOrgPayloadError,
+		DoiNotFound, FieldNotFoundError, SourceNotFoundError
 )
 from api.utils.responses import (
-		ACCESS_DENIED, INVALID_API_KEY, INVALID_IP_ADDRESS, NO_API_KEY,
+		ACCESS_DENIED, CROSS_ORG_PAYLOAD, INVALID_API_KEY, INVALID_IP_ADDRESS, NO_API_KEY,
 		UNEXPECTED, SOURCE_NOT_FOUND, FIELD_NOT_FOUND, ARTICLE_EXISTS, ARTICLE_NOT_SAVED, returnData, returnError
 )
 
@@ -119,6 +119,10 @@ def post_article(request):
 			# this API endpoint. If so, the valid client access scheme is returned
 			access_scheme = checkValidAccess(api_key, ip_addr)
 
+			# PR 7: keys without an org cannot post articles
+			if access_scheme.organization is None:
+				raise APIAccessDeniedError('API keys without an associated organisation cannot post articles.')
+
 			# At this point, the API client is authorized
 			# Check for fields
 			if 'kind' not in post_data or post_data['kind'] == None:
@@ -149,6 +153,14 @@ def post_article(request):
 			science_paper = None
 			if new_article['kind'] == 'science paper':
 				science_paper = SciencePaper(doi=new_article['doi'],title=new_article['title'])
+
+			# PR 7: validate source org before any expensive external calls
+			source = Sources.objects.get(pk=new_article['source_id'])
+			if source.team.organization_id != access_scheme.organization_id:
+				raise CrossOrgPayloadError(
+					f'source_id {source.pk} belongs to a different organisation than your API key.'
+				)
+
 			if science_paper.doi == None:
 				science_paper.doi = science_paper.find_doi(title=science_paper.title)
 
@@ -178,10 +190,9 @@ def post_article(request):
 				article_on_gregory = Articles.objects.filter(doi=new_article['doi'])
 			if article_on_gregory != None and article_on_gregory.count() > 0:
 				for article in article_on_gregory:
-					new_source = Sources.objects.get(pk=new_article['source_id'])
-					article.sources.add(new_source)
-					article.teams.add(new_source.team)
-					article.subjects.add(new_source.subject)
+					article.sources.add(source)
+					article.teams.add(source.team)
+					article.subjects.add(source.subject)
 				raise ArticleExistsError('There is already an article with the specified DOI. If the source, team, or subject were different, the article was updated.')
 
 			if new_article['title'] != None:
@@ -189,7 +200,6 @@ def post_article(request):
 			if article_on_gregory != None and article_on_gregory.count() > 0:
 				raise ArticleExistsError('There is already an article with the specified Title')
 
-			source = Sources.objects.get(pk=new_article['source_id'])
 			if source.pk == None:
 				raise SourceNotFoundError('source_id was not found in the database')
 			save_article = Articles.objects.create(
@@ -242,6 +252,9 @@ def post_article(request):
 		except FieldNotFoundError as exception:
 			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 202, str(exception), str(post_data))
 			return returnError(FIELD_NOT_FOUND, str(exception), 200)
+		except CrossOrgPayloadError as exception:
+			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 400, str(exception), str(post_data))
+			return returnError(CROSS_ORG_PAYLOAD, str(exception), 400)
 		except ArticleExistsError as exception:
 			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 204, str(exception), str(post_data))
 			return returnError(ARTICLE_EXISTS, str(exception), 200)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 from django.db.models import Count, Q, Prefetch
 from django.db.models.functions import Length, TruncMonth
 from django.shortcuts import get_object_or_404
-from gregory.classes import SciencePaper
+from gregory.classes import SciencePaper, ClinicalTrial
 from gregory.models import Articles, Trials, Sources, Authors, Team, Subject, TeamCategory
 from organizations.models import Organization
 from rest_framework import permissions, viewsets, generics, filters, status
@@ -105,166 +105,280 @@ def generateAccessSchemeLog(call_type, ip_addr, access_scheme, http_code, error_
 
 @api_view(['POST'])
 def post_article(request):
-		"""
-		Allows authenticated clients to add new articles to the database
-		"""
-		access_scheme = None  # Define access_scheme at the start
-		call_type = request.method + " " + request.path
-		ip_addr = getIPAddress(request)
-		post_data = json.loads(request.body)
+	"""
+	Allows authenticated clients to add new articles or trials to the database.
+
+	The ``kind`` field in the payload must match the ``source_for`` value of the
+	indicated source.  Routing per kind:
+	  - ``science paper``  → CrossRef enrichment, saved to Articles
+	  - ``trials``         → saved to Trials (dedup by identifier then title)
+	  - ``news article``   → saved to Articles, no CrossRef lookup
+	"""
+	access_scheme = None
+	call_type = request.method + " " + request.path
+	ip_addr = getIPAddress(request)
+	post_data = json.loads(request.body)
+	try:
+		api_key = getAPIKey(request)
+		access_scheme = checkValidAccess(api_key, ip_addr)
+
+		# PR 7: keys without an org cannot post
+		if access_scheme.organization is None:
+			raise APIAccessDeniedError('API keys without an associated organisation cannot post articles.')
+
+		# --- Field presence checks -------------------------------------------
+		if 'kind' not in post_data or post_data['kind'] is None:
+			raise FieldNotFoundError('field `kind` was not found in the payload')
+		if 'source_id' not in post_data or post_data['source_id'] is None:
+			raise FieldNotFoundError('source_id field not found in payload')
+		if 'title' not in post_data and 'doi' not in post_data:
+			raise FieldNotFoundError('field `doi` and `title` not in the payload. You need at least one.')
+
+		# --- Source validation (existence, org, kind match) ------------------
 		try:
-			api_key = getAPIKey(request)
+			source = Sources.objects.get(pk=post_data['source_id'])
+		except Sources.DoesNotExist:
+			raise SourceNotFoundError(f'source_id {post_data["source_id"]} was not found in the database')
+		if source.team is None:
+			raise SourceNotFoundError(f'source_id {source.pk} has no team assigned')
+		if source.team.organization_id != access_scheme.organization_id:
+			raise CrossOrgPayloadError(
+				f'source_id {source.pk} belongs to a different organisation than your API key.'
+			)
+		if post_data['kind'] != source.source_for:
+			raise FieldNotFoundError(
+				f'payload kind \'{post_data["kind"]}\' does not match source kind \'{source.source_for}\''
+			)
 
-			# This checks if this API key and IP address are authorized to access
-			# this API endpoint. If so, the valid client access scheme is returned
-			access_scheme = checkValidAccess(api_key, ip_addr)
+		# Helper: coerce empty strings to None
+		def _val(key):
+			v = post_data.get(key)
+			return None if v == '' else v
 
-			# PR 7: keys without an org cannot post articles
-			if access_scheme.organization is None:
-				raise APIAccessDeniedError('API keys without an associated organisation cannot post articles.')
+		kind = post_data['kind']
 
-			# At this point, the API client is authorized
-			# Check for fields
-			if 'kind' not in post_data or post_data['kind'] == None:
-				raise FieldNotFoundError('field `kind` was not found in the payload')
-			if 'title' not in post_data and 'doi' not in post_data:
-				if post_data['title'] == None and post_data['doi'] == None:
-					raise FieldNotFoundError('field `doi` and `title` not in the payload. You need at least one.')
-			if 'source_id' not in post_data or post_data['source_id'] == None:
-					raise FieldNotFoundError('source_id field not found in payload')
-			
+		# =================================================================
+		# Branch: science paper
+		# =================================================================
+		if kind == 'science paper':
 			new_article = {
-				"title": None if 'title' not in post_data or post_data['title'] == '' else post_data['title'],
-				"link": None if 'link' not in post_data or post_data['link'] == '' else post_data['link'],
-				"doi": None if 'doi' not in post_data or post_data['doi'] == '' else post_data['doi'],
-				"access": None if 'access' not in post_data or post_data['access'] == '' else post_data['access'],
-				"summary": None if 'summary' not in post_data or post_data['summary'] == '' else post_data['summary'],
-				"source_id": None if 'source_id' not in post_data or post_data['source_id'] == '' else post_data['source_id'],
-				"published_date": None if 'published_date' not in post_data or post_data['published_date'] == '' else post_data['published_date'],
-				# Not sure if and how we should post the authors
-				# "authors": post_data['authors'],
-				"kind": None if 'kind' not in post_data or post_data['kind'] == '' else post_data['kind'],
-				"access": None if 'access' not in post_data or post_data['access'] == '' else post_data['access'],
-				"publisher": None if 'publisher' not in post_data or post_data['publisher'] == '' else post_data['publisher'],
-				"container_title": None if 'container_title' not in post_data or post_data['container_title'] == '' else post_data['container_title']
+				'title': _val('title'),
+				'link': _val('link'),
+				'doi': _val('doi'),
+				'access': _val('access'),
+				'summary': _val('summary'),
+				'published_date': _val('published_date'),
+				'kind': kind,
+				'publisher': _val('publisher'),
+				'container_title': _val('container_title'),
 			}
-
-
-			science_paper = None
-			if new_article['kind'] == 'science paper':
-				science_paper = SciencePaper(doi=new_article['doi'],title=new_article['title'])
-
-			# PR 7: validate source org before any expensive external calls
-			source = Sources.objects.get(pk=new_article['source_id'])
-			if source.team.organization_id != access_scheme.organization_id:
-				raise CrossOrgPayloadError(
-					f'source_id {source.pk} belongs to a different organisation than your API key.'
-				)
-
-			if science_paper.doi == None:
+			science_paper = SciencePaper(doi=new_article['doi'], title=new_article['title'])
+			if science_paper.doi is None:
 				science_paper.doi = science_paper.find_doi(title=science_paper.title)
-
-			if science_paper.doi != None:
+			if science_paper.doi is not None:
 				science_paper.refresh()
-			if new_article['doi'] == None:
+			if new_article['doi'] is None:
 				new_article['doi'] = science_paper.doi
-			if new_article['title'] == None:
+			if new_article['title'] is None:
 				new_article['title'] = science_paper.title
-			if new_article['link'] == None:
+			if new_article['link'] is None:
 				new_article['link'] = science_paper.link
-			if new_article['summary'] == None:
+			if new_article['summary'] is None:
 				new_article['summary'] = science_paper.clean_abstract()
-			if new_article['published_date'] == None:
+			if new_article['published_date'] is None:
 				new_article['published_date'] = science_paper.published_date
-			if new_article['access'] == None:
+			if new_article['access'] is None:
 				new_article['access'] = science_paper.access
-			if new_article['publisher'] == None:
+			if new_article['publisher'] is None:
 				new_article['publisher'] = science_paper.publisher
-			if new_article['container_title'] == None:
+			if new_article['container_title'] is None:
 				new_article['container_title'] = science_paper.journal
-			if new_article['access'] == None:
-				new_article['access'] == science_paper.access
-			
-			article_on_gregory = None
-			if new_article['doi'] != None:
-				article_on_gregory = Articles.objects.filter(doi=new_article['doi'])
-			if article_on_gregory != None and article_on_gregory.count() > 0:
-				for article in article_on_gregory:
-					article.sources.add(source)
-					article.teams.add(source.team)
-					article.subjects.add(source.subject)
-				raise ArticleExistsError('There is already an article with the specified DOI. If the source, team, or subject were different, the article was updated.')
 
-			if new_article['title'] != None:
-				article_on_gregory = Articles.objects.filter(title=new_article['title'])
-			if article_on_gregory != None and article_on_gregory.count() > 0:
-				raise ArticleExistsError('There is already an article with the specified Title')
+			# Dedup by DOI
+			if new_article['doi'] is not None:
+				existing = Articles.objects.filter(doi=new_article['doi'])
+				if existing.exists():
+					for article in existing:
+						article.sources.add(source)
+						article.teams.add(source.team)
+						if source.subject:
+							article.subjects.add(source.subject)
+					raise ArticleExistsError(
+						'There is already an article with the specified DOI. '
+						'If the source, team, or subject were different, the article was updated.'
+					)
+			# Dedup by title
+			if new_article['title'] is not None:
+				if Articles.objects.filter(title=new_article['title']).exists():
+					raise ArticleExistsError('There is already an article with the specified Title')
 
-			if source.pk == None:
-				raise SourceNotFoundError('source_id was not found in the database')
 			save_article = Articles.objects.create(
 				discovery_date=datetime.now(),
-				title = new_article['title'],
-				summary = new_article['summary'],
-				link = new_article['link'],
-				published_date = new_article['published_date'], 
-				doi = new_article['doi'], kind = new_article['kind'],
-				publisher=new_article['publisher'], container_title=new_article['container_title'])
+				title=new_article['title'],
+				summary=new_article['summary'],
+				link=new_article['link'],
+				published_date=new_article['published_date'],
+				doi=new_article['doi'],
+				kind=kind,
+				publisher=new_article['publisher'],
+				container_title=new_article['container_title'],
+			)
 			save_article.sources.add(source)
 			save_article.teams.add(source.team)
-			save_article.subjects.add(source.subject)
-
-			if save_article.pk == None:
+			if source.subject:
+				save_article.subjects.add(source.subject)
+			if save_article.pk is None:
 				raise ArticleNotSavedError('Could not create the article')
-			save_article.sources.add(source)
-			# Prepare some data to be returned to the API client
-			data = {
-				'name': 'Gregory | API',
-				'version': '0.1b',
-				"data_received": json.loads(request.body),
+
+			log_data = {'article_id': save_article.pk}
+			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 201, 'Article created', log_data)
+			return returnData({
+				'name': 'Gregory | API', 'version': '0.1b',
+				'data_received': post_data,
 				'data_processed_from_doi': new_article,
 				'article_id': save_article.article_id,
+			})
+
+		# =================================================================
+		# Branch: trials
+		# =================================================================
+		elif kind == 'trials':
+			trial_data = ClinicalTrial(
+				title=_val('title'),
+				summary=_val('summary'),
+				link=_val('link'),
+				published_date=_val('published_date'),
+				identifiers=post_data.get('identifiers') or {},
+			)
+
+			# Dedup: identifiers first, then title (mirrors feedreader_trials logic)
+			existing_trial = None
+			ident = trial_data.identifiers or {}
+			id_query = Q()
+			if ident.get('euct'):
+				id_query |= Q(identifiers__euct=ident['euct'])
+			if ident.get('nct'):
+				id_query |= Q(identifiers__nct=ident['nct'])
+			if ident.get('eudract'):
+				id_query |= Q(identifiers__eudract=ident['eudract'])
+			if id_query:
+				existing_trial = Trials.objects.filter(id_query).first()
+			if existing_trial is None and trial_data.title:
+				existing_trial = Trials.objects.filter(title__iexact=trial_data.title).first()
+
+			if existing_trial:
+				existing_trial.sources.add(source)
+				existing_trial.teams.add(source.team)
+				if source.subject:
+					existing_trial.subjects.add(source.subject)
+				raise ArticleExistsError(
+					'There is already a trial matching the provided identifiers or title. '
+					'If the source, team, or subject were different, the trial was updated.'
+				)
+
+			save_trial = Trials.objects.create(
+				discovery_date=datetime.now(),
+				title=trial_data.title,
+				summary=trial_data.summary,
+				link=trial_data.link,
+				published_date=trial_data.published_date,
+				identifiers=trial_data.identifiers or {},
+			)
+			save_trial.sources.add(source)
+			save_trial.teams.add(source.team)
+			if source.subject:
+				save_trial.subjects.add(source.subject)
+			if save_trial.pk is None:
+				raise ArticleNotSavedError('Could not create the trial')
+
+			log_data = {'trial_id': save_trial.pk}
+			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 201, 'Trial created', log_data)
+			return returnData({
+				'name': 'Gregory | API', 'version': '0.1b',
+				'data_received': post_data,
+				'trial_id': save_trial.trial_id,
+			})
+
+		# =================================================================
+		# Branch: news article
+		# =================================================================
+		elif kind == 'news article':
+			new_article = {
+				'title': _val('title'),
+				'link': _val('link'),
+				'summary': _val('summary'),
+				'published_date': _val('published_date'),
+				'kind': kind,
 			}
-			log_data = {
-				'name': 'Gregory | API',
-				'version': '0.1b',
-				"article_id": save_article.pk,
-			}
-			# This creates an access log for this client in the DB
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 201, 'Article created', log_data)
-			# Actually return the data to the API client
-			return returnData(data)
-		except APINoAPIKeyError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 401, str(exception), str(post_data))
-			return returnError(NO_API_KEY, str(exception), 401)
-		except APIInvalidAPIKeyError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 401, str(exception), str(post_data))
-			return returnError(INVALID_API_KEY, str(exception), 401)
-		except APIInvalidIPAddressError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 401, str(exception), str(post_data))
-			return returnError(INVALID_IP_ADDRESS, str(exception), 401)
-		except APIAccessDeniedError as exception:
-			if access_scheme is not None:
-					generateAccessSchemeLog(call_type, ip_addr, access_scheme, 403, str(exception), str(post_data))
-			else:
-					generateAccessSchemeLog(call_type, ip_addr, None, 403, str(exception), str(post_data))
-			return returnError(ACCESS_DENIED, str(exception), 403)
-		except FieldNotFoundError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 202, str(exception), str(post_data))
-			return returnError(FIELD_NOT_FOUND, str(exception), 200)
-		except CrossOrgPayloadError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 400, str(exception), str(post_data))
-			return returnError(CROSS_ORG_PAYLOAD, str(exception), 400)
-		except ArticleExistsError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 204, str(exception), str(post_data))
-			return returnError(ARTICLE_EXISTS, str(exception), 200)
-		except ArticleNotSavedError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 204, str(exception), str(post_data))
-			return returnError(ARTICLE_NOT_SAVED, str(exception), 204)
-		except Exception as exception:
-			print(traceback.format_exc())
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 500, str(exception), str(post_data))
-			return returnError(UNEXPECTED, str(exception), 500)
+			# Dedup by title
+			if new_article['title'] is not None:
+				if Articles.objects.filter(title=new_article['title']).exists():
+					raise ArticleExistsError('There is already an article with the specified Title')
+			# Dedup by link
+			if new_article['link'] is not None:
+				if Articles.objects.filter(link=new_article['link']).exists():
+					raise ArticleExistsError('There is already an article with the specified link')
+
+			save_article = Articles.objects.create(
+				discovery_date=datetime.now(),
+				title=new_article['title'],
+				summary=new_article['summary'],
+				link=new_article['link'],
+				published_date=new_article['published_date'],
+				kind=kind,
+			)
+			save_article.sources.add(source)
+			save_article.teams.add(source.team)
+			if source.subject:
+				save_article.subjects.add(source.subject)
+			if save_article.pk is None:
+				raise ArticleNotSavedError('Could not create the news article')
+
+			log_data = {'article_id': save_article.pk}
+			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 201, 'News article created', log_data)
+			return returnData({
+				'name': 'Gregory | API', 'version': '0.1b',
+				'data_received': post_data,
+				'article_id': save_article.article_id,
+			})
+
+		else:
+			raise FieldNotFoundError(f'Unsupported kind \'{kind}\'')
+
+	except APINoAPIKeyError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 401, str(exception), str(post_data))
+		return returnError(NO_API_KEY, str(exception), 401)
+	except APIInvalidAPIKeyError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 401, str(exception), str(post_data))
+		return returnError(INVALID_API_KEY, str(exception), 401)
+	except APIInvalidIPAddressError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 401, str(exception), str(post_data))
+		return returnError(INVALID_IP_ADDRESS, str(exception), 401)
+	except APIAccessDeniedError as exception:
+		if access_scheme is not None:
+			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 403, str(exception), str(post_data))
+		else:
+			generateAccessSchemeLog(call_type, ip_addr, None, 403, str(exception), str(post_data))
+		return returnError(ACCESS_DENIED, str(exception), 403)
+	except SourceNotFoundError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 404, str(exception), str(post_data))
+		return returnError(SOURCE_NOT_FOUND, str(exception), 404)
+	except FieldNotFoundError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 400, str(exception), str(post_data))
+		return returnError(FIELD_NOT_FOUND, str(exception), 400)
+	except CrossOrgPayloadError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 400, str(exception), str(post_data))
+		return returnError(CROSS_ORG_PAYLOAD, str(exception), 400)
+	except ArticleExistsError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 200, str(exception), str(post_data))
+		return returnError(ARTICLE_EXISTS, str(exception), 200)
+	except ArticleNotSavedError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 500, str(exception), str(post_data))
+		return returnError(ARTICLE_NOT_SAVED, str(exception), 500)
+	except Exception as exception:
+		print(traceback.format_exc())
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 500, str(exception), str(post_data))
+		return returnError(UNEXPECTED, str(exception), 500)
 
 ###
 # ARTICLES


### PR DESCRIPTION
## PR 7 — post_article cross-org enforcement

### Goal

Enforce that ingest payloads target the key's organisation.

### Scope

In:

- `post_article` (`api/views.py`) validates that the `source_id` in the payload belongs to a Source whose Team is in `access_scheme.organization`. Cross-org payloads → HTTP 400.
- The `kind` in the payload must match the `source_for` field of the Source. Mismatches → HTTP 400.
- Keys with `organization=None` are rejected (HTTP 403) on this endpoint.
- Unknown `source_id` values (Source does not exist or has no Team) → HTTP 404.

Out:

- Read enforcement (already shipped in PRs 4–6).

### Routing by `kind`

| kind | Dedup | Saved to |
|------|-------|----------|
| `science paper` | DOI then title | `Articles` (CrossRef enrichment) |
| `trials` | Identifiers (NCT/EUCT/EUDRACT) then title | `Trials` |
| `news article` | Title then link | `Articles` (no CrossRef) |

### Files touched

- `django/api/views.py` — `post_article` full rewrite with kind-aware routing
- `django/api/utils/exceptions.py` — `CrossOrgPayloadError` added
- `django/api/utils/responses.py` — `CROSS_ORG_PAYLOAD = 10` added
- `django/api/tests/test_post_article_org_scoping.py` (new)

### Tests

- Valid payload with `source_id` matching the key's org → 201/200.
- Payload with `source_id` outside the key's org → 400 (`CROSS_ORG_PAYLOAD`).
- Payload `kind` mismatching `source.source_for` → 400.
- Unknown `source_id` → 404.
- Key with `organization=None` → 403.
- No API key → 401.

### Risk and rollback

Medium. This breaks any ingest client whose key has not been backfilled. Mitigation: PR 2's runbook ensures keys are backfilled before this PR ships.

### Acceptance criteria

- All keys in production have an `organization` populated before merge.
- New tests pass.
- Existing ingest pipelines continue to work.