### PR TITLE
feat(api): remove broken DRF Token endpoint (Phase 6 / spec §8)

### DIFF
--- a/django/admin/settings.py
+++ b/django/admin/settings.py
@@ -69,7 +69,6 @@ INSTALLED_APPS = [
 	'gregory.apps.GregoryConfig',
 	'subscriptions.apps.SubscriptionsConfig',
 	'rest_framework',
-	'rest_framework.authtoken',
 	'rest_framework_simplejwt',
 	'rest_framework_csv',  # Add CSV renderer support
 	'django_filters',

--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -18,7 +18,6 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import include, path, re_path
 from rest_framework import routers
-from rest_framework.authtoken import views
 
 from api.views import (
 	ArticleViewSet, AuthorsViewSet, SourceViewSet, TrialViewSet, 
@@ -61,7 +60,6 @@ urlpatterns = [
 	# API auth route
 	path('api-auth/', include('rest_framework.urls')),
 	path('api/token/', LoginView.as_view(), name='token_obtain_pair'),
-	path('api/token/get/', views.obtain_auth_token),
 
 	# API routes
 	path('articles/post/', post_article),

--- a/django/gregory/migrations/0047_drop_authtoken_tables.py
+++ b/django/gregory/migrations/0047_drop_authtoken_tables.py
@@ -25,11 +25,5 @@ class Migration(migrations.Migration):
 				'DROP TABLE IF EXISTS authtoken_token CASCADE;',
 				'DROP TABLE IF EXISTS authtoken_tokenproxy CASCADE;',
 			],
-			reverse_sql=[
-				# Recreating authtoken tables by hand is impractical; mark as
-				# non-reversible so rollback fails fast rather than silently
-				# leaving the database in an inconsistent state.
-				migrations.RunSQL.noop,
-			],
 		),
 	]

--- a/django/gregory/migrations/0047_drop_authtoken_tables.py
+++ b/django/gregory/migrations/0047_drop_authtoken_tables.py
@@ -1,0 +1,35 @@
+"""
+Drop the authtoken tables left behind when rest_framework.authtoken is removed
+from INSTALLED_APPS.  Django does not auto-generate a migration for app removal,
+so we do it manually via RunSQL.
+
+The two tables are:
+  authtoken_token   — one token per user
+  authtoken_tokenproxy — Django content-type proxy table (may or may not exist)
+
+Both DROP statements use IF EXISTS so the migration is safe to run on databases
+that never had the authtoken app installed.
+"""
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		('gregory', '0046_historicalarticleorgcontent_api_access_scheme_label_and_more'),
+	]
+
+	operations = [
+		migrations.RunSQL(
+			sql=[
+				'DROP TABLE IF EXISTS authtoken_token CASCADE;',
+				'DROP TABLE IF EXISTS authtoken_tokenproxy CASCADE;',
+			],
+			reverse_sql=[
+				# Recreating authtoken tables by hand is impractical; mark as
+				# non-reversible so rollback fails fast rather than silently
+				# leaving the database in an inconsistent state.
+				migrations.RunSQL.noop,
+			],
+		),
+	]


### PR DESCRIPTION

## Summary


Implements spec §8 — removes the broken `POST /api/token/get/` endpoint and the `rest_framework.authtoken` app entirely.

## Why

`obtain_auth_token` issued DRF tokens, but `TokenAuthentication` was never added to `DEFAULT_AUTHENTICATION_CLASSES`. Any token it issued was unusable on every protected endpoint — dead code that adds an unnecessary attack surface.

## Changes

### `django/admin/urls.py`
- Removed `from rest_framework.authtoken import views` import
- Removed `path('api/token/get/', views.obtain_auth_token)` URL pattern

### `django/admin/settings.py`
- Removed `'rest_framework.authtoken'` from `INSTALLED_APPS`

### `django/gregory/migrations/0047_drop_authtoken_tables.py`
- `RunSQL` migration that drops `authtoken_token` and `authtoken_tokenproxy` with `IF EXISTS` guards (safe on installs that never had the app)

## What is NOT changed

- `POST /api/token/` (SimpleJWT `LoginView`) is untouched — user-credential auth continues to work.
- `APIAccessScheme` / API-key auth is untouched.

## Related

- Part of the `api-improvements` spec branch