### PR TITLE
feat(api): per-org takeaways/summary_plain_english in serializers (Phase 4)

### DIFF
--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -307,25 +307,33 @@ class ArticleSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSe
 		trials = [ref.trial for ref in references]
 		return TrialReferenceSerializer(trials, many=True).data
 
+	def _get_org_content(self, obj, org):
+		"""Fetch ArticleOrgContent for (obj, org), cached per serializer instance."""
+		if not hasattr(self, '_org_content_cache'):
+			self._org_content_cache = {}
+		key = (obj.pk, org.pk)
+		if key not in self._org_content_cache:
+			try:
+				self._org_content_cache[key] = obj.org_contents.get(organization=org)
+			except Exception:
+				self._org_content_cache[key] = None
+		return self._org_content_cache[key]
+
 	def get_takeaways(self, obj):
 		"""Return takeaways from ArticleOrgContent for the caller's org, or None."""
 		org = _resolve_per_org_fields_org(self.context.get('request'))
 		if org is None:
 			return None  # field will be popped in to_representation
-		try:
-			return obj.org_contents.get(organization=org).takeaways
-		except Exception:
-			return None
+		content = self._get_org_content(obj, org)
+		return content.takeaways if content else None
 
 	def get_summary_plain_english(self, obj):
 		"""Return plain-English summary from ArticleOrgContent for the caller's org, or None."""
 		org = _resolve_per_org_fields_org(self.context.get('request'))
 		if org is None:
 			return None  # field will be popped in to_representation
-		try:
-			return obj.org_contents.get(organization=org).summary_plain_english
-		except Exception:
-			return None
+		content = self._get_org_content(obj, org)
+		return content.summary_plain_english if content else None
 
 class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSerializer):
 	source = serializers.SlugRelatedField(read_only=True, slug_field='name')
@@ -362,25 +370,33 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 		articles = [ref.article for ref in references]
 		return ArticleReferenceSerializer(articles, many=True).data
 
+	def _get_org_content(self, obj, org):
+		"""Fetch TrialOrgContent for (obj, org), cached per serializer instance."""
+		if not hasattr(self, '_org_content_cache'):
+			self._org_content_cache = {}
+		key = (obj.pk, org.pk)
+		if key not in self._org_content_cache:
+			try:
+				self._org_content_cache[key] = obj.org_contents.get(organization=org)
+			except Exception:
+				self._org_content_cache[key] = None
+		return self._org_content_cache[key]
+
 	def get_takeaways(self, obj):
 		"""Return takeaways from TrialOrgContent for the caller's org, or None."""
 		org = _resolve_per_org_fields_org(self.context.get('request'))
 		if org is None:
 			return None  # field will be popped in to_representation
-		try:
-			return obj.org_contents.get(organization=org).takeaways
-		except Exception:
-			return None
+		content = self._get_org_content(obj, org)
+		return content.takeaways if content else None
 
 	def get_summary_plain_english(self, obj):
 		"""Return plain-English summary from TrialOrgContent for the caller's org, or None."""
 		org = _resolve_per_org_fields_org(self.context.get('request'))
 		if org is None:
 			return None  # field will be popped in to_representation
-		try:
-			return obj.org_contents.get(organization=org).summary_plain_english
-		except Exception:
-			return None
+		content = self._get_org_content(obj, org)
+		return content.summary_plain_english if content else None
 
 class SourceSerializer(serializers.HyperlinkedModelSerializer):
 	class Meta:

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count, Q
 
-from api.serializers.mixins import OrgScopedSerializerMixin  # noqa: F401
+from api.serializers.mixins import OrgScopedSerializerMixin, _resolve_per_org_fields_org  # noqa: F401
 
 def get_custom_settings():
 		try:
@@ -284,6 +284,11 @@ class ArticleSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSe
 	ml_predictions = MLPredictionsSerializer(many=True, read_only=True, source='ml_predictions_detail')
 	article_subject_relevances = ArticleSubjectRelevanceSerializer(many=True, read_only=True)
 	clinical_trials = serializers.SerializerMethodField()
+	takeaways = serializers.SerializerMethodField()
+	summary_plain_english = serializers.SerializerMethodField()
+
+	# Omit these fields from the response when there is no organisation context
+	_per_org_fields = ['takeaways', 'summary_plain_english']
 
 	class Meta:
 		model = Articles
@@ -294,18 +299,43 @@ class ArticleSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSe
 			'discovery_date', 'article_subject_relevances',
 			'doi', 'access', 'takeaways', 'team_categories', 'ml_predictions', 'clinical_trials',
 		]
-		read_only_fields = ('discovery_date', 'ml_predictions', 'takeaways', 'clinical_trials')
-	
+		read_only_fields = ('discovery_date', 'ml_predictions', 'clinical_trials')
+
 	def get_clinical_trials(self, obj):
 		"""Get trials referenced in the article"""
 		references = ArticleTrialReference.objects.filter(article=obj)
 		trials = [ref.trial for ref in references]
 		return TrialReferenceSerializer(trials, many=True).data
 
+	def get_takeaways(self, obj):
+		"""Return takeaways from ArticleOrgContent for the caller's org, or None."""
+		org = _resolve_per_org_fields_org(self.context.get('request'))
+		if org is None:
+			return None  # field will be popped in to_representation
+		try:
+			return obj.org_contents.get(organization=org).takeaways
+		except Exception:
+			return None
+
+	def get_summary_plain_english(self, obj):
+		"""Return plain-English summary from ArticleOrgContent for the caller's org, or None."""
+		org = _resolve_per_org_fields_org(self.context.get('request'))
+		if org is None:
+			return None  # field will be popped in to_representation
+		try:
+			return obj.org_contents.get(organization=org).summary_plain_english
+		except Exception:
+			return None
+
 class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSerializer):
 	source = serializers.SlugRelatedField(read_only=True, slug_field='name')
 	team_categories = TeamCategorySerializer(many=True, read_only=True)
 	articles = serializers.SerializerMethodField()
+	takeaways = serializers.SerializerMethodField()
+	summary_plain_english = serializers.SerializerMethodField()
+
+	# Omit these fields from the response when there is no organisation context
+	_per_org_fields = ['takeaways', 'summary_plain_english']
 
 	class Meta:
 		model = Trials
@@ -321,15 +351,36 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 			'intervention', 'primary_outcome', 'secondary_outcome', 'secondary_id',
 			'source_support', 'ethics_review_status', 'ethics_review_approval_date',
 			'ethics_review_contact_name', 'ethics_review_contact_address', 'ethics_review_contact_phone',
-			'ethics_review_contact_email', 'results_date_completed', 'results_url_link', 'articles'
+			'ethics_review_contact_email', 'results_date_completed', 'results_url_link',
+			'takeaways', 'articles'
 		]
 		read_only_fields = ('discovery_date', 'articles')
-		
+
 	def get_articles(self, obj):
 		"""Get articles that reference this trial"""
 		references = ArticleTrialReference.objects.filter(trial=obj)
 		articles = [ref.article for ref in references]
 		return ArticleReferenceSerializer(articles, many=True).data
+
+	def get_takeaways(self, obj):
+		"""Return takeaways from TrialOrgContent for the caller's org, or None."""
+		org = _resolve_per_org_fields_org(self.context.get('request'))
+		if org is None:
+			return None  # field will be popped in to_representation
+		try:
+			return obj.org_contents.get(organization=org).takeaways
+		except Exception:
+			return None
+
+	def get_summary_plain_english(self, obj):
+		"""Return plain-English summary from TrialOrgContent for the caller's org, or None."""
+		org = _resolve_per_org_fields_org(self.context.get('request'))
+		if org is None:
+			return None  # field will be popped in to_representation
+		try:
+			return obj.org_contents.get(organization=org).summary_plain_english
+		except Exception:
+			return None
 
 class SourceSerializer(serializers.HyperlinkedModelSerializer):
 	class Meta:

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -49,39 +49,54 @@ Resolution order (spec §6):
 """
 
 
+# Sentinel for "not yet cached" — distinct from None ("no org").
+_ORG_CACHE_MISSING = object()
+_ORG_CACHE_ATTR = '_per_org_fields_org_cache'
+
+
 def _resolve_per_org_fields_org(request):
 	"""Return the Organisation whose per-org content should be exposed, or None.
 
 	See mixin docstring for the full resolution order.  Returns None when there
 	is no organisation context, which tells the caller to omit per-org fields.
+
+	The result is cached on the request object so the team/api_settings DB
+	lookup is issued at most once per request, regardless of how many objects
+	the serializer processes.
 	"""
 	if request is None:
 		return None
+
+	cached = getattr(request, _ORG_CACHE_ATTR, _ORG_CACHE_MISSING)
+	if cached is not _ORG_CACHE_MISSING:
+		return cached
+
+	org = None
 
 	# 1. API key path (set by ApiKeyMiddleware as a SimpleLazyObject)
 	scheme = getattr(request, 'api_access_scheme', None)
 	if scheme is not None:
 		org = getattr(scheme, 'organization', None)
-		if org is not None:
-			return org
 
 	# 2. Public org via ?team_id filter
-	team_id = request.GET.get('team_id')
-	if team_id:
-		try:
-			from gregory.models import Team
-			team = (
-				Team.objects
-				.select_related('organization__api_settings')
-				.get(pk=int(team_id))
-			)
-			api_settings = getattr(team.organization, 'api_settings', None)
-			if api_settings and api_settings.make_api_public:
-				return team.organization
-		except Exception:
-			pass
+	if org is None:
+		team_id = request.GET.get('team_id')
+		if team_id:
+			try:
+				from gregory.models import Team
+				team = (
+					Team.objects
+					.select_related('organization__api_settings')
+					.get(pk=int(team_id))
+				)
+				api_settings = getattr(team.organization, 'api_settings', None)
+				if api_settings and api_settings.make_api_public:
+					org = team.organization
+			except Exception:
+				pass
 
-	return None
+	setattr(request, _ORG_CACHE_ATTR, org)
+	return org
 
 
 def _request_visible_team_ids(request, visible_org_ids: set) -> set:

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -33,7 +33,55 @@ Query strategy (avoiding N+1 on list endpoints)
   ``request._org_scoped_mixin_subject_ids``.  Filtering is done entirely on
   ``ret['ml_predictions']`` — no extra DB query, no dependency on whether
   ``ml_predictions_detail`` was prefetched.
+
+Per-org fields (``_per_org_fields``)
+-------------------------------------
+Subclasses may declare a list of field names that should only appear in
+the response when an organisation context is available.  When no org can
+be resolved (anonymous request, no public-org filter), those keys are
+removed from the serialised output entirely — not just set to ``null``.
+
+Resolution order (spec §6):
+  1. Valid API key on the request → that key's organisation.
+  2. ``?team_id=<id>`` query-param on a request where that team's org has
+     ``OrganizationApiSettings.make_api_public=True`` → that organisation.
+  3. Otherwise → no org, per-org fields omitted.
 """
+
+
+def _resolve_per_org_fields_org(request):
+	"""Return the Organisation whose per-org content should be exposed, or None.
+
+	See mixin docstring for the full resolution order.  Returns None when there
+	is no organisation context, which tells the caller to omit per-org fields.
+	"""
+	if request is None:
+		return None
+
+	# 1. API key path (set by ApiKeyMiddleware as a SimpleLazyObject)
+	scheme = getattr(request, 'api_access_scheme', None)
+	if scheme is not None:
+		org = getattr(scheme, 'organization', None)
+		if org is not None:
+			return org
+
+	# 2. Public org via ?team_id filter
+	team_id = request.GET.get('team_id')
+	if team_id:
+		try:
+			from gregory.models import Team
+			team = (
+				Team.objects
+				.select_related('organization__api_settings')
+				.get(pk=int(team_id))
+			)
+			api_settings = getattr(team.organization, 'api_settings', None)
+			if api_settings and api_settings.make_api_public:
+				return team.organization
+		except Exception:
+			pass
+
+	return None
 
 
 def _request_visible_team_ids(request, visible_org_ids: set) -> set:
@@ -81,12 +129,26 @@ class OrgScopedSerializerMixin:
 	    class ArticleSerializer(OrgScopedSerializerMixin,
 	                            serializers.HyperlinkedModelSerializer):
 	        ...
+
+	Set ``_per_org_fields`` to a list of field names that should be omitted
+	entirely when there is no organisation context (spec §6.2).
 	"""
+
+	#: Field names to omit from the response when no org context is available.
+	_per_org_fields: list = []
 
 	def to_representation(self, instance):
 		ret = super().to_representation(instance)
 
 		request = self.context.get('request')
+
+		# ---- Per-org field omission (spec §6.2) ----------------------------
+		if self._per_org_fields:
+			org = _resolve_per_org_fields_org(request)
+			if org is None:
+				for field in self._per_org_fields:
+					ret.pop(field, None)
+
 		if request is None or not hasattr(request, 'visible_org_ids'):
 			return ret
 


### PR DESCRIPTION
## Summary

Implements spec §6 — per-organisation read behaviour for `takeaways` and `summary_plain_english` in `ArticleSerializer` and `TrialSerializer`.

## Changes

### `django/api/serializers/mixins.py`
- Added `_resolve_per_org_fields_org(request)` helper — resolves the caller's organisation using the spec §6 decision tree:
  1. Valid API key on the request → that key's organisation
  2. `?team_id=<id>` filter where that team's org has `make_api_public=True` → that organisation
  3. Otherwise → `None` (omit per-org fields)
- `OrgScopedSerializerMixin` gains a `_per_org_fields = []` class attribute; `to_representation` now pops those keys from the output entirely (not just sets to `null`) when no org is resolved

### `django/api/serializers/__init__.py`
- **`ArticleSerializer`**: `takeaways` and `summary_plain_english` replaced with `SerializerMethodField`s reading from `ArticleOrgContent` for the caller's org. `_per_org_fields = ['takeaways', 'summary_plain_english']` so they're omitted for anonymous callers.
- **`TrialSerializer`**: same pattern, reading from `TrialOrgContent`. `takeaways` added to the fields list (Trials has no global takeaways column).

## Behaviour

| Caller | `takeaways` / `summary_plain_english` |
|---|---|
| Valid API key | Returns that org's `ArticleOrgContent` / `TrialOrgContent` row (null if no row exists) |
| `?team_id=<id>` where org has `make_api_public=True` | Returns that org's content |
| Anonymous / JWT-only | Fields **omitted** from response |

## Notes

- N+1: `org_contents` lookups are per-row for now. Filtered `prefetch_related` is a P1 optimisation (spec §11).
- The legacy `Articles.takeaways` column is not dropped — removal is a follow-up branch per spec §3.5.

## Related

- Part of the `api-improvements` spec branch
- Depends on Phase 2 (`ArticleOrgContent` / `TrialOrgContent` models) and Phase 3 (edit endpoints)
