### PR TITLE
feat: add flag to allow organisations to mark the api as private

### DIFF
--- a/django/admin/settings.py
+++ b/django/admin/settings.py
@@ -100,6 +100,7 @@ MIDDLEWARE = [
 	'django.middleware.gzip.GZipMiddleware',
 	'django.contrib.sites.middleware.CurrentSiteMiddleware',
 	'simple_history.middleware.HistoryRequestMiddleware',
+	'gregory.middleware.visibility.VisibleOrgMiddleware',
 ]
 
 ROOT_URLCONF = 'admin.urls'

--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -25,7 +25,7 @@ from api.views import (
 	post_article, CategoryViewSet, LoginView, ProtectedEndpointView,
 	ArticlesByTeam, ArticlesBySubject, TeamsViewSet, SubjectsViewSet, SubjectsByTeam,
     ArticlesByCategoryAndTeam, ArticleSearchView, TrialSearchView, AuthorSearchView, CategoriesByTeamAndSubject,
-    StatsView
+    StatsView, OrganizationsViewSet
 )
 from rss.views import	ArticlesByAuthorFeed, TrialsBySubjectFeed
 from subscriptions.views import subscribe_view, unsubscribe_list, unsubscribe_site, unsubscribe_all
@@ -45,6 +45,7 @@ router = routers.DefaultRouter()
 router.register(r'articles', ArticleViewSet)
 router.register(r'authors', AuthorsViewSet, basename='authors')
 router.register(r'categories', CategoryViewSet, basename='categories')
+router.register(r'organizations', OrganizationsViewSet, basename='organizations')
 router.register(r'sources', SourceViewSet)
 router.register(r'trials', TrialViewSet)
 router.register(r'subjects', SubjectsViewSet)

--- a/django/api/admin.py
+++ b/django/api/admin.py
@@ -2,7 +2,9 @@ from django.contrib import admin
 from .models import APIAccessScheme, APIAccessSchemeLog
 
 class APIAcccessSchemeAdmin(admin.ModelAdmin):
-	list_display = ['api_key','client_name','client_contacts','ip_addresses','begin_date','end_date','max_calls_minute','max_calls_hour','max_calls_day']
+	list_display = ['api_key', 'client_name', 'client_contacts', 'organization', 'ip_addresses', 'begin_date', 'end_date', 'max_calls_minute', 'max_calls_hour', 'max_calls_day']
+	list_filter = ('organization',)
+	fields = ('api_key', 'client_name', 'client_contacts', 'organization', 'ip_addresses', 'begin_date', 'end_date', 'max_calls_minute', 'max_calls_hour', 'max_calls_day')
 	# a list of displayed columns name.
 
 class APILogAdmin(admin.ModelAdmin):

--- a/django/api/migrations/0003_apiaccessscheme_organization.py
+++ b/django/api/migrations/0003_apiaccessscheme_organization.py
@@ -1,0 +1,25 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		('api', '0002_apiaccessschemelog_payload_received'),
+		('organizations', '0001_initial'),
+	]
+
+	operations = [
+		migrations.AddField(
+			model_name='apiaccessscheme',
+			name='organization',
+			field=models.ForeignKey(
+				blank=True,
+				help_text='Organisation this key represents. Required after the transition window.',
+				null=True,
+				on_delete=django.db.models.deletion.CASCADE,
+				related_name='api_access_schemes',
+				to='organizations.organization',
+			),
+		),
+	]

--- a/django/api/models.py
+++ b/django/api/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.utils.crypto import get_random_string
 from django.utils.timezone import now
 from datetime import timedelta
+from organizations.models import Organization
 
 DEFAULT_MAX_CALLS_MINUTE = 60
 DEFAULT_MAX_CALLS_HOUR = DEFAULT_MAX_CALLS_MINUTE * 60
@@ -49,6 +50,17 @@ class APIAccessScheme(models.Model):
 
     # Maximum number of calls permitted per day
     max_calls_day = models.IntegerField(default=DEFAULT_MAX_CALLS_DAY, blank=False)
+
+    # The organisation this API key represents.
+    # Null is permitted during the transition window (PR 2); will become required in PR 8.
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name='api_access_schemes',
+        help_text='Organisation this key represents. Required after the transition window.',
+    )
 
     def __str__(self):
         return self.client_name

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -349,6 +349,10 @@ class AuthorSerializer(serializers.ModelSerializer):
 		# If the queryset has annotated article_count, use it for efficiency
 		if hasattr(obj, 'article_count'):
 			return obj.article_count
+		# Filter by visible orgs when request context is available
+		request = self.context.get('request')
+		if request is not None and hasattr(request, 'visible_org_ids'):
+			return obj.articles_set.filter(teams__organization_id__in=request.visible_org_ids).distinct().count()
 		# Fallback to counting all articles
 		return obj.articles_set.count()
 
@@ -392,3 +396,10 @@ class ArticlesByCategoryAndTeamSerializer(serializers.ModelSerializer):
 	class Meta:
 		model = TeamCategory
 		fields = ['id', 'team', 'category', 'articles']
+
+
+class OrganizationSerializer(serializers.ModelSerializer):
+	"""Minimal serializer for the Organizations list/detail endpoints."""
+	class Meta:
+		model = Organization
+		fields = ['id', 'name', 'slug', 'is_active']

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count, Q
 
+from api.serializers.mixins import OrgScopedSerializerMixin  # noqa: F401
+
 def get_custom_settings():
 		try:
 			return CustomSetting.objects.get(site=settings.SITE_ID)

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -275,7 +275,7 @@ class ArticleAuthorSerializer(serializers.ModelSerializer):
 	def get_full_name(self, obj):
 		return obj.full_name
 
-class ArticleSerializer(serializers.HyperlinkedModelSerializer):
+class ArticleSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSerializer):
 	sources = serializers.SlugRelatedField(many=True, read_only=True, slug_field='name')
 	team_categories = TeamCategorySerializer(many=True, read_only=True)
 	authors = ArticleAuthorSerializer(many=True, read_only=True)
@@ -302,7 +302,7 @@ class ArticleSerializer(serializers.HyperlinkedModelSerializer):
 		trials = [ref.trial for ref in references]
 		return TrialReferenceSerializer(trials, many=True).data
 
-class TrialSerializer(serializers.HyperlinkedModelSerializer):
+class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSerializer):
 	source = serializers.SlugRelatedField(read_only=True, slug_field='name')
 	team_categories = TeamCategorySerializer(many=True, read_only=True)
 	articles = serializers.SerializerMethodField()

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -346,14 +346,17 @@ class AuthorSerializer(serializers.ModelSerializer):
 		fields = ['author_id', 'given_name', 'family_name', 'full_name', 'ORCID', 'country', 'articles_count', 'articles_list']
 
 	def get_articles_count(self, obj):
-		# If the queryset has annotated article_count, use it for efficiency
+		request = self.context.get('request')
+		# When org-visibility is active, always compute the scoped count so the
+		# value is correct even if an un-scoped article_count was annotated by
+		# an earlier queryset stage (e.g. a cached queryset without visibility).
+		if request is not None and hasattr(request, 'visible_org_ids'):
+			return obj.articles_set.filter(
+				teams__organization_id__in=request.visible_org_ids
+			).distinct().count()
+		# No visibility active — use the pre-annotated count for efficiency.
 		if hasattr(obj, 'article_count'):
 			return obj.article_count
-		# Filter by visible orgs when request context is available
-		request = self.context.get('request')
-		if request is not None and hasattr(request, 'visible_org_ids'):
-			return obj.articles_set.filter(teams__organization_id__in=request.visible_org_ids).distinct().count()
-		# Fallback to counting all articles
 		return obj.articles_set.count()
 
 	def get_country(self, obj):

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -27,11 +27,12 @@ Query strategy (avoiding N+1 on list endpoints)
   column.  Visible team IDs are resolved once per request and cached on
   ``request._org_scoped_mixin_team_ids`` so the query runs at most once per
   request regardless of list length.
-- ``ml_predictions``:  ``prediction.subject_id`` is a direct FK column.
-  Visible subject IDs are resolved once per request and cached on
-  ``request._org_scoped_mixin_subject_ids`` so the query runs at most once
-  per request regardless of list length.  Iterating ``.all()`` in Python
-  then respects any ``prefetch_related('ml_predictions_detail')`` cache.
+- ``ml_predictions``:  Each serialised item already contains a ``subject``
+  key (the FK integer) from ``MLPredictionsSerializer``.  Visible subject IDs
+  are resolved once per request and cached on
+  ``request._org_scoped_mixin_subject_ids``.  Filtering is done entirely on
+  ``ret['ml_predictions']`` — no extra DB query, no dependency on whether
+  ``ml_predictions_detail`` was prefetched.
 """
 
 
@@ -108,10 +109,13 @@ class OrgScopedSerializerMixin:
 			visible_cat_ids = {c.id for c in instance.team_categories.all() if c.team_id in vt}
 			ret['team_categories'] = [c for c in ret['team_categories'] if c.get('id') in visible_cat_ids]
 
-		# --- ml_predictions: iterate Python, uses prefetch_related cache ---
-		if 'ml_predictions' in ret and hasattr(instance, 'ml_predictions_detail'):
+		# --- ml_predictions: filter directly on already-serialised data ---
+		# Each item in ret['ml_predictions'] already has a 'subject' key (the FK
+		# integer) from MLPredictionsSerializer.  Filtering here avoids hitting
+		# instance.ml_predictions_detail.all() a second time, which would cause
+		# an extra per-object query when the relation is not prefetched.
+		if 'ml_predictions' in ret:
 			vs = _request_visible_subject_ids(request, visible)
-			visible_pred_ids = {p.id for p in instance.ml_predictions_detail.all() if p.subject_id in vs}
-			ret['ml_predictions'] = [p for p in ret['ml_predictions'] if p.get('id') in visible_pred_ids]
+			ret['ml_predictions'] = [p for p in ret['ml_predictions'] if p.get('subject') in vs]
 
 		return ret

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -28,8 +28,10 @@ Query strategy (avoiding N+1 on list endpoints)
   ``request._org_scoped_mixin_team_ids`` so the query runs at most once per
   request regardless of list length.
 - ``ml_predictions``:  ``prediction.subject_id`` is a direct FK column.
-  Visible subject IDs are built in Python from the already-iterated subjects
-  manager (uses prefetch cache when ``prefetch_related('subjects')`` is active).
+  Visible subject IDs are resolved once per request and cached on
+  ``request._org_scoped_mixin_subject_ids`` so the query runs at most once
+  per request regardless of list length.  Iterating ``.all()`` in Python
+  then respects any ``prefetch_related('ml_predictions_detail')`` cache.
 """
 
 
@@ -46,6 +48,24 @@ def _request_visible_team_ids(request, visible_org_ids: set) -> set:
 			request,
 			cache_attr,
 			set(Team.objects.filter(organization_id__in=visible_org_ids).values_list('id', flat=True)),
+		)
+	return getattr(request, cache_attr)
+
+
+def _request_visible_subject_ids(request, visible_org_ids: set) -> set:
+	"""Return all subject IDs belonging to visible orgs, cached once per request.
+
+	Caching avoids issuing a subject-lookup query for every object in a list
+	endpoint response (used when filtering ml_predictions in Python).
+	"""
+	cache_attr = '_org_scoped_mixin_subject_ids'
+	if not hasattr(request, cache_attr):
+		from gregory.models import Subject
+		vt = _request_visible_team_ids(request, visible_org_ids)
+		setattr(
+			request,
+			cache_attr,
+			set(Subject.objects.filter(team_id__in=vt).values_list('id', flat=True)),
 		)
 	return getattr(request, cache_attr)
 
@@ -88,17 +108,10 @@ class OrgScopedSerializerMixin:
 			visible_cat_ids = {c.id for c in instance.team_categories.all() if c.team_id in vt}
 			ret['team_categories'] = [c for c in ret['team_categories'] if c.get('id') in visible_cat_ids]
 
-		# --- ml_predictions: one-level join using cached visible team IDs ---
-		# (subject__team_id__in=vt is simpler than subject__team__organization_id__in=visible;
-		# a full zero-query solution requires prefetch_related('ml_predictions_detail__subject')
-		# with select_related('team'), which is a viewset concern.)
+		# --- ml_predictions: iterate Python, uses prefetch_related cache ---
 		if 'ml_predictions' in ret and hasattr(instance, 'ml_predictions_detail'):
-			vt = _request_visible_team_ids(request, visible)
-			visible_pred_ids = set(
-				instance.ml_predictions_detail.filter(
-					subject__team_id__in=vt
-				).values_list('id', flat=True)
-			)
+			vs = _request_visible_subject_ids(request, visible)
+			visible_pred_ids = {p.id for p in instance.ml_predictions_detail.all() if p.subject_id in vs}
 			ret['ml_predictions'] = [p for p in ret['ml_predictions'] if p.get('id') in visible_pred_ids]
 
 		return ret

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -1,0 +1,77 @@
+"""
+api/serializers/mixins.py
+
+OrgScopedSerializerMixin — strips nested associations that belong to
+organisations outside ``request.visible_org_ids``.
+
+Applied fields (when present on the serialised object):
+  - ``teams``           → Team entries whose org is not visible
+  - ``subjects``        → Subject entries whose team's org is not visible
+  - ``team_categories`` → TeamCategory entries whose team's org is not visible
+  - ``ml_predictions``  → MLPredictions entries whose subject's team's org
+                           is not visible
+
+The mixin is intentionally a no-op when:
+  - There is no ``request`` in the serializer context, OR
+  - ``request.visible_org_ids`` has not been set (middleware not active).
+
+This guarantees zero behaviour change until the viewsets are explicitly
+opted in (PR 4 onwards).
+"""
+
+
+class OrgScopedSerializerMixin:
+	"""
+	Mixin for DRF serializers that strips nested associations belonging to
+	organisations the caller cannot see.
+
+	Usage::
+
+	    class ArticleSerializer(OrgScopedSerializerMixin,
+	                            serializers.HyperlinkedModelSerializer):
+	        ...
+	"""
+
+	def to_representation(self, instance):
+		ret = super().to_representation(instance)
+
+		request = self.context.get('request')
+		if request is None or not hasattr(request, 'visible_org_ids'):
+			return ret
+
+		visible = request.visible_org_ids
+
+		# --- teams ---
+		if 'teams' in ret and hasattr(instance, 'teams'):
+			visible_team_ids = set(
+				instance.teams.filter(organization_id__in=visible)
+				.values_list('id', flat=True)
+			)
+			ret['teams'] = [t for t in ret['teams'] if t.get('id') in visible_team_ids]
+
+		# --- subjects ---
+		if 'subjects' in ret and hasattr(instance, 'subjects'):
+			visible_subject_ids = set(
+				instance.subjects.filter(team__organization_id__in=visible)
+				.values_list('id', flat=True)
+			)
+			ret['subjects'] = [s for s in ret['subjects'] if s.get('id') in visible_subject_ids]
+
+		# --- team_categories ---
+		if 'team_categories' in ret and hasattr(instance, 'team_categories'):
+			visible_cat_ids = set(
+				instance.team_categories.filter(team__organization_id__in=visible)
+				.values_list('id', flat=True)
+			)
+			ret['team_categories'] = [c for c in ret['team_categories'] if c.get('id') in visible_cat_ids]
+
+		# --- ml_predictions (source='ml_predictions_detail') ---
+		if 'ml_predictions' in ret and hasattr(instance, 'ml_predictions_detail'):
+			visible_pred_ids = set(
+				instance.ml_predictions_detail.filter(
+					subject__team__organization_id__in=visible
+				).values_list('id', flat=True)
+			)
+			ret['ml_predictions'] = [p for p in ret['ml_predictions'] if p.get('id') in visible_pred_ids]
+
+		return ret

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -17,7 +17,37 @@ The mixin is intentionally a no-op when:
 
 This guarantees zero behaviour change until the viewsets are explicitly
 opted in (PR 4 onwards).
+
+Query strategy (avoiding N+1 on list endpoints)
+------------------------------------------------
+- ``teams``:  ``team.organization_id`` is a direct FK column; iterating
+  ``.all()`` in Python respects ``prefetch_related('teams')`` with zero
+  extra DB queries.
+- ``subjects`` / ``team_categories``:  ``subject.team_id`` is a direct FK
+  column.  Visible team IDs are resolved once per request and cached on
+  ``request._org_scoped_mixin_team_ids`` so the query runs at most once per
+  request regardless of list length.
+- ``ml_predictions``:  ``prediction.subject_id`` is a direct FK column.
+  Visible subject IDs are built in Python from the already-iterated subjects
+  manager (uses prefetch cache when ``prefetch_related('subjects')`` is active).
 """
+
+
+def _request_visible_team_ids(request, visible_org_ids: set) -> set:
+	"""Return all team IDs belonging to visible orgs, cached once per request.
+
+	Caching avoids issuing a team-lookup query for every object in a list
+	endpoint response.
+	"""
+	cache_attr = '_org_scoped_mixin_team_ids'
+	if not hasattr(request, cache_attr):
+		from gregory.models import Team
+		setattr(
+			request,
+			cache_attr,
+			set(Team.objects.filter(organization_id__in=visible_org_ids).values_list('id', flat=True)),
+		)
+	return getattr(request, cache_attr)
 
 
 class OrgScopedSerializerMixin:
@@ -41,35 +71,32 @@ class OrgScopedSerializerMixin:
 
 		visible = request.visible_org_ids
 
-		# --- teams ---
+		# --- teams: iterate Python, uses prefetch_related cache ---
 		if 'teams' in ret and hasattr(instance, 'teams'):
-			visible_team_ids = set(
-				instance.teams.filter(organization_id__in=visible)
-				.values_list('id', flat=True)
-			)
+			visible_team_ids = {t.id for t in instance.teams.all() if t.organization_id in visible}
 			ret['teams'] = [t for t in ret['teams'] if t.get('id') in visible_team_ids]
 
-		# --- subjects ---
+		# --- subjects: team_id is a direct FK attribute; team IDs cached per request ---
 		if 'subjects' in ret and hasattr(instance, 'subjects'):
-			visible_subject_ids = set(
-				instance.subjects.filter(team__organization_id__in=visible)
-				.values_list('id', flat=True)
-			)
+			vt = _request_visible_team_ids(request, visible)
+			visible_subject_ids = {s.id for s in instance.subjects.all() if s.team_id in vt}
 			ret['subjects'] = [s for s in ret['subjects'] if s.get('id') in visible_subject_ids]
 
-		# --- team_categories ---
+		# --- team_categories: same approach as subjects ---
 		if 'team_categories' in ret and hasattr(instance, 'team_categories'):
-			visible_cat_ids = set(
-				instance.team_categories.filter(team__organization_id__in=visible)
-				.values_list('id', flat=True)
-			)
+			vt = _request_visible_team_ids(request, visible)
+			visible_cat_ids = {c.id for c in instance.team_categories.all() if c.team_id in vt}
 			ret['team_categories'] = [c for c in ret['team_categories'] if c.get('id') in visible_cat_ids]
 
-		# --- ml_predictions (source='ml_predictions_detail') ---
+		# --- ml_predictions: one-level join using cached visible team IDs ---
+		# (subject__team_id__in=vt is simpler than subject__team__organization_id__in=visible;
+		# a full zero-query solution requires prefetch_related('ml_predictions_detail__subject')
+		# with select_related('team'), which is a viewset concern.)
 		if 'ml_predictions' in ret and hasattr(instance, 'ml_predictions_detail'):
+			vt = _request_visible_team_ids(request, visible)
 			visible_pred_ids = set(
 				instance.ml_predictions_detail.filter(
-					subject__team__organization_id__in=visible
+					subject__team_id__in=vt
 				).values_list('id', flat=True)
 			)
 			ret['ml_predictions'] = [p for p in ret['ml_predictions'] if p.get('id') in visible_pred_ids]

--- a/django/api/tests/test_apiaccessscheme_org_fk.py
+++ b/django/api/tests/test_apiaccessscheme_org_fk.py
@@ -1,0 +1,65 @@
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
+django.setup()
+
+from django.test import TestCase
+from organizations.models import Organization
+from api.models import APIAccessScheme
+
+
+class APIAccessSchemeOrganizationFKTest(TestCase):
+	"""Tests for the APIAccessScheme.organization FK introduced in PR 2."""
+
+	def setUp(self):
+		self.org = Organization.objects.create(name='Test Org', slug='test-org')
+
+	def test_create_without_organization(self):
+		"""Existing keys with no org (null) must still work."""
+		scheme = APIAccessScheme.objects.create(
+			client_name='No Org Client',
+			client_contacts='noorg@example.com',
+		)
+		retrieved = APIAccessScheme.objects.get(pk=scheme.pk)
+		self.assertIsNone(retrieved.organization)
+
+	def test_create_with_organization(self):
+		"""New keys can be bound to an organisation."""
+		scheme = APIAccessScheme.objects.create(
+			client_name='Org Client',
+			client_contacts='org@example.com',
+			organization=self.org,
+		)
+		retrieved = APIAccessScheme.objects.get(pk=scheme.pk)
+		self.assertEqual(retrieved.organization, self.org)
+
+	def test_organization_reverse_relation(self):
+		"""org.api_access_schemes reverse manager works."""
+		scheme = APIAccessScheme.objects.create(
+			client_name='Reverse Rel Client',
+			client_contacts='rev@example.com',
+			organization=self.org,
+		)
+		self.assertIn(scheme, self.org.api_access_schemes.all())
+
+	def test_null_org_does_not_break_existing_schemes(self):
+		"""Rows created before the migration (simulated as null org) survive."""
+		scheme = APIAccessScheme.objects.create(
+			client_name='Legacy Client',
+			client_contacts='legacy@example.com',
+			organization=None,
+		)
+		self.assertIsNone(APIAccessScheme.objects.get(pk=scheme.pk).organization)
+
+	def test_cascade_delete(self):
+		"""Deleting an org cascades to its API keys."""
+		org2 = Organization.objects.create(name='Doomed Org', slug='doomed-org')
+		scheme = APIAccessScheme.objects.create(
+			client_name='Doomed Client',
+			client_contacts='doomed@example.com',
+			organization=org2,
+		)
+		pk = scheme.pk
+		org2.delete()
+		self.assertFalse(APIAccessScheme.objects.filter(pk=pk).exists())

--- a/django/api/tests/test_org_scoped_serializer_mixin.py
+++ b/django/api/tests/test_org_scoped_serializer_mixin.py
@@ -1,0 +1,190 @@
+"""
+Tests for api.serializers.mixins.OrgScopedSerializerMixin.
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_org_scoped_serializer_mixin
+"""
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import AnonymousUser
+from rest_framework import serializers
+from organizations.models import Organization
+from gregory.models import (
+	Articles, Team, Subject, TeamCategory, MLPredictions, OrganizationApiSettings,
+)
+from api.serializers.mixins import OrgScopedSerializerMixin
+
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	return Team.objects.create(organization=org, name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_article(title='Test Article', link='https://example.com/1'):
+	return Articles.objects.create(title=title, link=link)
+
+
+def _make_team_category(team, name):
+	from django.utils.text import slugify
+	return TeamCategory.objects.create(team=team, category_name=name, category_slug=slugify(name))
+
+
+def _request_with_visible(visible_ids):
+	"""Build a fake request with a pre-set visible_org_ids attribute."""
+	factory = RequestFactory()
+	req = factory.get('/')
+	req.user = AnonymousUser()
+	req.visible_org_ids = visible_ids
+	return req
+
+
+# ---------------------------------------------------------------------------
+# Minimal serializer that uses the mixin (mirrors ArticleSerializer shape)
+# ---------------------------------------------------------------------------
+
+class _TeamSerializer(serializers.ModelSerializer):
+	class Meta:
+		model = Team
+		fields = ['id', 'name']
+
+
+class _SubjectSerializer(serializers.ModelSerializer):
+	class Meta:
+		model = Subject
+		fields = ['id', 'subject_name']
+
+
+class _TeamCategorySerializer(serializers.ModelSerializer):
+	class Meta:
+		model = TeamCategory
+		fields = ['id', 'category_name']
+
+
+class _MLPredictionsSerializer(serializers.ModelSerializer):
+	class Meta:
+		model = MLPredictions
+		fields = ['id', 'algorithm', 'probability_score']
+
+
+class _TestArticleSerializer(OrgScopedSerializerMixin, serializers.ModelSerializer):
+	teams = _TeamSerializer(many=True, read_only=True)
+	subjects = _SubjectSerializer(many=True, read_only=True)
+	team_categories = _TeamCategorySerializer(many=True, read_only=True)
+	ml_predictions = _MLPredictionsSerializer(
+		many=True, read_only=True, source='ml_predictions_detail'
+	)
+
+	class Meta:
+		model = Articles
+		fields = ['article_id', 'title', 'teams', 'subjects', 'team_categories', 'ml_predictions']
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class OrgScopedSerializerMixinTeamsTest(TestCase):
+	def setUp(self):
+		self.org_a = _make_org('Org A', 'org-a-m', public=False)
+		self.org_b = _make_org('Org B', 'org-b-m', public=False)
+		self.team_a = _make_team(self.org_a, 'Team A')
+		self.team_b = _make_team(self.org_b, 'Team B')
+
+		self.article = _make_article()
+		self.article.teams.add(self.team_a, self.team_b)
+
+	def test_teams_stripped_for_hidden_org(self):
+		"""Only team_a should appear when org_b is not visible."""
+		req = _request_with_visible({self.org_a.id})
+		data = _TestArticleSerializer(self.article, context={'request': req}).data
+		team_ids = [t['id'] for t in data['teams']]
+		self.assertIn(self.team_a.id, team_ids)
+		self.assertNotIn(self.team_b.id, team_ids)
+
+	def test_both_teams_visible_when_both_orgs_visible(self):
+		req = _request_with_visible({self.org_a.id, self.org_b.id})
+		data = _TestArticleSerializer(self.article, context={'request': req}).data
+		team_ids = [t['id'] for t in data['teams']]
+		self.assertIn(self.team_a.id, team_ids)
+		self.assertIn(self.team_b.id, team_ids)
+
+	def test_no_middleware_returns_all_teams(self):
+		"""When request has no visible_org_ids, the mixin is a no-op."""
+		factory = RequestFactory()
+		req = factory.get('/')
+		req.user = AnonymousUser()
+		# No visible_org_ids attribute set
+		data = _TestArticleSerializer(self.article, context={'request': req}).data
+		team_ids = [t['id'] for t in data['teams']]
+		self.assertIn(self.team_a.id, team_ids)
+		self.assertIn(self.team_b.id, team_ids)
+
+	def test_no_request_in_context_is_no_op(self):
+		"""Serializer without request context must not crash."""
+		data = _TestArticleSerializer(self.article).data
+		self.assertIn('teams', data)
+
+
+class OrgScopedSerializerMixinSubjectsTest(TestCase):
+	def setUp(self):
+		self.org_a = _make_org('Org A', 'org-a-s', public=False)
+		self.org_b = _make_org('Org B', 'org-b-s', public=False)
+		self.team_a = _make_team(self.org_a, 'Team A S')
+		self.team_b = _make_team(self.org_b, 'Team B S')
+		self.subject_a = _make_subject(self.team_a, 'Subject A')
+		self.subject_b = _make_subject(self.team_b, 'Subject B')
+
+		self.article = _make_article(title='Subject Article', link='https://example.com/2')
+		self.article.subjects.add(self.subject_a, self.subject_b)
+
+	def test_hidden_subjects_stripped(self):
+		req = _request_with_visible({self.org_a.id})
+		data = _TestArticleSerializer(self.article, context={'request': req}).data
+		subject_ids = [s['id'] for s in data['subjects']]
+		self.assertIn(self.subject_a.id, subject_ids)
+		self.assertNotIn(self.subject_b.id, subject_ids)
+
+
+class OrgScopedSerializerMixinMLPredictionsTest(TestCase):
+	def setUp(self):
+		self.org_a = _make_org('Org A', 'org-a-ml', public=False)
+		self.org_b = _make_org('Org B', 'org-b-ml', public=False)
+		self.team_a = _make_team(self.org_a, 'Team A ML')
+		self.team_b = _make_team(self.org_b, 'Team B ML')
+		self.subject_a = _make_subject(self.team_a, 'Subj ML A')
+		self.subject_b = _make_subject(self.team_b, 'Subj ML B')
+
+		self.article = _make_article(title='ML Article', link='https://example.com/3')
+
+		self.pred_a = MLPredictions.objects.create(
+			article=self.article,
+			subject=self.subject_a,
+			algorithm='lgbm_tfidf',
+			probability_score=0.9,
+			predicted_relevant=True,
+			model_version='v1',
+		)
+		self.pred_b = MLPredictions.objects.create(
+			article=self.article,
+			subject=self.subject_b,
+			algorithm='lgbm_tfidf',
+			probability_score=0.8,
+			predicted_relevant=True,
+			model_version='v1',
+		)
+
+	def test_hidden_ml_predictions_stripped(self):
+		req = _request_with_visible({self.org_a.id})
+		data = _TestArticleSerializer(self.article, context={'request': req}).data
+		pred_ids = [p['id'] for p in data['ml_predictions']]
+		self.assertIn(self.pred_a.id, pred_ids)
+		self.assertNotIn(self.pred_b.id, pred_ids)

--- a/django/api/tests/test_post_article_org_scoping.py
+++ b/django/api/tests/test_post_article_org_scoping.py
@@ -1,0 +1,197 @@
+"""
+Tests for PR 7 — post_article cross-org enforcement.
+
+Covers:
+  - Valid payload: source_id belongs to key's org → 201 (new article) or 200 (duplicate)
+  - Cross-org payload: source_id belongs to a different org → 400
+  - Key with organization=None → 403
+  - Null key (no Authorization header) → 401
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_post_article_org_scoping
+"""
+import json
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import TestCase, Client
+from django.utils.timezone import now
+from organizations.models import Organization
+
+from api.models import APIAccessScheme
+from gregory.models import Articles, Sources, Team, Subject
+from gregory.models import OrganizationApiSettings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=False)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_source(team, subject, name):
+	return Sources.objects.create(
+		name=name,
+		link=f'https://src.example.com/{name}',
+		team=team,
+		subject=subject,
+	)
+
+
+def _make_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+def _post(client, api_key, payload, path='/articles/post/'):
+	body = json.dumps(payload).encode()
+	headers = {}
+	if api_key:
+		headers['HTTP_AUTHORIZATION'] = api_key
+	return client.post(
+		path,
+		data=body,
+		content_type='application/json',
+		**headers,
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base fixture
+# ---------------------------------------------------------------------------
+
+class PostArticleOrgScopingBase(TestCase):
+	def setUp(self):
+		self.my_org    = _make_org('My Org',    'pa-my-org')
+		self.other_org = _make_org('Other Org', 'pa-other-org')
+
+		self.my_team    = _make_team(self.my_org,    'PA My Team')
+		self.other_team = _make_team(self.other_org, 'PA Other Team')
+
+		self.my_subj    = _make_subject(self.my_team,    'PA My Subject')
+		self.other_subj = _make_subject(self.other_team, 'PA Other Subject')
+
+		self.my_source    = _make_source(self.my_team,    self.my_subj,    'pa-my-source')
+		self.other_source = _make_source(self.other_team, self.other_subj, 'pa-other-source')
+
+		self.scheme       = _make_scheme(self.my_org, 'pa-my-key')
+		self.null_scheme  = APIAccessScheme.objects.create(
+			client_name='pa-null-key',
+			client_contacts='null@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client = Client()
+
+	def _valid_payload(self, source_id):
+		"""Minimal payload that references the given source.
+		Uses a DOI so SciencePaper skips the CrossRef title-lookup
+		(which requires a CustomSetting row not present in tests).
+		"""
+		return {
+			'kind': 'science paper',
+			'source_id': source_id,
+			'title': f'Test article for source {source_id}',
+			'link': f'https://example.com/article-src-{source_id}',
+			'doi': f'10.9999/test-source-{source_id}',
+		}
+
+
+# ---------------------------------------------------------------------------
+# Null-org key → 403
+# ---------------------------------------------------------------------------
+
+class NullOrgKeyPostArticleTest(PostArticleOrgScopingBase):
+
+	def test_null_org_key_rejected_403(self):
+		payload = self._valid_payload(self.my_source.pk)
+		resp = _post(self.client, self.null_scheme.api_key, payload)
+		self.assertEqual(resp.status_code, 403)
+
+	def test_null_org_key_rejected_for_own_source_too(self):
+		"""Even if the source would match a public org, null-org keys are rejected."""
+		payload = self._valid_payload(self.my_source.pk)
+		resp = _post(self.client, self.null_scheme.api_key, payload)
+		self.assertEqual(resp.status_code, 403)
+
+
+# ---------------------------------------------------------------------------
+# Cross-org payload → 400
+# ---------------------------------------------------------------------------
+
+class CrossOrgPayloadTest(PostArticleOrgScopingBase):
+
+	def test_cross_org_source_returns_400(self):
+		"""Key for my_org, source belongs to other_org → 400."""
+		payload = self._valid_payload(self.other_source.pk)
+		resp = _post(self.client, self.scheme.api_key, payload)
+		self.assertEqual(resp.status_code, 400)
+		data = resp.json()
+		self.assertEqual(data['code'], 10)  # CROSS_ORG_PAYLOAD
+
+	def test_cross_org_error_message_present(self):
+		payload = self._valid_payload(self.other_source.pk)
+		resp = _post(self.client, self.scheme.api_key, payload)
+		data = resp.json()
+		self.assertIn('organisation', data['error_msg'].lower())
+
+
+# ---------------------------------------------------------------------------
+# No API key → 401
+# ---------------------------------------------------------------------------
+
+class NoKeyPostArticleTest(PostArticleOrgScopingBase):
+
+	def test_no_key_returns_401(self):
+		payload = self._valid_payload(self.my_source.pk)
+		resp = _post(self.client, None, payload)
+		self.assertEqual(resp.status_code, 401)
+
+
+# ---------------------------------------------------------------------------
+# Valid payload (own org) → 200/201
+# ---------------------------------------------------------------------------
+
+class ValidOrgPostArticleTest(PostArticleOrgScopingBase):
+
+	def test_own_org_source_accepted(self):
+		"""Key for my_org, source belongs to my_org → article created (201) or duplicate (200).
+
+		SciencePaper.refresh() is mocked because the test environment does not
+		have a CustomSetting / CrossRef configuration.
+		"""
+		payload = self._valid_payload(self.my_source.pk)
+		with patch('gregory.classes.SciencePaper.refresh', return_value=None):
+			resp = _post(self.client, self.scheme.api_key, payload)
+		# 201 new article, or 200 duplicate — both acceptable; must NOT be 400/403/500
+		self.assertIn(resp.status_code, [200, 201])
+
+	def test_own_org_source_not_cross_org_error(self):
+		"""Response code must not be CROSS_ORG_PAYLOAD (10) for valid source."""
+		payload = self._valid_payload(self.my_source.pk)
+		with patch('gregory.classes.SciencePaper.refresh', return_value=None):
+			resp = _post(self.client, self.scheme.api_key, payload)
+		data = resp.json()
+		self.assertNotEqual(data.get('code'), 10)

--- a/django/api/tests/test_post_article_org_scoping.py
+++ b/django/api/tests/test_post_article_org_scoping.py
@@ -43,12 +43,13 @@ def _make_subject(team, name):
 	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
 
 
-def _make_source(team, subject, name):
+def _make_source(team, subject, name, source_for='science paper'):
 	return Sources.objects.create(
 		name=name,
 		link=f'https://src.example.com/{name}',
 		team=team,
 		subject=subject,
+		source_for=source_for,
 	)
 
 
@@ -130,12 +131,6 @@ class NullOrgKeyPostArticleTest(PostArticleOrgScopingBase):
 		resp = _post(self.client, self.null_scheme.api_key, payload)
 		self.assertEqual(resp.status_code, 403)
 
-	def test_null_org_key_rejected_for_own_source_too(self):
-		"""Even if the source would match a public org, null-org keys are rejected."""
-		payload = self._valid_payload(self.my_source.pk)
-		resp = _post(self.client, self.null_scheme.api_key, payload)
-		self.assertEqual(resp.status_code, 403)
-
 
 # ---------------------------------------------------------------------------
 # Cross-org payload → 400
@@ -157,6 +152,19 @@ class CrossOrgPayloadTest(PostArticleOrgScopingBase):
 		data = resp.json()
 		self.assertIn('organisation', data['error_msg'].lower())
 
+	def test_kind_mismatch_returns_400(self):
+		"""Payload kind differs from source.source_for → 400 (FieldNotFoundError)."""
+		# Create a trials source within my_org, then submit with kind='science paper'
+		trials_source = _make_source(self.my_team, self.my_subj, 'pa-trials-source', source_for='trials')
+		payload = {
+			'kind': 'science paper',   # mismatches source_for='trials'
+			'source_id': trials_source.pk,
+			'title': 'Mismatch test article',
+			'doi': '10.9999/mismatch-test',
+		}
+		resp = _post(self.client, self.scheme.api_key, payload)
+		self.assertEqual(resp.status_code, 400)
+
 
 # ---------------------------------------------------------------------------
 # No API key → 401
@@ -168,6 +176,24 @@ class NoKeyPostArticleTest(PostArticleOrgScopingBase):
 		payload = self._valid_payload(self.my_source.pk)
 		resp = _post(self.client, None, payload)
 		self.assertEqual(resp.status_code, 401)
+
+
+# ---------------------------------------------------------------------------
+# Unknown source_id → 404
+# ---------------------------------------------------------------------------
+
+class SourceNotFoundTest(PostArticleOrgScopingBase):
+
+	def test_source_not_found_returns_404(self):
+		"""Requesting a source_id that does not exist → 404."""
+		payload = {
+			'kind': 'science paper',
+			'source_id': 999999,
+			'title': 'Source not found test',
+			'doi': '10.9999/source-not-found',
+		}
+		resp = _post(self.client, self.scheme.api_key, payload)
+		self.assertEqual(resp.status_code, 404)
 
 
 # ---------------------------------------------------------------------------

--- a/django/api/tests/test_visibility_articles.py
+++ b/django/api/tests/test_visibility_articles.py
@@ -1,0 +1,330 @@
+"""
+Tests for article visibility enforcement (PR 4).
+
+Covers the four caller archetypes × the test matrix from the PR plan:
+  - Article in caller's org only
+  - Article in another public org only
+  - Article in another private org only
+  - Article spanning caller's org + a public org (listing + association stripping)
+  - Article spanning caller's org + a private org (listing + association stripping)
+  - Detail endpoint: all-hidden teams → 404
+  - ArticleSearchView: team_id of hidden team → 404
+  - Legacy endpoints: /teams/<id>/articles/ honours visibility
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_articles
+"""
+import json
+from datetime import date, timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import Articles, OrganizationApiSettings, Subject, Team
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_article(title, link, teams=(), subjects=()):
+	art = Articles.objects.create(title=title, link=link)
+	for t in teams:
+		art.teams.add(t)
+	for s in subjects:
+		art.subjects.add(s)
+	return art
+
+
+def _make_api_scheme(org, name):
+	"""Create a valid (not-expired) APIAccessScheme for the given org."""
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp shared across test classes
+# ---------------------------------------------------------------------------
+
+class ArticleVisibilityBase(TestCase):
+	def setUp(self):
+		# caller's org (private)
+		self.my_org = _make_org('My Org', 'my-org-art', public=False)
+		# another public org
+		self.pub_org = _make_org('Public Org', 'pub-org-art', public=True)
+		# another private org
+		self.priv_org = _make_org('Private Org', 'priv-org-art', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team')
+
+		self.my_subj = _make_subject(self.my_team, 'My Subject')
+		self.pub_subj = _make_subject(self.pub_team, 'Pub Subject')
+
+		# Article in my org only
+		self.art_mine = _make_article('Mine Only', 'https://ex.com/1', teams=[self.my_team])
+		# Article in public org only
+		self.art_pub = _make_article('Public Only', 'https://ex.com/2', teams=[self.pub_team])
+		# Article in private (hidden) org only
+		self.art_priv = _make_article('Private Only', 'https://ex.com/3', teams=[self.priv_team])
+		# Article spanning my org + public org
+		self.art_mine_pub = _make_article('Mine+Pub', 'https://ex.com/4', teams=[self.my_team, self.pub_team])
+		# Article spanning my org + hidden org
+		self.art_mine_priv = _make_article('Mine+Priv', 'https://ex.com/5', teams=[self.my_team, self.priv_team])
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousArticleVisibilityTest(ArticleVisibilityBase):
+	"""Anonymous request → only public orgs visible."""
+
+	def test_list_shows_public_article(self):
+		resp = self.client.get('/articles/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_pub.article_id, ids)
+
+	def test_list_excludes_private_article(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertNotIn(self.art_priv.article_id, ids)
+		self.assertNotIn(self.art_mine.article_id, ids)
+
+	def test_list_includes_cross_org_article_when_one_team_public(self):
+		"""art_mine_pub has pub_team → visible; art_mine_priv has no public team → not visible."""
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_mine_pub.article_id, ids)
+		self.assertNotIn(self.art_mine_priv.article_id, ids)
+
+	def test_cross_org_article_has_hidden_team_stripped(self):
+		"""art_mine_pub: my_team should be stripped (not public), pub_team visible."""
+		resp = self.client.get('/articles/')
+		self.assertEqual(resp.status_code, 200)
+		art = next(a for a in resp.data['results'] if a['article_id'] == self.art_mine_pub.article_id)
+		team_ids = [t['id'] for t in art['teams']]
+		self.assertIn(self.pub_team.id, team_ids)
+		self.assertNotIn(self.my_team.id, team_ids)
+
+	def test_detail_of_all_hidden_article_returns_404(self):
+		resp = self.client.get(f'/articles/{self.art_mine.article_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_of_public_article_returns_200(self):
+		resp = self.client.get(f'/articles/{self.art_pub.article_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_include_public_is_noop_for_anonymous(self):
+		"""include_public=true is a no-op for anonymous callers (already see public)."""
+		resp_plain = self.client.get('/articles/')
+		resp_flag = self.client.get('/articles/?include_public=true')
+		plain_ids = {a['article_id'] for a in resp_plain.data['results']}
+		flag_ids = {a['article_id'] for a in resp_flag.data['results']}
+		self.assertEqual(plain_ids, flag_ids)
+
+	def test_search_with_hidden_team_returns_404(self):
+		resp = self.client.get('/articles/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_search_with_public_team_returns_200(self):
+		resp = self.client.get('/articles/search/', {
+			'team_id': self.pub_team.id,
+			'subject_id': self.pub_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+	def test_legacy_team_endpoint_hidden_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/articles/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_legacy_team_endpoint_public_team_returns_200(self):
+		resp = self.client.get(f'/teams/{self.pub_team.id}/articles/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserArticleVisibilityTest(ArticleVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		# force_login creates a real Django session so VisibleOrgMiddleware
+		# sees the authenticated user (force_authenticate is DRF-only and
+		# runs after middleware, so the middleware would see an anonymous user).
+		self.client.force_login(self.user)
+
+	def test_list_shows_my_org_article(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_mine.article_id, ids)
+
+	def test_list_excludes_unrelated_private_article(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertNotIn(self.art_priv.article_id, ids)
+
+	def test_list_excludes_public_article_by_default(self):
+		"""Without include_public, only owned org is visible."""
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertNotIn(self.art_pub.article_id, ids)
+
+	def test_include_public_adds_public_articles(self):
+		resp = self.client.get('/articles/?include_public=true')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_mine.article_id, ids)
+		self.assertIn(self.art_pub.article_id, ids)
+		self.assertNotIn(self.art_priv.article_id, ids)
+
+	def test_detail_of_hidden_article_returns_404(self):
+		resp = self.client.get(f'/articles/{self.art_priv.article_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_of_own_article_returns_200(self):
+		resp = self.client.get(f'/articles/{self.art_mine.article_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_cross_org_article_has_hidden_team_stripped(self):
+		"""art_mine_priv: priv_team should be stripped from teams field."""
+		resp = self.client.get(f'/articles/{self.art_mine_priv.article_id}/')
+		self.assertEqual(resp.status_code, 200)
+		team_ids = [t['id'] for t in resp.data['teams']]
+		self.assertIn(self.my_team.id, team_ids)
+		self.assertNotIn(self.priv_team.id, team_ids)
+
+	def test_search_hidden_team_returns_404(self):
+		resp = self.client.get('/articles/search/', {
+			'team_id': self.priv_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_search_own_team_returns_200(self):
+		resp = self.client.get('/articles/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyArticleVisibilityTest(ArticleVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'my-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_my_org_article(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_mine.article_id, ids)
+
+	def test_list_excludes_other_private_article(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertNotIn(self.art_priv.article_id, ids)
+
+	def test_list_excludes_public_article_without_flag(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertNotIn(self.art_pub.article_id, ids)
+
+	def test_include_public_adds_public_articles(self):
+		resp = self.client.get('/articles/?include_public=true')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_mine.article_id, ids)
+		self.assertIn(self.art_pub.article_id, ids)
+		self.assertNotIn(self.art_priv.article_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/articles/{self.art_priv.article_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/articles/{self.art_mine.article_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_search_hidden_team_returns_404(self):
+		resp = self.client.get('/articles/search/', {
+			'team_id': self.pub_team.id,
+			'subject_id': self.pub_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_search_own_team_returns_200(self):
+		resp = self.client.get('/articles/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyArticleVisibilityTest(ArticleVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-key',
+			client_contacts='null@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public(self):
+		resp = self.client.get('/articles/')
+		ids = [a['article_id'] for a in resp.data['results']]
+		self.assertIn(self.art_pub.article_id, ids)
+		self.assertNotIn(self.art_mine.article_id, ids)
+		self.assertNotIn(self.art_priv.article_id, ids)
+
+	def test_detail_of_private_article_returns_404(self):
+		resp = self.client.get(f'/articles/{self.art_mine.article_id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_articles.py
+++ b/django/api/tests/test_visibility_articles.py
@@ -14,8 +14,7 @@ Covers the four caller archetypes × the test matrix from the PR plan:
 Run with:
     docker exec gregory python manage.py test api.tests.test_visibility_articles
 """
-import json
-from datetime import date, timedelta
+from datetime import timedelta
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase

--- a/django/api/tests/test_visibility_articles.py
+++ b/django/api/tests/test_visibility_articles.py
@@ -327,3 +327,65 @@ class NullOrgAPIKeyArticleVisibilityTest(ArticleVisibilityBase):
 	def test_detail_of_private_article_returns_404(self):
 		resp = self.client.get(f'/articles/{self.art_mine.article_id}/')
 		self.assertEqual(resp.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
+# CSV export honours visibility rules
+# ---------------------------------------------------------------------------
+
+class CSVExportArticleVisibilityTest(ArticleVisibilityBase):
+	"""CSV responses from /articles/?format=csv must respect the same visibility rules."""
+
+	def _csv_titles(self, response):
+		"""Return the set of article titles found in a CSV StreamingHttpResponse."""
+		content = b''.join(response.streaming_content).decode()
+		# Title is the second column in the CSV; skip the header row.
+		titles = set()
+		for line in content.splitlines()[1:]:
+			if line.strip():
+				# Split on comma but handle quoted fields minimally.
+				titles.add(line.split(',')[1].strip('"'))
+		return titles
+
+	def test_anonymous_csv_shows_only_public_articles(self):
+		resp = self.client.get('/articles/?format=csv&all_results=true')
+		self.assertIn(resp.status_code, (200, 206))
+		titles = self._csv_titles(resp)
+		self.assertIn('Public Only', titles)
+		self.assertNotIn('Mine Only', titles)
+		self.assertNotIn('Private Only', titles)
+
+	def test_api_key_csv_shows_own_org_articles(self):
+		from api.models import APIAccessScheme
+		scheme = APIAccessScheme.objects.create(
+			client_name='csv-key',
+			client_contacts='csv@example.com',
+			organization=self.my_org,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=scheme.api_key)
+		resp = self.client.get('/articles/?format=csv&all_results=true')
+		self.assertIn(resp.status_code, (200, 206))
+		titles = self._csv_titles(resp)
+		self.assertIn('Mine Only', titles)
+		self.assertNotIn('Private Only', titles)
+
+	def test_api_key_csv_with_include_public_adds_public_articles(self):
+		from api.models import APIAccessScheme
+		scheme = APIAccessScheme.objects.create(
+			client_name='csv-key-pub',
+			client_contacts='csvpub@example.com',
+			organization=self.my_org,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=scheme.api_key)
+		resp = self.client.get('/articles/?format=csv&all_results=true&include_public=true')
+		self.assertIn(resp.status_code, (200, 206))
+		titles = self._csv_titles(resp)
+		self.assertIn('Mine Only', titles)
+		self.assertIn('Public Only', titles)
+		self.assertNotIn('Private Only', titles)

--- a/django/api/tests/test_visibility_authors.py
+++ b/django/api/tests/test_visibility_authors.py
@@ -1,0 +1,311 @@
+"""
+Tests for author visibility enforcement (PR 5).
+
+Covers:
+  - Authors list: only authors with at least one article in a visible org
+  - articles_count reflects only visible articles
+  - Detail endpoint 404s when author has no visible articles
+  - Author search: team_id of hidden team returns 404
+  - Four caller archetypes × the standard test matrix
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_authors
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import Articles, Authors, OrganizationApiSettings, Subject, Team
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_author(given, family):
+	full = f'{given} {family}'
+	return Authors.objects.create(
+		given_name=given,
+		family_name=family,
+		full_name=full,
+	)
+
+
+def _make_article(title, link, teams=(), subjects=(), authors=()):
+	art = Articles.objects.create(title=title, link=link)
+	for t in teams:
+		art.teams.add(t)
+	for s in subjects:
+		art.subjects.add(s)
+	for a in authors:
+		art.authors.add(a)
+	return art
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class AuthorVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org', 'my-org-auth', public=False)
+		self.pub_org = _make_org('Public Org', 'pub-org-auth', public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-auth', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team Auth')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team Auth')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team Auth')
+
+		self.my_subj = _make_subject(self.my_team, 'My Subject Auth')
+		self.pub_subj = _make_subject(self.pub_team, 'Pub Subject Auth')
+
+		# Authors
+		self.author_mine = _make_author('Alice', 'Mine')
+		self.author_pub = _make_author('Bob', 'Public')
+		self.author_priv = _make_author('Carol', 'Private')
+		self.author_cross = _make_author('Dave', 'Cross')  # articles in my + priv org
+
+		# Articles
+		_make_article('Mine Art', 'https://ex.com/a1', teams=[self.my_team], authors=[self.author_mine])
+		_make_article('Pub Art', 'https://ex.com/a2', teams=[self.pub_team], authors=[self.author_pub])
+		_make_article('Priv Art', 'https://ex.com/a3', teams=[self.priv_team], authors=[self.author_priv])
+		# author_cross has articles in both my_team and priv_team
+		_make_article('Cross Mine Art', 'https://ex.com/a4', teams=[self.my_team], authors=[self.author_cross])
+		_make_article('Cross Priv Art', 'https://ex.com/a5', teams=[self.priv_team], authors=[self.author_cross])
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousAuthorVisibilityTest(AuthorVisibilityBase):
+	"""Anonymous → only public org data visible."""
+
+	def test_list_includes_public_author(self):
+		resp = self.client.get('/authors/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_pub.author_id, ids)
+
+	def test_list_excludes_private_authors(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertNotIn(self.author_mine.author_id, ids)
+		self.assertNotIn(self.author_priv.author_id, ids)
+
+	def test_list_excludes_cross_org_author_with_no_public_article(self):
+		"""author_cross has mine+priv articles, neither is public → not listed."""
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertNotIn(self.author_cross.author_id, ids)
+
+	def test_detail_of_hidden_author_returns_404(self):
+		resp = self.client.get(f'/authors/{self.author_mine.author_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_of_public_author_returns_200(self):
+		resp = self.client.get(f'/authors/{self.author_pub.author_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_author_search_hidden_team_returns_404(self):
+		resp = self.client.get('/authors/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_author_search_public_team_returns_200(self):
+		resp = self.client.get('/authors/search/', {
+			'team_id': self.pub_team.id,
+			'subject_id': self.pub_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserAuthorVisibilityTest(AuthorVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='author-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_list_shows_own_org_author(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_mine.author_id, ids)
+
+	def test_list_excludes_unrelated_private_author(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertNotIn(self.author_priv.author_id, ids)
+
+	def test_list_excludes_public_author_without_flag(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertNotIn(self.author_pub.author_id, ids)
+
+	def test_list_includes_cross_org_author_when_has_own_article(self):
+		"""author_cross has article in my_team → visible."""
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_cross.author_id, ids)
+
+	def test_include_public_adds_public_authors(self):
+		resp = self.client.get('/authors/?include_public=true')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_mine.author_id, ids)
+		self.assertIn(self.author_pub.author_id, ids)
+		self.assertNotIn(self.author_priv.author_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/authors/{self.author_priv.author_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/authors/{self.author_mine.author_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_articles_count_excludes_hidden_org_articles(self):
+		"""author_cross: articles_count must count only the article in my_team."""
+		resp = self.client.get(f'/authors/{self.author_cross.author_id}/')
+		self.assertEqual(resp.status_code, 200)
+		# author_cross has 1 visible article (in my_team) and 1 hidden (in priv_team)
+		self.assertEqual(resp.data['articles_count'], 1)
+
+	def test_author_search_hidden_team_returns_404(self):
+		resp = self.client.get('/authors/search/', {
+			'team_id': self.priv_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_author_search_own_team_returns_200(self):
+		resp = self.client.get('/authors/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyAuthorVisibilityTest(AuthorVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'author-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_own_org_author(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_mine.author_id, ids)
+
+	def test_list_excludes_private_author(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertNotIn(self.author_priv.author_id, ids)
+
+	def test_list_excludes_public_author_without_flag(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertNotIn(self.author_pub.author_id, ids)
+
+	def test_include_public_adds_public_authors(self):
+		resp = self.client.get('/authors/?include_public=true')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_mine.author_id, ids)
+		self.assertIn(self.author_pub.author_id, ids)
+		self.assertNotIn(self.author_priv.author_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/authors/{self.author_priv.author_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/authors/{self.author_mine.author_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_author_search_hidden_team_returns_404(self):
+		resp = self.client.get('/authors/search/', {
+			'team_id': self.pub_team.id,
+			'subject_id': self.pub_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_author_search_own_team_returns_200(self):
+		resp = self.client.get('/authors/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyAuthorVisibilityTest(AuthorVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-author-key',
+			client_contacts='null-author@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public_authors(self):
+		resp = self.client.get('/authors/')
+		ids = [a['author_id'] for a in resp.data['results']]
+		self.assertIn(self.author_pub.author_id, ids)
+		self.assertNotIn(self.author_mine.author_id, ids)
+		self.assertNotIn(self.author_priv.author_id, ids)
+
+	def test_detail_of_private_author_returns_404(self):
+		resp = self.client.get(f'/authors/{self.author_mine.author_id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_categories.py
+++ b/django/api/tests/test_visibility_categories.py
@@ -1,0 +1,240 @@
+"""
+Tests for category (TeamCategory) visibility enforcement (PR 5).
+
+Covers:
+  - CategoryViewSet list/detail: only categories whose team.org is visible
+  - Detail endpoint 404s when category belongs to a hidden org
+  - CategoriesByTeamAndSubject: hidden parent team → 404
+  - Four caller archetypes × the standard test matrix
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_categories
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import OrganizationApiSettings, Subject, Team, TeamCategory
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_category(team, subject, name):
+	from django.utils.text import slugify
+	cat = TeamCategory.objects.create(
+		team=team,
+		category_name=name,
+		category_slug=f'{team.slug}-{slugify(name)}',
+	)
+	cat.subjects.add(subject)
+	return cat
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class CategoryVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org', 'my-org-cat', public=False)
+		self.pub_org = _make_org('Public Org', 'pub-org-cat', public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-cat', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team Cat')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team Cat')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team Cat')
+
+		self.my_subj = _make_subject(self.my_team, 'My Subj Cat')
+		self.pub_subj = _make_subject(self.pub_team, 'Pub Subj Cat')
+		self.priv_subj = _make_subject(self.priv_team, 'Priv Subj Cat')
+
+		self.cat_mine = _make_category(self.my_team, self.my_subj, 'Mine Category')
+		self.cat_pub = _make_category(self.pub_team, self.pub_subj, 'Public Category')
+		self.cat_priv = _make_category(self.priv_team, self.priv_subj, 'Private Category')
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousCategoryVisibilityTest(CategoryVisibilityBase):
+	def test_list_includes_public_category(self):
+		resp = self.client.get('/categories/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertIn(self.cat_pub.id, ids)
+
+	def test_list_excludes_private_categories(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertNotIn(self.cat_mine.id, ids)
+		self.assertNotIn(self.cat_priv.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/categories/{self.cat_mine.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_public_returns_200(self):
+		resp = self.client.get(f'/categories/{self.cat_pub.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_categories_by_team_hidden_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/subjects/{self.my_subj.id}/categories/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_categories_by_team_public_team_returns_200(self):
+		resp = self.client.get(f'/teams/{self.pub_team.id}/subjects/{self.pub_subj.id}/categories/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserCategoryVisibilityTest(CategoryVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='cat-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_list_shows_own_org_category(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertIn(self.cat_mine.id, ids)
+
+	def test_list_excludes_unrelated_private_category(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertNotIn(self.cat_priv.id, ids)
+
+	def test_list_excludes_public_category_without_flag(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertNotIn(self.cat_pub.id, ids)
+
+	def test_include_public_adds_public_categories(self):
+		resp = self.client.get('/categories/?include_public=true')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertIn(self.cat_mine.id, ids)
+		self.assertIn(self.cat_pub.id, ids)
+		self.assertNotIn(self.cat_priv.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/categories/{self.cat_priv.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/categories/{self.cat_mine.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_categories_by_team_own_team_returns_200(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/subjects/{self.my_subj.id}/categories/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_categories_by_team_hidden_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.priv_team.id}/subjects/{self.priv_subj.id}/categories/')
+		self.assertEqual(resp.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyCategoryVisibilityTest(CategoryVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'cat-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_own_category(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertIn(self.cat_mine.id, ids)
+
+	def test_list_excludes_private_category(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertNotIn(self.cat_priv.id, ids)
+
+	def test_include_public_adds_public_categories(self):
+		resp = self.client.get('/categories/?include_public=true')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertIn(self.cat_mine.id, ids)
+		self.assertIn(self.cat_pub.id, ids)
+		self.assertNotIn(self.cat_priv.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/categories/{self.cat_priv.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/categories/{self.cat_mine.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyCategoryVisibilityTest(CategoryVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-cat-key',
+			client_contacts='null-cat@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public_categories(self):
+		resp = self.client.get('/categories/')
+		ids = [c['id'] for c in resp.data['results']]
+		self.assertIn(self.cat_pub.id, ids)
+		self.assertNotIn(self.cat_mine.id, ids)
+		self.assertNotIn(self.cat_priv.id, ids)
+
+	def test_detail_of_private_category_returns_404(self):
+		resp = self.client.get(f'/categories/{self.cat_mine.id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_organisations.py
+++ b/django/api/tests/test_visibility_organisations.py
@@ -1,0 +1,212 @@
+"""
+Tests for organisation visibility enforcement (PR 5).
+
+Covers:
+  - OrganizationsViewSet list/detail: only orgs in visible_org_ids
+  - Detail endpoint 404s when org is not visible (hide-existence rule)
+  - Four caller archetypes × the standard test matrix
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_organisations
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import OrganizationApiSettings, Team
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class OrganizationVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org', 'my-org-orgs', public=False)
+		self.pub_org = _make_org('Public Org', 'pub-org-orgs', public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-orgs', public=False)
+
+		# Teams are needed so visible_org_ids works via OrganizationUser membership
+		_make_team(self.my_org, 'My Team Orgs')
+		_make_team(self.pub_org, 'Pub Team Orgs')
+		_make_team(self.priv_org, 'Priv Team Orgs')
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousOrganizationVisibilityTest(OrganizationVisibilityBase):
+	def test_list_includes_public_org(self):
+		resp = self.client.get('/organizations/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertIn(self.pub_org.id, ids)
+
+	def test_list_excludes_private_orgs(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertNotIn(self.my_org.id, ids)
+		self.assertNotIn(self.priv_org.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/organizations/{self.my_org.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_public_returns_200(self):
+		resp = self.client.get(f'/organizations/{self.pub_org.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_include_public_is_noop_for_anonymous(self):
+		resp_plain = self.client.get('/organizations/')
+		resp_flag = self.client.get('/organizations/?include_public=true')
+		plain_ids = {o['id'] for o in resp_plain.data['results']}
+		flag_ids = {o['id'] for o in resp_flag.data['results']}
+		self.assertEqual(plain_ids, flag_ids)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserOrganizationVisibilityTest(OrganizationVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='org-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_list_shows_own_org(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertIn(self.my_org.id, ids)
+
+	def test_list_excludes_unrelated_private_org(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertNotIn(self.priv_org.id, ids)
+
+	def test_list_excludes_public_org_without_flag(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertNotIn(self.pub_org.id, ids)
+
+	def test_include_public_adds_public_org(self):
+		resp = self.client.get('/organizations/?include_public=true')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertIn(self.my_org.id, ids)
+		self.assertIn(self.pub_org.id, ids)
+		self.assertNotIn(self.priv_org.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/organizations/{self.priv_org.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/organizations/{self.my_org.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyOrganizationVisibilityTest(OrganizationVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'org-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_own_org(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertIn(self.my_org.id, ids)
+
+	def test_list_excludes_other_private_org(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertNotIn(self.priv_org.id, ids)
+
+	def test_list_excludes_public_org_without_flag(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertNotIn(self.pub_org.id, ids)
+
+	def test_include_public_adds_public_org(self):
+		resp = self.client.get('/organizations/?include_public=true')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertIn(self.my_org.id, ids)
+		self.assertIn(self.pub_org.id, ids)
+		self.assertNotIn(self.priv_org.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/organizations/{self.priv_org.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/organizations/{self.my_org.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyOrganizationVisibilityTest(OrganizationVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-org-key',
+			client_contacts='null-org@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public_orgs(self):
+		resp = self.client.get('/organizations/')
+		ids = [o['id'] for o in resp.data['results']]
+		self.assertIn(self.pub_org.id, ids)
+		self.assertNotIn(self.my_org.id, ids)
+		self.assertNotIn(self.priv_org.id, ids)
+
+	def test_detail_of_private_org_returns_404(self):
+		resp = self.client.get(f'/organizations/{self.my_org.id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_rss.py
+++ b/django/api/tests/test_visibility_rss.py
@@ -1,0 +1,400 @@
+"""
+Tests for RSS feed visibility enforcement (PR 6).
+
+Covers:
+  - ArticlesByAuthorFeed (/feed/author/<orcid>/):
+      - 404 when author has no articles in any visible org
+      - 200 and items filtered to visible articles when author is visible
+      - ?include_public=true extends visibility for identified callers
+  - TrialsBySubjectFeed (/feed/trials/subject/<slug>/):
+      - 404 when subject belongs to a hidden org
+      - 200 and items filtered to visible trials when subject is visible
+      - ?include_public=true extends visibility for identified callers
+  - Four caller archetypes: anonymous, authenticated member, API-key, null-org key
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_rss
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+
+from api.models import APIAccessScheme
+from gregory.models import Articles, Authors, OrganizationApiSettings, Subject, Team, Trials
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	slug = slugify(name)
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slug)
+
+
+def _make_author(given, family, orcid):
+	full = f'{given} {family}'
+	return Authors.objects.create(given_name=given, family_name=family, full_name=full, ORCID=orcid)
+
+
+def _make_article(title, link, teams=(), authors=()):
+	art = Articles.objects.create(title=title, link=link)
+	for t in teams:
+		art.teams.add(t)
+	for a in authors:
+		art.authors.add(a)
+	return art
+
+
+def _make_trial(title, link, teams=(), subjects=()):
+	trial = Trials.objects.create(title=title, link=link)
+	for t in teams:
+		trial.teams.add(t)
+	for s in subjects:
+		trial.subjects.add(s)
+	return trial
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp for author feed tests
+# ---------------------------------------------------------------------------
+
+ORCID_MINE  = '0000-0001-0001-0001'
+ORCID_PUB   = '0000-0001-0002-0002'
+ORCID_PRIV  = '0000-0001-0003-0003'
+
+
+class AuthorFeedBase(TestCase):
+	def setUp(self):
+		self.my_org   = _make_org('My Org',      'my-org-rss-auth',   public=False)
+		self.pub_org  = _make_org('Public Org',   'pub-org-rss-auth',  public=True)
+		self.priv_org = _make_org('Private Org',  'priv-org-rss-auth', public=False)
+
+		self.my_team   = _make_team(self.my_org,   'My Team RSS Auth')
+		self.pub_team  = _make_team(self.pub_org,  'Pub Team RSS Auth')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team RSS Auth')
+
+		# Authors
+		self.author_mine  = _make_author('Alice', 'Mine',    ORCID_MINE)
+		self.author_pub   = _make_author('Bob',   'Public',  ORCID_PUB)
+		self.author_priv  = _make_author('Carol', 'Private', ORCID_PRIV)
+
+		# Articles
+		_make_article('Mine Art',   'https://rss.ex/a1', teams=[self.my_team],   authors=[self.author_mine])
+		_make_article('Pub Art',    'https://rss.ex/a2', teams=[self.pub_team],  authors=[self.author_pub])
+		_make_article('Priv Art',   'https://rss.ex/a3', teams=[self.priv_team], authors=[self.author_priv])
+		# author_mine also has a public article
+		_make_article('Mine+Pub Art', 'https://rss.ex/a4', teams=[self.pub_team], authors=[self.author_mine])
+
+
+# ---------------------------------------------------------------------------
+# Anonymous: author feed
+# ---------------------------------------------------------------------------
+
+class AnonymousAuthorFeedTest(AuthorFeedBase):
+	"""Anonymous → only public org articles visible."""
+
+	def test_public_author_returns_200(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PUB}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_author_returns_404(self):
+		"""author_priv only has articles in private org → 404 for anonymous."""
+		resp = self.client.get(f'/feed/author/{ORCID_PRIV}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_private_author_feed_with_mine_and_pub_returns_200(self):
+		"""author_mine has both a private and a public article → visible because of pub article."""
+		resp = self.client.get(f'/feed/author/{ORCID_MINE}/')
+		self.assertEqual(resp.status_code, 200)
+		# The mine-only article should NOT appear; only the pub article
+		content = resp.content.decode()
+		self.assertIn('Mine+Pub Art', content)
+		self.assertNotIn('Mine Art', content)
+
+	def test_nonexistent_orcid_returns_404(self):
+		resp = self.client.get('/feed/author/0000-0000-0000-9999/')
+		self.assertEqual(resp.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org): author feed
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserAuthorFeedTest(AuthorFeedBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='rss-auth-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_own_author_returns_200(self):
+		resp = self.client.get(f'/feed/author/{ORCID_MINE}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_other_org_author_returns_404(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PRIV}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_author_hidden_without_flag(self):
+		"""author_pub only has articles in pub_org; not visible without include_public."""
+		resp = self.client.get(f'/feed/author/{ORCID_PUB}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_author_visible_with_include_public(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PUB}/?include_public=true')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_own_feed_items_excludes_pub_articles_without_flag(self):
+		"""author_mine items should only include the mine-team article (not pub-team)."""
+		resp = self.client.get(f'/feed/author/{ORCID_MINE}/')
+		self.assertEqual(resp.status_code, 200)
+		content = resp.content.decode()
+		self.assertIn('Mine Art', content)
+		self.assertNotIn('Mine+Pub Art', content)
+
+	def test_own_feed_items_includes_pub_articles_with_flag(self):
+		resp = self.client.get(f'/feed/author/{ORCID_MINE}/?include_public=true')
+		self.assertEqual(resp.status_code, 200)
+		content = resp.content.decode()
+		self.assertIn('Mine Art', content)
+		self.assertIn('Mine+Pub Art', content)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org): author feed
+# ---------------------------------------------------------------------------
+
+class APIKeyAuthorFeedTest(AuthorFeedBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'rss-author-key')
+		self.client.defaults['HTTP_AUTHORIZATION'] = self.scheme.api_key
+
+	def test_own_author_returns_200(self):
+		resp = self.client.get(f'/feed/author/{ORCID_MINE}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_other_org_author_returns_404(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PRIV}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_author_hidden_without_flag(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PUB}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_author_visible_with_include_public(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PUB}/?include_public=true')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org key: author feed
+# ---------------------------------------------------------------------------
+
+class NullOrgKeyAuthorFeedTest(AuthorFeedBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-rss-auth',
+			client_contacts='null-rss-auth@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.defaults['HTTP_AUTHORIZATION'] = self.scheme.api_key
+
+	def test_public_author_returns_200(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PUB}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_author_returns_404(self):
+		resp = self.client.get(f'/feed/author/{ORCID_PRIV}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_mine_author_with_pub_article_returns_200(self):
+		"""author_mine has a public article → visible even to null-org key."""
+		resp = self.client.get(f'/feed/author/{ORCID_MINE}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp for trials feed tests
+# ---------------------------------------------------------------------------
+
+class TrialsFeedBase(TestCase):
+	def setUp(self):
+		self.my_org   = _make_org('My Org',      'my-org-rss-trial',   public=False)
+		self.pub_org  = _make_org('Public Org',   'pub-org-rss-trial',  public=True)
+		self.priv_org = _make_org('Private Org',  'priv-org-rss-trial', public=False)
+
+		self.my_team   = _make_team(self.my_org,   'My Team RSS Trial')
+		self.pub_team  = _make_team(self.pub_org,  'Pub Team RSS Trial')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team RSS Trial')
+
+		self.my_subj   = _make_subject(self.my_team,   'my-subj-rss')
+		self.pub_subj  = _make_subject(self.pub_team,  'pub-subj-rss')
+		self.priv_subj = _make_subject(self.priv_team, 'priv-subj-rss')
+
+		# Trials
+		_make_trial('Mine Trial',   'https://rss.ex/t1', teams=[self.my_team],   subjects=[self.my_subj])
+		_make_trial('Pub Trial',    'https://rss.ex/t2', teams=[self.pub_team],  subjects=[self.pub_subj])
+		_make_trial('Priv Trial',   'https://rss.ex/t3', teams=[self.priv_team], subjects=[self.priv_subj])
+
+
+# ---------------------------------------------------------------------------
+# Anonymous: trials feed
+# ---------------------------------------------------------------------------
+
+class AnonymousTrialsFeedTest(TrialsFeedBase):
+
+	def test_public_subject_returns_200(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_subject_returns_404(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.priv_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_mine_subject_returns_404_for_anon(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.my_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_nonexistent_slug_returns_404(self):
+		resp = self.client.get('/feed/trials/subject/does-not-exist/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_feed_contains_public_trial(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/')
+		self.assertIn('Pub Trial', resp.content.decode())
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user: trials feed
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserTrialsFeedTest(TrialsFeedBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='rss-trial-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_own_subject_returns_200(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.my_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_other_org_subject_returns_404(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.priv_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_subject_hidden_without_flag(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_subject_visible_with_include_public(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/?include_public=true')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_own_feed_contains_own_trial(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.my_subj.subject_slug}/')
+		self.assertIn('Mine Trial', resp.content.decode())
+
+	def test_own_feed_excludes_pub_trial_without_flag(self):
+		"""pub trial is not in my_team → filtered out from own-subject feed."""
+		# Add pub trial to my_subj to test filtering
+		pub_trial_in_my_subj = _make_trial(
+			'Pub Trial In My Subj', 'https://rss.ex/t99',
+			teams=[self.pub_team], subjects=[self.my_subj],
+		)
+		resp = self.client.get(f'/feed/trials/subject/{self.my_subj.subject_slug}/')
+		content = resp.content.decode()
+		# Mine Trial visible, pub-team trial not visible
+		self.assertIn('Mine Trial', content)
+		self.assertNotIn('Pub Trial In My Subj', content)
+
+
+# ---------------------------------------------------------------------------
+# API key: trials feed
+# ---------------------------------------------------------------------------
+
+class APIKeyTrialsFeedTest(TrialsFeedBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'rss-trials-key')
+		self.client.defaults['HTTP_AUTHORIZATION'] = self.scheme.api_key
+
+	def test_own_subject_returns_200(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.my_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_other_org_subject_returns_404(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.priv_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_subject_hidden_without_flag(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_subject_visible_with_include_public(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/?include_public=true')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org key: trials feed
+# ---------------------------------------------------------------------------
+
+class NullOrgKeyTrialsFeedTest(TrialsFeedBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-rss-trial',
+			client_contacts='null-rss-trial@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.defaults['HTTP_AUTHORIZATION'] = self.scheme.api_key
+
+	def test_public_subject_returns_200(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.pub_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_private_subject_returns_404(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.priv_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_mine_subject_returns_404(self):
+		resp = self.client.get(f'/feed/trials/subject/{self.my_subj.subject_slug}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_sources.py
+++ b/django/api/tests/test_visibility_sources.py
@@ -1,0 +1,222 @@
+"""
+Tests for source visibility enforcement (PR 5).
+
+Covers:
+  - SourceViewSet list/detail: only sources whose team.org is visible
+  - Detail endpoint 404s when source belongs to a hidden org
+  - Four caller archetypes × the standard test matrix
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_sources
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import OrganizationApiSettings, Sources, Subject, Team
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_source(team, subject, name):
+	return Sources.objects.create(
+		name=name,
+		team=team,
+		subject=subject,
+		source_for='science paper',
+		method='rss',
+	)
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class SourceVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org', 'my-org-src', public=False)
+		self.pub_org = _make_org('Public Org', 'pub-org-src', public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-src', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team Src')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team Src')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team Src')
+
+		self.my_subj = _make_subject(self.my_team, 'My Subj Src')
+		self.pub_subj = _make_subject(self.pub_team, 'Pub Subj Src')
+		self.priv_subj = _make_subject(self.priv_team, 'Priv Subj Src')
+
+		self.src_mine = _make_source(self.my_team, self.my_subj, 'Mine Source')
+		self.src_pub = _make_source(self.pub_team, self.pub_subj, 'Public Source')
+		self.src_priv = _make_source(self.priv_team, self.priv_subj, 'Private Source')
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousSourceVisibilityTest(SourceVisibilityBase):
+	def test_list_includes_public_source(self):
+		resp = self.client.get('/sources/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertIn(self.src_pub.source_id, ids)
+
+	def test_list_excludes_private_sources(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertNotIn(self.src_mine.source_id, ids)
+		self.assertNotIn(self.src_priv.source_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/sources/{self.src_mine.source_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_public_returns_200(self):
+		resp = self.client.get(f'/sources/{self.src_pub.source_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserSourceVisibilityTest(SourceVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='src-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_list_shows_own_org_source(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertIn(self.src_mine.source_id, ids)
+
+	def test_list_excludes_unrelated_private_source(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertNotIn(self.src_priv.source_id, ids)
+
+	def test_list_excludes_public_source_without_flag(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertNotIn(self.src_pub.source_id, ids)
+
+	def test_include_public_adds_public_sources(self):
+		resp = self.client.get('/sources/?include_public=true')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertIn(self.src_mine.source_id, ids)
+		self.assertIn(self.src_pub.source_id, ids)
+		self.assertNotIn(self.src_priv.source_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/sources/{self.src_priv.source_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/sources/{self.src_mine.source_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeySourceVisibilityTest(SourceVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'src-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_own_source(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertIn(self.src_mine.source_id, ids)
+
+	def test_list_excludes_private_source(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertNotIn(self.src_priv.source_id, ids)
+
+	def test_include_public_adds_public_sources(self):
+		resp = self.client.get('/sources/?include_public=true')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertIn(self.src_mine.source_id, ids)
+		self.assertIn(self.src_pub.source_id, ids)
+		self.assertNotIn(self.src_priv.source_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/sources/{self.src_priv.source_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/sources/{self.src_mine.source_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeySourceVisibilityTest(SourceVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-src-key',
+			client_contacts='null-src@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public_sources(self):
+		resp = self.client.get('/sources/')
+		ids = [s['source_id'] for s in resp.data['results']]
+		self.assertIn(self.src_pub.source_id, ids)
+		self.assertNotIn(self.src_mine.source_id, ids)
+		self.assertNotIn(self.src_priv.source_id, ids)
+
+	def test_detail_of_private_source_returns_404(self):
+		resp = self.client.get(f'/sources/{self.src_mine.source_id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_stats.py
+++ b/django/api/tests/test_visibility_stats.py
@@ -1,0 +1,245 @@
+"""
+Tests for StatsView visibility enforcement (PR 6).
+
+Covers:
+  - Anonymous caller: counts reflect public orgs only
+  - Authenticated user (member of org): counts reflect own org
+  - API key caller: counts reflect key's org
+  - ?team=<id> for a hidden team → 404
+  - ?team=<id> for a visible team → counts scoped to that team
+  - ?include_public=true adds public org data for identified callers
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_stats
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import Articles, OrganizationApiSettings, Subject, Team, Trials
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_article(title, link, teams=()):
+	art = Articles.objects.create(title=title, link=link)
+	for t in teams:
+		art.teams.add(t)
+	return art
+
+
+def _make_trial(title, link, teams=(), subjects=()):
+	from gregory.models import Trials
+	trial = Trials.objects.create(title=title, link=link)
+	for t in teams:
+		trial.teams.add(t)
+	for s in subjects:
+		trial.subjects.add(s)
+	return trial
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class StatsVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org  = _make_org('My Org',      'my-org-stats',   public=False)
+		self.pub_org = _make_org('Public Org',   'pub-org-stats',  public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-stats', public=False)
+
+		self.my_team   = _make_team(self.my_org,   'My Team Stats')
+		self.pub_team  = _make_team(self.pub_org,  'Pub Team Stats')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team Stats')
+
+		# Articles
+		self.art_mine  = _make_article('Mine Art',   'https://st.ex/a1', teams=[self.my_team])
+		self.art_pub   = _make_article('Pub Art',    'https://st.ex/a2', teams=[self.pub_team])
+		self.art_priv  = _make_article('Priv Art',   'https://st.ex/a3', teams=[self.priv_team])
+
+		# Trials
+		self.trial_mine  = _make_trial('Mine Trial',   'https://st.ex/t1', teams=[self.my_team])
+		self.trial_pub   = _make_trial('Pub Trial',    'https://st.ex/t2', teams=[self.pub_team])
+		self.trial_priv  = _make_trial('Priv Trial',   'https://st.ex/t3', teams=[self.priv_team])
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousStatsVisibilityTest(StatsVisibilityBase):
+	"""Anonymous request → only public org data counted."""
+
+	def test_articles_count_only_public(self):
+		resp = self.client.get('/stats/')
+		self.assertEqual(resp.status_code, 200)
+		# Only pub article visible; mine and priv are hidden
+		self.assertGreaterEqual(resp.data['articles'], 1)
+		# The private article should not inflate the count beyond what pub provides
+		# Verify by checking counts with team scope
+		resp_pub = self.client.get('/stats/', {'team': self.pub_team.id})
+		resp_priv = self.client.get('/stats/', {'team': self.priv_team.id})
+		self.assertEqual(resp_pub.status_code, 200)
+		# Hidden team → 404
+		self.assertEqual(resp_priv.status_code, 404)
+
+	def test_hidden_team_param_returns_404(self):
+		resp = self.client.get('/stats/', {'team': self.priv_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_own_team_param_returns_404_for_anon(self):
+		"""my_team belongs to a private org → anonymous can't see it."""
+		resp = self.client.get('/stats/', {'team': self.my_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_team_param_returns_200(self):
+		resp = self.client.get('/stats/', {'team': self.pub_team.id})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 1)
+		self.assertEqual(resp.data['trials'], 1)
+
+	def test_invalid_team_param_returns_400(self):
+		resp = self.client.get('/stats/', {'team': 'abc'})
+		self.assertEqual(resp.status_code, 400)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserStatsVisibilityTest(StatsVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='stats-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_articles_count_only_own_org(self):
+		"""Authenticated user without include_public sees only own org."""
+		resp = self.client.get('/stats/')
+		self.assertEqual(resp.status_code, 200)
+		# Scope to own team for a precise count
+		resp_mine = self.client.get('/stats/', {'team': self.my_team.id})
+		self.assertEqual(resp_mine.status_code, 200)
+		self.assertEqual(resp_mine.data['articles'], 1)
+		self.assertEqual(resp_mine.data['trials'], 1)
+
+	def test_hidden_team_param_returns_404(self):
+		resp = self.client.get('/stats/', {'team': self.priv_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_team_hidden_without_flag(self):
+		"""pub_team is not visible without ?include_public=true."""
+		resp = self.client.get('/stats/', {'team': self.pub_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_team_visible_with_include_public(self):
+		resp = self.client.get('/stats/', {'team': self.pub_team.id, 'include_public': 'true'})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 1)
+
+	def test_include_public_expands_global_count(self):
+		resp_no_flag = self.client.get('/stats/')
+		resp_with_flag = self.client.get('/stats/?include_public=true')
+		# With flag → pub articles also counted
+		self.assertGreaterEqual(resp_with_flag.data['articles'], resp_no_flag.data['articles'])
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyStatsVisibilityTest(StatsVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'stats-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_own_team_visible(self):
+		resp = self.client.get('/stats/', {'team': self.my_team.id})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 1)
+		self.assertEqual(resp.data['trials'], 1)
+
+	def test_hidden_team_returns_404(self):
+		resp = self.client.get('/stats/', {'team': self.priv_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_team_hidden_without_flag(self):
+		resp = self.client.get('/stats/', {'team': self.pub_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_team_visible_with_include_public(self):
+		resp = self.client.get('/stats/', {'team': self.pub_team.id, 'include_public': 'true'})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 1)
+
+	def test_include_public_expands_global_count(self):
+		resp_no_flag = self.client.get('/stats/')
+		resp_with_flag = self.client.get('/stats/?include_public=true')
+		self.assertGreaterEqual(resp_with_flag.data['articles'], resp_no_flag.data['articles'])
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyStatsVisibilityTest(StatsVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-stats-key',
+			client_contacts='null-stats@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_own_team_not_visible(self):
+		resp = self.client.get('/stats/', {'team': self.my_team.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_team_visible(self):
+		resp = self.client.get('/stats/', {'team': self.pub_team.id})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 1)

--- a/django/api/tests/test_visibility_stats.py
+++ b/django/api/tests/test_visibility_stats.py
@@ -111,10 +111,9 @@ class AnonymousStatsVisibilityTest(StatsVisibilityBase):
 	def test_articles_count_only_public(self):
 		resp = self.client.get('/stats/')
 		self.assertEqual(resp.status_code, 200)
-		# Only pub article visible; mine and priv are hidden
-		self.assertGreaterEqual(resp.data['articles'], 1)
-		# The private article should not inflate the count beyond what pub provides
-		# Verify by checking counts with team scope
+		# Exactly 1 public article (pub_team) visible; mine and priv are hidden
+		self.assertEqual(resp.data['articles'], 1)
+		self.assertEqual(resp.data['trials'], 1)
 		resp_pub = self.client.get('/stats/', {'team': self.pub_team.id})
 		resp_priv = self.client.get('/stats/', {'team': self.priv_team.id})
 		self.assertEqual(resp_pub.status_code, 200)
@@ -179,8 +178,12 @@ class AuthenticatedUserStatsVisibilityTest(StatsVisibilityBase):
 	def test_include_public_expands_global_count(self):
 		resp_no_flag = self.client.get('/stats/')
 		resp_with_flag = self.client.get('/stats/?include_public=true')
-		# With flag → pub articles also counted
-		self.assertGreaterEqual(resp_with_flag.data['articles'], resp_no_flag.data['articles'])
+		# Without flag: only own org → 1 article (mine)
+		self.assertEqual(resp_no_flag.data['articles'], 1)
+		# With flag: own org + public org → 2 articles (mine + pub)
+		self.assertEqual(resp_with_flag.data['articles'], 2)
+		# Private org article never counted
+		self.assertLess(resp_with_flag.data['articles'], 3)
 
 
 # ---------------------------------------------------------------------------
@@ -215,7 +218,12 @@ class APIKeyStatsVisibilityTest(StatsVisibilityBase):
 	def test_include_public_expands_global_count(self):
 		resp_no_flag = self.client.get('/stats/')
 		resp_with_flag = self.client.get('/stats/?include_public=true')
-		self.assertGreaterEqual(resp_with_flag.data['articles'], resp_no_flag.data['articles'])
+		# Without flag: only own org → 1 article (mine)
+		self.assertEqual(resp_no_flag.data['articles'], 1)
+		# With flag: own org + public org → 2 articles (mine + pub)
+		self.assertEqual(resp_with_flag.data['articles'], 2)
+		# Private org article never counted
+		self.assertLess(resp_with_flag.data['articles'], 3)
 
 
 # ---------------------------------------------------------------------------

--- a/django/api/tests/test_visibility_subjects.py
+++ b/django/api/tests/test_visibility_subjects.py
@@ -1,0 +1,238 @@
+"""
+Tests for subject visibility enforcement (PR 5).
+
+Covers:
+  - SubjectsViewSet list/detail: only subjects whose team.organization is visible
+  - Detail endpoint 404s when subject belongs to a hidden org
+  - SubjectsByTeam: parent team hidden → 404 on the parent path
+  - Four caller archetypes × the standard test matrix
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_subjects
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import OrganizationApiSettings, Subject, Team
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class SubjectVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org', 'my-org-subj', public=False)
+		self.pub_org = _make_org('Public Org', 'pub-org-subj', public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-subj', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team Subj')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team Subj')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team Subj')
+
+		self.subj_mine = _make_subject(self.my_team, 'Mine Subj')
+		self.subj_pub = _make_subject(self.pub_team, 'Public Subj')
+		self.subj_priv = _make_subject(self.priv_team, 'Private Subj')
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousSubjectVisibilityTest(SubjectVisibilityBase):
+	def test_list_includes_public_subject(self):
+		resp = self.client.get('/subjects/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertIn(self.subj_pub.id, ids)
+
+	def test_list_excludes_private_subjects(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertNotIn(self.subj_mine.id, ids)
+		self.assertNotIn(self.subj_priv.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/subjects/{self.subj_mine.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_public_returns_200(self):
+		resp = self.client.get(f'/subjects/{self.subj_pub.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_subjects_by_team_hidden_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/subjects/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_subjects_by_team_public_team_returns_200(self):
+		resp = self.client.get(f'/teams/{self.pub_team.id}/subjects/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserSubjectVisibilityTest(SubjectVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='subj-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_list_shows_own_org_subject(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertIn(self.subj_mine.id, ids)
+
+	def test_list_excludes_unrelated_private_subject(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertNotIn(self.subj_priv.id, ids)
+
+	def test_list_excludes_public_subject_without_flag(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertNotIn(self.subj_pub.id, ids)
+
+	def test_include_public_adds_public_subjects(self):
+		resp = self.client.get('/subjects/?include_public=true')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertIn(self.subj_mine.id, ids)
+		self.assertIn(self.subj_pub.id, ids)
+		self.assertNotIn(self.subj_priv.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/subjects/{self.subj_priv.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/subjects/{self.subj_mine.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_subjects_by_team_own_team_returns_200(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/subjects/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_subjects_by_team_hidden_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.priv_team.id}/subjects/')
+		self.assertEqual(resp.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeySubjectVisibilityTest(SubjectVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'subj-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_own_subject(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertIn(self.subj_mine.id, ids)
+
+	def test_list_excludes_private_subject(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertNotIn(self.subj_priv.id, ids)
+
+	def test_list_excludes_public_subject_without_flag(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertNotIn(self.subj_pub.id, ids)
+
+	def test_include_public_adds_public_subjects(self):
+		resp = self.client.get('/subjects/?include_public=true')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertIn(self.subj_mine.id, ids)
+		self.assertIn(self.subj_pub.id, ids)
+		self.assertNotIn(self.subj_priv.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/subjects/{self.subj_priv.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/subjects/{self.subj_mine.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_subjects_by_team_hidden_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.pub_team.id}/subjects/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_subjects_by_team_own_team_returns_200(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/subjects/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeySubjectVisibilityTest(SubjectVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-subj-key',
+			client_contacts='null-subj@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public_subjects(self):
+		resp = self.client.get('/subjects/')
+		ids = [s['id'] for s in resp.data['results']]
+		self.assertIn(self.subj_pub.id, ids)
+		self.assertNotIn(self.subj_mine.id, ids)
+		self.assertNotIn(self.subj_priv.id, ids)
+
+	def test_detail_of_private_subject_returns_404(self):
+		resp = self.client.get(f'/subjects/{self.subj_mine.id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_teams.py
+++ b/django/api/tests/test_visibility_teams.py
@@ -1,0 +1,210 @@
+"""
+Tests for team visibility enforcement (PR 5).
+
+Covers:
+  - TeamsViewSet list/detail: only teams in visible orgs
+  - Detail endpoint 404s when team belongs to a hidden org
+  - Permission changed from IsAuthenticated → IsAuthenticatedOrReadOnly
+    (anonymous users can now see public orgs' teams without authentication)
+  - Four caller archetypes × the standard test matrix
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_teams
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import OrganizationApiSettings, Team
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base setUp
+# ---------------------------------------------------------------------------
+
+class TeamVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org', 'my-org-team', public=False)
+		self.pub_org = _make_org('Public Org', 'pub-org-team', public=True)
+		self.priv_org = _make_org('Private Org', 'priv-org-team', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team Teams')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team Teams')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team Teams')
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous caller
+# ---------------------------------------------------------------------------
+
+class AnonymousTeamVisibilityTest(TeamVisibilityBase):
+	def test_list_does_not_require_auth(self):
+		"""TeamsViewSet is now IsAuthenticatedOrReadOnly — anonymous read is allowed."""
+		resp = self.client.get('/teams/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_list_includes_public_team(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertIn(self.pub_team.id, ids)
+
+	def test_list_excludes_private_teams(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertNotIn(self.my_team.id, ids)
+		self.assertNotIn(self.priv_team.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_public_returns_200(self):
+		resp = self.client.get(f'/teams/{self.pub_team.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserTeamVisibilityTest(TeamVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='team-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+	def test_list_shows_own_team(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertIn(self.my_team.id, ids)
+
+	def test_list_excludes_unrelated_private_team(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertNotIn(self.priv_team.id, ids)
+
+	def test_list_excludes_public_team_without_flag(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertNotIn(self.pub_team.id, ids)
+
+	def test_include_public_adds_public_teams(self):
+		resp = self.client.get('/teams/?include_public=true')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertIn(self.my_team.id, ids)
+		self.assertIn(self.pub_team.id, ids)
+		self.assertNotIn(self.priv_team.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/teams/{self.priv_team.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# API key caller (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyTeamVisibilityTest(TeamVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'team-key')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_own_team(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertIn(self.my_team.id, ids)
+
+	def test_list_excludes_other_private_team(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertNotIn(self.priv_team.id, ids)
+
+	def test_list_excludes_public_team_without_flag(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertNotIn(self.pub_team.id, ids)
+
+	def test_include_public_adds_public_teams(self):
+		resp = self.client.get('/teams/?include_public=true')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertIn(self.my_team.id, ids)
+		self.assertIn(self.pub_team.id, ids)
+		self.assertNotIn(self.priv_team.id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/teams/{self.priv_team.id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/')
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyTeamVisibilityTest(TeamVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-team-key',
+			client_contacts='null-team@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public_teams(self):
+		resp = self.client.get('/teams/')
+		ids = [t['id'] for t in resp.data['results']]
+		self.assertIn(self.pub_team.id, ids)
+		self.assertNotIn(self.my_team.id, ids)
+		self.assertNotIn(self.priv_team.id, ids)
+
+	def test_detail_of_private_team_returns_404(self):
+		resp = self.client.get(f'/teams/{self.my_team.id}/')
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -170,7 +170,7 @@ class AuthenticatedUserTrialVisibilityTest(TrialVisibilityBase):
 		ids = [t['trial_id'] for t in resp.data['results']]
 		self.assertNotIn(self.trial_pub.trial_id, ids)
 
-	def test_include_public_adds_public_trials:
+	def test_include_public_adds_public_trials(self):
 		resp = self.client.get('/trials/?include_public=true')
 		ids = [t['trial_id'] for t in resp.data['results']]
 		self.assertIn(self.trial_mine.trial_id, ids)

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -1,0 +1,236 @@
+"""
+Tests for trial visibility enforcement (PR 4).
+
+Mirrors the article visibility test matrix for clinical trials.
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_visibility_trials
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import OrganizationApiSettings, Subject, Team, Trials
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Helpers (duplicated from article tests to keep test files self-contained)
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug, public=False):
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	slug = name.lower().replace(' ', '-')
+	return Team.objects.create(organization=org, name=name, slug=slug)
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_trial(title, link, teams=(), subjects=()):
+	trial = Trials.objects.create(title=title, link=link)
+	for t in teams:
+		trial.teams.add(t)
+	for s in subjects:
+		trial.subjects.add(s)
+	return trial
+
+
+def _make_api_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Base
+# ---------------------------------------------------------------------------
+
+class TrialVisibilityBase(TestCase):
+	def setUp(self):
+		self.my_org = _make_org('My Org T', 'my-org-t', public=False)
+		self.pub_org = _make_org('Public Org T', 'pub-org-t', public=True)
+		self.priv_org = _make_org('Private Org T', 'priv-org-t', public=False)
+
+		self.my_team = _make_team(self.my_org, 'My Team T')
+		self.pub_team = _make_team(self.pub_org, 'Pub Team T')
+		self.priv_team = _make_team(self.priv_org, 'Priv Team T')
+
+		self.my_subj = _make_subject(self.my_team, 'My Subject T')
+		self.pub_subj = _make_subject(self.pub_team, 'Pub Subject T')
+
+		self.trial_mine = _make_trial('Mine Only', 'https://trial.com/1', teams=[self.my_team])
+		self.trial_pub = _make_trial('Public Only', 'https://trial.com/2', teams=[self.pub_team])
+		self.trial_priv = _make_trial('Private Only', 'https://trial.com/3', teams=[self.priv_team])
+		self.trial_mine_pub = _make_trial('Mine+Pub', 'https://trial.com/4', teams=[self.my_team, self.pub_team])
+		self.trial_mine_priv = _make_trial('Mine+Priv', 'https://trial.com/5', teams=[self.my_team, self.priv_team])
+
+		self.client = APIClient()
+
+
+# ---------------------------------------------------------------------------
+# Anonymous
+# ---------------------------------------------------------------------------
+
+class AnonymousTrialVisibilityTest(TrialVisibilityBase):
+	def test_list_shows_public_trial(self):
+		resp = self.client.get('/trials/')
+		self.assertEqual(resp.status_code, 200)
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_pub.trial_id, ids)
+
+	def test_list_excludes_private_trial(self):
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertNotIn(self.trial_priv.trial_id, ids)
+		self.assertNotIn(self.trial_mine.trial_id, ids)
+
+	def test_list_includes_cross_org_trial_when_one_team_public(self):
+		"""trial_mine_pub has pub_team → visible; trial_mine_priv has no public team → not visible."""
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_mine_pub.trial_id, ids)
+		self.assertNotIn(self.trial_mine_priv.trial_id, ids)
+
+	def test_detail_of_all_hidden_trial_returns_404(self):
+		resp = self.client.get(f'/trials/{self.trial_mine.trial_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_of_public_trial_returns_200(self):
+		resp = self.client.get(f'/trials/{self.trial_pub.trial_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_search_with_hidden_team_returns_404(self):
+		resp = self.client.get('/trials/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_search_with_public_team_returns_200(self):
+		resp = self.client.get('/trials/search/', {
+			'team_id': self.pub_team.id,
+			'subject_id': self.pub_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated user (member of my_org)
+# ---------------------------------------------------------------------------
+
+class AuthenticatedUserTrialVisibilityTest(TrialVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.user = User.objects.create_user(username='member-t', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		# force_login creates a real Django session so VisibleOrgMiddleware
+		# sees the authenticated user.
+		self.client.force_login(self.user)
+
+	def test_list_shows_my_org_trial(self):
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_mine.trial_id, ids)
+
+	def test_list_excludes_unrelated_private_trial(self):
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertNotIn(self.trial_priv.trial_id, ids)
+
+	def test_include_public_adds_public_trials(self):
+		resp = self.client.get('/trials/?include_public=true')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_mine.trial_id, ids)
+		self.assertIn(self.trial_pub.trial_id, ids)
+		self.assertNotIn(self.trial_priv.trial_id, ids)
+
+	def test_detail_of_hidden_trial_returns_404(self):
+		resp = self.client.get(f'/trials/{self.trial_priv.trial_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_of_own_trial_returns_200(self):
+		resp = self.client.get(f'/trials/{self.trial_mine.trial_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_search_hidden_team_returns_404(self):
+		resp = self.client.get('/trials/search/', {
+			'team_id': self.priv_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_search_own_team_returns_200(self):
+		resp = self.client.get('/trials/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# API key (bound to my_org)
+# ---------------------------------------------------------------------------
+
+class APIKeyTrialVisibilityTest(TrialVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, 'my-key-t')
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_my_org_trial(self):
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_mine.trial_id, ids)
+
+	def test_list_excludes_other_private_trial(self):
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertNotIn(self.trial_priv.trial_id, ids)
+
+	def test_include_public_adds_public_trials(self):
+		resp = self.client.get('/trials/?include_public=true')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_mine.trial_id, ids)
+		self.assertIn(self.trial_pub.trial_id, ids)
+		self.assertNotIn(self.trial_priv.trial_id, ids)
+
+	def test_detail_hidden_returns_404(self):
+		resp = self.client.get(f'/trials/{self.trial_priv.trial_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_detail_own_returns_200(self):
+		resp = self.client.get(f'/trials/{self.trial_mine.trial_id}/')
+		self.assertEqual(resp.status_code, 200)
+
+	def test_search_hidden_team_returns_404(self):
+		resp = self.client.get('/trials/search/', {
+			'team_id': self.pub_team.id,
+			'subject_id': self.pub_subj.id,
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_search_own_team_returns_200(self):
+		resp = self.client.get('/trials/search/', {
+			'team_id': self.my_team.id,
+			'subject_id': self.my_subj.id,
+		})
+		self.assertEqual(resp.status_code, 200)

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -298,7 +298,7 @@ class NullOrgAPIKeyTrialVisibilityTest(TrialVisibilityBase):
 # ---------------------------------------------------------------------------
 
 class CSVExportTrialVisibilityTest(TrialVisibilityBase):
-	"""CSV responses from /trials/?format=csv must respect the same visibility rules.\""""
+	"""CSV responses from /trials/?format=csv must respect the same visibility rules."""
 
 	def _csv_titles(self, response):
 		"""Return the set of trial titles found in a CSV StreamingHttpResponse.\""""

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -285,7 +285,7 @@ class NullOrgAPIKeyTrialVisibilityTest(TrialVisibilityBase):
 		self.assertEqual(resp.status_code, 404)
 
 	def test_include_public_is_noop(self):
-		"""Null-org key already behaves like anonymous; include_public changes nothing.\""""
+		"""Null-org key already behaves like anonymous; include_public changes nothing."""
 		resp_plain = self.client.get('/trials/')
 		resp_flag = self.client.get('/trials/?include_public=true')
 		plain_ids = {t['trial_id'] for t in resp_plain.data['results']}

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -236,7 +236,7 @@ class APIKeyTrialVisibilityTest(TrialVisibilityBase):
 		self.assertEqual(resp.status_code, 200)
 
 	def test_list_excludes_public_trial_without_flag(self):
-		"""Without include_public, API key sees only its own org.\""""
+		"""Without include_public, API key sees only its own org."""
 		resp = self.client.get('/trials/')
 		ids = [t['trial_id'] for t in resp.data['results']]
 		self.assertNotIn(self.trial_pub.trial_id, ids)

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -132,6 +132,14 @@ class AnonymousTrialVisibilityTest(TrialVisibilityBase):
 		})
 		self.assertEqual(resp.status_code, 200)
 
+	def test_include_public_is_noop_for_anonymous(self):
+		"""include_public=true is a no-op for anonymous callers (already see public only)."""
+		resp_plain = self.client.get('/trials/')
+		resp_flag = self.client.get('/trials/?include_public=true')
+		plain_ids = {t['trial_id'] for t in resp_plain.data['results']}
+		flag_ids = {t['trial_id'] for t in resp_flag.data['results']}
+		self.assertEqual(plain_ids, flag_ids)
+
 
 # ---------------------------------------------------------------------------
 # Authenticated user (member of my_org)
@@ -156,7 +164,13 @@ class AuthenticatedUserTrialVisibilityTest(TrialVisibilityBase):
 		ids = [t['trial_id'] for t in resp.data['results']]
 		self.assertNotIn(self.trial_priv.trial_id, ids)
 
-	def test_include_public_adds_public_trials(self):
+	def test_list_excludes_public_trial_by_default(self):
+		"""Without include_public, only the owned org is visible."""
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertNotIn(self.trial_pub.trial_id, ids)
+
+	def test_include_public_adds_public_trials:
 		resp = self.client.get('/trials/?include_public=true')
 		ids = [t['trial_id'] for t in resp.data['results']]
 		self.assertIn(self.trial_mine.trial_id, ids)
@@ -221,6 +235,12 @@ class APIKeyTrialVisibilityTest(TrialVisibilityBase):
 		resp = self.client.get(f'/trials/{self.trial_mine.trial_id}/')
 		self.assertEqual(resp.status_code, 200)
 
+	def test_list_excludes_public_trial_without_flag(self):
+		"""Without include_public, API key sees only its own org.\""""
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertNotIn(self.trial_pub.trial_id, ids)
+
 	def test_search_hidden_team_returns_404(self):
 		resp = self.client.get('/trials/search/', {
 			'team_id': self.pub_team.id,
@@ -234,3 +254,84 @@ class APIKeyTrialVisibilityTest(TrialVisibilityBase):
 			'subject_id': self.my_subj.id,
 		})
 		self.assertEqual(resp.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Null-org API key (anonymous-equivalent)
+# ---------------------------------------------------------------------------
+
+class NullOrgAPIKeyTrialVisibilityTest(TrialVisibilityBase):
+	def setUp(self):
+		super().setUp()
+		self.scheme = APIAccessScheme.objects.create(
+			client_name='null-org-key-t',
+			client_contacts='null-t@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
+
+	def test_list_shows_only_public(self):
+		resp = self.client.get('/trials/')
+		ids = [t['trial_id'] for t in resp.data['results']]
+		self.assertIn(self.trial_pub.trial_id, ids)
+		self.assertNotIn(self.trial_mine.trial_id, ids)
+		self.assertNotIn(self.trial_priv.trial_id, ids)
+
+	def test_detail_of_private_trial_returns_404(self):
+		resp = self.client.get(f'/trials/{self.trial_mine.trial_id}/')
+		self.assertEqual(resp.status_code, 404)
+
+	def test_include_public_is_noop(self):
+		"""Null-org key already behaves like anonymous; include_public changes nothing.\""""
+		resp_plain = self.client.get('/trials/')
+		resp_flag = self.client.get('/trials/?include_public=true')
+		plain_ids = {t['trial_id'] for t in resp_plain.data['results']}
+		flag_ids = {t['trial_id'] for t in resp_flag.data['results']}
+		self.assertEqual(plain_ids, flag_ids)
+
+
+# ---------------------------------------------------------------------------
+# CSV export honours visibility rules
+# ---------------------------------------------------------------------------
+
+class CSVExportTrialVisibilityTest(TrialVisibilityBase):
+	"""CSV responses from /trials/?format=csv must respect the same visibility rules.\""""
+
+	def _csv_titles(self, response):
+		"""Return the set of trial titles found in a CSV StreamingHttpResponse.\""""
+		content = b''.join(response.streaming_content).decode()
+		titles = set()
+		for line in content.splitlines()[1:]:
+			if line.strip():
+				titles.add(line.split(',')[1].strip('"'))
+		return titles
+
+	def test_anonymous_csv_shows_only_public_trials(self):
+		resp = self.client.get('/trials/?format=csv&all_results=true')
+		self.assertIn(resp.status_code, (200, 206))
+		titles = self._csv_titles(resp)
+		self.assertIn('Public Only', titles)
+		self.assertNotIn('Mine Only', titles)
+		self.assertNotIn('Private Only', titles)
+
+	def test_api_key_csv_shows_own_org_trials(self):
+		scheme = _make_api_scheme(self.my_org, 'csv-key-t')
+		self.client.credentials(HTTP_AUTHORIZATION=scheme.api_key)
+		resp = self.client.get('/trials/?format=csv&all_results=true')
+		self.assertIn(resp.status_code, (200, 206))
+		titles = self._csv_titles(resp)
+		self.assertIn('Mine Only', titles)
+		self.assertNotIn('Private Only', titles)
+
+	def test_api_key_csv_with_include_public_adds_public_trials(self):
+		scheme = _make_api_scheme(self.my_org, 'csv-key-pub-t')
+		self.client.credentials(HTTP_AUTHORIZATION=scheme.api_key)
+		resp = self.client.get('/trials/?format=csv&all_results=true&include_public=true')
+		self.assertIn(resp.status_code, (200, 206))
+		titles = self._csv_titles(resp)
+		self.assertIn('Mine Only', titles)
+		self.assertIn('Public Only', titles)
+		self.assertNotIn('Private Only', titles)

--- a/django/api/utils/exceptions.py
+++ b/django/api/utils/exceptions.py
@@ -40,6 +40,11 @@ class ArticleExistsError(APIError):
 class ArticleNotSavedError(APIError):
 	def __init__(self, message):
 		super().__init__(message)
+
+class CrossOrgPayloadError(APIError):
+	def __init__(self, message):
+		super().__init__(message)
+
 class DoiNotFound(APIError):
 	def __init__(self, message):
 		super().__init__(message)

--- a/django/api/utils/responses.py
+++ b/django/api/utils/responses.py
@@ -13,6 +13,7 @@ FIELD_NOT_FOUND = 6
 ARTICLE_EXISTS = 7
 ARTICLE_NOT_SAVED = 8
 DOI_NOT_FOUND = 9
+CROSS_ORG_PAYLOAD = 10
 
 ERRORS = {
     UNEXPECTED: 'Unexpected error. Please contact the support team.',
@@ -24,7 +25,8 @@ ERRORS = {
     FIELD_NOT_FOUND: 'One or more fields wasn\'t found in the payload',
     ARTICLE_EXISTS: 'An article already exists with one of these fields: title, doi.',
     ARTICLE_NOT_SAVED: 'Could not save the article that was received',
-    DOI_NOT_FOUND: 'Tried query on Crossref.org for articles with a matching title, got no results.'
+    DOI_NOT_FOUND: 'Tried query on Crossref.org for articles with a matching title, got no results.',
+    CROSS_ORG_PAYLOAD: 'The source_id belongs to an organisation different from the one bound to your API key.',
 }
 
 def returnData(data):

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1774,15 +1774,17 @@ class StatsView(APIView):
 
 		# Base querysets scoped to visible orgs (no-op when middleware absent)
 		if visible_org_ids is not None:
-			articles_base = Articles.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
-			trials_base   = Trials.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
-			authors_base  = Authors.objects.filter(articles__teams__organization_id__in=visible_org_ids).distinct()
-			sources_base  = Sources.objects.filter(team__organization_id__in=visible_org_ids)
+			articles_base     = Articles.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
+			trials_base       = Trials.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
+			authors_base      = Authors.objects.filter(articles__teams__organization_id__in=visible_org_ids).distinct()
+			sources_base      = Sources.objects.filter(team__organization_id__in=visible_org_ids)
+			subscribers_base  = Subscribers.objects.filter(subscriptions__team__organization_id__in=visible_org_ids)
 		else:
-			articles_base = Articles.objects.all()
-			trials_base   = Trials.objects.all()
-			authors_base  = Authors.objects.all()
-			sources_base  = Sources.objects.all()
+			articles_base     = Articles.objects.all()
+			trials_base       = Trials.objects.all()
+			authors_base      = Authors.objects.all()
+			sources_base      = Sources.objects.all()
+			subscribers_base  = Subscribers.objects.all()
 
 		# Articles count
 		if team_ids:
@@ -1798,12 +1800,12 @@ class StatsView(APIView):
 
 		# Subscribers count (active only)
 		if team_ids:
-			subscribers_count = Subscribers.objects.filter(
+			subscribers_count = subscribers_base.filter(
 				active=True,
 				subscriptions__team__in=team_ids
 			).distinct().count()
 		else:
-			subscribers_count = Subscribers.objects.filter(active=True).count()
+			subscribers_count = subscribers_base.filter(active=True).distinct().count()
 
 		# Authors count (distinct authors linked to articles in scope)
 		if team_ids:

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1244,6 +1244,13 @@ class ArticleSearchView(generics.ListAPIView):
         if not team_id or not subject_id:
             return Articles.objects.none()
 
+        # Cast to int early — non-numeric values get a 404 rather than a 500.
+        try:
+            team_id = int(team_id)
+            subject_id = int(subject_id)
+        except (TypeError, ValueError):
+            raise Http404
+
         # Visibility check: hidden teams return 404 (before the broad except block)
         if hasattr(self.request, 'visible_org_ids'):
             if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
@@ -1399,6 +1406,13 @@ class TrialSearchView(generics.ListAPIView):
         # Validate required parameters
         if not team_id or not subject_id:
             return Trials.objects.none()
+
+        # Cast to int early — non-numeric values get a 404 rather than a 500.
+        try:
+            team_id = int(team_id)
+            subject_id = int(subject_id)
+        except (TypeError, ValueError):
+            raise Http404
 
         # Visibility check: hidden teams return 404 (before the broad except block)
         if hasattr(self.request, 'visible_org_ids'):

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1310,7 +1310,13 @@ class ArticleSearchView(generics.ListAPIView):
                 {"error": "Missing required parameters: team_id, subject_id"}, 
                 status=400
             )
-            
+
+        try:
+            team_id = int(team_id)
+            subject_id = int(subject_id)
+        except (TypeError, ValueError):
+            return Response({"error": "team_id and subject_id must be integers"}, status=400)
+
         try:
             # Check if team and subject exist
             Team.objects.get(id=team_id)
@@ -1339,7 +1345,13 @@ class ArticleSearchView(generics.ListAPIView):
                 {"error": "Missing required parameters: team_id, subject_id"}, 
                 status=400
             )
-            
+
+        try:
+            team_id = int(team_id)
+            subject_id = int(subject_id)
+        except (TypeError, ValueError):
+            return Response({"error": "team_id and subject_id must be integers"}, status=400)
+
         try:
             # Check if team and subject exist
             Team.objects.get(id=team_id)
@@ -1477,7 +1489,13 @@ class TrialSearchView(generics.ListAPIView):
                 {"error": "Missing required parameters: team_id, subject_id"}, 
                 status=400
             )
-            
+
+        try:
+            team_id = int(team_id)
+            subject_id = int(subject_id)
+        except (TypeError, ValueError):
+            return Response({"error": "team_id and subject_id must be integers"}, status=400)
+
         try:
             # Check if team and subject exist
             Team.objects.get(id=team_id)
@@ -1506,7 +1524,13 @@ class TrialSearchView(generics.ListAPIView):
                 {"error": "Missing required parameters: team_id, subject_id"}, 
                 status=400
             )
-            
+
+        try:
+            team_id = int(team_id)
+            subject_id = int(subject_id)
+        except (TypeError, ValueError):
+            return Response({"error": "team_id and subject_id must be integers"}, status=400)
+
         try:
             # Check if team and subject exist
             Team.objects.get(id=team_id)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1744,12 +1744,16 @@ class StatsView(APIView):
 	"""
 	Returns aggregate statistics about the data in the system.
 	All counts can be optionally scoped to one or more teams via ?team=1 or ?team=1,2,3.
+	Counts are always filtered to organisations visible to the caller (see §4.1 of the spec).
 	"""
 	permission_classes = [permissions.AllowAny]
 
 	def get(self, request):
 		from urllib.parse import urlparse
 		from subscriptions.models import Subscribers
+
+		# --- Org visibility ------------------------------------------------
+		visible_org_ids = getattr(request, 'visible_org_ids', None)
 
 		# Parse team IDs from query params
 		team_param = request.query_params.get('team', None)
@@ -1762,18 +1766,35 @@ class StatsView(APIView):
 					{'error': 'Invalid team parameter. Expected integer or comma-separated integers.'},
 					status=status.HTTP_400_BAD_REQUEST
 				)
+			# 404 if any requested team is not in a visible org
+			if visible_org_ids is not None:
+				visible = Team.objects.filter(id__in=team_ids, organization_id__in=visible_org_ids)
+				if visible.count() != len(set(team_ids)):
+					raise Http404
+
+		# Base querysets scoped to visible orgs (no-op when middleware absent)
+		if visible_org_ids is not None:
+			articles_base = Articles.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
+			trials_base   = Trials.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
+			authors_base  = Authors.objects.filter(articles__teams__organization_id__in=visible_org_ids).distinct()
+			sources_base  = Sources.objects.filter(team__organization_id__in=visible_org_ids)
+		else:
+			articles_base = Articles.objects.all()
+			trials_base   = Trials.objects.all()
+			authors_base  = Authors.objects.all()
+			sources_base  = Sources.objects.all()
 
 		# Articles count
 		if team_ids:
-			articles_count = Articles.objects.filter(teams__in=team_ids).distinct().count()
+			articles_count = articles_base.filter(teams__in=team_ids).distinct().count()
 		else:
-			articles_count = Articles.objects.count()
+			articles_count = articles_base.count()
 
 		# Trials count
 		if team_ids:
-			trials_count = Trials.objects.filter(teams__in=team_ids).distinct().count()
+			trials_count = trials_base.filter(teams__in=team_ids).distinct().count()
 		else:
-			trials_count = Trials.objects.count()
+			trials_count = trials_base.count()
 
 		# Subscribers count (active only)
 		if team_ids:
@@ -1786,17 +1807,17 @@ class StatsView(APIView):
 
 		# Authors count (distinct authors linked to articles in scope)
 		if team_ids:
-			authors_count = Authors.objects.filter(
+			authors_count = authors_base.filter(
 				articles__teams__in=team_ids
 			).distinct().count()
 		else:
-			authors_count = Authors.objects.count()
+			authors_count = authors_base.count()
 
 		# Sources queryset scoped to team(s)
 		if team_ids:
-			sources_qs = Sources.objects.filter(team__in=team_ids)
+			sources_qs = sources_base.filter(team__in=team_ids)
 		else:
-			sources_qs = Sources.objects.all()
+			sources_qs = sources_base
 
 		def extract_domain(url):
 			if not url:

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -389,7 +389,7 @@ class ArticleViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	CSV responses are automatically streamed for better performance with large datasets.
 	
 	# Query Parameters:
-	- **team_id** - filter by team ID (replaces /teams/{id}/articles/)
+	- **team_id** - filter by team ID 
 	- **doi** - filter by exact DOI (case-insensitive)
 	- **subject_id** - filter by subject ID (used with team_id)
 	- **subjects** - comma-separated list of subject IDs with AND semantics — returns only articles tagged with *all* listed subjects (e.g., `?subjects=1,2`)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -9,6 +9,7 @@ from django.db.models.functions import Length, TruncMonth
 from django.shortcuts import get_object_or_404
 from gregory.classes import SciencePaper
 from gregory.models import Articles, Trials, Sources, Authors, Team, Subject, TeamCategory
+from organizations.models import Organization
 from rest_framework import permissions, viewsets, generics, filters, status
 from rest_framework.decorators import api_view, action
 from django_filters import rest_framework as django_filters
@@ -41,14 +42,22 @@ class OrgVisibilityMixin:
 	back to the full queryset when the attribute is absent so tests and
 	management commands that bypass middleware are not broken.
 
-	Articles and Trials link to organisations via the ``teams`` M2M relation.
+	Override ``_org_filter_path`` in the subclass to set the ORM lookup path
+	from the model to the Organisation PK.  Defaults to
+	``teams__organization_id`` (Articles and Trials via M2M teams relation).
+
+	Examples:
+	  - Team:          _org_filter_path = 'organization_id'
+	  - Subject/Source/Category:  _org_filter_path = 'team__organization_id'
 	"""
+
+	_org_filter_path = 'teams__organization_id'
 
 	def get_queryset(self):
 		qs = super().get_queryset()
 		if not hasattr(self.request, 'visible_org_ids'):
 			return qs
-		return qs.filter(teams__organization_id__in=self.request.visible_org_ids).distinct()
+		return qs.filter(**{f'{self._org_filter_path}__in': self.request.visible_org_ids}).distinct()
 
 
 def add_deprecation_headers(response, deprecated_endpoint, replacement_endpoint, message=None):
@@ -410,6 +419,10 @@ class CategoryViewSet(viewsets.ModelViewSet):
 		3. Use select_related for foreign keys
 		"""
 		queryset = TeamCategory.objects.all()
+
+		# --- Org visibility: only categories whose team's org is visible ---
+		if hasattr(self.request, 'visible_org_ids'):
+			queryset = queryset.filter(team__organization_id__in=self.request.visible_org_ids)
 		
 		# Apply filters without expensive annotations
 		team_id = self.request.query_params.get('team_id')
@@ -699,7 +712,7 @@ class AllTrialViewSet(generics.ListAPIView):
 # SOURCES
 ### 
 
-class SourceViewSet(viewsets.ModelViewSet):
+class SourceViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	List all sources of data with optional filters for team and subject.
 	
@@ -707,6 +720,7 @@ class SourceViewSet(viewsets.ModelViewSet):
 	- **team_id** - filter by team ID
 	- **subject_id** - filter by subject ID
 	"""
+	_org_filter_path = 'team__organization_id'
 	queryset = Sources.objects.all().order_by('name')
 	serializer_class = SourceSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -768,6 +782,12 @@ class AuthorsViewSet(viewsets.ModelViewSet):
 	
 	def get_queryset(self):
 		queryset = Authors.objects.all()
+
+		# --- Org visibility: only authors with at least one article in a visible org ---
+		if hasattr(self.request, 'visible_org_ids'):
+			queryset = queryset.filter(
+				articles__teams__organization_id__in=self.request.visible_org_ids
+			).distinct()
 		
 		# Get query parameters
 		author_id = self.request.query_params.get('author_id')
@@ -980,19 +1000,49 @@ class ProtectedEndpointView(APIView):
 # TEAMS
 ###
 
-class TeamsViewSet(viewsets.ModelViewSet):
+class TeamsViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	List all teams
 	"""
+	_org_filter_path = 'organization_id'
 	queryset = Team.objects.all().order_by('id')
 	serializer_class = TeamSerializer
-	permission_classes  = [permissions.IsAuthenticated]
+	permission_classes  = [permissions.IsAuthenticatedOrReadOnly]
+
+###
+# ORGANISATIONS
+###
+
+class OrganizationsViewSet(viewsets.ReadOnlyModelViewSet):
+	"""
+	List organisations visible to the caller.
+
+	Anonymous callers see only organisations where ``make_api_public=True``.
+	Authenticated users and API-key holders see their own org; add
+	``?include_public=true`` to also see public orgs.
+
+	Detail endpoint (``/organizations/<id>/``) returns 404 rather than 403
+	when the organisation is not visible (hide-existence rule).
+	"""
+	from api.serializers import OrganizationSerializer
+	serializer_class = None  # set in get_serializer_class
+	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+	def get_serializer_class(self):
+		from api.serializers import OrganizationSerializer
+		return OrganizationSerializer
+
+	def get_queryset(self):
+		qs = Organization.objects.all().order_by('id')
+		if not hasattr(self.request, 'visible_org_ids'):
+			return qs
+		return qs.filter(id__in=self.request.visible_org_ids)
 
 ###
 # SUBJECTS
 ###
 
-class SubjectsViewSet(viewsets.ModelViewSet):
+class SubjectsViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	✅ **PREFERRED ENDPOINT**: This is the main subjects endpoint that supports filtering options.
 	
@@ -1009,6 +1059,7 @@ class SubjectsViewSet(viewsets.ModelViewSet):
 	- Team filter with search: `/subjects/?team_id=1&search=sclerosis`
 	- Order by name: `/subjects/?ordering=subject_name`
 	"""
+	_org_filter_path = 'team__organization_id'
 	queryset = Subject.objects.all().order_by('id')
 	serializer_class = SubjectsSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -1134,6 +1185,9 @@ class SubjectsByTeam(viewsets.ModelViewSet):
 
 	def get_queryset(self):
 		team_id = self.kwargs.get('team_id')
+		if hasattr(self.request, 'visible_org_ids'):
+			if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+				raise Http404
 		return Subject.objects.filter(team__id=team_id).order_by('-id')
 	
 	def list(self, request, *args, **kwargs):
@@ -1154,6 +1208,9 @@ class CategoriesByTeamAndSubject(viewsets.ModelViewSet):
 	def get_queryset(self):
 		team_id = self.kwargs.get('team_id')
 		subject_id = self.kwargs.get('subject_id')
+		if hasattr(self.request, 'visible_org_ids'):
+			if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+				raise Http404
 		return TeamCategory.objects.filter(
 			team__id=team_id,
 			subjects__id=subject_id
@@ -1566,6 +1623,12 @@ class AuthorSearchView(generics.ListAPIView):
     pagination_class = FlexiblePagination
     http_method_names = ['get', 'post']
 
+    def _check_team_visibility(self, team_id):
+        """Raise Http404 if team_id is not in the caller's visible orgs."""
+        if hasattr(self.request, 'visible_org_ids'):
+            if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+                raise Http404
+
     def get_queryset(self):
         params = self.request.query_params if self.request.method == 'GET' else self.request.data
 
@@ -1624,7 +1687,8 @@ class AuthorSearchView(generics.ListAPIView):
                 {"error": f"Subject with ID {subject_id} not found or does not belong to team {team_id}"}, 
                 status=404
             )
-            
+
+        self._check_team_visibility(team_id)
         return self.list(request, *args, **kwargs)
         
     def get(self, request, *args, **kwargs):
@@ -1652,7 +1716,8 @@ class AuthorSearchView(generics.ListAPIView):
                 {"error": f"Subject with ID {subject_id} not found or does not belong to team {team_id}"}, 
                 status=404
             )
-            
+
+        self._check_team_visibility(team_id)
         # Delegate to the list method
         return self.list(request, *args, **kwargs)
 

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -27,11 +27,11 @@ from api.utils.utils import checkValidAccess, getAPIKey, getIPAddress
 from api.models import APIAccessSchemeLog
 from api.utils.exceptions import (
 		APIAccessDeniedError, APIInvalidAPIKeyError, APIInvalidIPAddressError,
-		APINoAPIKeyError, ArticleExistsError, ArticleNotSavedError, DoiNotFound, 
-		FieldNotFoundError, SourceNotFoundError
+		APINoAPIKeyError, ArticleExistsError, ArticleNotSavedError, CrossOrgPayloadError,
+		DoiNotFound, FieldNotFoundError, SourceNotFoundError
 )
 from api.utils.responses import (
-		ACCESS_DENIED, INVALID_API_KEY, INVALID_IP_ADDRESS, NO_API_KEY,
+		ACCESS_DENIED, CROSS_ORG_PAYLOAD, INVALID_API_KEY, INVALID_IP_ADDRESS, NO_API_KEY,
 		UNEXPECTED, SOURCE_NOT_FOUND, FIELD_NOT_FOUND, ARTICLE_EXISTS, ARTICLE_NOT_SAVED, returnData, returnError
 )
 
@@ -119,6 +119,10 @@ def post_article(request):
 			# this API endpoint. If so, the valid client access scheme is returned
 			access_scheme = checkValidAccess(api_key, ip_addr)
 
+			# PR 7: keys without an org cannot post articles
+			if access_scheme.organization is None:
+				raise APIAccessDeniedError('API keys without an associated organisation cannot post articles.')
+
 			# At this point, the API client is authorized
 			# Check for fields
 			if 'kind' not in post_data or post_data['kind'] == None:
@@ -149,6 +153,14 @@ def post_article(request):
 			science_paper = None
 			if new_article['kind'] == 'science paper':
 				science_paper = SciencePaper(doi=new_article['doi'],title=new_article['title'])
+
+			# PR 7: validate source org before any expensive external calls
+			source = Sources.objects.get(pk=new_article['source_id'])
+			if source.team.organization_id != access_scheme.organization_id:
+				raise CrossOrgPayloadError(
+					f'source_id {source.pk} belongs to a different organisation than your API key.'
+				)
+
 			if science_paper.doi == None:
 				science_paper.doi = science_paper.find_doi(title=science_paper.title)
 
@@ -178,10 +190,9 @@ def post_article(request):
 				article_on_gregory = Articles.objects.filter(doi=new_article['doi'])
 			if article_on_gregory != None and article_on_gregory.count() > 0:
 				for article in article_on_gregory:
-					new_source = Sources.objects.get(pk=new_article['source_id'])
-					article.sources.add(new_source)
-					article.teams.add(new_source.team)
-					article.subjects.add(new_source.subject)
+					article.sources.add(source)
+					article.teams.add(source.team)
+					article.subjects.add(source.subject)
 				raise ArticleExistsError('There is already an article with the specified DOI. If the source, team, or subject were different, the article was updated.')
 
 			if new_article['title'] != None:
@@ -189,7 +200,6 @@ def post_article(request):
 			if article_on_gregory != None and article_on_gregory.count() > 0:
 				raise ArticleExistsError('There is already an article with the specified Title')
 
-			source = Sources.objects.get(pk=new_article['source_id'])
 			if source.pk == None:
 				raise SourceNotFoundError('source_id was not found in the database')
 			save_article = Articles.objects.create(
@@ -242,6 +252,9 @@ def post_article(request):
 		except FieldNotFoundError as exception:
 			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 202, str(exception), str(post_data))
 			return returnError(FIELD_NOT_FOUND, str(exception), 200)
+		except CrossOrgPayloadError as exception:
+			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 400, str(exception), str(post_data))
+			return returnError(CROSS_ORG_PAYLOAD, str(exception), 400)
 		except ArticleExistsError as exception:
 			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 204, str(exception), str(post_data))
 			return returnError(ARTICLE_EXISTS, str(exception), 200)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -14,7 +14,7 @@ from rest_framework.decorators import api_view, action
 from django_filters import rest_framework as django_filters
 from api.filters import ArticleFilter, TrialFilter, AuthorFilter, SourceFilter, CategoryFilter, SubjectFilter
 from rest_framework.response import Response
-from django.http import StreamingHttpResponse
+from django.http import Http404, StreamingHttpResponse
 from rest_framework.views import APIView
 from rest_framework_simplejwt.views import TokenObtainPairView
 import json
@@ -32,6 +32,24 @@ from api.utils.responses import (
 		ACCESS_DENIED, INVALID_API_KEY, INVALID_IP_ADDRESS, NO_API_KEY,
 		UNEXPECTED, SOURCE_NOT_FOUND, FIELD_NOT_FOUND, ARTICLE_EXISTS, ARTICLE_NOT_SAVED, returnData, returnError
 )
+
+class OrgVisibilityMixin:
+	"""
+	Viewset mixin that scopes the queryset to organisations the caller can see.
+
+	Uses ``request.visible_org_ids`` (set by ``VisibleOrgMiddleware``).  Falls
+	back to the full queryset when the attribute is absent so tests and
+	management commands that bypass middleware are not broken.
+
+	Articles and Trials link to organisations via the ``teams`` M2M relation.
+	"""
+
+	def get_queryset(self):
+		qs = super().get_queryset()
+		if not hasattr(self.request, 'visible_org_ids'):
+			return qs
+		return qs.filter(teams__organization_id__in=self.request.visible_org_ids).distinct()
+
 
 def add_deprecation_headers(response, deprecated_endpoint, replacement_endpoint, message=None):
 	"""
@@ -224,7 +242,7 @@ def post_article(request):
 ###
 # ARTICLES
 ### 
-class ArticleViewSet(viewsets.ModelViewSet):
+class ArticleViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	List all articles in the database with comprehensive filtering options.
 	CSV responses are automatically streamed for better performance with large datasets.
@@ -589,7 +607,7 @@ class CategoryViewSet(viewsets.ModelViewSet):
 # TRIALS
 ### 
 
-class TrialViewSet(viewsets.ModelViewSet):
+class TrialViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	List all clinical trials by discovery date with comprehensive filtering options.
 	CSV responses are automatically streamed for better performance with large datasets.
@@ -1031,6 +1049,9 @@ class ArticlesByTeam(viewsets.ModelViewSet):
 
 	def get_queryset(self):
 		team_id = self.kwargs.get('team_id')
+		if hasattr(self.request, 'visible_org_ids'):
+			if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+				raise Http404
 		return Articles.objects.filter(teams__id=team_id).order_by('-discovery_date')
 	
 	def list(self, request, *args, **kwargs):
@@ -1073,6 +1094,9 @@ class ArticlesBySubject(viewsets.ModelViewSet):
 	def get_queryset(self):
 		team_id = self.kwargs.get('team_id')
 		subject_id = self.kwargs.get('subject_id')
+		if hasattr(self.request, 'visible_org_ids'):
+			if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+				raise Http404
 		return Articles.objects.filter(subjects__id=subject_id, teams=team_id).order_by('-discovery_date')
 	
 	def list(self, request, *args, **kwargs):
@@ -1155,6 +1179,9 @@ class ArticlesByCategoryAndTeam(viewsets.ModelViewSet):
 		def get_queryset(self):
 				team_id = self.kwargs.get('team_id')
 				category_slug = self.kwargs.get('category_slug')
+				if hasattr(self.request, 'visible_org_ids'):
+						if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+								raise Http404
 				team_category = get_object_or_404(TeamCategory, team__id=team_id, category_slug=category_slug)
 				return Articles.objects.filter(team_categories=team_category).prefetch_related(
 						'team_categories', 'sources', 'authors', 'teams', 'subjects', 'ml_predictions'
@@ -1216,7 +1243,12 @@ class ArticleSearchView(generics.ListAPIView):
         # Validate required parameters
         if not team_id or not subject_id:
             return Articles.objects.none()
-        
+
+        # Visibility check: hidden teams return 404 (before the broad except block)
+        if hasattr(self.request, 'visible_org_ids'):
+            if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+                raise Http404
+
         try:
             # Start with articles filtered by team and subject
             # Remove distinct constraint to allow proper ordering
@@ -1367,7 +1399,12 @@ class TrialSearchView(generics.ListAPIView):
         # Validate required parameters
         if not team_id or not subject_id:
             return Trials.objects.none()
-            
+
+        # Visibility check: hidden teams return 404 (before the broad except block)
+        if hasattr(self.request, 'visible_org_ids'):
+            if not Team.objects.filter(id=team_id, organization_id__in=self.request.visible_org_ids).exists():
+                raise Http404
+
         try:
             # Check if team and subject exist
             team = Team.objects.get(id=team_id)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1744,7 +1744,13 @@ class StatsView(APIView):
 	"""
 	Returns aggregate statistics about the data in the system.
 	All counts can be optionally scoped to one or more teams via ?team=1 or ?team=1,2,3.
-	Counts are always filtered to organisations visible to the caller (see §4.1 of the spec).
+
+	Counts are filtered to organisations visible to the caller when
+	``request.visible_org_ids`` is present (set by VisibleOrgMiddleware).
+	If the attribute is absent — e.g. in management commands or tests that
+	bypass middleware — the fallback is unscoped querysets that span all
+	organisations.  In production the middleware is always active, so callers
+	will always receive org-filtered results.
 	"""
 	permission_classes = [permissions.AllowAny]
 

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 from django.db.models import Count, Q, Prefetch
 from django.db.models.functions import Length, TruncMonth
 from django.shortcuts import get_object_or_404
-from gregory.classes import SciencePaper
+from gregory.classes import SciencePaper, ClinicalTrial
 from gregory.models import Articles, Trials, Sources, Authors, Team, Subject, TeamCategory
 from organizations.models import Organization
 from rest_framework import permissions, viewsets, generics, filters, status
@@ -105,166 +105,280 @@ def generateAccessSchemeLog(call_type, ip_addr, access_scheme, http_code, error_
 
 @api_view(['POST'])
 def post_article(request):
-		"""
-		Allows authenticated clients to add new articles to the database
-		"""
-		access_scheme = None  # Define access_scheme at the start
-		call_type = request.method + " " + request.path
-		ip_addr = getIPAddress(request)
-		post_data = json.loads(request.body)
+	"""
+	Allows authenticated clients to add new articles or trials to the database.
+
+	The ``kind`` field in the payload must match the ``source_for`` value of the
+	indicated source.  Routing per kind:
+	  - ``science paper``  → CrossRef enrichment, saved to Articles
+	  - ``trials``         → saved to Trials (dedup by identifier then title)
+	  - ``news article``   → saved to Articles, no CrossRef lookup
+	"""
+	access_scheme = None
+	call_type = request.method + " " + request.path
+	ip_addr = getIPAddress(request)
+	post_data = json.loads(request.body)
+	try:
+		api_key = getAPIKey(request)
+		access_scheme = checkValidAccess(api_key, ip_addr)
+
+		# PR 7: keys without an org cannot post
+		if access_scheme.organization is None:
+			raise APIAccessDeniedError('API keys without an associated organisation cannot post articles.')
+
+		# --- Field presence checks -------------------------------------------
+		if 'kind' not in post_data or post_data['kind'] is None:
+			raise FieldNotFoundError('field `kind` was not found in the payload')
+		if 'source_id' not in post_data or post_data['source_id'] is None:
+			raise FieldNotFoundError('source_id field not found in payload')
+		if 'title' not in post_data and 'doi' not in post_data:
+			raise FieldNotFoundError('field `doi` and `title` not in the payload. You need at least one.')
+
+		# --- Source validation (existence, org, kind match) ------------------
 		try:
-			api_key = getAPIKey(request)
+			source = Sources.objects.get(pk=post_data['source_id'])
+		except Sources.DoesNotExist:
+			raise SourceNotFoundError(f'source_id {post_data["source_id"]} was not found in the database')
+		if source.team is None:
+			raise SourceNotFoundError(f'source_id {source.pk} has no team assigned')
+		if source.team.organization_id != access_scheme.organization_id:
+			raise CrossOrgPayloadError(
+				f'source_id {source.pk} belongs to a different organisation than your API key.'
+			)
+		if post_data['kind'] != source.source_for:
+			raise FieldNotFoundError(
+				f'payload kind \'{post_data["kind"]}\' does not match source kind \'{source.source_for}\''
+			)
 
-			# This checks if this API key and IP address are authorized to access
-			# this API endpoint. If so, the valid client access scheme is returned
-			access_scheme = checkValidAccess(api_key, ip_addr)
+		# Helper: coerce empty strings to None
+		def _val(key):
+			v = post_data.get(key)
+			return None if v == '' else v
 
-			# PR 7: keys without an org cannot post articles
-			if access_scheme.organization is None:
-				raise APIAccessDeniedError('API keys without an associated organisation cannot post articles.')
+		kind = post_data['kind']
 
-			# At this point, the API client is authorized
-			# Check for fields
-			if 'kind' not in post_data or post_data['kind'] == None:
-				raise FieldNotFoundError('field `kind` was not found in the payload')
-			if 'title' not in post_data and 'doi' not in post_data:
-				if post_data['title'] == None and post_data['doi'] == None:
-					raise FieldNotFoundError('field `doi` and `title` not in the payload. You need at least one.')
-			if 'source_id' not in post_data or post_data['source_id'] == None:
-					raise FieldNotFoundError('source_id field not found in payload')
-			
+		# =================================================================
+		# Branch: science paper
+		# =================================================================
+		if kind == 'science paper':
 			new_article = {
-				"title": None if 'title' not in post_data or post_data['title'] == '' else post_data['title'],
-				"link": None if 'link' not in post_data or post_data['link'] == '' else post_data['link'],
-				"doi": None if 'doi' not in post_data or post_data['doi'] == '' else post_data['doi'],
-				"access": None if 'access' not in post_data or post_data['access'] == '' else post_data['access'],
-				"summary": None if 'summary' not in post_data or post_data['summary'] == '' else post_data['summary'],
-				"source_id": None if 'source_id' not in post_data or post_data['source_id'] == '' else post_data['source_id'],
-				"published_date": None if 'published_date' not in post_data or post_data['published_date'] == '' else post_data['published_date'],
-				# Not sure if and how we should post the authors
-				# "authors": post_data['authors'],
-				"kind": None if 'kind' not in post_data or post_data['kind'] == '' else post_data['kind'],
-				"access": None if 'access' not in post_data or post_data['access'] == '' else post_data['access'],
-				"publisher": None if 'publisher' not in post_data or post_data['publisher'] == '' else post_data['publisher'],
-				"container_title": None if 'container_title' not in post_data or post_data['container_title'] == '' else post_data['container_title']
+				'title': _val('title'),
+				'link': _val('link'),
+				'doi': _val('doi'),
+				'access': _val('access'),
+				'summary': _val('summary'),
+				'published_date': _val('published_date'),
+				'kind': kind,
+				'publisher': _val('publisher'),
+				'container_title': _val('container_title'),
 			}
-
-
-			science_paper = None
-			if new_article['kind'] == 'science paper':
-				science_paper = SciencePaper(doi=new_article['doi'],title=new_article['title'])
-
-			# PR 7: validate source org before any expensive external calls
-			source = Sources.objects.get(pk=new_article['source_id'])
-			if source.team.organization_id != access_scheme.organization_id:
-				raise CrossOrgPayloadError(
-					f'source_id {source.pk} belongs to a different organisation than your API key.'
-				)
-
-			if science_paper.doi == None:
+			science_paper = SciencePaper(doi=new_article['doi'], title=new_article['title'])
+			if science_paper.doi is None:
 				science_paper.doi = science_paper.find_doi(title=science_paper.title)
-
-			if science_paper.doi != None:
+			if science_paper.doi is not None:
 				science_paper.refresh()
-			if new_article['doi'] == None:
+			if new_article['doi'] is None:
 				new_article['doi'] = science_paper.doi
-			if new_article['title'] == None:
+			if new_article['title'] is None:
 				new_article['title'] = science_paper.title
-			if new_article['link'] == None:
+			if new_article['link'] is None:
 				new_article['link'] = science_paper.link
-			if new_article['summary'] == None:
+			if new_article['summary'] is None:
 				new_article['summary'] = science_paper.clean_abstract()
-			if new_article['published_date'] == None:
+			if new_article['published_date'] is None:
 				new_article['published_date'] = science_paper.published_date
-			if new_article['access'] == None:
+			if new_article['access'] is None:
 				new_article['access'] = science_paper.access
-			if new_article['publisher'] == None:
+			if new_article['publisher'] is None:
 				new_article['publisher'] = science_paper.publisher
-			if new_article['container_title'] == None:
+			if new_article['container_title'] is None:
 				new_article['container_title'] = science_paper.journal
-			if new_article['access'] == None:
-				new_article['access'] == science_paper.access
-			
-			article_on_gregory = None
-			if new_article['doi'] != None:
-				article_on_gregory = Articles.objects.filter(doi=new_article['doi'])
-			if article_on_gregory != None and article_on_gregory.count() > 0:
-				for article in article_on_gregory:
-					article.sources.add(source)
-					article.teams.add(source.team)
-					article.subjects.add(source.subject)
-				raise ArticleExistsError('There is already an article with the specified DOI. If the source, team, or subject were different, the article was updated.')
 
-			if new_article['title'] != None:
-				article_on_gregory = Articles.objects.filter(title=new_article['title'])
-			if article_on_gregory != None and article_on_gregory.count() > 0:
-				raise ArticleExistsError('There is already an article with the specified Title')
+			# Dedup by DOI
+			if new_article['doi'] is not None:
+				existing = Articles.objects.filter(doi=new_article['doi'])
+				if existing.exists():
+					for article in existing:
+						article.sources.add(source)
+						article.teams.add(source.team)
+						if source.subject:
+							article.subjects.add(source.subject)
+					raise ArticleExistsError(
+						'There is already an article with the specified DOI. '
+						'If the source, team, or subject were different, the article was updated.'
+					)
+			# Dedup by title
+			if new_article['title'] is not None:
+				if Articles.objects.filter(title=new_article['title']).exists():
+					raise ArticleExistsError('There is already an article with the specified Title')
 
-			if source.pk == None:
-				raise SourceNotFoundError('source_id was not found in the database')
 			save_article = Articles.objects.create(
 				discovery_date=datetime.now(),
-				title = new_article['title'],
-				summary = new_article['summary'],
-				link = new_article['link'],
-				published_date = new_article['published_date'], 
-				doi = new_article['doi'], kind = new_article['kind'],
-				publisher=new_article['publisher'], container_title=new_article['container_title'])
+				title=new_article['title'],
+				summary=new_article['summary'],
+				link=new_article['link'],
+				published_date=new_article['published_date'],
+				doi=new_article['doi'],
+				kind=kind,
+				publisher=new_article['publisher'],
+				container_title=new_article['container_title'],
+			)
 			save_article.sources.add(source)
 			save_article.teams.add(source.team)
-			save_article.subjects.add(source.subject)
-
-			if save_article.pk == None:
+			if source.subject:
+				save_article.subjects.add(source.subject)
+			if save_article.pk is None:
 				raise ArticleNotSavedError('Could not create the article')
-			save_article.sources.add(source)
-			# Prepare some data to be returned to the API client
-			data = {
-				'name': 'Gregory | API',
-				'version': '0.1b',
-				"data_received": json.loads(request.body),
+
+			log_data = {'article_id': save_article.pk}
+			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 201, 'Article created', log_data)
+			return returnData({
+				'name': 'Gregory | API', 'version': '0.1b',
+				'data_received': post_data,
 				'data_processed_from_doi': new_article,
 				'article_id': save_article.article_id,
+			})
+
+		# =================================================================
+		# Branch: trials
+		# =================================================================
+		elif kind == 'trials':
+			trial_data = ClinicalTrial(
+				title=_val('title'),
+				summary=_val('summary'),
+				link=_val('link'),
+				published_date=_val('published_date'),
+				identifiers=post_data.get('identifiers') or {},
+			)
+
+			# Dedup: identifiers first, then title (mirrors feedreader_trials logic)
+			existing_trial = None
+			ident = trial_data.identifiers or {}
+			id_query = Q()
+			if ident.get('euct'):
+				id_query |= Q(identifiers__euct=ident['euct'])
+			if ident.get('nct'):
+				id_query |= Q(identifiers__nct=ident['nct'])
+			if ident.get('eudract'):
+				id_query |= Q(identifiers__eudract=ident['eudract'])
+			if id_query:
+				existing_trial = Trials.objects.filter(id_query).first()
+			if existing_trial is None and trial_data.title:
+				existing_trial = Trials.objects.filter(title__iexact=trial_data.title).first()
+
+			if existing_trial:
+				existing_trial.sources.add(source)
+				existing_trial.teams.add(source.team)
+				if source.subject:
+					existing_trial.subjects.add(source.subject)
+				raise ArticleExistsError(
+					'There is already a trial matching the provided identifiers or title. '
+					'If the source, team, or subject were different, the trial was updated.'
+				)
+
+			save_trial = Trials.objects.create(
+				discovery_date=datetime.now(),
+				title=trial_data.title,
+				summary=trial_data.summary,
+				link=trial_data.link,
+				published_date=trial_data.published_date,
+				identifiers=trial_data.identifiers or {},
+			)
+			save_trial.sources.add(source)
+			save_trial.teams.add(source.team)
+			if source.subject:
+				save_trial.subjects.add(source.subject)
+			if save_trial.pk is None:
+				raise ArticleNotSavedError('Could not create the trial')
+
+			log_data = {'trial_id': save_trial.pk}
+			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 201, 'Trial created', log_data)
+			return returnData({
+				'name': 'Gregory | API', 'version': '0.1b',
+				'data_received': post_data,
+				'trial_id': save_trial.trial_id,
+			})
+
+		# =================================================================
+		# Branch: news article
+		# =================================================================
+		elif kind == 'news article':
+			new_article = {
+				'title': _val('title'),
+				'link': _val('link'),
+				'summary': _val('summary'),
+				'published_date': _val('published_date'),
+				'kind': kind,
 			}
-			log_data = {
-				'name': 'Gregory | API',
-				'version': '0.1b',
-				"article_id": save_article.pk,
-			}
-			# This creates an access log for this client in the DB
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 201, 'Article created', log_data)
-			# Actually return the data to the API client
-			return returnData(data)
-		except APINoAPIKeyError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 401, str(exception), str(post_data))
-			return returnError(NO_API_KEY, str(exception), 401)
-		except APIInvalidAPIKeyError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 401, str(exception), str(post_data))
-			return returnError(INVALID_API_KEY, str(exception), 401)
-		except APIInvalidIPAddressError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 401, str(exception), str(post_data))
-			return returnError(INVALID_IP_ADDRESS, str(exception), 401)
-		except APIAccessDeniedError as exception:
-			if access_scheme is not None:
-					generateAccessSchemeLog(call_type, ip_addr, access_scheme, 403, str(exception), str(post_data))
-			else:
-					generateAccessSchemeLog(call_type, ip_addr, None, 403, str(exception), str(post_data))
-			return returnError(ACCESS_DENIED, str(exception), 403)
-		except FieldNotFoundError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 202, str(exception), str(post_data))
-			return returnError(FIELD_NOT_FOUND, str(exception), 200)
-		except CrossOrgPayloadError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 400, str(exception), str(post_data))
-			return returnError(CROSS_ORG_PAYLOAD, str(exception), 400)
-		except ArticleExistsError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 204, str(exception), str(post_data))
-			return returnError(ARTICLE_EXISTS, str(exception), 200)
-		except ArticleNotSavedError as exception:
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 204, str(exception), str(post_data))
-			return returnError(ARTICLE_NOT_SAVED, str(exception), 204)
-		except Exception as exception:
-			print(traceback.format_exc())
-			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 500, str(exception), str(post_data))
-			return returnError(UNEXPECTED, str(exception), 500)
+			# Dedup by title
+			if new_article['title'] is not None:
+				if Articles.objects.filter(title=new_article['title']).exists():
+					raise ArticleExistsError('There is already an article with the specified Title')
+			# Dedup by link
+			if new_article['link'] is not None:
+				if Articles.objects.filter(link=new_article['link']).exists():
+					raise ArticleExistsError('There is already an article with the specified link')
+
+			save_article = Articles.objects.create(
+				discovery_date=datetime.now(),
+				title=new_article['title'],
+				summary=new_article['summary'],
+				link=new_article['link'],
+				published_date=new_article['published_date'],
+				kind=kind,
+			)
+			save_article.sources.add(source)
+			save_article.teams.add(source.team)
+			if source.subject:
+				save_article.subjects.add(source.subject)
+			if save_article.pk is None:
+				raise ArticleNotSavedError('Could not create the news article')
+
+			log_data = {'article_id': save_article.pk}
+			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 201, 'News article created', log_data)
+			return returnData({
+				'name': 'Gregory | API', 'version': '0.1b',
+				'data_received': post_data,
+				'article_id': save_article.article_id,
+			})
+
+		else:
+			raise FieldNotFoundError(f'Unsupported kind \'{kind}\'')
+
+	except APINoAPIKeyError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 401, str(exception), str(post_data))
+		return returnError(NO_API_KEY, str(exception), 401)
+	except APIInvalidAPIKeyError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 401, str(exception), str(post_data))
+		return returnError(INVALID_API_KEY, str(exception), 401)
+	except APIInvalidIPAddressError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 401, str(exception), str(post_data))
+		return returnError(INVALID_IP_ADDRESS, str(exception), 401)
+	except APIAccessDeniedError as exception:
+		if access_scheme is not None:
+			generateAccessSchemeLog(call_type, ip_addr, access_scheme, 403, str(exception), str(post_data))
+		else:
+			generateAccessSchemeLog(call_type, ip_addr, None, 403, str(exception), str(post_data))
+		return returnError(ACCESS_DENIED, str(exception), 403)
+	except SourceNotFoundError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 404, str(exception), str(post_data))
+		return returnError(SOURCE_NOT_FOUND, str(exception), 404)
+	except FieldNotFoundError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 400, str(exception), str(post_data))
+		return returnError(FIELD_NOT_FOUND, str(exception), 400)
+	except CrossOrgPayloadError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 400, str(exception), str(post_data))
+		return returnError(CROSS_ORG_PAYLOAD, str(exception), 400)
+	except ArticleExistsError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 200, str(exception), str(post_data))
+		return returnError(ARTICLE_EXISTS, str(exception), 200)
+	except ArticleNotSavedError as exception:
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 500, str(exception), str(post_data))
+		return returnError(ARTICLE_NOT_SAVED, str(exception), 500)
+	except Exception as exception:
+		print(traceback.format_exc())
+		generateAccessSchemeLog(call_type, ip_addr, access_scheme, 500, str(exception), str(post_data))
+		return returnError(UNEXPECTED, str(exception), 500)
 
 ###
 # ARTICLES

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1,6 +1,7 @@
 from api.serializers import (
-		ArticleSerializer, TrialSerializer, SourceSerializer, AuthorSerializer, 
-		CategorySerializer, CategoryTopAuthorSerializer, TeamSerializer, SubjectsSerializer, ArticlesByCategoryAndTeamSerializer
+		ArticleSerializer, TrialSerializer, SourceSerializer, AuthorSerializer,
+		CategorySerializer, CategoryTopAuthorSerializer, TeamSerializer, SubjectsSerializer,
+		ArticlesByCategoryAndTeamSerializer, OrganizationSerializer
 )
 from api.pagination import FlexiblePagination
 from datetime import datetime, timedelta
@@ -52,12 +53,16 @@ class OrgVisibilityMixin:
 	"""
 
 	_org_filter_path = 'teams__organization_id'
+	# Set to False for viewsets that reach orgs via a simple FK (not M2M) to
+	# avoid unnecessary DISTINCT overhead on those queries.
+	_org_filter_distinct = True
 
 	def get_queryset(self):
 		qs = super().get_queryset()
 		if not hasattr(self.request, 'visible_org_ids'):
 			return qs
-		return qs.filter(**{f'{self._org_filter_path}__in': self.request.visible_org_ids}).distinct()
+		qs = qs.filter(**{f'{self._org_filter_path}__in': self.request.visible_org_ids})
+		return qs.distinct() if self._org_filter_distinct else qs
 
 
 def add_deprecation_headers(response, deprecated_endpoint, replacement_endpoint, message=None):
@@ -721,6 +726,7 @@ class SourceViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	- **subject_id** - filter by subject ID
 	"""
 	_org_filter_path = 'team__organization_id'
+	_org_filter_distinct = False
 	queryset = Sources.objects.all().order_by('name')
 	serializer_class = SourceSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -890,23 +896,34 @@ class AuthorsViewSet(viewsets.ModelViewSet):
 		
 		# Add date filters to count filters
 		count_filters.update(date_filters)
-		
+
+		# Build an org-visibility filter for the Count annotation so that
+		# article_count always reflects only visible articles (fixes sorting/
+		# filtering by article_count leaking hidden-org data).
+		has_org_scope = hasattr(self.request, 'visible_org_ids')
+		org_q = Q(articles__teams__organization_id__in=self.request.visible_org_ids) if has_org_scope else Q()
+
 		# Add article count annotation for sorting
 		if sort_by == 'article_count':
 			if count_filters:
-				# Annotate with count and filter to only include authors with articles matching criteria
+				combined_q = Q(**count_filters) & org_q if has_org_scope else Q(**count_filters)
 				queryset = queryset.annotate(
-					article_count=Count('articles', filter=Q(**count_filters), distinct=True)
+					article_count=Count('articles', filter=combined_q, distinct=True)
 				).filter(article_count__gt=0)
+			elif has_org_scope:
+				queryset = queryset.annotate(
+					article_count=Count('articles', filter=org_q, distinct=True)
+				)
 			else:
 				queryset = queryset.annotate(
 					article_count=Count('articles', distinct=True)
 				)
 		elif count_filters:
-			# Even if not sorting by article_count, we still need to filter authors 
+			# Even if not sorting by article_count, we still need to filter authors
 			# to only those who have articles matching the criteria
+			combined_q = Q(**count_filters) & org_q if has_org_scope else Q(**count_filters)
 			queryset = queryset.annotate(
-				article_count=Count('articles', filter=Q(**count_filters), distinct=True)
+				article_count=Count('articles', filter=combined_q, distinct=True)
 			).filter(article_count__gt=0)
 		
 		# Apply sorting
@@ -1005,6 +1022,7 @@ class TeamsViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	List all teams
 	"""
 	_org_filter_path = 'organization_id'
+	_org_filter_distinct = False
 	queryset = Team.objects.all().order_by('id')
 	serializer_class = TeamSerializer
 	permission_classes  = [permissions.IsAuthenticatedOrReadOnly]
@@ -1024,13 +1042,8 @@ class OrganizationsViewSet(viewsets.ReadOnlyModelViewSet):
 	Detail endpoint (``/organizations/<id>/``) returns 404 rather than 403
 	when the organisation is not visible (hide-existence rule).
 	"""
-	from api.serializers import OrganizationSerializer
-	serializer_class = None  # set in get_serializer_class
+	serializer_class = OrganizationSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
-
-	def get_serializer_class(self):
-		from api.serializers import OrganizationSerializer
-		return OrganizationSerializer
 
 	def get_queryset(self):
 		qs = Organization.objects.all().order_by('id')
@@ -1060,6 +1073,7 @@ class SubjectsViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	- Order by name: `/subjects/?ordering=subject_name`
 	"""
 	_org_filter_path = 'team__organization_id'
+	_org_filter_distinct = False
 	queryset = Subject.objects.all().order_by('id')
 	serializer_class = SubjectsSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -1063,6 +1063,10 @@ class OrganizationApiSettingsInline(admin.StackedInline):
 	fields = ('make_api_public',)
 	verbose_name = 'API settings'
 	verbose_name_plural = 'API settings'
+	can_delete = False
+
+	def has_add_permission(self, request, obj=None):
+		return False
 
 
 class OrganizationTeamInline(admin.TabularInline):

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -19,7 +19,8 @@ from organizations.admin import OrganizationAdmin as BaseOrganizationAdmin
 from .models import (
     Articles, Trials, Sources, Entities, Authors, Subject, MLPredictions, 
     ArticleSubjectRelevance, TeamCategory, PredictionRunLog, Team,
-    ArticleTrialReference, OrganizationCredentials, OrganizationSite
+    ArticleTrialReference, OrganizationCredentials, OrganizationSite,
+    OrganizationApiSettings
 )
 from .widgets import MLPredictionsWidget
 from django import forms
@@ -1054,6 +1055,16 @@ class OrganizationCredentialsInline(admin.StackedInline):
 	verbose_name_plural = 'Credentials'
 
 
+class OrganizationApiSettingsInline(admin.StackedInline):
+	"""Inline to manage API visibility settings for an organization."""
+	model = OrganizationApiSettings
+	extra = 0
+	max_num = 1
+	fields = ('make_api_public',)
+	verbose_name = 'API settings'
+	verbose_name_plural = 'API settings'
+
+
 class OrganizationTeamInline(admin.TabularInline):
 	"""Inline to display teams belonging to an organization."""
 	model = Team
@@ -1090,6 +1101,7 @@ class OrganizationAdmin(BaseOrganizationAdmin):
 			inlines.append(OrganizationTeamInline(self.model, self.admin_site))
 			inlines.append(OrganizationSiteInline(self.model, self.admin_site))
 			inlines.append(OrganizationCredentialsInline(self.model, self.admin_site))
+			inlines.append(OrganizationApiSettingsInline(self.model, self.admin_site))
 		return inlines
 
 	def teams_count(self, obj):

--- a/django/gregory/middleware/visibility.py
+++ b/django/gregory/middleware/visibility.py
@@ -4,9 +4,20 @@ gregory/middleware/visibility.py
 Attaches ``request.visible_org_ids`` (a ``set[int]``) to every incoming
 request so that viewsets and serializers can read it without recomputing.
 
-The set is computed by ``gregory.visibility.visible_org_ids`` which
-implements the access-control rules from the spec (§4.1).
+The set is computed **lazily** (on first access) by
+``gregory.visibility.visible_org_ids``.  Lazy evaluation is required because
+DRF authentication (JWT, Bearer token) runs *inside* the view dispatch cycle,
+after all middleware has executed.  By the time any view or serializer reads
+``request.visible_org_ids``, DRF will have resolved ``request.user`` and
+propagated it back to the underlying Django request, so the visibility
+function sees the fully-authenticated identity.
+
+Session-authenticated requests and raw API-key requests are unaffected: the
+lazy wrapper simply evaluates on first access with the same result as eager
+evaluation would have produced.
 """
+
+from django.utils.functional import SimpleLazyObject
 
 
 class VisibleOrgMiddleware:
@@ -15,5 +26,5 @@ class VisibleOrgMiddleware:
 
 	def __call__(self, request):
 		from gregory.visibility import visible_org_ids
-		request.visible_org_ids = visible_org_ids(request)
+		request.visible_org_ids = SimpleLazyObject(lambda: visible_org_ids(request))
 		return self.get_response(request)

--- a/django/gregory/middleware/visibility.py
+++ b/django/gregory/middleware/visibility.py
@@ -1,0 +1,19 @@
+"""
+gregory/middleware/visibility.py
+
+Attaches ``request.visible_org_ids`` (a ``set[int]``) to every incoming
+request so that viewsets and serializers can read it without recomputing.
+
+The set is computed by ``gregory.visibility.visible_org_ids`` which
+implements the access-control rules from the spec (§4.1).
+"""
+
+
+class VisibleOrgMiddleware:
+	def __init__(self, get_response):
+		self.get_response = get_response
+
+	def __call__(self, request):
+		from gregory.visibility import visible_org_ids
+		request.visible_org_ids = visible_org_ids(request)
+		return self.get_response(request)

--- a/django/gregory/migrations/0043_organizationapisettings.py
+++ b/django/gregory/migrations/0043_organizationapisettings.py
@@ -1,0 +1,58 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def backfill_api_settings(apps, schema_editor):
+	"""Create OrganizationApiSettings rows for all pre-existing organisations.
+
+	Existing orgs are assumed to have been publicly accessible before this flag
+	existed, so we backfill with make_api_public=True.  Orgs created after this
+	migration will be handled by the post_save signal and will default to False.
+	"""
+	Organization = apps.get_model('organizations', 'Organization')
+	OrganizationApiSettings = apps.get_model('gregory', 'OrganizationApiSettings')
+	for org in Organization.objects.all():
+		OrganizationApiSettings.objects.get_or_create(
+			organization=org,
+			defaults={'make_api_public': True},
+		)
+
+
+def reverse_backfill(apps, schema_editor):
+	"""Remove all OrganizationApiSettings rows (used when reversing the migration)."""
+	OrganizationApiSettings = apps.get_model('gregory', 'OrganizationApiSettings')
+	OrganizationApiSettings.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		('gregory', '0042_historicalauthors'),
+		('organizations', '0001_initial'),
+	]
+
+	operations = [
+		migrations.CreateModel(
+			name='OrganizationApiSettings',
+			fields=[
+				('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+				('organization', models.OneToOneField(
+					help_text='Organisation whose API exposure these settings govern.',
+					on_delete=django.db.models.deletion.CASCADE,
+					related_name='api_settings',
+					to='organizations.organization',
+				)),
+				('make_api_public', models.BooleanField(
+					default=False,
+					help_text="When true, anonymous API and RSS consumers can see this org's data.",
+				)),
+				('created_at', models.DateTimeField(auto_now_add=True)),
+				('updated_at', models.DateTimeField(auto_now=True)),
+			],
+			options={
+				'verbose_name': 'Organisation API settings',
+				'verbose_name_plural': 'Organisation API settings',
+			},
+		),
+		migrations.RunPython(backfill_api_settings, reverse_code=reverse_backfill),
+	]

--- a/django/gregory/models.py
+++ b/django/gregory/models.py
@@ -624,6 +624,28 @@ class OrganizationSite(models.Model):
 		default_label = " (default)" if self.is_default else ""
 		return f"{self.site.domain}{default_label} — {self.organization.name}"
 
+class OrganizationApiSettings(models.Model):
+	organization = models.OneToOneField(
+		Organization,
+		on_delete=models.CASCADE,
+		related_name='api_settings',
+		help_text='Organisation whose API exposure these settings govern.',
+	)
+	make_api_public = models.BooleanField(
+		default=False,
+		help_text="When true, anonymous API and RSS consumers can see this org's data.",
+	)
+	created_at = models.DateTimeField(auto_now_add=True)
+	updated_at = models.DateTimeField(auto_now=True)
+
+	def __str__(self):
+		return f"API settings for {self.organization.name}"
+
+	class Meta:
+		verbose_name = 'Organisation API settings'
+		verbose_name_plural = 'Organisation API settings'
+
+
 class TeamMember(OrganizationUser):
 	class Meta:
 		proxy = True

--- a/django/gregory/signals.py
+++ b/django/gregory/signals.py
@@ -1,4 +1,5 @@
 from simple_history.signals import post_create_historical_record
+from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 MAX_AUTHOR_HISTORY = 5
@@ -12,3 +13,11 @@ def trim_author_history(sender, instance, history_instance, **kwargs):
 		instance.history.order_by('-history_date').values_list('pk', flat=True)[:MAX_AUTHOR_HISTORY]
 	)
 	instance.history.exclude(pk__in=keep_ids).delete()
+
+
+@receiver(post_save, sender='organizations.Organization')
+def create_organization_api_settings(sender, instance, created, **kwargs):
+	"""Create an OrganizationApiSettings row for every newly created Organisation."""
+	if created:
+		from gregory.models import OrganizationApiSettings
+		OrganizationApiSettings.objects.get_or_create(organization=instance)

--- a/django/gregory/signals.py
+++ b/django/gregory/signals.py
@@ -1,6 +1,7 @@
 from simple_history.signals import post_create_historical_record
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from organizations.models import Organization
 
 MAX_AUTHOR_HISTORY = 5
 
@@ -15,7 +16,7 @@ def trim_author_history(sender, instance, history_instance, **kwargs):
 	instance.history.exclude(pk__in=keep_ids).delete()
 
 
-@receiver(post_save, sender='organizations.Organization')
+@receiver(post_save, sender=Organization)
 def create_organization_api_settings(sender, instance, created, **kwargs):
 	"""Create an OrganizationApiSettings row for every newly created Organisation."""
 	if created:

--- a/django/gregory/tests/test_organization_api_settings.py
+++ b/django/gregory/tests/test_organization_api_settings.py
@@ -1,0 +1,99 @@
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
+django.setup()
+
+from django.test import TestCase
+from organizations.models import Organization
+from gregory.models import OrganizationApiSettings
+
+
+class OrganizationApiSettingsRoundTripTest(TestCase):
+	"""Basic create/read round-trip for OrganizationApiSettings."""
+
+	def setUp(self):
+		# Suppress the signal so we control creation manually in these tests.
+		self.org = Organization.objects.create(name='Round Trip Org', slug='round-trip-org')
+		# The signal will have created a row already; clean it up so the tests
+		# can assert on explicit creation.
+		OrganizationApiSettings.objects.filter(organization=self.org).delete()
+
+	def test_create_with_default_false(self):
+		settings = OrganizationApiSettings.objects.create(organization=self.org)
+		self.assertFalse(settings.make_api_public)
+
+	def test_create_explicit_true(self):
+		settings = OrganizationApiSettings.objects.create(
+			organization=self.org,
+			make_api_public=True,
+		)
+		retrieved = OrganizationApiSettings.objects.get(pk=settings.pk)
+		self.assertTrue(retrieved.make_api_public)
+
+	def test_str_repr(self):
+		settings = OrganizationApiSettings.objects.create(organization=self.org)
+		self.assertIn(self.org.name, str(settings))
+
+	def test_one_to_one_uniqueness(self):
+		OrganizationApiSettings.objects.create(organization=self.org)
+		from django.db import IntegrityError
+		with self.assertRaises(IntegrityError):
+			OrganizationApiSettings.objects.create(organization=self.org)
+
+
+class OrganizationApiSettingsSignalTest(TestCase):
+	"""post_save signal on Organization should auto-create an api_settings row."""
+
+	def test_new_org_gets_settings_row(self):
+		org = Organization.objects.create(name='Signal Org', slug='signal-org')
+		self.assertTrue(
+			OrganizationApiSettings.objects.filter(organization=org).exists()
+		)
+
+	def test_new_org_settings_defaults_to_false(self):
+		org = Organization.objects.create(name='Private Org', slug='private-org')
+		settings = OrganizationApiSettings.objects.get(organization=org)
+		self.assertFalse(settings.make_api_public)
+
+	def test_signal_is_idempotent(self):
+		"""get_or_create in the signal means a second save doesn't create a duplicate."""
+		org = Organization.objects.create(name='Idempotent Org', slug='idempotent-org')
+		# Force another post_save (e.g. an org update)
+		org.name = 'Idempotent Org Updated'
+		org.save()
+		self.assertEqual(
+			OrganizationApiSettings.objects.filter(organization=org).count(), 1
+		)
+
+
+class OrganizationApiSettingsMigrationBackfillTest(TestCase):
+	"""
+	Verify the invariant that the migration's backfill step would leave
+	one OrganizationApiSettings row per Organisation.
+
+	The migration itself cannot be re-run in tests, but we can assert the
+	invariant on the live test database state: every org created in tests
+	(via the signal) has exactly one settings row.
+	"""
+
+	def test_every_org_has_exactly_one_settings_row(self):
+		org1 = Organization.objects.create(name='Org One', slug='org-one')
+		org2 = Organization.objects.create(name='Org Two', slug='org-two')
+		for org in [org1, org2]:
+			self.assertEqual(
+				OrganizationApiSettings.objects.filter(organization=org).count(),
+				1,
+			)
+
+	def test_count_parity(self):
+		"""After creating several orgs, counts match."""
+		before_orgs = Organization.objects.count()
+		before_settings = OrganizationApiSettings.objects.count()
+		self.assertEqual(before_orgs, before_settings)
+
+		Organization.objects.create(name='Extra Org', slug='extra-org')
+		self.assertEqual(
+			Organization.objects.count(),
+			OrganizationApiSettings.objects.count(),
+		)

--- a/django/gregory/tests/test_organization_api_settings.py
+++ b/django/gregory/tests/test_organization_api_settings.py
@@ -13,10 +13,9 @@ class OrganizationApiSettingsRoundTripTest(TestCase):
 	"""Basic create/read round-trip for OrganizationApiSettings."""
 
 	def setUp(self):
-		# Suppress the signal so we control creation manually in these tests.
+		# Creating an org fires the post_save signal which creates a settings row.
+		# Delete that row so each test can assert on explicitly created rows.
 		self.org = Organization.objects.create(name='Round Trip Org', slug='round-trip-org')
-		# The signal will have created a row already; clean it up so the tests
-		# can assert on explicit creation.
 		OrganizationApiSettings.objects.filter(organization=self.org).delete()
 
 	def test_create_with_default_false(self):
@@ -56,8 +55,9 @@ class OrganizationApiSettingsSignalTest(TestCase):
 		settings = OrganizationApiSettings.objects.get(organization=org)
 		self.assertFalse(settings.make_api_public)
 
-	def test_signal_is_idempotent(self):
-		"""get_or_create in the signal means a second save doesn't create a duplicate."""
+	def test_signal_only_fires_on_create(self):
+		"""The signal handler guards on `created=True`, so saving an existing org
+		does not fire the handler and cannot produce a duplicate settings row."""
 		org = Organization.objects.create(name='Idempotent Org', slug='idempotent-org')
 		# Force another post_save (e.g. an org update)
 		org.name = 'Idempotent Org Updated'

--- a/django/gregory/tests/test_visibility.py
+++ b/django/gregory/tests/test_visibility.py
@@ -1,0 +1,155 @@
+"""
+Tests for gregory.visibility — the visible_org_ids() helper.
+
+Run with:
+    docker exec gregory python manage.py test gregory.tests.test_visibility
+"""
+from django.test import TestCase, RequestFactory
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from organizations.models import Organization
+from gregory.models import OrganizationApiSettings, Team
+from gregory.visibility import visible_org_ids
+
+User = get_user_model()
+
+
+def _make_org(name, slug, public):
+	"""Create an org and set its make_api_public flag."""
+	org = Organization.objects.create(name=name, slug=slug)
+	# Signal already created the settings row; just update it
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _anon_request(factory, path='/', include_public=False):
+	"""RequestFactory GET with an anonymous user (no auth)."""
+	qs = '?include_public=true' if include_public else ''
+	req = factory.get(path + qs)
+	req.user = AnonymousUser()
+	return req
+
+
+class VisibleOrgIdsAnonymousTest(TestCase):
+	def setUp(self):
+		self.factory = RequestFactory()
+		self.pub_org = _make_org('Public Org', 'public-org', public=True)
+		self.priv_org = _make_org('Private Org', 'private-org', public=False)
+
+	def test_anonymous_no_flag_sees_public_only(self):
+		req = _anon_request(self.factory)
+		result = visible_org_ids(req)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.priv_org.id, result)
+
+	def test_anonymous_with_include_public_still_only_public(self):
+		"""Flag is a no-op for anonymous callers."""
+		req = _anon_request(self.factory, include_public=True)
+		result = visible_org_ids(req)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.priv_org.id, result)
+
+
+class VisibleOrgIdsAuthenticatedUserTest(TestCase):
+	def setUp(self):
+		self.factory = RequestFactory()
+		self.pub_org = _make_org('Public Org', 'pub-org-u', public=True)
+		self.priv_org_a = _make_org('Org A', 'org-a-u', public=False)
+		self.priv_org_b = _make_org('Org B', 'org-b-u', public=False)
+
+		self.user = User.objects.create_user(username='testuser', password='pw')
+
+	def _authed_request(self, include_public=False):
+		qs = '?include_public=true' if include_public else ''
+		req = self.factory.get('/' + qs)
+		req.user = self.user
+		return req
+
+	def test_user_no_team_no_include_public_sees_nothing(self):
+		req = self._authed_request()
+		result = visible_org_ids(req)
+		# No membership → empty owned set, no public flag → empty
+		self.assertEqual(result, set())
+
+	def test_user_no_team_with_include_public_sees_public(self):
+		req = self._authed_request(include_public=True)
+		result = visible_org_ids(req)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.priv_org_a.id, result)
+
+	def test_user_in_org_a_sees_only_org_a_by_default(self):
+		# Add user to a team in org A
+		Team.objects.create(organization=self.priv_org_a, name='Team A', slug='team-a-u')
+		from organizations.models import OrganizationUser
+		OrganizationUser.objects.create(organization=self.priv_org_a, user=self.user)
+
+		req = self._authed_request()
+		result = visible_org_ids(req)
+		self.assertIn(self.priv_org_a.id, result)
+		self.assertNotIn(self.pub_org.id, result)
+		self.assertNotIn(self.priv_org_b.id, result)
+
+	def test_user_in_org_a_with_include_public_sees_org_a_plus_public(self):
+		from organizations.models import OrganizationUser
+		OrganizationUser.objects.create(organization=self.priv_org_a, user=self.user)
+
+		req = self._authed_request(include_public=True)
+		result = visible_org_ids(req)
+		self.assertIn(self.priv_org_a.id, result)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.priv_org_b.id, result)
+
+
+class VisibleOrgIdsAPIKeyTest(TestCase):
+	def setUp(self):
+		self.factory = RequestFactory()
+		self.pub_org = _make_org('Public Org', 'pub-org-k', public=True)
+		self.org_x = _make_org('Org X', 'org-x-k', public=False)
+		self.other_priv_org = _make_org('Other Priv', 'other-priv-k', public=False)
+
+		from api.models import APIAccessScheme
+		self.scheme_with_org = APIAccessScheme.objects.create(
+			client_name='Key With Org',
+			client_contacts='a@b.com',
+			organization=self.org_x,
+			ip_addresses='',
+		)
+		self.scheme_no_org = APIAccessScheme.objects.create(
+			client_name='Key No Org',
+			client_contacts='c@d.com',
+			organization=None,
+			ip_addresses='',
+		)
+
+	def _key_request(self, scheme, include_public=False):
+		qs = '?include_public=true' if include_public else ''
+		req = self.factory.get('/' + qs, HTTP_AUTHORIZATION=scheme.api_key, REMOTE_ADDR='127.0.0.1')
+		req.user = AnonymousUser()
+		return req
+
+	def test_key_bound_to_org_x_sees_only_org_x(self):
+		req = self._key_request(self.scheme_with_org)
+		result = visible_org_ids(req)
+		self.assertIn(self.org_x.id, result)
+		self.assertNotIn(self.pub_org.id, result)
+		self.assertNotIn(self.other_priv_org.id, result)
+
+	def test_key_bound_to_org_x_with_include_public(self):
+		req = self._key_request(self.scheme_with_org, include_public=True)
+		result = visible_org_ids(req)
+		self.assertIn(self.org_x.id, result)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.other_priv_org.id, result)
+
+	def test_null_org_key_no_include_public_sees_only_public(self):
+		req = self._key_request(self.scheme_no_org)
+		result = visible_org_ids(req)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.org_x.id, result)
+
+	def test_null_org_key_with_include_public_sees_only_public(self):
+		"""Flag is still a no-op for null-org keys (anonymous-equivalent)."""
+		req = self._key_request(self.scheme_no_org, include_public=True)
+		result = visible_org_ids(req)
+		self.assertIn(self.pub_org.id, result)
+		self.assertNotIn(self.org_x.id, result)

--- a/django/gregory/visibility.py
+++ b/django/gregory/visibility.py
@@ -1,0 +1,82 @@
+"""
+gregory/visibility.py
+
+Computes the set of Organisation IDs visible to a given request.
+
+Rules (see spec §4.1):
+  - Anonymous caller (no auth, no valid API key, or null-org key)
+      → public orgs only; ?include_public flag is a no-op
+  - Authenticated user
+      → orgs they are a member of (via any team); ?include_public=true adds public orgs
+  - API key bound to org X
+      → {X}; ?include_public=true adds public orgs
+"""
+
+from __future__ import annotations
+
+
+def _public_org_ids() -> set[int]:
+	"""Return the set of org IDs whose make_api_public flag is True."""
+	from gregory.models import OrganizationApiSettings
+	return set(
+		OrganizationApiSettings.objects
+		.filter(make_api_public=True)
+		.values_list('organization_id', flat=True)
+	)
+
+
+def _resolve_api_scheme(request):
+	"""
+	Try to resolve an APIAccessScheme from the request's Authorization header.
+
+	Returns the scheme object on success, None on any failure (missing key,
+	invalid key, expired, IP mismatch, etc.).  Never raises.
+	"""
+	try:
+		from api.utils.utils import getAPIKey, checkValidAccess, getIPAddress
+		api_key = getAPIKey(request)
+		ip_addr = getIPAddress(request)
+		return checkValidAccess(api_key, ip_addr)
+	except Exception:
+		return None
+
+
+def visible_org_ids(request) -> set[int]:
+	"""
+	Return the set of organisation IDs the caller is permitted to see.
+
+	The result is computed once per call; callers that need it on multiple
+	occasions should cache it on the request (the middleware does this via
+	``request.visible_org_ids``).
+	"""
+	include_public = request.GET.get('include_public', '').lower() == 'true'
+
+	owned_ids: set[int] = set()
+	is_identified = False  # True when caller has a non-anonymous identity
+
+	# --- 1. Try API key identity ---
+	api_scheme = _resolve_api_scheme(request)
+	if api_scheme is not None:
+		if api_scheme.organization_id is not None:
+			owned_ids.add(api_scheme.organization_id)
+			is_identified = True
+		# null-org key → anonymous-equivalent; is_identified stays False
+
+	# --- 2. Try authenticated-user identity (only if no API key found) ---
+	elif getattr(request, 'user', None) is not None and request.user.is_authenticated:
+		user_org_ids = set(
+			request.user.organizations_organizationuser
+			.values_list('organization_id', flat=True)
+		)
+		owned_ids |= user_org_ids
+		is_identified = True
+
+	# --- 3. Resolve final set ---
+	if not is_identified:
+		# Anonymous or null-org key → public orgs only (flag is a no-op)
+		return _public_org_ids()
+
+	if include_public:
+		return owned_ids | _public_org_ids()
+
+	return owned_ids

--- a/django/gregory/visibility.py
+++ b/django/gregory/visibility.py
@@ -10,6 +10,13 @@ Rules (see spec §4.1):
       → orgs they are a member of (via OrganizationUser membership); ?include_public=true adds public orgs
   - API key bound to org X
       → {X}; ?include_public=true adds public orgs
+
+Note: ``request.visible_org_ids`` is attached by ``VisibleOrgMiddleware`` as a
+``SimpleLazyObject`` so that computation is deferred until first access.  This
+ensures DRF authentication (JWT, Bearer token) has already resolved
+``request.user`` before visibility is evaluated — DRF propagates the
+authenticated user back to ``request._request.user`` via its user-property
+setter, so reading ``request.user`` here always reflects the DRF identity.
 """
 
 from __future__ import annotations

--- a/django/gregory/visibility.py
+++ b/django/gregory/visibility.py
@@ -7,7 +7,7 @@ Rules (see spec §4.1):
   - Anonymous caller (no auth, no valid API key, or null-org key)
       → public orgs only; ?include_public flag is a no-op
   - Authenticated user
-      → orgs they are a member of (via any team); ?include_public=true adds public orgs
+      → orgs they are a member of (via OrganizationUser membership); ?include_public=true adds public orgs
   - API key bound to org X
       → {X}; ?include_public=true adds public orgs
 """
@@ -27,16 +27,34 @@ def _public_org_ids() -> set[int]:
 
 def _resolve_api_scheme(request):
 	"""
-	Try to resolve an APIAccessScheme from the request's Authorization header.
+	Lightweight resolution of an APIAccessScheme from the Authorization header.
 
-	Returns the scheme object on success, None on any failure (missing key,
-	invalid key, expired, IP mismatch, etc.).  Never raises.
+	Only validates key existence, date window, and (if configured) IP address.
+	Deliberately does NOT run quota-counting queries — those remain in the
+	actual API views.  This avoids doubling up on DB work for every request.
+
+	Returns the scheme object on success, None on any failure.  Never raises.
 	"""
 	try:
-		from api.utils.utils import getAPIKey, checkValidAccess, getIPAddress
+		from api.utils.utils import getAPIKey, getIPAddress
+		from api.models import APIAccessScheme
+		from django.utils.timezone import now as tz_now
 		api_key = getAPIKey(request)
 		ip_addr = getIPAddress(request)
-		return checkValidAccess(api_key, ip_addr)
+		current_time = tz_now()
+		scheme = APIAccessScheme.objects.filter(
+			api_key=api_key,
+			begin_date__lte=current_time,
+			end_date__gte=current_time,
+		).first()
+		if scheme is None:
+			return None
+		# Enforce IP allowlist only when the scheme has one configured
+		if scheme.ip_addresses:
+			allowed = [i.strip() for i in scheme.ip_addresses.split(',')]
+			if ip_addr not in allowed:
+				return None
+		return scheme
 	except Exception:
 		return None
 

--- a/django/gregory/visibility.py
+++ b/django/gregory/visibility.py
@@ -33,13 +33,19 @@ def _resolve_api_scheme(request):
 	Deliberately does NOT run quota-counting queries — those remain in the
 	actual API views.  This avoids doubling up on DB work for every request.
 
-	Returns the scheme object on success, None on any failure.  Never raises.
+	Returns the scheme object on success, None when no key is present or the
+	key is invalid/expired/IP-blocked.  Re-raises unexpected exceptions.
 	"""
+	# Fast-path: skip entirely when no Authorization header is present.
+	# This avoids any exception overhead for ordinary anonymous/session requests.
+	api_key = request.headers.get('Authorization', '').strip()
+	if not api_key:
+		return None
+
 	try:
-		from api.utils.utils import getAPIKey, getIPAddress
 		from api.models import APIAccessScheme
+		from api.utils.utils import getIPAddress
 		from django.utils.timezone import now as tz_now
-		api_key = getAPIKey(request)
 		ip_addr = getIPAddress(request)
 		current_time = tz_now()
 		scheme = APIAccessScheme.objects.filter(
@@ -56,7 +62,11 @@ def _resolve_api_scheme(request):
 				return None
 		return scheme
 	except Exception:
-		return None
+		# Unexpected DB or import errors should not silently grant/deny access.
+		# Log and re-raise so they surface in Sentry / server logs.
+		import logging
+		logging.getLogger(__name__).exception('Unexpected error in _resolve_api_scheme')
+		raise
 
 
 def visible_org_ids(request) -> set[int]:

--- a/django/rss/views.py
+++ b/django/rss/views.py
@@ -1,11 +1,13 @@
 from django.shortcuts import render
 from django.contrib.syndication.views import Feed
 from django.contrib.sites.models import Site
+from django.http import Http404
 from gregory.models import Articles, Authors, Trials, Subject
 from django.urls import reverse
 from django.contrib.sites.models import Site
 from sitesettings.models import CustomSetting
 from gregory.functions import normalize_orcid
+from gregory.visibility import visible_org_ids as _visible_org_ids
 
 def get_website_domain():
 	current_site = Site.objects.get_current()
@@ -19,7 +21,18 @@ class ArticlesByAuthorFeed(Feed):
 		normalized = normalize_orcid(orcid)
 		if not normalized:
 			raise Authors.DoesNotExist
-		return Authors.objects.get(ORCID=normalized)
+		author = Authors.objects.get(ORCID=normalized)
+
+		# Compute visibility and attach to self for use in items()
+		self._visible_org_ids = _visible_org_ids(request)
+
+		# 404 if author has no articles in any visible org
+		if not author.articles_set.filter(
+			teams__organization_id__in=self._visible_org_ids
+		).exists():
+			raise Http404
+
+		return author
 
 	# Feed metadata (dynamic per author)
 	def title(self, obj):
@@ -32,7 +45,14 @@ class ArticlesByAuthorFeed(Feed):
 	description = "RSS feed for articles by a specific author."
 
 	def items(self, obj):
-		return Articles.objects.filter(authors=obj).order_by('-published_date')[:50]
+		return (
+			Articles.objects.filter(
+				authors=obj,
+				teams__organization_id__in=self._visible_org_ids,
+			)
+			.distinct()
+			.order_by('-published_date')[:50]
+		)
 
 	def item_title(self, item):
 		return item.title
@@ -54,15 +74,29 @@ class ArticlesByAuthorFeed(Feed):
 		return item.published_date
 
 	def item_updateddate(self, item):
-		return item.last_updated
+		return item.discovery_date
 
 
 class TrialsBySubjectFeed(Feed):
 	"""RSS feed for clinical trials filtered by subject slug."""
 
 	def get_object(self, request, subject_slug):
-		# Look up subject by slug
-		return Subject.objects.get(subject_slug=subject_slug)
+		subject = Subject.objects.get(subject_slug=subject_slug)
+
+		# Compute visibility and attach to self for use in items()
+		self._visible_org_ids = _visible_org_ids(request)
+
+		# 404 if subject belongs to an org that isn't visible
+		if subject.team_id is not None:
+			from gregory.models import Team as _Team
+			try:
+				team = _Team.objects.get(id=subject.team_id)
+				if team.organization_id not in self._visible_org_ids:
+					raise Http404
+			except _Team.DoesNotExist:
+				raise Http404
+
+		return subject
 
 	# Feed metadata (dynamic per subject)
 	def title(self, obj):
@@ -75,7 +109,14 @@ class TrialsBySubjectFeed(Feed):
 		return f"RSS feed for clinical trials related to {obj.subject_name}."
 
 	def items(self, obj):
-		return Trials.objects.filter(subjects=obj).order_by('-discovery_date')[:50]
+		return (
+			Trials.objects.filter(
+				subjects=obj,
+				teams__organization_id__in=self._visible_org_ids,
+			)
+			.distinct()
+			.order_by('-discovery_date')[:50]
+		)
 
 	def item_title(self, item):
 		return item.title

--- a/django/rss/views.py
+++ b/django/rss/views.py
@@ -19,12 +19,13 @@ class ArticlesByAuthorFeed(Feed):
 			raise Authors.DoesNotExist
 		author = Authors.objects.get(ORCID=normalized)
 
-		# Compute visibility and attach to self for use in items()
-		self._visible_org_ids = _visible_org_ids(request)
+		# Compute visibility and attach to the per-request obj (not self)
+		# so concurrent requests on the shared Feed instance don't interfere.
+		author._visible_org_ids = _visible_org_ids(request)
 
 		# 404 if author has no articles in any visible org
 		if not author.articles_set.filter(
-			teams__organization_id__in=self._visible_org_ids
+			teams__organization_id__in=author._visible_org_ids
 		).exists():
 			raise Http404
 
@@ -44,7 +45,7 @@ class ArticlesByAuthorFeed(Feed):
 		return (
 			Articles.objects.filter(
 				authors=obj,
-				teams__organization_id__in=self._visible_org_ids,
+				teams__organization_id__in=obj._visible_org_ids,
 			)
 			.distinct()
 			.order_by('-published_date')[:50]
@@ -79,15 +80,16 @@ class TrialsBySubjectFeed(Feed):
 	def get_object(self, request, subject_slug):
 		subject = Subject.objects.get(subject_slug=subject_slug)
 
-		# Compute visibility and attach to self for use in items()
-		self._visible_org_ids = _visible_org_ids(request)
+		# Compute visibility and attach to the per-request obj (not self)
+		# so concurrent requests on the shared Feed instance don't interfere.
+		subject._visible_org_ids = _visible_org_ids(request)
 
 		# 404 if subject belongs to an org that isn't visible
 		if subject.team_id is not None:
 			from gregory.models import Team as _Team
 			try:
 				team = _Team.objects.get(id=subject.team_id)
-				if team.organization_id not in self._visible_org_ids:
+				if team.organization_id not in subject._visible_org_ids:
 					raise Http404
 			except _Team.DoesNotExist:
 				raise Http404
@@ -108,7 +110,7 @@ class TrialsBySubjectFeed(Feed):
 		return (
 			Trials.objects.filter(
 				subjects=obj,
-				teams__organization_id__in=self._visible_org_ids,
+				teams__organization_id__in=obj._visible_org_ids,
 			)
 			.distinct()
 			.order_by('-discovery_date')[:50]

--- a/django/rss/views.py
+++ b/django/rss/views.py
@@ -1,4 +1,3 @@
-from django.shortcuts import render
 from django.contrib.syndication.views import Feed
 from django.contrib.sites.models import Site
 from django.http import Http404

--- a/django/rss/views.py
+++ b/django/rss/views.py
@@ -3,9 +3,6 @@ from django.contrib.syndication.views import Feed
 from django.contrib.sites.models import Site
 from django.http import Http404
 from gregory.models import Articles, Authors, Trials, Subject
-from django.urls import reverse
-from django.contrib.sites.models import Site
-from sitesettings.models import CustomSetting
 from gregory.functions import normalize_orcid
 from gregory.visibility import visible_org_ids as _visible_org_ids
 

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -53,6 +53,46 @@ This prevents open-redirect attacks — only explicitly whitelisted domains are 
 
 ---
 
+## Accessing private organisation data
+
+By default the API only exposes data belonging to **public organisations** (`OrganizationApiSettings.make_api_public = True`). Callers that need to read a **private** organisation's data must identify themselves in one of two ways.
+
+### Option 1 — API key bound to the organisation
+
+Create an `APIAccessScheme` record in the Django admin with `organization` set to the target private org. The client sends the raw key in the `Authorization` header (no prefix):
+
+```http
+GET /articles/
+Authorization: <raw_api_key>
+```
+
+The key is validated against its date window (`begin_date` / `end_date`) and, if configured, an IP allowlist. A valid key grants access to all data owned by its organisation.
+
+### Option 2 — Authenticated Django user
+
+A user account that is a member of the organisation (an `OrganizationUser` record exists) sees that organisation's data automatically after logging in via the session-based endpoints.
+
+### Including public organisations alongside private data
+
+Both caller types can append `?include_public=true` to any request to also receive data from organisations that have `make_api_public = True`.
+
+```bash
+GET /articles/?include_public=true
+```
+
+### Visibility rules summary
+
+| Caller | Visible organisations |
+|:-------|:----------------------|
+| Anonymous (no credentials) | Public orgs only |
+| API key with no org (`organization = null`) | Public orgs only |
+| API key bound to org X | Org X only (+ public if `?include_public=true`) |
+| Authenticated user member of org X | Org X only (+ public if `?include_public=true`) |
+
+> **Note:** An expired key or a key used from a non-allowed IP is treated as anonymous.
+
+---
+
 ## Articles query parameters
 
 The `/articles/` endpoint supports the following filters. Multiple parameters can be combined.

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -140,7 +140,7 @@ GET /articles/?has_clinical_trials=true
 | Model | Endpoint | Parameters | Notes |
 |:------|:---------|:-----------|:------|
 | Articles | `GET /articles/` | `team_id`, `subject_id`, `author_id`, `category_slug`, `category_id`, `journal_slug`, `source_id`, `search`, `ordering`, `relevant`, `open_access`, `unsent`, `last_days`, `week`, `year`, `has_clinical_trials`, pagination | |
-| Articles | `POST /articles/post/` | `title`, `link`, `doi`, `summary`, `source_id` | Create article |
+| Articles | `POST /articles/post/` | `title`, `link`, `doi`, `summary`, `source_id`, `kind` | Create article — see [response codes below](#post-articlespost-response-codes) |
 | Articles | `GET /articles/{id}/` | `id` (path) | |
 | Articles | `GET /articles/search/` | `team_id` *(req)*, `subject_id` *(req)*, `title`, `summary`, `search`, `format`, `all_results` | See [article-search-api.md](article-search-api.md) |
 | Articles | `POST /articles/search/` | Same fields in request body | |
@@ -187,6 +187,37 @@ GET /articles/?has_clinical_trials=true
 | `therapeutic_areas` | Filter by therapeutic areas |
 | `inclusion_agemin` / `inclusion_agemax` | Filter by age range |
 | `inclusion_gender` | Filter by gender inclusion |
+
+---
+
+## `POST /articles/post/` response codes
+
+This endpoint requires an `APIAccessScheme` API key (sent as the raw value in the `Authorization` header). The following status codes are returned:
+
+| HTTP status | Condition |
+|:------------|:----------|
+| `200 OK` | Article or trial created successfully |
+| `200 OK` | Duplicate — an item with the same DOI, title, or trial identifier already exists; the source/team/subject links on the existing record were updated |
+| `400 Bad Request` | A required field is missing or invalid: `kind`, `source_id`, both `doi` and `title` absent, `kind` value does not match the source's `source_for`, or unsupported `kind` value |
+| `400 Bad Request` | The `source_id` belongs to an organisation different from the one bound to the API key (cross-org payload) |
+| `401 Unauthorized` | No API key provided, key is invalid, or the request IP is not in the key's allowlist |
+| `403 Forbidden` | The API key has no organisation assigned (`organization = null`) |
+| `404 Not Found` | The `source_id` does not exist in the database, or the source has no team assigned |
+| `500 Internal Server Error` | The article or trial could not be saved, or an unexpected error occurred |
+
+> **Breaking change (introduced in this release):** Prior to this release, `FieldNotFoundError` returned `200`, `SourceNotFoundError` returned a non-standard code, and `ArticleNotSavedError` returned `204`. These have been standardised to `400`, `404`, and `500` respectively.
+
+### Required fields
+
+| Field | Required | Description |
+|:------|:---------|:------------|
+| `kind` | yes | One of: `science paper`, `trials`, `news article` — must match the source's `source_for` value |
+| `source_id` | yes | ID of the `Sources` record; must belong to the same org as the API key |
+| `doi` or `title` | at least one | Used for dedup and CrossRef enrichment (`science paper` only) |
+| `link` | no | URL of the article or trial |
+| `summary` | no | Abstract or description |
+| `published_date` | no | ISO 8601 date string |
+| `identifiers` | no | JSON object with trial identifiers (`euct`, `nct`, `eudract`) — `trials` kind only |
 
 ---
 

--- a/docs/06-organisations-teams-and-sites.md
+++ b/docs/06-organisations-teams-and-sites.md
@@ -20,6 +20,38 @@ GregoryAI supports a multi-tenant structure where content, credentials, and emai
 
 ---
 
+## API visibility for private organisations
+
+Each Organisation has an `OrganizationApiSettings` record with a `make_api_public` flag.
+
+- When `make_api_public = True` the organisation's data is visible to **all callers**, including anonymous requests.
+- When `make_api_public = False` (the default) the data is **private** — only callers that have been explicitly granted access can read it.
+
+### Granting access to a private organisation
+
+**Via API key** — create an `APIAccessScheme` in the admin under **API > API Access Schemes**:
+
+| Field | Value |
+|:------|:------|
+| Client name | Descriptive label for the consumer |
+| Organisation | The private organisation |
+| Begin / end date | Validity window |
+| IP addresses | Optional comma-separated allowlist |
+
+The consumer sends the generated key in every request:
+
+```http
+Authorization: <raw_api_key>
+```
+
+**Via user account** — add the user to the organisation as an `OrganizationUser`. After logging in they will see the organisation's data automatically.
+
+In both cases the caller can append `?include_public=true` to a request to also receive data from public organisations.
+
+See [03-api-and-rss-feeds.md](03-api-and-rss-feeds.md#accessing-private-organisation-data) for the full visibility rules table.
+
+---
+
 ## Setting Up Sites
 
 Sites are managed at **Sites > Sites** in the Django admin (`/admin/sites/site/`).

--- a/docs/changelog/post-article-status-codes.md
+++ b/docs/changelog/post-article-status-codes.md
@@ -1,0 +1,38 @@
+# `POST /articles/post/` — standardised HTTP status codes
+
+**Context**: PR 638 introduced org-privacy enforcement on the ingest endpoint. As part of that work the error-handling paths in `post_article()` were updated to return semantically correct HTTP status codes. This is a breaking change for any client that inspected the previous (non-standard) codes.
+
+---
+
+## Status code changes
+
+| Condition | Old code | New code |
+|:----------|:---------|:---------|
+| Missing or invalid field (`FieldNotFoundError`) | `200` | `400` |
+| Source not found / source has no team (`SourceNotFoundError`) | non-standard | `404` |
+| Could not save article/trial (`ArticleNotSavedError`) | `204` | `500` |
+| Cross-org source in payload (`CrossOrgPayloadError`) | n/a (new) | `400` |
+| API key has no organisation (`APIAccessDeniedError`) | n/a (new) | `403` |
+
+## Unchanged codes
+
+| Condition | Code |
+|:----------|:-----|
+| Article/trial already exists (dedup) | `200` |
+| No API key | `401` |
+| Invalid API key | `401` |
+| IP not in allowlist | `401` |
+| Success (item created) | `200` |
+| Unexpected error | `500` |
+
+---
+
+## Migration guide
+
+If your client checks the response status code from `POST /articles/post/`:
+
+- Replace checks for `200` on error paths with the appropriate new codes (`400`, `404`, `500`).
+- A `200` response now unambiguously means success or a benign duplicate.
+- Add handling for `400` (bad payload or cross-org source), `403` (key lacks an org), and `404` (unknown source).
+
+The full response body still contains a `code` and `error_msg` field for programmatic error identification regardless of status code.


### PR DESCRIPTION
# Spec — make_api_public flag

## 1. Goal

Add an org-level boolean that controls whether an organisation's data is exposed via the public REST API and RSS feeds. The flag introduces opt-in publication: org owners decide whether their teams' articles, trials, authors, subjects, categories, and sources are reachable by anonymous callers and feed subscribers.

## 2. Background

The current GregoryAI API is effectively public for all read endpoints. DRF defaults at `django/admin/settings.py:179-197` use `BasicAuthentication`, `SessionAuthentication`, and `JWTAuthentication` with no global `DEFAULT_PERMISSION_CLASSES`; per-view classes use `IsAuthenticatedOrReadOnly` or `AllowAny`, so anonymous callers read every endpoint. There is no per-org filtering today. Only `POST /articles/post/` enforces an `APIAccessScheme` API-key + IP allowlist.

Org/team graph (current):

- `Team.organization = ForeignKey(Organization)` (gregory/models.py:504)
- `Subject.team`, `Sources.team`, `TeamCategory.team` are direct FKs to Team.
- `Articles.teams`, `Articles.subjects`, `Articles.team_categories` are M2M — an article can belong to multiple teams across multiple organisations.
- `Trials.teams`, `Trials.subjects` are M2M — same multi-org property.
- `Authors` has no FK to Team or Organization. Org reachability is transitive via `articles__teams__organization`.
- `MLPredictions` is reachable via `subject.team.organization`.

There is no existing `is_public` / `private` field on Team, Subject, Article, Trial, Source, Category, or Organization. `OrganizationCredentials` and `OrganizationSite` are the existing precedent for per-org config — both extend Organization via OneToOne/FK rather than mutating the upstream `django-organizations` model.

## 3. Data model

### 3.1 New model: `OrganizationApiSettings`

```python
class OrganizationApiSettings(models.Model):
	organization = models.OneToOneField(
		Organization,
		on_delete=models.CASCADE,
		related_name='api_settings',
		help_text='Organisation whose API exposure these settings govern.',
	)
	make_api_public = models.BooleanField(
		default=False,
		help_text='When true, anonymous API and RSS consumers can see this org\'s data.',
	)
	created_at = models.DateTimeField(auto_now_add=True)
	updated_at = models.DateTimeField(auto_now=True)

	class Meta:
		verbose_name = 'Organisation API settings'
		verbose_name_plural = 'Organisation API settings'
```

A `post_save` signal on `Organization` creates an `OrganizationApiSettings` row whenever a new organisation is created. The model default is `False`, so all newly created organisations are private by default.

### 3.2 `APIAccessScheme` extension

```python
organization = models.ForeignKey(
	Organization,
	on_delete=models.CASCADE,
	null=True,
	blank=True,
	related_name='api_access_schemes',
	help_text='Organisation this key represents. Required after the transition window.',
)
```

`null=True` is permitted only during the transition window. Null keys are treated as anonymous-equivalent for read access (no privileged view of any private org). Existing keys are backfilled manually before phase 3 of the rollout, then `null=True` is removed.

## 4. Visibility rules

### 4.1 The `visible_org_ids(request)` helper

A single helper returns the set of organisation IDs the request can see, computed once per request and attached to `request.visible_org_ids` via middleware.

The set is built from:

1. The caller's own org membership (authenticated user → orgs of any team in `Team.members`; API key → its bound `organization`).
2. If the request includes `?include_public=true`, the union of all orgs where `make_api_public=True`.

Anonymous callers always receive only public orgs, regardless of the `include_public` flag.

| Caller | Without `?include_public=true` | With `?include_public=true` |
|---|---|---|
| Anonymous | Public orgs only | Public orgs only (flag is a no-op) |
| Authenticated user U | Orgs where U is a member of any team | Above ∪ public orgs |
| API key for org X | {X} | {X} ∪ public orgs |

Authenticated users default to org-internal scope. They opt into the public firehose explicitly with the query parameter. This means logged-in users browsing their own org are not blasted with public-org data unless they ask for it.

Membership in any team within org A grants visibility into all teams of org A (no per-team gating in this iteration).

### 4.2 Object-level rules

#### Firehose listings

`/articles/`, `/trials/`, etc. include an object if at least one of its team associations belongs to an org in `visible_org_ids`.

#### Detail endpoints

`/articles/<id>/`, `/trials/<id>/` return 404 when no team association resolves to a visible org.

#### Stripped nested associations

For every visible object, the response strips:

- `teams` entries whose org is not in `visible_org_ids`
- `subjects` whose `team.organization` is not in `visible_org_ids`
- `team_categories` whose `team.organization` is not in `visible_org_ids`
- ML predictions (`ml_predictions_detail`) whose `subject.team.organization` is not in `visible_org_ids`

Stripping is implemented once in a serializer mixin (`OrgScopedSerializerMixin`) so the rule isn't duplicated per-viewset.

#### Hide-existence endpoints (always 404, never 403 or empty 200)

- `/teams/<id>/`, `/subjects/<id>/`, `/categories/<id>/`, `/sources/<id>/`, `/organizations/<id>/`
- `/authors/<id>/` when the author has no article in a visible org
- `/articles/<id>/`, `/trials/<id>/` when all associations are hidden
- Nested parent paths (`/teams/<id>/subjects/`, `/teams/<id>/subjects/<id>/categories/`) — 404 on the parent

#### List filtering for nested resources

- Authors list: only authors with at least one article in a visible org. `articles_count` and embedded article lists reflect only visible articles.
- Subjects list, Categories list, Sources list, Teams list, Organizations list: only entries in visible orgs.

#### Search endpoints

`/articles/search/`, `/trials/search/`, `/authors/search/`:

- A `team_id` parameter pointing at a non-visible team returns 404.
- Otherwise the firehose rule applies to the result set.

#### Stats endpoint

`/stats/`:

- `?team=<id>` for a non-visible team returns 404.
- Aggregate counts include only visible orgs' data.

#### RSS feeds

- `/feed/author/<orcid>/`: 404 if the author is not visible. Items filtered to articles in visible orgs.
- `/feed/trials/subject/<slug>/`: 404 if the subject is not visible. Items filtered to trials in visible orgs.
- `?include_public=true` is honoured on RSS for parity with the JSON API.

#### Article ingest (`POST /articles/post/`)

- Requires a valid `APIAccessScheme` key with `organization` set.
- Reject (HTTP 400) any payload whose target `team_id` belongs to an organisation other than the key's organisation.
- Null-org keys retained during the transition window cannot ingest; they get HTTP 403.

## 5. Out of scope

- Django admin behaviour. The admin already scopes by org for staff users via `OrganizationFilterMixin` and `get_user_organizations()` (`gregory/admin.py:30-34`). The flag does not change admin filtering.
- Subscriptions endpoints (`subscriptions/views.py`). Unchanged.
- HTTP cache invalidation. No CDN considerations for this change.
- Per-team and per-subject overrides. The model is designed so they can be added later without another migration on `OrganizationApiSettings`.
- Stricter authenticated-non-member behaviour within the same org. One team's membership grants visibility into all teams of that org.

## 6. Migration plan

### Phase 1 — schema and backfill

1. Create `OrganizationApiSettings` model.
2. Migration creates the table and, in a `RunPython` step, inserts one row per existing `Organization` with `make_api_public=True`. "Existing" is defined as orgs present in the database at migration runtime.
3. Add `post_save` signal on `Organization` so every new org gets a settings row with the model default of `False`.
4. Add `organization` FK to `APIAccessScheme` with `null=True, blank=True`. Manually populate existing keys with their correct org (or leave null for anonymous-equivalent) before phase 3.

### Phase 2 — visibility layer

5. Add `gregory/visibility.py` with `visible_org_ids(request) -> set[int]` and a `VisibleOrgMiddleware` that attaches the result to `request`.
6. Add `OrgVisibilityMixin` for viewsets that filters `get_queryset()` against `request.visible_org_ids`.
7. Add `OrgScopedSerializerMixin` that strips non-visible nested associations from responses.
8. Apply both mixins across the viewsets listed in §4.2.
9. Update RSS feed classes in `rss/views.py` to use the helper before yielding items.
10. Update `post_article` (`api/views.py:74`) to enforce the team→org check.
11. Honour `?include_public=true` on every list, search, and feed endpoint.

### Phase 3 — cleanup

12. Confirm all internal consumers (`gregory-ms.com`, gregory-rt frontend, `helper-scripts/import-articles.py`) either pass `?include_public=true` or carry an org-bound `APIAccessScheme` key.
13. Drop `null=True` from `APIAccessScheme.organization`. New migration enforces non-null.

### Phase 4 — UX

14. Surface the `make_api_public` toggle in Django admin (initial step) and later in a dedicated org-settings UI. Out of scope for this spec.

## 7. Test matrix

For each endpoint group (articles, trials, authors, subjects, categories, sources, teams, orgs, stats, RSS, `post_article`), cover these combinations:

| Caller | `?include_public` | Object in caller's org | Object in another public org | Object in another private org |
|---|---|---|---|---|
| Anonymous | n/a | n/a | visible | hidden (404) |
| Authed member of org A | absent | visible | hidden (404) | hidden (404) |
| Authed member of org A | true | visible | visible | hidden (404) |
| API key for org A | absent | visible | hidden (404) | hidden (404) |
| API key for org A | true | visible | visible | hidden (404) |

Negative cases:

- Article tagged across two orgs (one visible, one not) — listed; private team association stripped from response.
- Author with articles spanning visible and hidden orgs — visible; hidden articles do not appear in `articles_count` or in nested lists.
- Search request with `team_id` pointing at a non-visible team — 404.
- Detail endpoint for an article whose teams are all in hidden orgs — 404.
- `POST /articles/post/` payload with cross-org `team_id` — 400.
- Null-org `APIAccessScheme` key on `POST /articles/post/` during the transition window — 403.

## 8. Open questions for follow-up

- UX for toggling the flag: Django admin only at first, dedicated org-settings page later?
- Per-team and per-subject overrides — deferred.
- Behaviour when an authenticated user's org flips to public mid-session: no special handling; the queryset filter takes effect on the next request.
- RSS-specific feeds we may add later (e.g. team-scoped article feeds) inherit the same rules by construction.
