### PR TITLE
feat(admin): Subject content analytics page

### DIFF
--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -896,6 +896,30 @@ class SubjectAdmin(OrganizationFilterMixin, ReassignToTeamMixin, admin.ModelAdmi
 
 		return super().delete_view(request, object_id, extra_context=extra_context)
 
+	def get_urls(self):
+		from django.urls import path
+		from .admin_views import (
+			subject_analytics_view,
+			subject_analytics_data,
+			subject_analytics_orgs,
+			subject_analytics_teams,
+			subject_analytics_subjects,
+		)
+		urls = super().get_urls()
+		custom_urls = [
+			path('analytics/', self.admin_site.admin_view(subject_analytics_view), name='gregory_subject_analytics'),
+			path('analytics/data/', self.admin_site.admin_view(subject_analytics_data), name='gregory_subject_analytics_data'),
+			path('analytics/orgs/', self.admin_site.admin_view(subject_analytics_orgs), name='gregory_subject_analytics_orgs'),
+			path('analytics/teams/', self.admin_site.admin_view(subject_analytics_teams), name='gregory_subject_analytics_teams'),
+			path('analytics/subjects/', self.admin_site.admin_view(subject_analytics_subjects), name='gregory_subject_analytics_subjects'),
+		]
+		return custom_urls + urls
+
+	def changelist_view(self, request, extra_context=None):
+		extra_context = extra_context or {}
+		extra_context['subject_analytics_url'] = reverse('admin:gregory_subject_analytics')
+		return super().changelist_view(request, extra_context=extra_context)
+
 
 class AuthorArticlesInline(admin.TabularInline):
 	model = Articles.authors.through

--- a/django/gregory/admin_views.py
+++ b/django/gregory/admin_views.py
@@ -4,6 +4,7 @@ from django.http import HttpResponse, JsonResponse
 from django.core.paginator import Paginator
 from django.utils.html import format_html, mark_safe
 from django.db.models import Q, Case, When, Value, BooleanField, Count
+from django.db.models.functions import TruncDate, TruncWeek, TruncMonth
 from django.contrib import messages
 from django.utils.dateparse import parse_date
 from django.utils import timezone
@@ -650,3 +651,214 @@ def sources_overview_view(request):
         'filter_params': filter_params,
     }
     return render(request, 'admin/sources_overview.html', context)
+
+
+# ── Subject analytics views ────────────────────────────────────────────────
+
+def _get_scoped_org_ids_for_user(request):
+    """Return list of org IDs the request user may see, or None for all."""
+    if request.user.is_superuser:
+        org_param = request.GET.get('org')
+        if org_param:
+            try:
+                return [int(org_param)]
+            except (ValueError, TypeError):
+                pass
+        return None
+    return list(
+        request.user.organizations_organizationuser.values_list(
+            'organization__id', flat=True
+        )
+    )
+
+
+@staff_member_required
+def subject_analytics_view(request):
+    """Landing page for subject content analytics."""
+    from organizations.models import Organization
+    if request.user.is_superuser:
+        orgs = Organization.objects.order_by('name')
+    else:
+        user_org_ids = list(
+            request.user.organizations_organizationuser.values_list(
+                'organization__id', flat=True
+            )
+        )
+        orgs = Organization.objects.filter(id__in=user_org_ids).order_by('name')
+
+    context = {
+        'title': 'Subject Content Analytics',
+        'orgs': orgs,
+        'is_superuser': request.user.is_superuser,
+    }
+    return render(request, 'admin/gregory/subject/analytics.html', context)
+
+
+@staff_member_required
+def subject_analytics_orgs(request):
+    """JSON: organisations visible to the current user."""
+    from organizations.models import Organization
+    org_ids = _get_scoped_org_ids_for_user(request)
+    qs = Organization.objects.all()
+    if org_ids is not None:
+        qs = qs.filter(id__in=org_ids)
+    return JsonResponse({'organisations': [{'id': o.id, 'name': o.name} for o in qs.order_by('name')]})
+
+
+@staff_member_required
+def subject_analytics_teams(request):
+    """JSON: teams scoped to the effective org."""
+    org_ids = _get_scoped_org_ids_for_user(request)
+    qs = Team.objects.filter(is_active=True)
+    if org_ids is not None:
+        qs = qs.filter(organization__id__in=org_ids)
+    return JsonResponse({'teams': [{'id': t.id, 'name': str(t)} for t in qs.order_by('name')]})
+
+
+@staff_member_required
+def subject_analytics_subjects(request):
+    """JSON: subjects scoped to the effective org and/or team."""
+    org_ids = _get_scoped_org_ids_for_user(request)
+    team_param = request.GET.get('team')
+    qs = Subject.objects.all()
+    if org_ids is not None:
+        qs = qs.filter(team__organization__id__in=org_ids)
+    if team_param:
+        try:
+            qs = qs.filter(team_id=int(team_param))
+        except (ValueError, TypeError):
+            pass
+    return JsonResponse({'subjects': [{'id': s.id, 'name': s.subject_name} for s in qs.order_by('subject_name')]})
+
+
+@staff_member_required
+def subject_analytics_data(request):
+    """
+    JSON: articles and trials counts over time for a subject (and optional org/team scope).
+    Query params: range (7d|30d|90d|365d|custom), start, end, org, team, subject
+    """
+    range_param = request.GET.get('range', '30d')
+    subject_param = request.GET.get('subject', '')
+    team_param = request.GET.get('team', '')
+
+    RANGES = {
+        '7d':   (7,   TruncDate,  '%Y-%m-%d'),
+        '30d':  (30,  TruncDate,  '%Y-%m-%d'),
+        '90d':  (90,  TruncWeek,  '%Y-%m-%d'),
+        '365d': (365, TruncMonth, '%Y-%m'),
+    }
+
+    if range_param == 'custom':
+        start_str = request.GET.get('start', '')
+        end_str   = request.GET.get('end', '')
+        try:
+            start_date = date.fromisoformat(start_str)
+            end_date   = date.fromisoformat(end_str)
+        except (ValueError, TypeError):
+            return JsonResponse({'error': 'Invalid custom date range'}, status=400)
+        if end_date < start_date:
+            start_date, end_date = end_date, start_date
+        span = (end_date - start_date).days
+        if span <= 60:
+            trunc_fn, date_fmt = TruncDate, '%Y-%m-%d'
+        elif span <= 180:
+            trunc_fn, date_fmt = TruncWeek, '%Y-%m-%d'
+        else:
+            trunc_fn, date_fmt = TruncMonth, '%Y-%m'
+    else:
+        if range_param not in RANGES:
+            range_param = '30d'
+        days, trunc_fn, date_fmt = RANGES[range_param]
+        end_date   = timezone.now().date()
+        start_date = end_date - timedelta(days=days - 1)
+
+    # Build full period sequence for zero-filling
+    if trunc_fn is TruncDate:
+        period_range = []
+        d = start_date
+        while d <= end_date:
+            period_range.append(d)
+            d += timedelta(days=1)
+    elif trunc_fn is TruncWeek:
+        period_range = []
+        d = start_date - timedelta(days=start_date.weekday())
+        while d <= end_date:
+            period_range.append(d)
+            d += timedelta(weeks=1)
+    else:  # TruncMonth
+        period_range = []
+        d = start_date.replace(day=1)
+        while d <= end_date:
+            period_range.append(d)
+            if d.month == 12:
+                d = date(d.year + 1, 1, 1)
+            else:
+                d = date(d.year, d.month + 1, 1)
+
+    def _build_series(qs, date_field):
+        counts = (
+            qs
+            .annotate(period=trunc_fn(date_field))
+            .values('period')
+            .annotate(count=Count('pk', distinct=True))
+            .order_by('period')
+        )
+        lookup = {}
+        for item in counts:
+            p = item['period']
+            if not p:
+                continue
+            if hasattr(p, 'date'):
+                p = p.date()
+            lookup[p] = item['count']
+        return [lookup.get(p, 0) for p in period_range]
+
+    # Scope: org → team → subject
+    org_ids = _get_scoped_org_ids_for_user(request)
+
+    articles_qs = Articles.objects.filter(
+        published_date__date__gte=start_date,
+        published_date__date__lte=end_date,
+    )
+    trials_qs = Trials.objects.filter(
+        discovery_date__date__gte=start_date,
+        discovery_date__date__lte=end_date,
+    )
+
+    if org_ids is not None:
+        articles_qs = articles_qs.filter(teams__organization__id__in=org_ids)
+        trials_qs   = trials_qs.filter(teams__organization__id__in=org_ids)
+
+    if team_param:
+        try:
+            tid = int(team_param)
+            articles_qs = articles_qs.filter(teams__id=tid)
+            trials_qs   = trials_qs.filter(teams__id=tid)
+        except (ValueError, TypeError):
+            pass
+
+    if subject_param:
+        try:
+            sid = int(subject_param)
+            articles_qs = articles_qs.filter(subjects__id=sid)
+            trials_qs   = trials_qs.filter(subjects__id=sid)
+        except (ValueError, TypeError):
+            pass
+
+    articles_qs = articles_qs.distinct()
+    trials_qs   = trials_qs.distinct()
+
+    articles_data = _build_series(articles_qs, 'published_date')
+    trials_data   = _build_series(trials_qs, 'discovery_date')
+
+    labels = [p.strftime(date_fmt) for p in period_range]
+
+    return JsonResponse({
+        'labels':   labels,
+        'articles': articles_data,
+        'trials':   trials_data,
+        'totals': {
+            'articles': sum(articles_data),
+            'trials':   sum(trials_data),
+        },
+    })

--- a/django/gregory/admin_views.py
+++ b/django/gregory/admin_views.py
@@ -656,7 +656,13 @@ def sources_overview_view(request):
 # ── Subject analytics views ────────────────────────────────────────────────
 
 def _get_scoped_org_ids_for_user(request):
-    """Return list of org IDs the request user may see, or None for all."""
+    """Return list of org IDs the request user may see, or None for all.
+
+    Delegates to get_user_organizations() for the non-superuser branch so that
+    org-visibility rules stay consistent across admin views. Superusers can
+    further narrow scope to a single org via the ?org= query parameter.
+    """
+    from .admin import get_user_organizations
     if request.user.is_superuser:
         org_param = request.GET.get('org')
         if org_param:
@@ -665,11 +671,7 @@ def _get_scoped_org_ids_for_user(request):
             except (ValueError, TypeError):
                 pass
         return None
-    return list(
-        request.user.organizations_organizationuser.values_list(
-            'organization__id', flat=True
-        )
-    )
+    return list(get_user_organizations(request.user))
 
 
 @staff_member_required

--- a/django/gregory/templates/admin/gregory/subject/analytics.html
+++ b/django/gregory/templates/admin/gregory/subject/analytics.html
@@ -1,0 +1,556 @@
+{% load i18n static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Subject Content Analytics — Gregory AI</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      background-color: #f3f4f6;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      font-size: 15px;
+      line-height: 1.6;
+      margin: 0;
+      padding: 0;
+      color: #374151;
+    }
+
+    .page-header {
+      background: linear-gradient(135deg, #1e3a8a 0%, #1e40af 50%, #2563eb 100%);
+      padding: 32px 40px 28px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .page-header-brand {
+      color: #ffffff;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: -0.3px;
+      margin: 0;
+    }
+
+    .page-header-subtitle {
+      color: #dbeafe;
+      font-size: 14px;
+      margin: 4px 0 0;
+    }
+
+    .back-link {
+      color: #bfdbfe;
+      text-decoration: none;
+      font-size: 13px;
+      font-weight: 500;
+      border: 1px solid rgba(255,255,255,0.25);
+      padding: 6px 14px;
+      border-radius: 6px;
+      transition: background 0.15s, color 0.15s;
+      white-space: nowrap;
+    }
+
+    .back-link:hover {
+      background: rgba(255,255,255,0.15);
+      color: #ffffff;
+      text-decoration: none;
+    }
+
+    .page-body {
+      max-width: 1400px;
+      margin: 0 auto;
+      padding: 32px 24px 60px;
+    }
+
+    /* ── Filter panel ── */
+    .filter-panel {
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+      padding: 20px 24px;
+      margin-bottom: 24px;
+    }
+
+    .filter-form {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+      align-items: flex-end;
+    }
+
+    .filter-group {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .filter-label {
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.6px;
+      color: #6b7280;
+    }
+
+    .filter-group select {
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      padding: 7px 10px;
+      font-size: 14px;
+      color: #374151;
+      background: #fff;
+      outline: none;
+      min-width: 160px;
+    }
+
+    .filter-group select:focus {
+      border-color: #3b82f6;
+      box-shadow: 0 0 0 3px rgba(59,130,246,0.15);
+    }
+
+    /* ── Summary cards ── */
+    .summary-cards {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+      margin-bottom: 24px;
+    }
+
+    .summary-card {
+      flex: 1;
+      min-width: 160px;
+      padding: 16px 20px;
+      background: #fff;
+      border: 1px solid #e0e0e0;
+      border-radius: 6px;
+      text-align: center;
+    }
+
+    .summary-card .card-value {
+      font-size: 28px;
+      font-weight: 700;
+      color: #1a1a1a;
+      line-height: 1.2;
+    }
+
+    .summary-card .card-label {
+      font-size: 12px;
+      color: #666;
+      margin-top: 4px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .summary-card.articles .card-value { color: #2563eb; }
+    .summary-card.trials   .card-value { color: #16a34a; }
+
+    /* ── Period selector ── */
+    .analytics-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-bottom: 20px;
+    }
+
+    .period-selector {
+      display: flex;
+      gap: 6px;
+    }
+
+    .period-btn {
+      padding: 6px 14px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      background: #fff;
+      cursor: pointer;
+      font-size: 13px;
+      color: #444;
+      text-decoration: none;
+    }
+
+    .period-btn:hover,
+    .period-btn.active {
+      background: #1e40af;
+      border-color: #1e40af;
+      color: #fff;
+    }
+
+    /* ── Custom date range bar ── */
+    #custom-range-bar {
+      display: none;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+    }
+
+    #custom-range-bar label {
+      font-size: 13px;
+      font-weight: 600;
+      color: #555;
+    }
+
+    #custom-range-bar input[type="date"] {
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      padding: 6px 10px;
+      font-size: 13px;
+    }
+
+    #custom-apply-btn {
+      padding: 6px 16px;
+      background: #1e40af;
+      color: #fff;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 13px;
+      font-weight: 600;
+    }
+
+    #custom-apply-btn:hover { background: #1e3a8a; }
+
+    /* ── Chart cards ── */
+    .chart-card {
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+      padding: 24px;
+      margin-bottom: 24px;
+    }
+
+    .chart-card h3 {
+      margin: 0 0 16px;
+      font-size: 15px;
+      font-weight: 700;
+      color: #1f2937;
+    }
+  </style>
+</head>
+<body>
+
+<div class="page-header">
+  <div>
+    <h1 class="page-header-brand">Subject Content Analytics</h1>
+    <p class="page-header-subtitle">Articles and clinical trials over time, scoped by organisation, team and subject</p>
+  </div>
+  <a class="back-link" href="{% url 'admin:gregory_subject_changelist' %}">&#8592; Subjects</a>
+</div>
+
+<div class="page-body">
+
+  <!-- Scope filters -->
+  <div class="filter-panel">
+    <div class="filter-form">
+      {% if is_superuser %}
+      <div class="filter-group">
+        <label class="filter-label" for="org-filter">Organisation</label>
+        <select id="org-filter">
+          <option value="">All Organisations</option>
+          {% for org in orgs %}
+          <option value="{{ org.id }}">{{ org.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      {% endif %}
+      <div class="filter-group">
+        <label class="filter-label" for="team-filter">Team</label>
+        <select id="team-filter">
+          <option value="">All Teams</option>
+        </select>
+      </div>
+      <div class="filter-group">
+        <label class="filter-label" for="subject-filter">Subject</label>
+        <select id="subject-filter">
+          <option value="">All Subjects</option>
+        </select>
+      </div>
+    </div>
+  </div>
+
+  <!-- Period selector -->
+  <div class="analytics-header">
+    <h2 style="margin: 0; font-size: 18px; color: #1f2937;">Content Over Time</h2>
+    <div class="period-selector">
+      <button class="period-btn" data-range="7d">7 days</button>
+      <button class="period-btn active" data-range="30d">30 days</button>
+      <button class="period-btn" data-range="90d">90 days</button>
+      <button class="period-btn" data-range="365d">12 months</button>
+      <button class="period-btn" data-range="custom">Custom</button>
+    </div>
+  </div>
+
+  <div id="custom-range-bar">
+    <label for="custom-start">From:</label>
+    <input type="date" id="custom-start">
+    <label for="custom-end">To:</label>
+    <input type="date" id="custom-end">
+    <button id="custom-apply-btn" type="button">Apply</button>
+  </div>
+
+  <!-- Summary cards -->
+  <div class="summary-cards">
+    <div class="summary-card articles">
+      <div class="card-value" id="total-articles">—</div>
+      <div class="card-label">Articles</div>
+    </div>
+    <div class="summary-card trials">
+      <div class="card-value" id="total-trials">—</div>
+      <div class="card-label">Clinical Trials</div>
+    </div>
+  </div>
+
+  <!-- Main chart -->
+  <div class="chart-card">
+    <div style="height: 420px;">
+      <canvas id="contentChart"></canvas>
+    </div>
+  </div>
+
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
+<script>
+
+// ── State ──────────────────────────────────────────────────────────────────
+var activeOrg     = '';
+var activeTeam    = '';
+var activeSubject = '';
+var activeRange   = '30d';
+var customStart   = '';
+var customEnd     = '';
+
+// ── URLs ───────────────────────────────────────────────────────────────────
+var URLS = {
+  data:     '{% url "admin:gregory_subject_analytics_data" %}',
+  orgs:     '{% url "admin:gregory_subject_analytics_orgs" %}',
+  teams:    '{% url "admin:gregory_subject_analytics_teams" %}',
+  subjects: '{% url "admin:gregory_subject_analytics_subjects" %}',
+};
+
+// ── Build query params ─────────────────────────────────────────────────────
+function buildParams(extra) {
+  var p = new URLSearchParams(extra || {});
+  if (activeOrg)     p.set('org',     activeOrg);
+  if (activeTeam)    p.set('team',    activeTeam);
+  if (activeSubject) p.set('subject', activeSubject);
+  if (activeRange === 'custom' && customStart && customEnd) {
+    p.set('range', 'custom');
+    p.set('start', customStart);
+    p.set('end',   customEnd);
+  }
+  return p;
+}
+
+// ── Chart instance ─────────────────────────────────────────────────────────
+var contentChart = null;
+
+function fetchAndRender(range) {
+  var params = buildParams({ range: range });
+  fetch(URLS.data + '?' + params.toString())
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      document.getElementById('total-articles').textContent = data.totals.articles;
+      document.getElementById('total-trials').textContent   = data.totals.trials;
+
+      var chartTitle = {
+        '7d':    'Daily — Last 7 Days',
+        '30d':   'Daily — Last 30 Days',
+        '90d':   'Weekly — Last 90 Days',
+        '365d':  'Monthly — Last 12 Months',
+        'custom': customStart && customEnd ? customStart + ' to ' + customEnd : 'Custom Range',
+      }[range] || '';
+
+      if (contentChart) {
+        contentChart.data.labels                    = data.labels;
+        contentChart.data.datasets[0].data          = data.articles;
+        contentChart.data.datasets[1].data          = data.trials;
+        contentChart.options.plugins.title.text     = chartTitle;
+        contentChart.update();
+      } else {
+        var ctx = document.getElementById('contentChart').getContext('2d');
+        contentChart = new Chart(ctx, {
+          type: 'line',
+          data: {
+            labels: data.labels,
+            datasets: [
+              {
+                label: 'Articles',
+                data: data.articles,
+                borderColor: '#2563eb',
+                backgroundColor: 'rgba(37,99,235,0.08)',
+                tension: 0.2,
+                fill: true,
+                pointRadius: 3,
+              },
+              {
+                label: 'Clinical Trials',
+                data: data.trials,
+                borderColor: '#16a34a',
+                backgroundColor: 'rgba(22,163,74,0.08)',
+                tension: 0.2,
+                fill: true,
+                pointRadius: 3,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            interaction: { mode: 'index', intersect: false },
+            scales: {
+              y: { beginAtZero: true, ticks: { stepSize: 1, precision: 0 } },
+              x: { ticks: { maxTicksLimit: 12 } },
+            },
+            plugins: {
+              title: {
+                display: true,
+                text: chartTitle,
+                font: { size: 14 },
+              },
+              legend: { display: true, position: 'top' },
+            },
+          },
+        });
+      }
+    })
+    .catch(function(err) { console.error('Subject analytics fetch error:', err); });
+}
+
+// ── Reload team + subject dropdowns, then chart ────────────────────────────
+function reloadTeams() {
+  var sel = document.getElementById('team-filter');
+  if (!sel) return;
+  var params = buildParams();
+  fetch(URLS.teams + '?' + params.toString())
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      while (sel.options.length > 1) sel.remove(1);
+      data.teams.forEach(function(t) {
+        var opt = document.createElement('option');
+        opt.value = t.id;
+        opt.textContent = t.name;
+        sel.appendChild(opt);
+      });
+      if (activeTeam && Array.from(sel.options).some(function(o) { return o.value == activeTeam; })) {
+        sel.value = activeTeam;
+      } else {
+        activeTeam = '';
+        sel.value = '';
+      }
+    });
+}
+
+function reloadSubjects() {
+  var sel = document.getElementById('subject-filter');
+  if (!sel) return;
+  var params = buildParams();
+  fetch(URLS.subjects + '?' + params.toString())
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      while (sel.options.length > 1) sel.remove(1);
+      data.subjects.forEach(function(s) {
+        var opt = document.createElement('option');
+        opt.value = s.id;
+        opt.textContent = s.name;
+        sel.appendChild(opt);
+      });
+      if (activeSubject && Array.from(sel.options).some(function(o) { return o.value == activeSubject; })) {
+        sel.value = activeSubject;
+      } else {
+        activeSubject = '';
+        sel.value = '';
+      }
+    });
+}
+
+function reloadAll() {
+  reloadTeams();
+  reloadSubjects();
+  fetchAndRender(activeRange);
+}
+
+// ── Org selector ───────────────────────────────────────────────────────────
+(function () {
+  var orgSel = document.getElementById('org-filter');
+  if (!orgSel) return;
+  orgSel.addEventListener('change', function() {
+    activeOrg     = this.value;
+    activeTeam    = '';
+    activeSubject = '';
+    reloadAll();
+  });
+})();
+
+// ── Team selector ──────────────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', function() {
+  var teamSel = document.getElementById('team-filter');
+  if (teamSel) {
+    teamSel.addEventListener('change', function() {
+      activeTeam    = this.value;
+      activeSubject = '';
+      reloadSubjects();
+      fetchAndRender(activeRange);
+    });
+  }
+
+  var subjectSel = document.getElementById('subject-filter');
+  if (subjectSel) {
+    subjectSel.addEventListener('change', function() {
+      activeSubject = this.value;
+      fetchAndRender(activeRange);
+    });
+  }
+
+  // Initial load
+  reloadAll();
+});
+
+// ── Period buttons ─────────────────────────────────────────────────────────
+document.querySelectorAll('.period-btn').forEach(function(btn) {
+  btn.addEventListener('click', function() {
+    document.querySelectorAll('.period-btn').forEach(function(b) { b.classList.remove('active'); });
+    this.classList.add('active');
+    activeRange = this.dataset.range;
+    var customBar = document.getElementById('custom-range-bar');
+    if (activeRange === 'custom') {
+      if (customBar) customBar.style.display = 'flex';
+    } else {
+      if (customBar) customBar.style.display = 'none';
+      customStart = '';
+      customEnd   = '';
+      fetchAndRender(activeRange);
+    }
+  });
+});
+
+// ── Custom date range ──────────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', function() {
+  var applyBtn = document.getElementById('custom-apply-btn');
+  if (!applyBtn) return;
+  applyBtn.addEventListener('click', function() {
+    var startInput = document.getElementById('custom-start');
+    var endInput   = document.getElementById('custom-end');
+    if (!startInput.value) {
+      alert('Please select a start date.');
+      return;
+    }
+    if (!endInput.value) {
+      endInput.value = new Date().toISOString().slice(0, 10);
+    }
+    customStart = startInput.value;
+    customEnd   = endInput.value;
+    fetchAndRender('custom');
+  });
+});
+
+</script>
+</body>
+</html>

--- a/django/gregory/templates/admin/gregory/subject/analytics.html
+++ b/django/gregory/templates/admin/gregory/subject/analytics.html
@@ -316,7 +316,7 @@
 
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
+{% include "admin/_chartjs.html" %}
 <script>
 
 // ── State ──────────────────────────────────────────────────────────────────

--- a/django/gregory/templates/admin/gregory/subject/change_list.html
+++ b/django/gregory/templates/admin/gregory/subject/change_list.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+  <li>
+    <a href="{{ subject_analytics_url }}" class="addlink" style="background-color: #417690;">
+      Content Analytics
+    </a>
+  </li>
+  {{ block.super }}
+{% endblock %}


### PR DESCRIPTION
## Summary

Adds an analytics page at `/admin/gregory/subject/analytics/` for tracking the volume of **articles** and **clinical trials** indexed per subject over time, with cascading scope filters for organisation, team and subject.

A **Content Analytics** button is added to the Subject changelist toolbar for easy navigation.

---

## Changes

### `django/gregory/admin_views.py`

- Import `TruncDate`, `TruncWeek`, `TruncMonth` from `django.db.models.functions`.
- Add `_get_scoped_org_ids_for_user()` — reusable helper that returns the list of org IDs visible to the current user (`None` = all for superusers, scoped list for staff).
- **`subject_analytics_view`** — renders the analytics HTML page and passes visible organisations to the template.
- **`subject_analytics_data`** — JSON endpoint; accepts `range` (7d / 30d / 90d / 365d / custom), `org`, `team`, and `subject` query params; returns per-period article and trial counts (zero-filled) plus a `totals` object. Date fields: `Articles.published_date`, `Trials.discovery_date`.
- **`subject_analytics_orgs`**, **`subject_analytics_teams`**, **`subject_analytics_subjects`** — lightweight JSON endpoints for the cascade dropdowns, each scoped to the upstream selection.

### `django/gregory/admin.py` — `SubjectAdmin`

- **`get_urls()`** — registers five URL patterns under `/admin/gregory/subject/analytics/`:
  - `analytics/` → `subject_analytics_view`
  - `analytics/data/` → `subject_analytics_data`
  - `analytics/orgs/` → `subject_analytics_orgs`
  - `analytics/teams/` → `subject_analytics_teams`
  - `analytics/subjects/` → `subject_analytics_subjects`
- **`changelist_view()`** — injects `subject_analytics_url` into context to power the toolbar button.

### `django/gregory/templates/admin/gregory/subject/analytics.html` _(new)_

- Standalone page matching the **sources_overview** look and feel: gradient header, card-based filter panel, summary cards, Chart.js line chart.
- **Cascading scope filters**: Organisation (superusers only) → Team → Subject. Changing a parent reloads child options and refreshes the chart.
- **Two chart datasets**: Articles (blue) and Clinical Trials (green).
- **Period selector**: 7d / 30d / 90d / 12 months / Custom — granularity switches automatically between daily, weekly and monthly.
- Custom date range bar with start/end inputs.
- Chart.js 4.4.2 from CDN (same version as subscriber analytics page — keeps the stack consistent).

### `django/gregory/templates/admin/gregory/subject/change_list.html` _(new)_

- Extends `admin/change_list.html` to add a **Content Analytics** toolbar button (same pattern as `sources/change_list.html`).

---

## Testing

```bash
# Django system check — no issues
docker exec gregory python manage.py check

# URL resolution
docker exec gregory python -c "
import django, os
os.environ['DJANGO_SETTINGS_MODULE'] = 'admin.settings'
django.setup()
from django.urls import reverse
print(reverse('admin:gregory_subject_analytics'))
print(reverse('admin:gregory_subject_analytics_data'))
"
# /admin/gregory/subject/analytics/
# /admin/gregory/subject/analytics/data/
```