### PR TITLE
Add organization filter to Source admin list view

### DIFF
--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -75,8 +75,8 @@ class OrganizationRestrictedFieldListFilter(admin.RelatedFieldListFilter):
 		return filtered_choices
 
 
-class ArticleOrganizationFilter(admin.SimpleListFilter):
-	"""Filter articles by organisation (via teams__organization)."""
+class BaseOrganizationFilter(admin.SimpleListFilter):
+	"""Base filter that lists organisations scoped to the current user's access."""
 	title = 'organisation'
 	parameter_name = 'organisation'
 
@@ -87,6 +87,10 @@ class ArticleOrganizationFilter(admin.SimpleListFilter):
 			user_org_ids = get_user_organizations(request.user)
 			orgs = Organization.objects.filter(id__in=user_org_ids).order_by('name')
 		return [(org.pk, org.name) for org in orgs]
+
+
+class ArticleOrganizationFilter(BaseOrganizationFilter):
+	"""Filter articles by organisation (via teams M2M → organization)."""
 
 	def queryset(self, request, queryset):
 		if self.value():
@@ -94,22 +98,12 @@ class ArticleOrganizationFilter(admin.SimpleListFilter):
 		return queryset
 
 
-class SourceOrganizationFilter(admin.SimpleListFilter):
-	"""Filter sources by organisation (via team__organization)."""
-	title = 'organisation'
-	parameter_name = 'organisation'
-
-	def lookups(self, request, model_admin):
-		if request.user.is_superuser:
-			orgs = Organization.objects.all().order_by('name')
-		else:
-			user_org_ids = get_user_organizations(request.user)
-			orgs = Organization.objects.filter(id__in=user_org_ids).order_by('name')
-		return [(org.pk, org.name) for org in orgs]
+class SourceOrganizationFilter(BaseOrganizationFilter):
+	"""Filter sources by organisation (via team FK → organization)."""
 
 	def queryset(self, request, queryset):
 		if self.value():
-			return queryset.filter(team__organization__id=self.value())
+			return queryset.filter(team__organization_id=self.value())
 		return queryset
 
 

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -94,6 +94,25 @@ class ArticleOrganizationFilter(admin.SimpleListFilter):
 		return queryset
 
 
+class SourceOrganizationFilter(admin.SimpleListFilter):
+	"""Filter sources by organisation (via team__organization)."""
+	title = 'organisation'
+	parameter_name = 'organisation'
+
+	def lookups(self, request, model_admin):
+		if request.user.is_superuser:
+			orgs = Organization.objects.all().order_by('name')
+		else:
+			user_org_ids = get_user_organizations(request.user)
+			orgs = Organization.objects.filter(id__in=user_org_ids).order_by('name')
+		return [(org.pk, org.name) for org in orgs]
+
+	def queryset(self, request, queryset):
+		if self.value():
+			return queryset.filter(team__organization__id=self.value())
+		return queryset
+
+
 class OrganizationFilterMixin:
 	"""
 	Mixin to restrict admin queryset visibility based on user's organization.
@@ -598,6 +617,7 @@ class SourceAdmin(OrganizationFilterMixin, ReassignToTeamMixin, admin.ModelAdmin
 	list_display = ['name', 'active', 'source_for', 'subject', 'last_article_date', 'article_count', 'health_status_indicator', 'has_keyword_filter']
 	list_filter = [
 		'active', 'source_for', 'method', SourceHealthFilter,
+		SourceOrganizationFilter,
 		('team', OrganizationRestrictedFieldListFilter),
 		('subject', OrganizationRestrictedFieldListFilter),
 	]


### PR DESCRIPTION
## Summary
Added a new `SourceOrganizationFilter` to the Source admin interface, allowing users to filter sources by their associated organization through the team relationship.

## Key Changes
- **New `SourceOrganizationFilter` class**: A `SimpleListFilter` that filters sources by organization via the `team__organization` relationship
  - Superusers see all organizations
  - Regular users see only organizations they belong to (via `get_user_organizations()`)
  - Organizations are sorted alphabetically by name
- **Updated `SourceAdmin.list_filter`**: Added `SourceOrganizationFilter` to the admin list filters for easier source discovery and management by organization

## Implementation Details
- The filter respects user permissions: superusers have access to all organizations while regular users are restricted to their own organizations
- The filter uses the existing `get_user_organizations()` utility function to determine user access
- The queryset filtering uses `team__organization__id` to traverse the relationship from Source → Team → Organization

https://claude.ai/code/session_0179cockVxwZeU6Y67Z9W3Gg