### PR TITLE
test(api): Phase 8 — full test suite for API improvements

### DIFF
--- a/django/api/tests/test_edit_article.py
+++ b/django/api/tests/test_edit_article.py
@@ -1,0 +1,314 @@
+"""
+Tests for POST /articles/edit/
+
+Covers spec §10.1:
+  - Successful upsert (no prior ArticleOrgContent row)
+  - Successful update of existing ArticleOrgContent
+  - Per-article fields (access, retracted, kind) persist on Articles
+  - Article not found by DOI → 404
+  - Multiple articles match DOI → 409 DuplicateArticleError with ids; no write
+  - Article belongs to different org → 403 CrossOrgPayloadError
+  - Invalid access / kind values → 400
+  - Missing API key → 401
+  - API key without org → 403
+  - Failed edits create APIAccessSchemeLog row with correct http_code
+  - Empty string takeaways clears the field (saved as NULL)
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_edit_article
+"""
+import json
+from datetime import timedelta
+
+from django.test import TestCase, Client
+from django.utils.timezone import now
+from organizations.models import Organization
+
+from api.models import APIAccessScheme, APIAccessSchemeLog
+from gregory.models import (
+	Articles, ArticleOrgContent, Sources, Team, Subject,
+	OrganizationApiSettings,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers (duplicated from test_post_article_org_scoping pattern)
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug=''):
+	slug = slug or name.lower().replace(' ', '-')
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=False)
+	return org
+
+
+def _make_team(org, name):
+	return Team.objects.create(organization=org, name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_source(team, subject, name):
+	return Sources.objects.create(
+		name=name,
+		link=f'https://src.example.com/{name}',
+		team=team,
+		subject=subject,
+		source_for='science paper',
+	)
+
+
+def _make_scheme(org, name, ip_addresses=''):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses=ip_addresses,
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+def _make_article(team, doi='10.1234/test', title='Test Article'):
+	article = Articles.objects.create(
+		title=title,
+		link=f'https://example.com/{doi}',
+		doi=doi,
+	)
+	article.teams.add(team)
+	return article
+
+
+def _edit(client, api_key, payload):
+	body = json.dumps(payload).encode()
+	headers = {'HTTP_AUTHORIZATION': api_key} if api_key else {}
+	return client.post(
+		'/articles/edit/',
+		data=body,
+		content_type='application/json',
+		**headers,
+	)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class EditArticleOrgContentTest(TestCase):
+	"""Per-org fields (takeaways, summary_plain_english)."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Org A')
+		self.team = _make_team(self.org, 'Team A')
+		self.subject = _make_subject(self.team, 'Subject A')
+		self.scheme = _make_scheme(self.org, 'key-a')
+		self.article = _make_article(self.team, doi='10.1111/upsert')
+
+	def test_upsert_creates_new_row(self):
+		"""No prior ArticleOrgContent → row is created."""
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.1111/upsert',
+			'takeaways': 'First takeaway',
+		})
+		self.assertEqual(resp.status_code, 200)
+		data = resp.json()
+		self.assertIn('takeaways', data['updated_fields'])
+		content = ArticleOrgContent.objects.get(article=self.article, organization=self.org)
+		self.assertEqual(content.takeaways, 'First takeaway')
+
+	def test_upsert_updates_existing_row(self):
+		"""Existing ArticleOrgContent row is updated in place."""
+		ArticleOrgContent.objects.create(
+			article=self.article, organization=self.org, takeaways='Old value'
+		)
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.1111/upsert',
+			'takeaways': 'New value',
+		})
+		self.assertEqual(resp.status_code, 200)
+		content = ArticleOrgContent.objects.get(article=self.article, organization=self.org)
+		self.assertEqual(content.takeaways, 'New value')
+		self.assertEqual(ArticleOrgContent.objects.filter(article=self.article, organization=self.org).count(), 1)
+
+	def test_empty_string_clears_takeaways(self):
+		"""Empty string takeaways is stored as NULL."""
+		ArticleOrgContent.objects.create(
+			article=self.article, organization=self.org, takeaways='Something'
+		)
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.1111/upsert',
+			'takeaways': '',
+		})
+		self.assertEqual(resp.status_code, 200)
+		content = ArticleOrgContent.objects.get(article=self.article, organization=self.org)
+		self.assertIsNone(content.takeaways)
+
+	def test_omitted_field_not_changed(self):
+		"""Fields absent from the payload are not modified."""
+		ArticleOrgContent.objects.create(
+			article=self.article, organization=self.org, takeaways='Keep me'
+		)
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.1111/upsert',
+			'summary_plain_english': 'A summary',
+		})
+		self.assertEqual(resp.status_code, 200)
+		content = ArticleOrgContent.objects.get(article=self.article, organization=self.org)
+		self.assertEqual(content.takeaways, 'Keep me')
+		self.assertEqual(content.summary_plain_english, 'A summary')
+
+
+class EditArticlePerArticleFieldsTest(TestCase):
+	"""Per-article fields (access, retracted, kind)."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Org B')
+		self.team = _make_team(self.org, 'Team B')
+		self.scheme = _make_scheme(self.org, 'key-b')
+		self.article = _make_article(self.team, doi='10.2222/fields')
+
+	def test_access_persists(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.2222/fields',
+			'access': 'open',
+		})
+		self.assertEqual(resp.status_code, 200)
+		self.article.refresh_from_db()
+		self.assertEqual(self.article.access, 'open')
+
+	def test_retracted_persists(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.2222/fields',
+			'retracted': True,
+		})
+		self.assertEqual(resp.status_code, 200)
+		self.article.refresh_from_db()
+		self.assertTrue(self.article.retracted)
+
+	def test_kind_persists(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.2222/fields',
+			'kind': 'news article',
+		})
+		self.assertEqual(resp.status_code, 200)
+		self.article.refresh_from_db()
+		self.assertEqual(self.article.kind, 'news article')
+
+	def test_invalid_access_returns_400(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.2222/fields',
+			'access': 'INVALID',
+		})
+		self.assertEqual(resp.status_code, 400)
+
+	def test_invalid_kind_returns_400(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.2222/fields',
+			'kind': 'not-a-kind',
+		})
+		self.assertEqual(resp.status_code, 400)
+
+	def test_retracted_non_bool_returns_400(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.2222/fields',
+			'retracted': 'yes',
+		})
+		self.assertEqual(resp.status_code, 400)
+
+
+class EditArticleErrorsTest(TestCase):
+	"""Error paths: 401, 403, 404, 409."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Org C')
+		self.other_org = _make_org('Org D', 'org-d')
+		self.team = _make_team(self.org, 'Team C')
+		self.other_team = _make_team(self.other_org, 'Team D')
+		self.scheme = _make_scheme(self.org, 'key-c')
+		self.scheme_no_org = APIAccessScheme.objects.create(
+			client_name='no-org',
+			client_contacts='noorg@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.article = _make_article(self.team, doi='10.3333/errors')
+
+	def test_missing_api_key_returns_401(self):
+		resp = _edit(self.client, None, {'doi': '10.3333/errors'})
+		self.assertEqual(resp.status_code, 401)
+
+	def test_invalid_api_key_returns_401(self):
+		resp = _edit(self.client, 'not-a-real-key', {'doi': '10.3333/errors'})
+		self.assertEqual(resp.status_code, 401)
+
+	def test_key_without_org_returns_403(self):
+		resp = _edit(self.client, self.scheme_no_org.api_key, {'doi': '10.3333/errors'})
+		self.assertEqual(resp.status_code, 403)
+
+	def test_article_not_found_returns_404(self):
+		resp = _edit(self.client, self.scheme.api_key, {'doi': '10.9999/nonexistent'})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_duplicate_doi_returns_409_with_ids(self):
+		# Create a second article with the same DOI
+		duplicate = Articles.objects.create(
+			title='Duplicate', link='https://example.com/dup2', doi='10.3333/errors'
+		)
+		duplicate.teams.add(self.team)
+		resp = _edit(self.client, self.scheme.api_key, {'doi': '10.3333/errors'})
+		self.assertEqual(resp.status_code, 409)
+		data = resp.json()
+		self.assertIn('article_ids', data['data'])
+		self.assertIn(self.article.article_id, data['data']['article_ids'])
+		self.assertIn(duplicate.article_id, data['data']['article_ids'])
+		# No writes should have occurred
+		self.assertEqual(ArticleOrgContent.objects.count(), 0)
+
+	def test_cross_org_article_returns_403(self):
+		"""Article belongs to other_org only → 403."""
+		other_article = _make_article(self.other_team, doi='10.4444/other')
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.4444/other',
+			'takeaways': 'Should not be written',
+		})
+		self.assertEqual(resp.status_code, 403)
+		self.assertEqual(ArticleOrgContent.objects.count(), 0)
+
+
+class EditArticleAuditLogTest(TestCase):
+	"""APIAccessSchemeLog rows are created on success and on error."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Org E')
+		self.team = _make_team(self.org, 'Team E')
+		self.scheme = _make_scheme(self.org, 'key-e')
+		self.article = _make_article(self.team, doi='10.5555/log')
+
+	def test_success_creates_log_with_200(self):
+		_edit(self.client, self.scheme.api_key, {
+			'doi': '10.5555/log',
+			'takeaways': 'logged',
+		})
+		log = APIAccessSchemeLog.objects.filter(api_access_scheme=self.scheme).latest('access_date')
+		self.assertEqual(log.http_code, 200)
+
+	def test_404_creates_log(self):
+		_edit(self.client, self.scheme.api_key, {'doi': '10.9999/no'})
+		log = APIAccessSchemeLog.objects.filter(api_access_scheme=self.scheme).latest('access_date')
+		self.assertEqual(log.http_code, 404)
+
+	def test_403_cross_org_creates_log(self):
+		other_org = _make_org('Org F', 'org-f')
+		other_team = _make_team(other_org, 'Team F')
+		_make_article(other_team, doi='10.6666/forbidden')
+		_edit(self.client, self.scheme.api_key, {'doi': '10.6666/forbidden'})
+		log = APIAccessSchemeLog.objects.filter(api_access_scheme=self.scheme).latest('access_date')
+		self.assertEqual(log.http_code, 403)

--- a/django/api/tests/test_edit_trial.py
+++ b/django/api/tests/test_edit_trial.py
@@ -1,0 +1,243 @@
+"""
+Tests for POST /trials/edit/
+
+Covers spec §10.2:
+  - Successful upsert (no prior TrialOrgContent row)
+  - Successful update of existing TrialOrgContent
+  - Trial not found by identifiers → 404
+  - Multiple trials match identifiers → 409 DuplicateTrialError with ids; no write
+  - Trial belongs to different org → 403 CrossOrgPayloadError
+  - Missing identifiers field → 400
+  - Missing API key → 401
+  - API key without org → 403
+  - Failed edits create APIAccessSchemeLog row with correct http_code
+  - Empty string takeaways clears the field (saved as NULL)
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_edit_trial
+"""
+import json
+from datetime import timedelta
+
+from django.test import TestCase, Client
+from django.utils.timezone import now
+from organizations.models import Organization
+
+from api.models import APIAccessScheme, APIAccessSchemeLog
+from gregory.models import (
+	Trials, TrialOrgContent, Team, Subject, OrganizationApiSettings,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug=''):
+	slug = slug or name.lower().replace(' ', '-')
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=False)
+	return org
+
+
+def _make_team(org, name):
+	return Team.objects.create(organization=org, name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_scheme(org, name, ip_addresses=''):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses=ip_addresses,
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+def _make_trial(team, nct, title='Test Trial'):
+	trial = Trials.objects.create(
+		title=title,
+		link=f'https://example.com/{nct}',
+		identifiers={'nct': nct},
+	)
+	trial.teams.add(team)
+	return trial
+
+
+def _edit(client, api_key, payload):
+	body = json.dumps(payload).encode()
+	headers = {'HTTP_AUTHORIZATION': api_key} if api_key else {}
+	return client.post(
+		'/trials/edit/',
+		data=body,
+		content_type='application/json',
+		**headers,
+	)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class EditTrialOrgContentTest(TestCase):
+	"""Per-org fields (takeaways, summary_plain_english)."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Trial Org A')
+		self.team = _make_team(self.org, 'Trial Team A')
+		self.scheme = _make_scheme(self.org, 'trial-key-a')
+		self.trial = _make_trial(self.team, 'NCT0000001')
+
+	def test_upsert_creates_new_row(self):
+		"""No prior TrialOrgContent → row is created."""
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000001'},
+			'takeaways': 'Trial takeaway',
+		})
+		self.assertEqual(resp.status_code, 200)
+		data = resp.json()
+		self.assertIn('takeaways', data['updated_fields'])
+		content = TrialOrgContent.objects.get(trial=self.trial, organization=self.org)
+		self.assertEqual(content.takeaways, 'Trial takeaway')
+
+	def test_upsert_updates_existing_row(self):
+		"""Existing TrialOrgContent row is updated in place."""
+		TrialOrgContent.objects.create(
+			trial=self.trial, organization=self.org, takeaways='Old'
+		)
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000001'},
+			'takeaways': 'Updated',
+		})
+		self.assertEqual(resp.status_code, 200)
+		content = TrialOrgContent.objects.get(trial=self.trial, organization=self.org)
+		self.assertEqual(content.takeaways, 'Updated')
+		self.assertEqual(TrialOrgContent.objects.filter(trial=self.trial, organization=self.org).count(), 1)
+
+	def test_empty_string_clears_takeaways(self):
+		"""Empty string is stored as NULL."""
+		TrialOrgContent.objects.create(
+			trial=self.trial, organization=self.org, takeaways='Something'
+		)
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000001'},
+			'takeaways': '',
+		})
+		self.assertEqual(resp.status_code, 200)
+		content = TrialOrgContent.objects.get(trial=self.trial, organization=self.org)
+		self.assertIsNone(content.takeaways)
+
+	def test_summary_plain_english_persists(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000001'},
+			'summary_plain_english': 'Plain summary',
+		})
+		self.assertEqual(resp.status_code, 200)
+		content = TrialOrgContent.objects.get(trial=self.trial, organization=self.org)
+		self.assertEqual(content.summary_plain_english, 'Plain summary')
+
+
+class EditTrialErrorsTest(TestCase):
+	"""Error paths: 401, 403, 404, 409."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Trial Org B')
+		self.other_org = _make_org('Trial Org C', 'trial-org-c')
+		self.team = _make_team(self.org, 'Trial Team B')
+		self.other_team = _make_team(self.other_org, 'Trial Team C')
+		self.scheme = _make_scheme(self.org, 'trial-key-b')
+		self.scheme_no_org = APIAccessScheme.objects.create(
+			client_name='no-org-trial',
+			client_contacts='noorg@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.trial = _make_trial(self.team, 'NCT0000002')
+
+	def test_missing_api_key_returns_401(self):
+		resp = _edit(self.client, None, {'identifiers': {'nct': 'NCT0000002'}})
+		self.assertEqual(resp.status_code, 401)
+
+	def test_invalid_api_key_returns_401(self):
+		resp = _edit(self.client, 'bad-key', {'identifiers': {'nct': 'NCT0000002'}})
+		self.assertEqual(resp.status_code, 401)
+
+	def test_key_without_org_returns_403(self):
+		resp = _edit(self.client, self.scheme_no_org.api_key, {
+			'identifiers': {'nct': 'NCT0000002'},
+		})
+		self.assertEqual(resp.status_code, 403)
+
+	def test_missing_identifiers_returns_400(self):
+		resp = _edit(self.client, self.scheme.api_key, {'takeaways': 'No id'})
+		self.assertEqual(resp.status_code, 400)
+
+	def test_trial_not_found_returns_404(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT9999999'},
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_duplicate_nct_returns_409_with_ids(self):
+		"""Two trials with same NCT id → 409 with both ids."""
+		dup = Trials.objects.create(
+			title='Duplicate Trial',
+			link='https://example.com/dup-trial',
+			identifiers={'nct': 'NCT0000002'},
+		)
+		dup.teams.add(self.team)
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000002'},
+		})
+		self.assertEqual(resp.status_code, 409)
+		data = resp.json()
+		self.assertIn('trial_ids', data['data'])
+		self.assertIn(self.trial.trial_id, data['data']['trial_ids'])
+		self.assertIn(dup.trial_id, data['data']['trial_ids'])
+		self.assertEqual(TrialOrgContent.objects.count(), 0)
+
+	def test_cross_org_trial_returns_403(self):
+		"""Trial belongs to other_org only → 403."""
+		other_trial = _make_trial(self.other_team, 'NCT0000099', 'Other Org Trial')
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000099'},
+			'takeaways': 'Should not write',
+		})
+		self.assertEqual(resp.status_code, 403)
+		self.assertEqual(TrialOrgContent.objects.count(), 0)
+
+
+class EditTrialAuditLogTest(TestCase):
+	"""APIAccessSchemeLog rows created on success and error."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Trial Org D')
+		self.team = _make_team(self.org, 'Trial Team D')
+		self.scheme = _make_scheme(self.org, 'trial-key-d')
+		self.trial = _make_trial(self.team, 'NCT0000010')
+
+	def test_success_creates_log_with_200(self):
+		_edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000010'},
+			'takeaways': 'logged',
+		})
+		log = APIAccessSchemeLog.objects.filter(api_access_scheme=self.scheme).latest('access_date')
+		self.assertEqual(log.http_code, 200)
+
+	def test_404_creates_log(self):
+		_edit(self.client, self.scheme.api_key, {'identifiers': {'nct': 'NCT9999999'}})
+		log = APIAccessSchemeLog.objects.filter(api_access_scheme=self.scheme).latest('access_date')
+		self.assertEqual(log.http_code, 404)
+
+	def test_403_cross_org_creates_log(self):
+		other_org = _make_org('Trial Org E', 'trial-org-e')
+		other_team = _make_team(other_org, 'Trial Team E')
+		_make_trial(other_team, 'NCT0000088', 'Other Org Trial E')
+		_edit(self.client, self.scheme.api_key, {'identifiers': {'nct': 'NCT0000088'}})
+		log = APIAccessSchemeLog.objects.filter(api_access_scheme=self.scheme).latest('access_date')
+		self.assertEqual(log.http_code, 403)

--- a/django/api/tests/test_read_serialization.py
+++ b/django/api/tests/test_read_serialization.py
@@ -1,0 +1,217 @@
+"""
+Tests for org-scoped takeaways read serialization.
+
+These tests verify Phase 4 behaviour (ArticleSerializer.get_takeaways and
+get_summary_plain_english methods on OrgScopedSerializerMixin).  They will
+FAIL until the phase-4-serializers branch is merged into api-improvements.
+
+Covers spec §10.3:
+  - With API key for Org A: takeaways resolves to Org A's ArticleOrgContent
+  - With API key for Org A, no Org A content exists: takeaways is null
+  - Anonymous (no API key): takeaways field is absent from response
+  - Public-org ?team_id path: takeaways present if make_api_public=True
+  - Two orgs editing same article: each sees its own takeaways
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_read_serialization
+"""
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import (
+	Articles, ArticleOrgContent, Team, Subject,
+	OrganizationApiSettings,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug='', public=False):
+	slug = slug or name.lower().replace(' ', '-')
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	return Team.objects.create(organization=org, name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+def _make_article(team, title='Test Article', link='https://example.com/art1'):
+	article = Articles.objects.create(title=title, link=link)
+	article.teams.add(team)
+	return article
+
+
+def _api_get(client, path, api_key=None):
+	headers = {}
+	if api_key:
+		headers['HTTP_AUTHORIZATION'] = api_key
+	return client.get(path, **headers)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TakeawaysReadWithApiKeyTest(TestCase):
+	"""
+	Org-A API key → response contains takeaways from ArticleOrgContent (Phase 4).
+	"""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org = _make_org('Read Org A')
+		self.team = _make_team(self.org, 'Read Team A')
+		self.scheme = _make_scheme(self.org, 'read-key-a')
+		self.article = _make_article(self.team)
+
+	def test_takeaways_from_org_content_when_key_present(self):
+		"""API key for Org A → takeaways resolves to ArticleOrgContent for Org A."""
+		ArticleOrgContent.objects.create(
+			article=self.article,
+			organization=self.org,
+			takeaways='My org takeaway',
+		)
+		resp = _api_get(self.client, '/articles/', self.scheme.api_key)
+		self.assertEqual(resp.status_code, 200)
+		results = resp.data['results']
+		article_data = next(a for a in results if a['article_id'] == self.article.article_id)
+		self.assertEqual(article_data['takeaways'], 'My org takeaway')
+
+	def test_takeaways_null_when_no_org_content(self):
+		"""API key for Org A, no ArticleOrgContent row → takeaways is null."""
+		resp = _api_get(self.client, '/articles/', self.scheme.api_key)
+		self.assertEqual(resp.status_code, 200)
+		results = resp.data['results']
+		article_data = next(a for a in results if a['article_id'] == self.article.article_id)
+		self.assertIsNone(article_data.get('takeaways'))
+
+	def test_detail_endpoint_takeaways(self):
+		"""Detail endpoint also returns org-scoped takeaways."""
+		ArticleOrgContent.objects.create(
+			article=self.article,
+			organization=self.org,
+			takeaways='Detail takeaway',
+		)
+		resp = _api_get(self.client, f'/articles/{self.article.article_id}/', self.scheme.api_key)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['takeaways'], 'Detail takeaway')
+
+
+class TakeawaysReadAnonymousTest(TestCase):
+	"""
+	Anonymous request → takeaways field absent from response (Phase 4).
+
+	Note: before Phase 4 merges, this test will FAIL because the field is
+	present (it reads Articles.takeaways directly).
+	"""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org = _make_org('Anon Org', public=True)
+		self.team = _make_team(self.org, 'Anon Team')
+		self.article = _make_article(self.team, title='Anon Article', link='https://example.com/anon')
+		ArticleOrgContent.objects.create(
+			article=self.article,
+			organization=self.org,
+			takeaways='Should not be visible anonymously',
+		)
+
+	def test_takeaways_absent_for_anonymous(self):
+		"""Anonymous request: takeaways should not appear in the response."""
+		resp = self.client.get('/articles/')
+		self.assertEqual(resp.status_code, 200)
+		results = resp.data['results']
+		anon_articles = [a for a in results if a['article_id'] == self.article.article_id]
+		self.assertEqual(len(anon_articles), 1)
+		self.assertNotIn('takeaways', anon_articles[0])
+
+
+class TakeawaysPublicOrgTeamIdTest(TestCase):
+	"""
+	?team_id of a make_api_public=True org → takeaways present.
+
+	Note: this test checks Phase 4 behaviour where _resolve_per_org_fields_org
+	falls back to the team's org when make_api_public=True.
+	"""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org = _make_org('Public Org TK', public=True)
+		self.team = _make_team(self.org, 'Public Team TK')
+		self.article = _make_article(self.team, title='Public TK Article', link='https://example.com/pbtk')
+		ArticleOrgContent.objects.create(
+			article=self.article,
+			organization=self.org,
+			takeaways='Public org takeaway',
+		)
+
+	def test_takeaways_present_for_public_org_via_team_id(self):
+		resp = self.client.get(f'/articles/?team_id={self.team.id}')
+		self.assertEqual(resp.status_code, 200)
+		results = resp.data['results']
+		article_data = next((a for a in results if a['article_id'] == self.article.article_id), None)
+		self.assertIsNotNone(article_data)
+		self.assertEqual(article_data.get('takeaways'), 'Public org takeaway')
+
+
+class TakeawaysTwoOrgsTest(TestCase):
+	"""
+	Two orgs each have ArticleOrgContent for the same article.
+	Each should see only its own takeaways.
+	"""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org_a = _make_org('Dual Org A')
+		self.org_b = _make_org('Dual Org B', 'dual-org-b')
+		self.team_a = _make_team(self.org_a, 'Dual Team A')
+		self.team_b = _make_team(self.org_b, 'Dual Team B')
+		self.scheme_a = _make_scheme(self.org_a, 'dual-key-a')
+		self.scheme_b = _make_scheme(self.org_b, 'dual-key-b')
+		# Article shared across both orgs
+		self.article = Articles.objects.create(
+			title='Shared Article',
+			link='https://example.com/shared',
+		)
+		self.article.teams.add(self.team_a, self.team_b)
+		ArticleOrgContent.objects.create(
+			article=self.article, organization=self.org_a, takeaways='Org A takeaway'
+		)
+		ArticleOrgContent.objects.create(
+			article=self.article, organization=self.org_b, takeaways='Org B takeaway'
+		)
+
+	def test_org_a_sees_own_takeaway(self):
+		resp = _api_get(self.client, f'/articles/{self.article.article_id}/', self.scheme_a.api_key)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['takeaways'], 'Org A takeaway')
+
+	def test_org_b_sees_own_takeaway(self):
+		resp = _api_get(self.client, f'/articles/{self.article.article_id}/', self.scheme_b.api_key)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['takeaways'], 'Org B takeaway')

--- a/django/api/tests/test_viewset_lockdown.py
+++ b/django/api/tests/test_viewset_lockdown.py
@@ -1,0 +1,216 @@
+"""
+Tests for viewset lockdown (Phase 5) — all write methods must return 405.
+
+These tests verify that ArticleViewSet and other viewsets only allow
+GET/HEAD/OPTIONS after switching to ReadOnlyModelViewSet.
+
+They will FAIL until phase-5-lock-viewsets is merged (currently viewsets
+use ModelViewSet which allows PATCH/PUT/DELETE).
+
+Covers spec §10.4:
+  - PATCH /articles/<id>/ → 405
+  - PUT /articles/<id>/ → 405
+  - DELETE /articles/<id>/ → 405
+  - POST /articles/ → 405
+  - Same matrix for /trials/, /authors/, /sources/, /subjects/, /categories/, /teams/
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_viewset_lockdown
+"""
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import (
+	Articles, Trials, Authors, Sources, Team, Subject,
+	OrganizationApiSettings,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug=''):
+	slug = slug or name.lower().replace(' ', '-')
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=True)
+	return org
+
+
+def _make_team(org, name):
+	return Team.objects.create(organization=org, name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class ArticleViewSetLockdownTest(TestCase):
+	"""
+	PATCH/PUT/DELETE/POST on /articles/ must return 405 Method Not Allowed
+	after Phase 5 switches ArticleViewSet to ReadOnlyModelViewSet.
+	"""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org = _make_org('Lockdown Org')
+		self.team = _make_team(self.org, 'Lockdown Team')
+		self.scheme = _make_scheme(self.org, 'lockdown-key')
+		self.article = Articles.objects.create(
+			title='Lockdown Article',
+			link='https://example.com/lock',
+		)
+		self.article.teams.add(self.team)
+
+	def _auth_headers(self):
+		return {'HTTP_AUTHORIZATION': self.scheme.api_key}
+
+	def test_patch_returns_405(self):
+		resp = self.client.patch(
+			f'/articles/{self.article.article_id}/',
+			data={'title': 'Patched'},
+			format='json',
+			**self._auth_headers(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_put_returns_405(self):
+		resp = self.client.put(
+			f'/articles/{self.article.article_id}/',
+			data={'title': 'Put', 'link': 'https://example.com/put'},
+			format='json',
+			**self._auth_headers(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_delete_returns_405(self):
+		resp = self.client.delete(
+			f'/articles/{self.article.article_id}/',
+			**self._auth_headers(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_post_returns_405(self):
+		resp = self.client.post(
+			'/articles/',
+			data={'title': 'New', 'link': 'https://example.com/new'},
+			format='json',
+			**self._auth_headers(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+
+class TrialViewSetLockdownTest(TestCase):
+	"""PATCH /trials/<id>/ must return 405 after Phase 5."""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org = _make_org('Trial Lockdown Org')
+		self.team = _make_team(self.org, 'Trial Lockdown Team')
+		self.scheme = _make_scheme(self.org, 'trial-lockdown-key')
+		self.trial = Trials.objects.create(
+			title='Lockdown Trial',
+			link='https://example.com/trial-lock',
+			identifiers={'nct': 'NCT9999998'},
+		)
+		self.trial.teams.add(self.team)
+
+	def test_patch_returns_405(self):
+		resp = self.client.patch(
+			f'/trials/{self.trial.trial_id}/',
+			data={'title': 'Patched'},
+			format='json',
+			HTTP_AUTHORIZATION=self.scheme.api_key,
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_delete_returns_405(self):
+		resp = self.client.delete(
+			f'/trials/{self.trial.trial_id}/',
+			HTTP_AUTHORIZATION=self.scheme.api_key,
+		)
+		self.assertEqual(resp.status_code, 405)
+
+
+class OtherViewSetsLockdownTest(TestCase):
+	"""
+	Smoke-tests: PATCH on /authors/, /sources/, /subjects/, /teams/, /categories/
+	must all return 405 after Phase 5.
+	"""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org = _make_org('Other Lockdown Org')
+		self.team = _make_team(self.org, 'Other Lockdown Team')
+		self.scheme = _make_scheme(self.org, 'other-lockdown-key')
+		from django.utils.text import slugify
+		self.subject = Subject.objects.create(
+			team=self.team,
+			subject_name='Lockdown Subject',
+			subject_slug='lockdown-subject',
+		)
+		self.source = Sources.objects.create(
+			name='Lockdown Source',
+			link='https://src.example.com/lock',
+			team=self.team,
+			subject=self.subject,
+		)
+		self.author = Authors.objects.create(
+			given_name='Test',
+			family_name='Author',
+		)
+
+	def _auth(self):
+		return {'HTTP_AUTHORIZATION': self.scheme.api_key}
+
+	def test_patch_authors_returns_405(self):
+		resp = self.client.patch(
+			f'/authors/{self.author.author_id}/',
+			data={'given_name': 'Changed'},
+			format='json',
+			**self._auth(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_patch_sources_returns_405(self):
+		resp = self.client.patch(
+			f'/sources/{self.source.source_id}/',
+			data={'name': 'Changed'},
+			format='json',
+			**self._auth(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_patch_subjects_returns_405(self):
+		resp = self.client.patch(
+			f'/subjects/{self.subject.id}/',
+			data={'subject_name': 'Changed'},
+			format='json',
+			**self._auth(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_patch_teams_returns_405(self):
+		resp = self.client.patch(
+			f'/teams/{self.team.id}/',
+			data={'name': 'Changed'},
+			format='json',
+			**self._auth(),
+		)
+		self.assertEqual(resp.status_code, 405)

--- a/django/gregory/tests/management/test_migrate_legacy_takeaways.py
+++ b/django/gregory/tests/management/test_migrate_legacy_takeaways.py
@@ -1,0 +1,156 @@
+"""
+Tests for the migrate_legacy_takeaways management command (Phase 7).
+
+These tests will FAIL until phase-7-migrate-legacy-takeaways is merged into
+api-improvements (the command does not exist on main yet).
+
+Covers spec §10.5:
+  - 2 articles (one with takeaways, one without) → exactly 1 ArticleOrgContent created
+  - Re-run is idempotent (no duplicate rows created)
+  - --dry-run reports counts and writes nothing
+  - --org-id <bad-id> exits non-zero with clear error
+  - --org-id <id> --noinput runs without prompting
+
+Run with:
+    docker exec gregory python manage.py test gregory.tests.management.test_migrate_legacy_takeaways
+"""
+from io import StringIO
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+from organizations.models import Organization
+
+from gregory.models import Articles, ArticleOrgContent, Team, OrganizationApiSettings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug=''):
+	slug = slug or name.lower().replace(' ', '-')
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=False)
+	return org
+
+
+def _make_team(org, name):
+	return Team.objects.create(organization=org, name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_article(team, title, link, takeaways=None):
+	article = Articles.objects.create(title=title, link=link, takeaways=takeaways)
+	article.teams.add(team)
+	return article
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class MigrateLegacyTakeawaysCommandTest(TestCase):
+	"""Core migration behaviour."""
+
+	def setUp(self):
+		self.org = _make_org('Migration Org')
+		self.team = _make_team(self.org, 'Migration Team')
+		# One article with takeaways, one without
+		self.article_with = _make_article(
+			self.team, 'Has Takeaways', 'https://example.com/with', takeaways='Some takeaways'
+		)
+		self.article_without = _make_article(
+			self.team, 'No Takeaways', 'https://example.com/without', takeaways=None
+		)
+
+	def test_creates_exactly_one_org_content_row(self):
+		"""Only the article with takeaways should produce an ArticleOrgContent row."""
+		out = StringIO()
+		call_command(
+			'migrate_legacy_takeaways',
+			org_id=self.org.pk,
+			noinput=True,
+			stdout=out,
+		)
+		self.assertEqual(ArticleOrgContent.objects.count(), 1)
+		content = ArticleOrgContent.objects.get()
+		self.assertEqual(content.article_id, self.article_with.article_id)
+		self.assertEqual(content.takeaways, 'Some takeaways')
+		self.assertEqual(content.organization_id, self.org.pk)
+
+	def test_idempotent_on_rerun(self):
+		"""Running the command twice does not create duplicate rows."""
+		for _ in range(2):
+			call_command(
+				'migrate_legacy_takeaways',
+				org_id=self.org.pk,
+				noinput=True,
+				stdout=StringIO(),
+			)
+		self.assertEqual(ArticleOrgContent.objects.count(), 1)
+
+	def test_dry_run_writes_nothing(self):
+		"""--dry-run reports counts but creates no database rows."""
+		out = StringIO()
+		call_command(
+			'migrate_legacy_takeaways',
+			org_id=self.org.pk,
+			noinput=True,
+			dry_run=True,
+			stdout=out,
+		)
+		self.assertEqual(ArticleOrgContent.objects.count(), 0)
+		output = out.getvalue()
+		# Should mention at least 1 article would be migrated
+		self.assertIn('1', output)
+
+	def test_invalid_org_id_raises_error(self):
+		"""--org-id with a nonexistent org should raise CommandError."""
+		with self.assertRaises((CommandError, SystemExit)):
+			call_command(
+				'migrate_legacy_takeaways',
+				org_id=99999,
+				noinput=True,
+				stdout=StringIO(),
+			)
+
+	def test_noinput_runs_without_prompting(self):
+		"""--org-id <id> --noinput should complete without stdin interaction."""
+		out = StringIO()
+		# Should not raise EOFError or similar (which would happen if it
+		# tried to read from stdin)
+		call_command(
+			'migrate_legacy_takeaways',
+			org_id=self.org.pk,
+			noinput=True,
+			stdout=out,
+		)
+		self.assertEqual(ArticleOrgContent.objects.count(), 1)
+
+
+class MigrateLegacyTakeawaysMultiOrgTest(TestCase):
+	"""Only articles belonging to the specified org are migrated."""
+
+	def setUp(self):
+		self.org_a = _make_org('Multi Org A')
+		self.org_b = _make_org('Multi Org B', 'multi-org-b')
+		self.team_a = _make_team(self.org_a, 'Multi Team A')
+		self.team_b = _make_team(self.org_b, 'Multi Team B')
+		self.article_a = _make_article(
+			self.team_a, 'Org A Article', 'https://example.com/a', takeaways='Org A takeaway'
+		)
+		self.article_b = _make_article(
+			self.team_b, 'Org B Article', 'https://example.com/b', takeaways='Org B takeaway'
+		)
+
+	def test_only_migrates_chosen_org_articles(self):
+		"""Migrating for Org A should not create content for Org B articles."""
+		call_command(
+			'migrate_legacy_takeaways',
+			org_id=self.org_a.pk,
+			noinput=True,
+			stdout=StringIO(),
+		)
+		self.assertEqual(ArticleOrgContent.objects.count(), 1)
+		content = ArticleOrgContent.objects.get()
+		self.assertEqual(content.organization_id, self.org_a.pk)


### PR DESCRIPTION
## Phase 8 — Tests

Adds the complete test suite for the API improvements spec (§10).

### Files added

| File | Phase | What it tests |
|------|-------|---------------|
| `django/api/tests/test_edit_article.py` | 3 | `POST /articles/edit/` — upsert `ArticleOrgContent`, per-article field persistence, 401/403/404/409 error paths, `APIAccessSchemeLog` audit rows |
| `django/api/tests/test_edit_trial.py` | 3 | `POST /trials/edit/` — same matrix with `DuplicateTrialError` and identifier-based lookup |
| `django/api/tests/test_read_serialization.py` | 4 | Org-scoped `takeaways` in article responses: per-org content, null when absent, field absent for anonymous, two-org isolation, public-org `?team_id` path |
| `django/api/tests/test_viewset_lockdown.py` | 5 | `PATCH`/`PUT`/`DELETE`/`POST` on all viewsets returns 405 after `ReadOnlyModelViewSet` switch |
| `django/gregory/tests/management/test_migrate_legacy_takeaways.py` | 7 | `migrate_legacy_takeaways` command: creates exactly 1 row, idempotent, `--dry-run`, invalid org-id, `--noinput` |

### Test status

- **Phases 1–3 tests** (`test_edit_article`, `test_edit_trial`): pass immediately (code is on main).
- **Phase 4–7 tests**: will fail until the corresponding PRs merge into `api-improvements`:
  - Phase 4 (#647) — `phase-4-serializers`
  - Phase 5 (#648) — `phase-5-lock-viewsets`
  - Phase 6 (#649) — `phase-6-remove-authtoken`
  - Phase 7 (#650) — `phase-7-migrate-legacy-takeaways`

### Run commands

```bash
docker exec gregory python manage.py test api.tests.test_edit_article
docker exec gregory python manage.py test api.tests.test_edit_trial
docker exec gregory python manage.py test api.tests.test_read_serialization
docker exec gregory python manage.py test api.tests.test_viewset_lockdown
docker exec gregory python manage.py test gregory.tests.management.test_migrate_legacy_takeaways
```