### PR TITLE
feat(admin): edit per-org article/trial content via inlines

### DIFF
--- a/django/admin/settings.py
+++ b/django/admin/settings.py
@@ -69,7 +69,6 @@ INSTALLED_APPS = [
 	'gregory.apps.GregoryConfig',
 	'subscriptions.apps.SubscriptionsConfig',
 	'rest_framework',
-	'rest_framework.authtoken',
 	'rest_framework_simplejwt',
 	'rest_framework_csv',  # Add CSV renderer support
 	'django_filters',

--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -18,7 +18,6 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import include, path, re_path
 from rest_framework import routers
-from rest_framework.authtoken import views
 
 from api.views import (
 	ArticleViewSet, AuthorsViewSet, SourceViewSet, TrialViewSet, 
@@ -61,7 +60,6 @@ urlpatterns = [
 	# API auth route
 	path('api-auth/', include('rest_framework.urls')),
 	path('api/token/', LoginView.as_view(), name='token_obtain_pair'),
-	path('api/token/get/', views.obtain_auth_token),
 
 	# API routes
 	path('articles/post/', post_article),

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -307,25 +307,33 @@ class ArticleSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSe
 		trials = [ref.trial for ref in references]
 		return TrialReferenceSerializer(trials, many=True).data
 
+	def _get_org_content(self, obj, org):
+		"""Fetch ArticleOrgContent for (obj, org), cached per serializer instance."""
+		if not hasattr(self, '_org_content_cache'):
+			self._org_content_cache = {}
+		key = (obj.pk, org.pk)
+		if key not in self._org_content_cache:
+			try:
+				self._org_content_cache[key] = obj.org_contents.get(organization=org)
+			except Exception:
+				self._org_content_cache[key] = None
+		return self._org_content_cache[key]
+
 	def get_takeaways(self, obj):
 		"""Return takeaways from ArticleOrgContent for the caller's org, or None."""
 		org = _resolve_per_org_fields_org(self.context.get('request'))
 		if org is None:
 			return None  # field will be popped in to_representation
-		try:
-			return obj.org_contents.get(organization=org).takeaways
-		except Exception:
-			return None
+		content = self._get_org_content(obj, org)
+		return content.takeaways if content else None
 
 	def get_summary_plain_english(self, obj):
 		"""Return plain-English summary from ArticleOrgContent for the caller's org, or None."""
 		org = _resolve_per_org_fields_org(self.context.get('request'))
 		if org is None:
 			return None  # field will be popped in to_representation
-		try:
-			return obj.org_contents.get(organization=org).summary_plain_english
-		except Exception:
-			return None
+		content = self._get_org_content(obj, org)
+		return content.summary_plain_english if content else None
 
 class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSerializer):
 	source = serializers.SlugRelatedField(read_only=True, slug_field='name')
@@ -362,25 +370,33 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 		articles = [ref.article for ref in references]
 		return ArticleReferenceSerializer(articles, many=True).data
 
+	def _get_org_content(self, obj, org):
+		"""Fetch TrialOrgContent for (obj, org), cached per serializer instance."""
+		if not hasattr(self, '_org_content_cache'):
+			self._org_content_cache = {}
+		key = (obj.pk, org.pk)
+		if key not in self._org_content_cache:
+			try:
+				self._org_content_cache[key] = obj.org_contents.get(organization=org)
+			except Exception:
+				self._org_content_cache[key] = None
+		return self._org_content_cache[key]
+
 	def get_takeaways(self, obj):
 		"""Return takeaways from TrialOrgContent for the caller's org, or None."""
 		org = _resolve_per_org_fields_org(self.context.get('request'))
 		if org is None:
 			return None  # field will be popped in to_representation
-		try:
-			return obj.org_contents.get(organization=org).takeaways
-		except Exception:
-			return None
+		content = self._get_org_content(obj, org)
+		return content.takeaways if content else None
 
 	def get_summary_plain_english(self, obj):
 		"""Return plain-English summary from TrialOrgContent for the caller's org, or None."""
 		org = _resolve_per_org_fields_org(self.context.get('request'))
 		if org is None:
 			return None  # field will be popped in to_representation
-		try:
-			return obj.org_contents.get(organization=org).summary_plain_english
-		except Exception:
-			return None
+		content = self._get_org_content(obj, org)
+		return content.summary_plain_english if content else None
 
 class SourceSerializer(serializers.HyperlinkedModelSerializer):
 	class Meta:

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from gregory.models import Articles, Trials, Sources, Authors, Subject, Team, MLPredictions, ArticleSubjectRelevance, TeamCategory, ArticleTrialReference
+from gregory.models import Articles, Trials, Sources, Authors, Subject, Team, MLPredictions, ArticleSubjectRelevance, TeamCategory, ArticleTrialReference, ArticleOrgContent, TrialOrgContent
 from organizations.models import Organization
 from sitesettings.models import CustomSetting
 from django.contrib.sites.models import Site
@@ -308,16 +308,33 @@ class ArticleSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSe
 		return TrialReferenceSerializer(trials, many=True).data
 
 	def _get_org_content(self, obj, org):
-		"""Fetch ArticleOrgContent for (obj, org), cached per serializer instance."""
+		"""Return the caller-org's ArticleOrgContent for *obj*, or None.
+
+		Uses the per-org prefetch attached by ``ArticleViewSet.get_queryset``
+		when present (zero extra queries per row); falls back to a single
+		``.get()`` lookup for detail responses and other callers that didn't
+		prefetch.  Result is cached per serializer instance so calling this
+		from both ``get_takeaways`` and ``get_summary_plain_english`` only
+		costs one lookup.
+		"""
 		if not hasattr(self, '_org_content_cache'):
 			self._org_content_cache = {}
 		key = (obj.pk, org.pk)
-		if key not in self._org_content_cache:
-			try:
-				self._org_content_cache[key] = obj.org_contents.get(organization=org)
-			except Exception:
-				self._org_content_cache[key] = None
-		return self._org_content_cache[key]
+		if key in self._org_content_cache:
+			return self._org_content_cache[key]
+
+		prefetched = getattr(obj, '_prefetched_org_contents', None)
+		if prefetched is not None:
+			match = next((c for c in prefetched if c.organization_id == org.pk), None)
+			self._org_content_cache[key] = match
+			return match
+
+		try:
+			content = obj.org_contents.get(organization=org)
+		except ArticleOrgContent.DoesNotExist:
+			content = None
+		self._org_content_cache[key] = content
+		return content
 
 	def get_takeaways(self, obj):
 		"""Return takeaways from ArticleOrgContent for the caller's org, or None."""
@@ -371,16 +388,31 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 		return ArticleReferenceSerializer(articles, many=True).data
 
 	def _get_org_content(self, obj, org):
-		"""Fetch TrialOrgContent for (obj, org), cached per serializer instance."""
+		"""Return the caller-org's TrialOrgContent for *obj*, or None.
+
+		Uses the per-org prefetch attached by ``TrialViewSet.get_queryset``
+		when present (zero extra queries per row); falls back to a single
+		``.get()`` lookup for detail responses and other callers that didn't
+		prefetch.  Result is cached per serializer instance.
+		"""
 		if not hasattr(self, '_org_content_cache'):
 			self._org_content_cache = {}
 		key = (obj.pk, org.pk)
-		if key not in self._org_content_cache:
-			try:
-				self._org_content_cache[key] = obj.org_contents.get(organization=org)
-			except Exception:
-				self._org_content_cache[key] = None
-		return self._org_content_cache[key]
+		if key in self._org_content_cache:
+			return self._org_content_cache[key]
+
+		prefetched = getattr(obj, '_prefetched_org_contents', None)
+		if prefetched is not None:
+			match = next((c for c in prefetched if c.organization_id == org.pk), None)
+			self._org_content_cache[key] = match
+			return match
+
+		try:
+			content = obj.org_contents.get(organization=org)
+		except TrialOrgContent.DoesNotExist:
+			content = None
+		self._org_content_cache[key] = content
+		return content
 
 	def get_takeaways(self, obj):
 		"""Return takeaways from TrialOrgContent for the caller's org, or None."""

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count, Q
 
-from api.serializers.mixins import OrgScopedSerializerMixin  # noqa: F401
+from api.serializers.mixins import OrgScopedSerializerMixin, _resolve_per_org_fields_org  # noqa: F401
 
 def get_custom_settings():
 		try:
@@ -284,6 +284,11 @@ class ArticleSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSe
 	ml_predictions = MLPredictionsSerializer(many=True, read_only=True, source='ml_predictions_detail')
 	article_subject_relevances = ArticleSubjectRelevanceSerializer(many=True, read_only=True)
 	clinical_trials = serializers.SerializerMethodField()
+	takeaways = serializers.SerializerMethodField()
+	summary_plain_english = serializers.SerializerMethodField()
+
+	# Omit these fields from the response when there is no organisation context
+	_per_org_fields = ['takeaways', 'summary_plain_english']
 
 	class Meta:
 		model = Articles
@@ -294,18 +299,43 @@ class ArticleSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSe
 			'discovery_date', 'article_subject_relevances',
 			'doi', 'access', 'takeaways', 'team_categories', 'ml_predictions', 'clinical_trials',
 		]
-		read_only_fields = ('discovery_date', 'ml_predictions', 'takeaways', 'clinical_trials')
-	
+		read_only_fields = ('discovery_date', 'ml_predictions', 'clinical_trials')
+
 	def get_clinical_trials(self, obj):
 		"""Get trials referenced in the article"""
 		references = ArticleTrialReference.objects.filter(article=obj)
 		trials = [ref.trial for ref in references]
 		return TrialReferenceSerializer(trials, many=True).data
 
+	def get_takeaways(self, obj):
+		"""Return takeaways from ArticleOrgContent for the caller's org, or None."""
+		org = _resolve_per_org_fields_org(self.context.get('request'))
+		if org is None:
+			return None  # field will be popped in to_representation
+		try:
+			return obj.org_contents.get(organization=org).takeaways
+		except Exception:
+			return None
+
+	def get_summary_plain_english(self, obj):
+		"""Return plain-English summary from ArticleOrgContent for the caller's org, or None."""
+		org = _resolve_per_org_fields_org(self.context.get('request'))
+		if org is None:
+			return None  # field will be popped in to_representation
+		try:
+			return obj.org_contents.get(organization=org).summary_plain_english
+		except Exception:
+			return None
+
 class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSerializer):
 	source = serializers.SlugRelatedField(read_only=True, slug_field='name')
 	team_categories = TeamCategorySerializer(many=True, read_only=True)
 	articles = serializers.SerializerMethodField()
+	takeaways = serializers.SerializerMethodField()
+	summary_plain_english = serializers.SerializerMethodField()
+
+	# Omit these fields from the response when there is no organisation context
+	_per_org_fields = ['takeaways', 'summary_plain_english']
 
 	class Meta:
 		model = Trials
@@ -321,15 +351,36 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 			'intervention', 'primary_outcome', 'secondary_outcome', 'secondary_id',
 			'source_support', 'ethics_review_status', 'ethics_review_approval_date',
 			'ethics_review_contact_name', 'ethics_review_contact_address', 'ethics_review_contact_phone',
-			'ethics_review_contact_email', 'results_date_completed', 'results_url_link', 'articles'
+			'ethics_review_contact_email', 'results_date_completed', 'results_url_link',
+			'takeaways', 'articles'
 		]
 		read_only_fields = ('discovery_date', 'articles')
-		
+
 	def get_articles(self, obj):
 		"""Get articles that reference this trial"""
 		references = ArticleTrialReference.objects.filter(trial=obj)
 		articles = [ref.article for ref in references]
 		return ArticleReferenceSerializer(articles, many=True).data
+
+	def get_takeaways(self, obj):
+		"""Return takeaways from TrialOrgContent for the caller's org, or None."""
+		org = _resolve_per_org_fields_org(self.context.get('request'))
+		if org is None:
+			return None  # field will be popped in to_representation
+		try:
+			return obj.org_contents.get(organization=org).takeaways
+		except Exception:
+			return None
+
+	def get_summary_plain_english(self, obj):
+		"""Return plain-English summary from TrialOrgContent for the caller's org, or None."""
+		org = _resolve_per_org_fields_org(self.context.get('request'))
+		if org is None:
+			return None  # field will be popped in to_representation
+		try:
+			return obj.org_contents.get(organization=org).summary_plain_english
+		except Exception:
+			return None
 
 class SourceSerializer(serializers.HyperlinkedModelSerializer):
 	class Meta:

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -49,39 +49,54 @@ Resolution order (spec §6):
 """
 
 
+# Sentinel for "not yet cached" — distinct from None ("no org").
+_ORG_CACHE_MISSING = object()
+_ORG_CACHE_ATTR = '_per_org_fields_org_cache'
+
+
 def _resolve_per_org_fields_org(request):
 	"""Return the Organisation whose per-org content should be exposed, or None.
 
 	See mixin docstring for the full resolution order.  Returns None when there
 	is no organisation context, which tells the caller to omit per-org fields.
+
+	The result is cached on the request object so the team/api_settings DB
+	lookup is issued at most once per request, regardless of how many objects
+	the serializer processes.
 	"""
 	if request is None:
 		return None
+
+	cached = getattr(request, _ORG_CACHE_ATTR, _ORG_CACHE_MISSING)
+	if cached is not _ORG_CACHE_MISSING:
+		return cached
+
+	org = None
 
 	# 1. API key path (set by ApiKeyMiddleware as a SimpleLazyObject)
 	scheme = getattr(request, 'api_access_scheme', None)
 	if scheme is not None:
 		org = getattr(scheme, 'organization', None)
-		if org is not None:
-			return org
 
 	# 2. Public org via ?team_id filter
-	team_id = request.GET.get('team_id')
-	if team_id:
-		try:
-			from gregory.models import Team
-			team = (
-				Team.objects
-				.select_related('organization__api_settings')
-				.get(pk=int(team_id))
-			)
-			api_settings = getattr(team.organization, 'api_settings', None)
-			if api_settings and api_settings.make_api_public:
-				return team.organization
-		except Exception:
-			pass
+	if org is None:
+		team_id = request.GET.get('team_id')
+		if team_id:
+			try:
+				from gregory.models import Team
+				team = (
+					Team.objects
+					.select_related('organization__api_settings')
+					.get(pk=int(team_id))
+				)
+				api_settings = getattr(team.organization, 'api_settings', None)
+				if api_settings and api_settings.make_api_public:
+					org = team.organization
+			except Exception:
+				pass
 
-	return None
+	setattr(request, _ORG_CACHE_ATTR, org)
+	return org
 
 
 def _request_visible_team_ids(request, visible_org_ids: set) -> set:

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -33,7 +33,55 @@ Query strategy (avoiding N+1 on list endpoints)
   ``request._org_scoped_mixin_subject_ids``.  Filtering is done entirely on
   ``ret['ml_predictions']`` — no extra DB query, no dependency on whether
   ``ml_predictions_detail`` was prefetched.
+
+Per-org fields (``_per_org_fields``)
+-------------------------------------
+Subclasses may declare a list of field names that should only appear in
+the response when an organisation context is available.  When no org can
+be resolved (anonymous request, no public-org filter), those keys are
+removed from the serialised output entirely — not just set to ``null``.
+
+Resolution order (spec §6):
+  1. Valid API key on the request → that key's organisation.
+  2. ``?team_id=<id>`` query-param on a request where that team's org has
+     ``OrganizationApiSettings.make_api_public=True`` → that organisation.
+  3. Otherwise → no org, per-org fields omitted.
 """
+
+
+def _resolve_per_org_fields_org(request):
+	"""Return the Organisation whose per-org content should be exposed, or None.
+
+	See mixin docstring for the full resolution order.  Returns None when there
+	is no organisation context, which tells the caller to omit per-org fields.
+	"""
+	if request is None:
+		return None
+
+	# 1. API key path (set by ApiKeyMiddleware as a SimpleLazyObject)
+	scheme = getattr(request, 'api_access_scheme', None)
+	if scheme is not None:
+		org = getattr(scheme, 'organization', None)
+		if org is not None:
+			return org
+
+	# 2. Public org via ?team_id filter
+	team_id = request.GET.get('team_id')
+	if team_id:
+		try:
+			from gregory.models import Team
+			team = (
+				Team.objects
+				.select_related('organization__api_settings')
+				.get(pk=int(team_id))
+			)
+			api_settings = getattr(team.organization, 'api_settings', None)
+			if api_settings and api_settings.make_api_public:
+				return team.organization
+		except Exception:
+			pass
+
+	return None
 
 
 def _request_visible_team_ids(request, visible_org_ids: set) -> set:
@@ -81,12 +129,26 @@ class OrgScopedSerializerMixin:
 	    class ArticleSerializer(OrgScopedSerializerMixin,
 	                            serializers.HyperlinkedModelSerializer):
 	        ...
+
+	Set ``_per_org_fields`` to a list of field names that should be omitted
+	entirely when there is no organisation context (spec §6.2).
 	"""
+
+	#: Field names to omit from the response when no org context is available.
+	_per_org_fields: list = []
 
 	def to_representation(self, instance):
 		ret = super().to_representation(instance)
 
 		request = self.context.get('request')
+
+		# ---- Per-org field omission (spec §6.2) ----------------------------
+		if self._per_org_fields:
+			org = _resolve_per_org_fields_org(request)
+			if org is None:
+				for field in self._per_org_fields:
+					ret.pop(field, None)
+
 		if request is None or not hasattr(request, 'visible_org_ids'):
 			return ret
 

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -82,18 +82,20 @@ def _resolve_per_org_fields_org(request):
 	if org is None:
 		team_id = request.GET.get('team_id')
 		if team_id:
+			from gregory.models import Team
 			try:
-				from gregory.models import Team
 				team = (
 					Team.objects
 					.select_related('organization__api_settings')
 					.get(pk=int(team_id))
 				)
+			except (ValueError, TypeError, Team.DoesNotExist):
+				# Bad/unknown team_id — treat as "no org context".
+				team = None
+			if team is not None:
 				api_settings = getattr(team.organization, 'api_settings', None)
 				if api_settings and api_settings.make_api_public:
 					org = team.organization
-			except Exception:
-				pass
 
 	setattr(request, _ORG_CACHE_ATTR, org)
 	return org

--- a/django/api/tests/test_edit_article.py
+++ b/django/api/tests/test_edit_article.py
@@ -1,0 +1,314 @@
+"""
+Tests for POST /articles/edit/
+
+Covers spec §10.1:
+  - Successful upsert (no prior ArticleOrgContent row)
+  - Successful update of existing ArticleOrgContent
+  - Per-article fields (access, retracted, kind) persist on Articles
+  - Article not found by DOI → 404
+  - Multiple articles match DOI → 409 DuplicateArticleError with ids; no write
+  - Article belongs to different org → 403 CrossOrgPayloadError
+  - Invalid access / kind values → 400
+  - Missing API key → 401
+  - API key without org → 403
+  - Failed edits create APIAccessSchemeLog row with correct http_code
+  - Empty string takeaways clears the field (saved as NULL)
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_edit_article
+"""
+import json
+from datetime import timedelta
+
+from django.test import TestCase, Client
+from django.utils.timezone import now
+from organizations.models import Organization
+
+from api.models import APIAccessScheme, APIAccessSchemeLog
+from gregory.models import (
+	Articles, ArticleOrgContent, Sources, Team, Subject,
+	OrganizationApiSettings,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers (duplicated from test_post_article_org_scoping pattern)
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug=''):
+	slug = slug or name.lower().replace(' ', '-')
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=False)
+	return org
+
+
+def _make_team(org, name):
+	return Team.objects.create(organization=org, name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_source(team, subject, name):
+	return Sources.objects.create(
+		name=name,
+		link=f'https://src.example.com/{name}',
+		team=team,
+		subject=subject,
+		source_for='science paper',
+	)
+
+
+def _make_scheme(org, name, ip_addresses=''):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses=ip_addresses,
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+def _make_article(team, doi='10.1234/test', title='Test Article'):
+	article = Articles.objects.create(
+		title=title,
+		link=f'https://example.com/{doi}',
+		doi=doi,
+	)
+	article.teams.add(team)
+	return article
+
+
+def _edit(client, api_key, payload):
+	body = json.dumps(payload).encode()
+	headers = {'HTTP_AUTHORIZATION': api_key} if api_key else {}
+	return client.post(
+		'/articles/edit/',
+		data=body,
+		content_type='application/json',
+		**headers,
+	)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class EditArticleOrgContentTest(TestCase):
+	"""Per-org fields (takeaways, summary_plain_english)."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Org A')
+		self.team = _make_team(self.org, 'Team A')
+		self.subject = _make_subject(self.team, 'Subject A')
+		self.scheme = _make_scheme(self.org, 'key-a')
+		self.article = _make_article(self.team, doi='10.1111/upsert')
+
+	def test_upsert_creates_new_row(self):
+		"""No prior ArticleOrgContent → row is created."""
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.1111/upsert',
+			'takeaways': 'First takeaway',
+		})
+		self.assertEqual(resp.status_code, 200)
+		data = resp.json()
+		self.assertIn('takeaways', data['updated_fields'])
+		content = ArticleOrgContent.objects.get(article=self.article, organization=self.org)
+		self.assertEqual(content.takeaways, 'First takeaway')
+
+	def test_upsert_updates_existing_row(self):
+		"""Existing ArticleOrgContent row is updated in place."""
+		ArticleOrgContent.objects.create(
+			article=self.article, organization=self.org, takeaways='Old value'
+		)
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.1111/upsert',
+			'takeaways': 'New value',
+		})
+		self.assertEqual(resp.status_code, 200)
+		content = ArticleOrgContent.objects.get(article=self.article, organization=self.org)
+		self.assertEqual(content.takeaways, 'New value')
+		self.assertEqual(ArticleOrgContent.objects.filter(article=self.article, organization=self.org).count(), 1)
+
+	def test_empty_string_clears_takeaways(self):
+		"""Empty string takeaways is stored as NULL."""
+		ArticleOrgContent.objects.create(
+			article=self.article, organization=self.org, takeaways='Something'
+		)
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.1111/upsert',
+			'takeaways': '',
+		})
+		self.assertEqual(resp.status_code, 200)
+		content = ArticleOrgContent.objects.get(article=self.article, organization=self.org)
+		self.assertIsNone(content.takeaways)
+
+	def test_omitted_field_not_changed(self):
+		"""Fields absent from the payload are not modified."""
+		ArticleOrgContent.objects.create(
+			article=self.article, organization=self.org, takeaways='Keep me'
+		)
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.1111/upsert',
+			'summary_plain_english': 'A summary',
+		})
+		self.assertEqual(resp.status_code, 200)
+		content = ArticleOrgContent.objects.get(article=self.article, organization=self.org)
+		self.assertEqual(content.takeaways, 'Keep me')
+		self.assertEqual(content.summary_plain_english, 'A summary')
+
+
+class EditArticlePerArticleFieldsTest(TestCase):
+	"""Per-article fields (access, retracted, kind)."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Org B')
+		self.team = _make_team(self.org, 'Team B')
+		self.scheme = _make_scheme(self.org, 'key-b')
+		self.article = _make_article(self.team, doi='10.2222/fields')
+
+	def test_access_persists(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.2222/fields',
+			'access': 'open',
+		})
+		self.assertEqual(resp.status_code, 200)
+		self.article.refresh_from_db()
+		self.assertEqual(self.article.access, 'open')
+
+	def test_retracted_persists(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.2222/fields',
+			'retracted': True,
+		})
+		self.assertEqual(resp.status_code, 200)
+		self.article.refresh_from_db()
+		self.assertTrue(self.article.retracted)
+
+	def test_kind_persists(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.2222/fields',
+			'kind': 'news article',
+		})
+		self.assertEqual(resp.status_code, 200)
+		self.article.refresh_from_db()
+		self.assertEqual(self.article.kind, 'news article')
+
+	def test_invalid_access_returns_400(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.2222/fields',
+			'access': 'INVALID',
+		})
+		self.assertEqual(resp.status_code, 400)
+
+	def test_invalid_kind_returns_400(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.2222/fields',
+			'kind': 'not-a-kind',
+		})
+		self.assertEqual(resp.status_code, 400)
+
+	def test_retracted_non_bool_returns_400(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.2222/fields',
+			'retracted': 'yes',
+		})
+		self.assertEqual(resp.status_code, 400)
+
+
+class EditArticleErrorsTest(TestCase):
+	"""Error paths: 401, 403, 404, 409."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Org C')
+		self.other_org = _make_org('Org D', 'org-d')
+		self.team = _make_team(self.org, 'Team C')
+		self.other_team = _make_team(self.other_org, 'Team D')
+		self.scheme = _make_scheme(self.org, 'key-c')
+		self.scheme_no_org = APIAccessScheme.objects.create(
+			client_name='no-org',
+			client_contacts='noorg@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.article = _make_article(self.team, doi='10.3333/errors')
+
+	def test_missing_api_key_returns_401(self):
+		resp = _edit(self.client, None, {'doi': '10.3333/errors'})
+		self.assertEqual(resp.status_code, 401)
+
+	def test_invalid_api_key_returns_401(self):
+		resp = _edit(self.client, 'not-a-real-key', {'doi': '10.3333/errors'})
+		self.assertEqual(resp.status_code, 401)
+
+	def test_key_without_org_returns_403(self):
+		resp = _edit(self.client, self.scheme_no_org.api_key, {'doi': '10.3333/errors'})
+		self.assertEqual(resp.status_code, 403)
+
+	def test_article_not_found_returns_404(self):
+		resp = _edit(self.client, self.scheme.api_key, {'doi': '10.9999/nonexistent'})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_duplicate_doi_returns_409_with_ids(self):
+		# Create a second article with the same DOI
+		duplicate = Articles.objects.create(
+			title='Duplicate', link='https://example.com/dup2', doi='10.3333/errors'
+		)
+		duplicate.teams.add(self.team)
+		resp = _edit(self.client, self.scheme.api_key, {'doi': '10.3333/errors'})
+		self.assertEqual(resp.status_code, 409)
+		data = resp.json()
+		self.assertIn('article_ids', data['data'])
+		self.assertIn(self.article.article_id, data['data']['article_ids'])
+		self.assertIn(duplicate.article_id, data['data']['article_ids'])
+		# No writes should have occurred
+		self.assertEqual(ArticleOrgContent.objects.count(), 0)
+
+	def test_cross_org_article_returns_403(self):
+		"""Article belongs to other_org only → 403."""
+		other_article = _make_article(self.other_team, doi='10.4444/other')
+		resp = _edit(self.client, self.scheme.api_key, {
+			'doi': '10.4444/other',
+			'takeaways': 'Should not be written',
+		})
+		self.assertEqual(resp.status_code, 403)
+		self.assertEqual(ArticleOrgContent.objects.count(), 0)
+
+
+class EditArticleAuditLogTest(TestCase):
+	"""APIAccessSchemeLog rows are created on success and on error."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Org E')
+		self.team = _make_team(self.org, 'Team E')
+		self.scheme = _make_scheme(self.org, 'key-e')
+		self.article = _make_article(self.team, doi='10.5555/log')
+
+	def test_success_creates_log_with_200(self):
+		_edit(self.client, self.scheme.api_key, {
+			'doi': '10.5555/log',
+			'takeaways': 'logged',
+		})
+		log = APIAccessSchemeLog.objects.filter(api_access_scheme=self.scheme).latest('access_date')
+		self.assertEqual(log.http_code, 200)
+
+	def test_404_creates_log(self):
+		_edit(self.client, self.scheme.api_key, {'doi': '10.9999/no'})
+		log = APIAccessSchemeLog.objects.filter(api_access_scheme=self.scheme).latest('access_date')
+		self.assertEqual(log.http_code, 404)
+
+	def test_403_cross_org_creates_log(self):
+		other_org = _make_org('Org F', 'org-f')
+		other_team = _make_team(other_org, 'Team F')
+		_make_article(other_team, doi='10.6666/forbidden')
+		_edit(self.client, self.scheme.api_key, {'doi': '10.6666/forbidden'})
+		log = APIAccessSchemeLog.objects.filter(api_access_scheme=self.scheme).latest('access_date')
+		self.assertEqual(log.http_code, 403)

--- a/django/api/tests/test_edit_trial.py
+++ b/django/api/tests/test_edit_trial.py
@@ -1,0 +1,243 @@
+"""
+Tests for POST /trials/edit/
+
+Covers spec §10.2:
+  - Successful upsert (no prior TrialOrgContent row)
+  - Successful update of existing TrialOrgContent
+  - Trial not found by identifiers → 404
+  - Multiple trials match identifiers → 409 DuplicateTrialError with ids; no write
+  - Trial belongs to different org → 403 CrossOrgPayloadError
+  - Missing identifiers field → 400
+  - Missing API key → 401
+  - API key without org → 403
+  - Failed edits create APIAccessSchemeLog row with correct http_code
+  - Empty string takeaways clears the field (saved as NULL)
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_edit_trial
+"""
+import json
+from datetime import timedelta
+
+from django.test import TestCase, Client
+from django.utils.timezone import now
+from organizations.models import Organization
+
+from api.models import APIAccessScheme, APIAccessSchemeLog
+from gregory.models import (
+	Trials, TrialOrgContent, Team, Subject, OrganizationApiSettings,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug=''):
+	slug = slug or name.lower().replace(' ', '-')
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=False)
+	return org
+
+
+def _make_team(org, name):
+	return Team.objects.create(organization=org, name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_scheme(org, name, ip_addresses=''):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses=ip_addresses,
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+def _make_trial(team, nct, title='Test Trial'):
+	trial = Trials.objects.create(
+		title=title,
+		link=f'https://example.com/{nct}',
+		identifiers={'nct': nct},
+	)
+	trial.teams.add(team)
+	return trial
+
+
+def _edit(client, api_key, payload):
+	body = json.dumps(payload).encode()
+	headers = {'HTTP_AUTHORIZATION': api_key} if api_key else {}
+	return client.post(
+		'/trials/edit/',
+		data=body,
+		content_type='application/json',
+		**headers,
+	)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class EditTrialOrgContentTest(TestCase):
+	"""Per-org fields (takeaways, summary_plain_english)."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Trial Org A')
+		self.team = _make_team(self.org, 'Trial Team A')
+		self.scheme = _make_scheme(self.org, 'trial-key-a')
+		self.trial = _make_trial(self.team, 'NCT0000001')
+
+	def test_upsert_creates_new_row(self):
+		"""No prior TrialOrgContent → row is created."""
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000001'},
+			'takeaways': 'Trial takeaway',
+		})
+		self.assertEqual(resp.status_code, 200)
+		data = resp.json()
+		self.assertIn('takeaways', data['updated_fields'])
+		content = TrialOrgContent.objects.get(trial=self.trial, organization=self.org)
+		self.assertEqual(content.takeaways, 'Trial takeaway')
+
+	def test_upsert_updates_existing_row(self):
+		"""Existing TrialOrgContent row is updated in place."""
+		TrialOrgContent.objects.create(
+			trial=self.trial, organization=self.org, takeaways='Old'
+		)
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000001'},
+			'takeaways': 'Updated',
+		})
+		self.assertEqual(resp.status_code, 200)
+		content = TrialOrgContent.objects.get(trial=self.trial, organization=self.org)
+		self.assertEqual(content.takeaways, 'Updated')
+		self.assertEqual(TrialOrgContent.objects.filter(trial=self.trial, organization=self.org).count(), 1)
+
+	def test_empty_string_clears_takeaways(self):
+		"""Empty string is stored as NULL."""
+		TrialOrgContent.objects.create(
+			trial=self.trial, organization=self.org, takeaways='Something'
+		)
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000001'},
+			'takeaways': '',
+		})
+		self.assertEqual(resp.status_code, 200)
+		content = TrialOrgContent.objects.get(trial=self.trial, organization=self.org)
+		self.assertIsNone(content.takeaways)
+
+	def test_summary_plain_english_persists(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000001'},
+			'summary_plain_english': 'Plain summary',
+		})
+		self.assertEqual(resp.status_code, 200)
+		content = TrialOrgContent.objects.get(trial=self.trial, organization=self.org)
+		self.assertEqual(content.summary_plain_english, 'Plain summary')
+
+
+class EditTrialErrorsTest(TestCase):
+	"""Error paths: 401, 403, 404, 409."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Trial Org B')
+		self.other_org = _make_org('Trial Org C', 'trial-org-c')
+		self.team = _make_team(self.org, 'Trial Team B')
+		self.other_team = _make_team(self.other_org, 'Trial Team C')
+		self.scheme = _make_scheme(self.org, 'trial-key-b')
+		self.scheme_no_org = APIAccessScheme.objects.create(
+			client_name='no-org-trial',
+			client_contacts='noorg@example.com',
+			organization=None,
+			ip_addresses='',
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.trial = _make_trial(self.team, 'NCT0000002')
+
+	def test_missing_api_key_returns_401(self):
+		resp = _edit(self.client, None, {'identifiers': {'nct': 'NCT0000002'}})
+		self.assertEqual(resp.status_code, 401)
+
+	def test_invalid_api_key_returns_401(self):
+		resp = _edit(self.client, 'bad-key', {'identifiers': {'nct': 'NCT0000002'}})
+		self.assertEqual(resp.status_code, 401)
+
+	def test_key_without_org_returns_403(self):
+		resp = _edit(self.client, self.scheme_no_org.api_key, {
+			'identifiers': {'nct': 'NCT0000002'},
+		})
+		self.assertEqual(resp.status_code, 403)
+
+	def test_missing_identifiers_returns_400(self):
+		resp = _edit(self.client, self.scheme.api_key, {'takeaways': 'No id'})
+		self.assertEqual(resp.status_code, 400)
+
+	def test_trial_not_found_returns_404(self):
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT9999999'},
+		})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_duplicate_nct_returns_409_with_ids(self):
+		"""Two trials with same NCT id → 409 with both ids."""
+		dup = Trials.objects.create(
+			title='Duplicate Trial',
+			link='https://example.com/dup-trial',
+			identifiers={'nct': 'NCT0000002'},
+		)
+		dup.teams.add(self.team)
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000002'},
+		})
+		self.assertEqual(resp.status_code, 409)
+		data = resp.json()
+		self.assertIn('trial_ids', data['data'])
+		self.assertIn(self.trial.trial_id, data['data']['trial_ids'])
+		self.assertIn(dup.trial_id, data['data']['trial_ids'])
+		self.assertEqual(TrialOrgContent.objects.count(), 0)
+
+	def test_cross_org_trial_returns_403(self):
+		"""Trial belongs to other_org only → 403."""
+		other_trial = _make_trial(self.other_team, 'NCT0000099', 'Other Org Trial')
+		resp = _edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000099'},
+			'takeaways': 'Should not write',
+		})
+		self.assertEqual(resp.status_code, 403)
+		self.assertEqual(TrialOrgContent.objects.count(), 0)
+
+
+class EditTrialAuditLogTest(TestCase):
+	"""APIAccessSchemeLog rows created on success and error."""
+
+	def setUp(self):
+		self.client = Client()
+		self.org = _make_org('Trial Org D')
+		self.team = _make_team(self.org, 'Trial Team D')
+		self.scheme = _make_scheme(self.org, 'trial-key-d')
+		self.trial = _make_trial(self.team, 'NCT0000010')
+
+	def test_success_creates_log_with_200(self):
+		_edit(self.client, self.scheme.api_key, {
+			'identifiers': {'nct': 'NCT0000010'},
+			'takeaways': 'logged',
+		})
+		log = APIAccessSchemeLog.objects.filter(api_access_scheme=self.scheme).latest('access_date')
+		self.assertEqual(log.http_code, 200)
+
+	def test_404_creates_log(self):
+		_edit(self.client, self.scheme.api_key, {'identifiers': {'nct': 'NCT9999999'}})
+		log = APIAccessSchemeLog.objects.filter(api_access_scheme=self.scheme).latest('access_date')
+		self.assertEqual(log.http_code, 404)
+
+	def test_403_cross_org_creates_log(self):
+		other_org = _make_org('Trial Org E', 'trial-org-e')
+		other_team = _make_team(other_org, 'Trial Team E')
+		_make_trial(other_team, 'NCT0000088', 'Other Org Trial E')
+		_edit(self.client, self.scheme.api_key, {'identifiers': {'nct': 'NCT0000088'}})
+		log = APIAccessSchemeLog.objects.filter(api_access_scheme=self.scheme).latest('access_date')
+		self.assertEqual(log.http_code, 403)

--- a/django/api/tests/test_read_serialization.py
+++ b/django/api/tests/test_read_serialization.py
@@ -1,0 +1,217 @@
+"""
+Tests for org-scoped takeaways read serialization.
+
+These tests verify Phase 4 behaviour (ArticleSerializer.get_takeaways and
+get_summary_plain_english methods on OrgScopedSerializerMixin).  They will
+FAIL until the phase-4-serializers branch is merged into api-improvements.
+
+Covers spec §10.3:
+  - With API key for Org A: takeaways resolves to Org A's ArticleOrgContent
+  - With API key for Org A, no Org A content exists: takeaways is null
+  - Anonymous (no API key): takeaways field is absent from response
+  - Public-org ?team_id path: takeaways present if make_api_public=True
+  - Two orgs editing same article: each sees its own takeaways
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_read_serialization
+"""
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import (
+	Articles, ArticleOrgContent, Team, Subject,
+	OrganizationApiSettings,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug='', public=False):
+	slug = slug or name.lower().replace(' ', '-')
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=public)
+	return org
+
+
+def _make_team(org, name):
+	return Team.objects.create(organization=org, name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_subject(team, name):
+	from django.utils.text import slugify
+	return Subject.objects.create(team=team, subject_name=name, subject_slug=slugify(name))
+
+
+def _make_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+def _make_article(team, title='Test Article', link='https://example.com/art1'):
+	article = Articles.objects.create(title=title, link=link)
+	article.teams.add(team)
+	return article
+
+
+def _api_get(client, path, api_key=None):
+	headers = {}
+	if api_key:
+		headers['HTTP_AUTHORIZATION'] = api_key
+	return client.get(path, **headers)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TakeawaysReadWithApiKeyTest(TestCase):
+	"""
+	Org-A API key → response contains takeaways from ArticleOrgContent (Phase 4).
+	"""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org = _make_org('Read Org A')
+		self.team = _make_team(self.org, 'Read Team A')
+		self.scheme = _make_scheme(self.org, 'read-key-a')
+		self.article = _make_article(self.team)
+
+	def test_takeaways_from_org_content_when_key_present(self):
+		"""API key for Org A → takeaways resolves to ArticleOrgContent for Org A."""
+		ArticleOrgContent.objects.create(
+			article=self.article,
+			organization=self.org,
+			takeaways='My org takeaway',
+		)
+		resp = _api_get(self.client, '/articles/', self.scheme.api_key)
+		self.assertEqual(resp.status_code, 200)
+		results = resp.data['results']
+		article_data = next(a for a in results if a['article_id'] == self.article.article_id)
+		self.assertEqual(article_data['takeaways'], 'My org takeaway')
+
+	def test_takeaways_null_when_no_org_content(self):
+		"""API key for Org A, no ArticleOrgContent row → takeaways is null."""
+		resp = _api_get(self.client, '/articles/', self.scheme.api_key)
+		self.assertEqual(resp.status_code, 200)
+		results = resp.data['results']
+		article_data = next(a for a in results if a['article_id'] == self.article.article_id)
+		self.assertIsNone(article_data.get('takeaways'))
+
+	def test_detail_endpoint_takeaways(self):
+		"""Detail endpoint also returns org-scoped takeaways."""
+		ArticleOrgContent.objects.create(
+			article=self.article,
+			organization=self.org,
+			takeaways='Detail takeaway',
+		)
+		resp = _api_get(self.client, f'/articles/{self.article.article_id}/', self.scheme.api_key)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['takeaways'], 'Detail takeaway')
+
+
+class TakeawaysReadAnonymousTest(TestCase):
+	"""
+	Anonymous request → takeaways field absent from response (Phase 4).
+
+	Note: before Phase 4 merges, this test will FAIL because the field is
+	present (it reads Articles.takeaways directly).
+	"""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org = _make_org('Anon Org', public=True)
+		self.team = _make_team(self.org, 'Anon Team')
+		self.article = _make_article(self.team, title='Anon Article', link='https://example.com/anon')
+		ArticleOrgContent.objects.create(
+			article=self.article,
+			organization=self.org,
+			takeaways='Should not be visible anonymously',
+		)
+
+	def test_takeaways_absent_for_anonymous(self):
+		"""Anonymous request: takeaways should not appear in the response."""
+		resp = self.client.get('/articles/')
+		self.assertEqual(resp.status_code, 200)
+		results = resp.data['results']
+		anon_articles = [a for a in results if a['article_id'] == self.article.article_id]
+		self.assertEqual(len(anon_articles), 1)
+		self.assertNotIn('takeaways', anon_articles[0])
+
+
+class TakeawaysPublicOrgTeamIdTest(TestCase):
+	"""
+	?team_id of a make_api_public=True org → takeaways present.
+
+	Note: this test checks Phase 4 behaviour where _resolve_per_org_fields_org
+	falls back to the team's org when make_api_public=True.
+	"""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org = _make_org('Public Org TK', public=True)
+		self.team = _make_team(self.org, 'Public Team TK')
+		self.article = _make_article(self.team, title='Public TK Article', link='https://example.com/pbtk')
+		ArticleOrgContent.objects.create(
+			article=self.article,
+			organization=self.org,
+			takeaways='Public org takeaway',
+		)
+
+	def test_takeaways_present_for_public_org_via_team_id(self):
+		resp = self.client.get(f'/articles/?team_id={self.team.id}')
+		self.assertEqual(resp.status_code, 200)
+		results = resp.data['results']
+		article_data = next((a for a in results if a['article_id'] == self.article.article_id), None)
+		self.assertIsNotNone(article_data)
+		self.assertEqual(article_data.get('takeaways'), 'Public org takeaway')
+
+
+class TakeawaysTwoOrgsTest(TestCase):
+	"""
+	Two orgs each have ArticleOrgContent for the same article.
+	Each should see only its own takeaways.
+	"""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org_a = _make_org('Dual Org A')
+		self.org_b = _make_org('Dual Org B', 'dual-org-b')
+		self.team_a = _make_team(self.org_a, 'Dual Team A')
+		self.team_b = _make_team(self.org_b, 'Dual Team B')
+		self.scheme_a = _make_scheme(self.org_a, 'dual-key-a')
+		self.scheme_b = _make_scheme(self.org_b, 'dual-key-b')
+		# Article shared across both orgs
+		self.article = Articles.objects.create(
+			title='Shared Article',
+			link='https://example.com/shared',
+		)
+		self.article.teams.add(self.team_a, self.team_b)
+		ArticleOrgContent.objects.create(
+			article=self.article, organization=self.org_a, takeaways='Org A takeaway'
+		)
+		ArticleOrgContent.objects.create(
+			article=self.article, organization=self.org_b, takeaways='Org B takeaway'
+		)
+
+	def test_org_a_sees_own_takeaway(self):
+		resp = _api_get(self.client, f'/articles/{self.article.article_id}/', self.scheme_a.api_key)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['takeaways'], 'Org A takeaway')
+
+	def test_org_b_sees_own_takeaway(self):
+		resp = _api_get(self.client, f'/articles/{self.article.article_id}/', self.scheme_b.api_key)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['takeaways'], 'Org B takeaway')

--- a/django/api/tests/test_read_serialization.py
+++ b/django/api/tests/test_read_serialization.py
@@ -1,9 +1,8 @@
 """
 Tests for org-scoped takeaways read serialization.
 
-These tests verify Phase 4 behaviour (ArticleSerializer.get_takeaways and
-get_summary_plain_english methods on OrgScopedSerializerMixin).  They will
-FAIL until the phase-4-serializers branch is merged into api-improvements.
+Verify ``ArticleSerializer.get_takeaways`` / ``get_summary_plain_english``
+and the omission behaviour added by ``OrgScopedSerializerMixin``.
 
 Covers spec §10.3:
   - With API key for Org A: takeaways resolves to Org A's ArticleOrgContent
@@ -123,12 +122,7 @@ class TakeawaysReadWithApiKeyTest(TestCase):
 
 
 class TakeawaysReadAnonymousTest(TestCase):
-	"""
-	Anonymous request → takeaways field absent from response (Phase 4).
-
-	Note: before Phase 4 merges, this test will FAIL because the field is
-	present (it reads Articles.takeaways directly).
-	"""
+	"""Anonymous request → takeaways field absent from response."""
 
 	def setUp(self):
 		self.client = APIClient()

--- a/django/api/tests/test_viewset_lockdown.py
+++ b/django/api/tests/test_viewset_lockdown.py
@@ -1,0 +1,216 @@
+"""
+Tests for viewset lockdown (Phase 5) — all write methods must return 405.
+
+These tests verify that ArticleViewSet and other viewsets only allow
+GET/HEAD/OPTIONS after switching to ReadOnlyModelViewSet.
+
+They will FAIL until phase-5-lock-viewsets is merged (currently viewsets
+use ModelViewSet which allows PATCH/PUT/DELETE).
+
+Covers spec §10.4:
+  - PATCH /articles/<id>/ → 405
+  - PUT /articles/<id>/ → 405
+  - DELETE /articles/<id>/ → 405
+  - POST /articles/ → 405
+  - Same matrix for /trials/, /authors/, /sources/, /subjects/, /categories/, /teams/
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_viewset_lockdown
+"""
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from gregory.models import (
+	Articles, Trials, Authors, Sources, Team, Subject,
+	OrganizationApiSettings,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug=''):
+	slug = slug or name.lower().replace(' ', '-')
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=True)
+	return org
+
+
+def _make_team(org, name):
+	return Team.objects.create(organization=org, name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_scheme(org, name):
+	return APIAccessScheme.objects.create(
+		client_name=name,
+		client_contacts=f'{name}@example.com',
+		organization=org,
+		ip_addresses='',
+		begin_date=now() - timedelta(days=1),
+		end_date=now() + timedelta(days=30),
+	)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class ArticleViewSetLockdownTest(TestCase):
+	"""
+	PATCH/PUT/DELETE/POST on /articles/ must return 405 Method Not Allowed
+	after Phase 5 switches ArticleViewSet to ReadOnlyModelViewSet.
+	"""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org = _make_org('Lockdown Org')
+		self.team = _make_team(self.org, 'Lockdown Team')
+		self.scheme = _make_scheme(self.org, 'lockdown-key')
+		self.article = Articles.objects.create(
+			title='Lockdown Article',
+			link='https://example.com/lock',
+		)
+		self.article.teams.add(self.team)
+
+	def _auth_headers(self):
+		return {'HTTP_AUTHORIZATION': self.scheme.api_key}
+
+	def test_patch_returns_405(self):
+		resp = self.client.patch(
+			f'/articles/{self.article.article_id}/',
+			data={'title': 'Patched'},
+			format='json',
+			**self._auth_headers(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_put_returns_405(self):
+		resp = self.client.put(
+			f'/articles/{self.article.article_id}/',
+			data={'title': 'Put', 'link': 'https://example.com/put'},
+			format='json',
+			**self._auth_headers(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_delete_returns_405(self):
+		resp = self.client.delete(
+			f'/articles/{self.article.article_id}/',
+			**self._auth_headers(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_post_returns_405(self):
+		resp = self.client.post(
+			'/articles/',
+			data={'title': 'New', 'link': 'https://example.com/new'},
+			format='json',
+			**self._auth_headers(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+
+class TrialViewSetLockdownTest(TestCase):
+	"""PATCH /trials/<id>/ must return 405 after Phase 5."""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org = _make_org('Trial Lockdown Org')
+		self.team = _make_team(self.org, 'Trial Lockdown Team')
+		self.scheme = _make_scheme(self.org, 'trial-lockdown-key')
+		self.trial = Trials.objects.create(
+			title='Lockdown Trial',
+			link='https://example.com/trial-lock',
+			identifiers={'nct': 'NCT9999998'},
+		)
+		self.trial.teams.add(self.team)
+
+	def test_patch_returns_405(self):
+		resp = self.client.patch(
+			f'/trials/{self.trial.trial_id}/',
+			data={'title': 'Patched'},
+			format='json',
+			HTTP_AUTHORIZATION=self.scheme.api_key,
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_delete_returns_405(self):
+		resp = self.client.delete(
+			f'/trials/{self.trial.trial_id}/',
+			HTTP_AUTHORIZATION=self.scheme.api_key,
+		)
+		self.assertEqual(resp.status_code, 405)
+
+
+class OtherViewSetsLockdownTest(TestCase):
+	"""
+	Smoke-tests: PATCH on /authors/, /sources/, /subjects/, /teams/, /categories/
+	must all return 405 after Phase 5.
+	"""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org = _make_org('Other Lockdown Org')
+		self.team = _make_team(self.org, 'Other Lockdown Team')
+		self.scheme = _make_scheme(self.org, 'other-lockdown-key')
+		from django.utils.text import slugify
+		self.subject = Subject.objects.create(
+			team=self.team,
+			subject_name='Lockdown Subject',
+			subject_slug='lockdown-subject',
+		)
+		self.source = Sources.objects.create(
+			name='Lockdown Source',
+			link='https://src.example.com/lock',
+			team=self.team,
+			subject=self.subject,
+		)
+		self.author = Authors.objects.create(
+			given_name='Test',
+			family_name='Author',
+		)
+
+	def _auth(self):
+		return {'HTTP_AUTHORIZATION': self.scheme.api_key}
+
+	def test_patch_authors_returns_405(self):
+		resp = self.client.patch(
+			f'/authors/{self.author.author_id}/',
+			data={'given_name': 'Changed'},
+			format='json',
+			**self._auth(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_patch_sources_returns_405(self):
+		resp = self.client.patch(
+			f'/sources/{self.source.source_id}/',
+			data={'name': 'Changed'},
+			format='json',
+			**self._auth(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_patch_subjects_returns_405(self):
+		resp = self.client.patch(
+			f'/subjects/{self.subject.id}/',
+			data={'subject_name': 'Changed'},
+			format='json',
+			**self._auth(),
+		)
+		self.assertEqual(resp.status_code, 405)
+
+	def test_patch_teams_returns_405(self):
+		resp = self.client.patch(
+			f'/teams/{self.team.id}/',
+			data={'name': 'Changed'},
+			format='json',
+			**self._auth(),
+		)
+		self.assertEqual(resp.status_code, 405)

--- a/django/api/tests/test_viewset_lockdown.py
+++ b/django/api/tests/test_viewset_lockdown.py
@@ -1,11 +1,8 @@
 """
-Tests for viewset lockdown (Phase 5) — all write methods must return 405.
+Tests for viewset lockdown — all write methods must return 405.
 
-These tests verify that ArticleViewSet and other viewsets only allow
-GET/HEAD/OPTIONS after switching to ReadOnlyModelViewSet.
-
-They will FAIL until phase-5-lock-viewsets is merged (currently viewsets
-use ModelViewSet which allows PATCH/PUT/DELETE).
+Verify that ArticleViewSet and the other API viewsets only allow
+GET/HEAD/OPTIONS now that they subclass ReadOnlyModelViewSet.
 
 Covers spec §10.4:
   - PATCH /articles/<id>/ → 405

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -667,6 +667,7 @@ class ArticleViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	- CSV export all results: `/articles/?format=csv&all_results=true`
 	- Complex filter: `/articles/?team_id=1&subject_id=4&author_id=123&search=regeneration&relevant=true&ml_threshold=0.8&ordering=-published_date`
 	"""
+	http_method_names = ['get', 'head', 'options']
 	queryset = Articles.objects.all().order_by('-discovery_date')
 	serializer_class = ArticleSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -772,6 +773,7 @@ class CategoryViewSet(viewsets.ModelViewSet):
 	- Single category with monthly counts: `GET /categories/?category_id=6&monthly_counts=true`
 	- Multiple categories by ID: `GET /categories/?get_categories=1,2,3`
 	"""
+	http_method_names = ['get', 'head', 'options']
 	serializer_class = CategorySerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 	filter_backends = [django_filters.DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
@@ -1029,6 +1031,7 @@ class TrialViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	- All trials as CSV: `/trials/?format=csv&all_results=true`
 	- Filtered trials: `/trials/?team_id=1&status=Recruiting&format=csv&all_results=true`
 	"""
+	http_method_names = ['get', 'head', 'options']
 	queryset = Trials.objects.all().order_by('-discovery_date')
 	serializer_class = TrialSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -1093,6 +1096,7 @@ class SourceViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	_org_filter_path = 'team__organization_id'
 	_org_filter_distinct = False
+	http_method_names = ['get', 'head', 'options']
 	queryset = Sources.objects.all().order_by('name')
 	serializer_class = SourceSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -1144,6 +1148,7 @@ class AuthorsViewSet(viewsets.ModelViewSet):
 	- Category with timeframe: `?team_id=1&category_slug=natalizumab&timeframe=year&sort_by=article_count`
 	- Date range: `?date_from=2024-06-01&date_to=2024-12-31&team_id=1&subject_id=1&sort_by=article_count`
 	"""
+	http_method_names = ['get', 'head', 'options']
 	serializer_class = AuthorSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 	filter_backends = [django_filters.DjangoFilterBackend, filters.SearchFilter]
@@ -1389,6 +1394,7 @@ class TeamsViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	_org_filter_path = 'organization_id'
 	_org_filter_distinct = False
+	http_method_names = ['get', 'head', 'options']
 	queryset = Team.objects.all().order_by('id')
 	serializer_class = TeamSerializer
 	permission_classes  = [permissions.IsAuthenticatedOrReadOnly]
@@ -1440,6 +1446,7 @@ class SubjectsViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	_org_filter_path = 'team__organization_id'
 	_org_filter_distinct = False
+	http_method_names = ['get', 'head', 'options']
 	queryset = Subject.objects.all().order_by('id')
 	serializer_class = SubjectsSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -23,6 +23,7 @@ import json
 import traceback
 from django.utils.dateparse import parse_date
 
+from api.serializers.mixins import _resolve_per_org_fields_org
 from api.utils.utils import checkValidAccess, getAPIKey, getIPAddress, find_trial_by_identifier
 from api.models import APIAccessSchemeLog
 from api.utils.exceptions import (
@@ -677,6 +678,26 @@ class ArticleViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 	ordering_fields = ['discovery_date', 'published_date', 'title', 'article_id']
 	ordering = ['-discovery_date']
 
+	def get_queryset(self):
+		"""Prefetch the caller-org's ArticleOrgContent to avoid N+1 on list responses.
+
+		When a request resolves to an organisation (API key or public-org
+		filter), attach the matching ``ArticleOrgContent`` rows as
+		``_prefetched_org_contents`` so the serializer can resolve per-org
+		fields without issuing one query per article.
+		"""
+		qs = super().get_queryset()
+		org = _resolve_per_org_fields_org(self.request)
+		if org is not None:
+			qs = qs.prefetch_related(
+				Prefetch(
+					'org_contents',
+					queryset=ArticleOrgContent.objects.filter(organization=org),
+					to_attr='_prefetched_org_contents',
+				)
+			)
+		return qs
+
 	def finalize_response(self, request, response, *args, **kwargs):
 		"""
 		Override to handle CSV streaming. If CSV format is requested, convert the response
@@ -1035,6 +1056,26 @@ class TrialViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 	pagination_class = FlexiblePagination
 	filter_backends = [django_filters.DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
 	filterset_class = TrialFilter
+
+	def get_queryset(self):
+		"""Prefetch the caller-org's TrialOrgContent to avoid N+1 on list responses.
+
+		When a request resolves to an organisation (API key or public-org
+		filter), attach the matching ``TrialOrgContent`` rows as
+		``_prefetched_org_contents`` so the serializer can resolve per-org
+		fields without issuing one query per trial.
+		"""
+		qs = super().get_queryset()
+		org = _resolve_per_org_fields_org(self.request)
+		if org is not None:
+			qs = qs.prefetch_related(
+				Prefetch(
+					'org_contents',
+					queryset=TrialOrgContent.objects.filter(organization=org),
+					to_attr='_prefetched_org_contents',
+				)
+			)
+		return qs
 	search_fields = ['title', 'summary']
 	ordering_fields = ['discovery_date', 'published_date', 'title', 'trial_id', 'last_updated']
 	ordering = ['-discovery_date']

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -622,7 +622,7 @@ def edit_trial(request):
 ###
 # ARTICLES
 ### 
-class ArticleViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
+class ArticleViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 	"""
 	List all articles in the database with comprehensive filtering options.
 	CSV responses are automatically streamed for better performance with large datasets.
@@ -667,7 +667,6 @@ class ArticleViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	- CSV export all results: `/articles/?format=csv&all_results=true`
 	- Complex filter: `/articles/?team_id=1&subject_id=4&author_id=123&search=regeneration&relevant=true&ml_threshold=0.8&ordering=-published_date`
 	"""
-	http_method_names = ['get', 'head', 'options']
 	queryset = Articles.objects.all().order_by('-discovery_date')
 	serializer_class = ArticleSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -735,7 +734,7 @@ class ArticlesByKeyword(generics.ListAPIView):
 # CATEGORIES
 ###
 
-class CategoryViewSet(viewsets.ModelViewSet):
+class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 	"""
 	List all categories in the database with optional filters for team and subject.
 	Now includes author statistics for each category.
@@ -773,7 +772,6 @@ class CategoryViewSet(viewsets.ModelViewSet):
 	- Single category with monthly counts: `GET /categories/?category_id=6&monthly_counts=true`
 	- Multiple categories by ID: `GET /categories/?get_categories=1,2,3`
 	"""
-	http_method_names = ['get', 'head', 'options']
 	serializer_class = CategorySerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 	filter_backends = [django_filters.DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
@@ -993,7 +991,7 @@ class CategoryViewSet(viewsets.ModelViewSet):
 # TRIALS
 ### 
 
-class TrialViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
+class TrialViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 	"""
 	List all clinical trials by discovery date with comprehensive filtering options.
 	CSV responses are automatically streamed for better performance with large datasets.
@@ -1031,7 +1029,6 @@ class TrialViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	- All trials as CSV: `/trials/?format=csv&all_results=true`
 	- Filtered trials: `/trials/?team_id=1&status=Recruiting&format=csv&all_results=true`
 	"""
-	http_method_names = ['get', 'head', 'options']
 	queryset = Trials.objects.all().order_by('-discovery_date')
 	serializer_class = TrialSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -1086,7 +1083,7 @@ class AllTrialViewSet(generics.ListAPIView):
 # SOURCES
 ### 
 
-class SourceViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
+class SourceViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 	"""
 	List all sources of data with optional filters for team and subject.
 	
@@ -1096,7 +1093,6 @@ class SourceViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	_org_filter_path = 'team__organization_id'
 	_org_filter_distinct = False
-	http_method_names = ['get', 'head', 'options']
 	queryset = Sources.objects.all().order_by('name')
 	serializer_class = SourceSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -1110,7 +1106,7 @@ class SourceViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 # AUTHORS
 ### 
 
-class AuthorsViewSet(viewsets.ModelViewSet):
+class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 	"""
 	Enhanced Authors API with sorting and filtering capabilities.
 	
@@ -1148,7 +1144,6 @@ class AuthorsViewSet(viewsets.ModelViewSet):
 	- Category with timeframe: `?team_id=1&category_slug=natalizumab&timeframe=year&sort_by=article_count`
 	- Date range: `?date_from=2024-06-01&date_to=2024-12-31&team_id=1&subject_id=1&sort_by=article_count`
 	"""
-	http_method_names = ['get', 'head', 'options']
 	serializer_class = AuthorSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 	filter_backends = [django_filters.DjangoFilterBackend, filters.SearchFilter]
@@ -1388,13 +1383,12 @@ class ProtectedEndpointView(APIView):
 # TEAMS
 ###
 
-class TeamsViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
+class TeamsViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 	"""
 	List all teams
 	"""
 	_org_filter_path = 'organization_id'
 	_org_filter_distinct = False
-	http_method_names = ['get', 'head', 'options']
 	queryset = Team.objects.all().order_by('id')
 	serializer_class = TeamSerializer
 	permission_classes  = [permissions.IsAuthenticatedOrReadOnly]
@@ -1427,7 +1421,7 @@ class OrganizationsViewSet(viewsets.ReadOnlyModelViewSet):
 # SUBJECTS
 ###
 
-class SubjectsViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
+class SubjectsViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 	"""
 	✅ **PREFERRED ENDPOINT**: This is the main subjects endpoint that supports filtering options.
 	
@@ -1446,7 +1440,6 @@ class SubjectsViewSet(OrgVisibilityMixin, viewsets.ModelViewSet):
 	"""
 	_org_filter_path = 'team__organization_id'
 	_org_filter_distinct = False
-	http_method_names = ['get', 'head', 'options']
 	queryset = Subject.objects.all().order_by('id')
 	serializer_class = SubjectsSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -17,10 +17,10 @@ from organizations.models import Organization, OrganizationUser
 from organizations.admin import OrganizationAdmin as BaseOrganizationAdmin
 
 from .models import (
-    Articles, Trials, Sources, Entities, Authors, Subject, MLPredictions, 
+    Articles, Trials, Sources, Entities, Authors, Subject, MLPredictions,
     ArticleSubjectRelevance, TeamCategory, PredictionRunLog, Team,
     ArticleTrialReference, OrganizationCredentials, OrganizationSite,
-    OrganizationApiSettings
+    OrganizationApiSettings, ArticleOrgContent, TrialOrgContent
 )
 from .widgets import MLPredictionsWidget
 from django import forms
@@ -330,6 +330,102 @@ class ArticleSubjectRelevanceInline(admin.TabularInline):
 			qs = qs.filter(subject__auto_predict=True)
 		return qs.order_by('subject__subject_name')
 
+class _BaseOrgContentInline(admin.StackedInline):
+	"""Shared inline behaviour for ArticleOrgContent / TrialOrgContent.
+
+	- Staff users only see/edit rows for their own organisation(s).
+	- Superusers see every row and can add new rows for any organisation.
+	- For staff, the organisation field is pre-filled and locked so they can
+	  never reassign content between orgs.
+	- Empty extra rows (both textareas blank) are skipped at save time, so
+	  opening an article without typing anything does not pollute the table.
+	"""
+	extra = 0
+	classes = ('collapse',)
+	fields = ('organization', 'takeaways', 'summary_plain_english', 'updated_at')
+	readonly_fields = ('updated_at',)
+
+	def get_queryset(self, request):
+		qs = super().get_queryset(request).select_related('organization')
+		if request.user.is_superuser:
+			return qs
+		user_orgs = get_user_organizations(request.user)
+		return qs.filter(organization_id__in=user_orgs)
+
+	def has_add_permission(self, request, obj=None):
+		if request.user.is_superuser:
+			return True
+		return bool(get_user_organizations(request.user))
+
+	def _missing_org_ids(self, request, obj):
+		"""Return user-orgs that don't yet have a content row for this parent."""
+		if obj is None or not obj.pk:
+			return []
+		user_orgs = list(get_user_organizations(request.user) or [])
+		if not user_orgs:
+			return []
+		existing = set(
+			obj.org_contents.filter(organization_id__in=user_orgs)
+			.values_list('organization_id', flat=True)
+		)
+		return [oid for oid in user_orgs if oid not in existing]
+
+	def get_extra(self, request, obj=None, **kwargs):
+		if obj is None or not obj.pk:
+			return 0
+		if request.user.is_superuser:
+			return 1
+		return len(self._missing_org_ids(request, obj))
+
+	def get_max_num(self, request, obj=None, **kwargs):
+		if request.user.is_superuser:
+			return None
+		# Cap at user's org count so they can't create rows for orgs they don't belong to.
+		user_orgs = list(get_user_organizations(request.user) or [])
+		return len(user_orgs)
+
+	def get_formset(self, request, obj=None, **kwargs):
+		formset_class = super().get_formset(request, obj, **kwargs)
+		is_superuser = request.user.is_superuser
+
+		if is_superuser:
+			allowed_org_qs = Organization.objects.all().order_by('name')
+			extra_org_ids = []
+		else:
+			user_org_ids = list(get_user_organizations(request.user) or [])
+			allowed_org_qs = Organization.objects.filter(id__in=user_org_ids).order_by('name')
+			extra_org_ids = self._missing_org_ids(request, obj)
+
+		class ScopedOrgContentFormSet(formset_class):
+			def _construct_form(self, i, **form_kwargs):
+				form = super()._construct_form(i, **form_kwargs)
+				form.fields['organization'].queryset = allowed_org_qs
+				if form.instance.pk:
+					# Existing row: lock the org so content can't be reassigned.
+					form.fields['organization'].disabled = True
+				elif not is_superuser:
+					# Extra row for staff: pre-fill and lock to their next missing org.
+					extra_index = i - self.initial_form_count()
+					if 0 <= extra_index < len(extra_org_ids):
+						form.fields['organization'].initial = extra_org_ids[extra_index]
+						form.fields['organization'].disabled = True
+				return form
+
+		return ScopedOrgContentFormSet
+
+
+class ArticleOrgContentInline(_BaseOrgContentInline):
+	model = ArticleOrgContent
+	verbose_name = 'Editorial content (per organisation)'
+	verbose_name_plural = 'Editorial content (per organisation)'
+
+
+class TrialOrgContentInline(_BaseOrgContentInline):
+	model = TrialOrgContent
+	verbose_name = 'Editorial content (per organisation)'
+	verbose_name_plural = 'Editorial content (per organisation)'
+
+
 class ArticleAdminForm(forms.ModelForm):
 	ml_predictions_display = MLPredictionsField(required=False)
 
@@ -359,14 +455,14 @@ class ArticleAdminForm(forms.ModelForm):
 
 class ArticleAdmin(OrganizationFilterMixin, SimpleHistoryAdmin):
 	form = ArticleAdminForm
-	inlines = [ArticleSubjectRelevanceInline, ArticleTrialReferenceInline]
+	inlines = [ArticleOrgContentInline, ArticleSubjectRelevanceInline, ArticleTrialReferenceInline]
 	fieldsets = (
 		('Article Information', {
 			'fields': (
-				'title', 'link', 'doi', 'summary','summary_plain_english', 'teams', 'subjects', 'sources',
+				'title', 'link', 'doi', 'summary', 'teams', 'subjects', 'sources',
 				'published_date', 'discovery_date', 'authors', 'team_categories',
 				'entities', 'kind', 'access',
-				'publisher', 'container_title', 'crossref_check', 'takeaways',
+				'publisher', 'container_title', 'crossref_check',
 			),
 			'description': 'This section contains general information about the article'
 		}),
@@ -374,6 +470,16 @@ class ArticleAdmin(OrganizationFilterMixin, SimpleHistoryAdmin):
 			'fields': ('ml_predictions_display',),
 			'description': 'Grouping machine learning prediction indicators',
 			'classes': ('ml-predictions-section',),
+		}),
+		('Legacy editorial fields (read-only)', {
+			'fields': ('takeaways', 'summary_plain_english'),
+			'classes': ('collapse',),
+			'description': (
+				"Deprecated. Editorial content is now per-organisation — edit it in "
+				"the 'Editorial content (per organisation)' section above. These "
+				"legacy columns are kept read-only until the follow-up migration "
+				"drops them."
+			),
 		}),
 	)
 	list_display = ['article_id', 'title', 'discovery_date', 'display_sources']
@@ -389,7 +495,7 @@ class ArticleAdmin(OrganizationFilterMixin, SimpleHistoryAdmin):
 		qs = super().get_queryset(request)
 		return qs.prefetch_related('sources')
 	
-	readonly_fields = ['entities', 'discovery_date']
+	readonly_fields = ['entities', 'discovery_date', 'takeaways', 'summary_plain_english']
 	search_fields = ['article_id', 'title', 'doi']
 	list_filter = [
 		ArticleOrganizationFilter,
@@ -435,8 +541,8 @@ class ArticleAdmin(OrganizationFilterMixin, SimpleHistoryAdmin):
 class TrialAdmin(OrganizationFilterMixin, SimpleHistoryAdmin):
 	list_display = ['trial_id', 'title', 'display_identifiers', 'discovery_date', 'last_updated']
 	exclude = ['ml_predictions']
-	readonly_fields = ['last_updated', 'team_categories']
-	inlines = [TrialArticleReferenceInline]
+	readonly_fields = ['last_updated', 'team_categories', 'summary_plain_english']
+	inlines = [TrialOrgContentInline, TrialArticleReferenceInline]
 	search_fields = [
 		'trial_id', 'title', 'summary', 'summary_plain_english', 'scientific_title',
 		'primary_sponsor', 'source_register', 'recruitment_status', 'condition',
@@ -456,7 +562,7 @@ class TrialAdmin(OrganizationFilterMixin, SimpleHistoryAdmin):
 			'fields': ('title', 'scientific_title', 'link', 'identifiers', 'discovery_date', 'published_date', 'last_updated')
 		}),
 		('Description', {
-			'fields': ('summary', 'summary_plain_english', 'ctg_detailed_description'),
+			'fields': ('summary', 'ctg_detailed_description'),
 			'classes': ('collapse',),
 		}),
 		('Study Details', {
@@ -493,6 +599,15 @@ class TrialAdmin(OrganizationFilterMixin, SimpleHistoryAdmin):
 		('Results', {
 			'fields': ('results_date_completed', 'results_url_link'),
 			'classes': ('collapse',),
+		}),
+		('Legacy editorial fields (read-only)', {
+			'fields': ('summary_plain_english',),
+			'classes': ('collapse',),
+			'description': (
+				"Deprecated. Plain-English summaries are now per-organisation — "
+				"edit them in the 'Editorial content (per organisation)' section "
+				"at the top of the page."
+			),
 		}),
 	)
 
@@ -1759,6 +1874,51 @@ admin.site.register(Authors, AuthorsAdmin)
 admin.site.register(Entities)
 admin.site.register(Sources, SourceAdmin)
 admin.site.register(Trials, TrialAdmin)
+
+
+class _BaseOrgContentAdmin(OrganizationFilterMixin, SimpleHistoryAdmin):
+	"""Shared admin for ArticleOrgContent / TrialOrgContent standalone pages.
+
+	Use the parent Article/Trial admin for routine editing; this admin exists
+	so users can browse audit history and so superusers can clean up rows
+	across organisations.
+	"""
+	list_filter = ('organization',)
+	readonly_fields = ('created_at', 'updated_at')
+	search_fields = ('takeaways', 'summary_plain_english')
+
+	def get_form(self, request, obj=None, **kwargs):
+		form_class = super().get_form(request, obj, **kwargs)
+		if request.user.is_superuser:
+			return form_class
+
+		user_org_ids = list(get_user_organizations(request.user) or [])
+
+		class ScopedOrgForm(form_class):
+			def __init__(self, *args, **form_kwargs):
+				super().__init__(*args, **form_kwargs)
+				if 'organization' in self.fields:
+					self.fields['organization'].queryset = (
+						Organization.objects.filter(id__in=user_org_ids).order_by('name')
+					)
+					if self.instance and self.instance.pk:
+						self.fields['organization'].disabled = True
+
+		return ScopedOrgForm
+
+
+@admin.register(ArticleOrgContent)
+class ArticleOrgContentAdmin(_BaseOrgContentAdmin):
+	list_display = ('article', 'organization', 'updated_at')
+	raw_id_fields = ('article',)
+	search_fields = _BaseOrgContentAdmin.search_fields + ('article__title', 'article__doi')
+
+
+@admin.register(TrialOrgContent)
+class TrialOrgContentAdmin(_BaseOrgContentAdmin):
+	list_display = ('trial', 'organization', 'updated_at')
+	raw_id_fields = ('trial',)
+	search_fields = _BaseOrgContentAdmin.search_fields + ('trial__title',)
 
 
 # --- Custom UserAdmin with Team membership inline ---

--- a/django/gregory/management/commands/migrate_legacy_takeaways.py
+++ b/django/gregory/management/commands/migrate_legacy_takeaways.py
@@ -128,11 +128,15 @@ class Command(BaseCommand):
 				return
 
 		# --- gather candidate articles ---
+		# Only articles that belong to the chosen organisation (via a team).
+		# Without this scope the command would copy legacy takeaways onto
+		# articles that have no relationship to the target org.
 		articles_qs = (
 			Articles.objects
-			.filter(takeaways__isnull=False)
+			.filter(takeaways__isnull=False, teams__organization=org)
 			.exclude(takeaways='')
 			.only('article_id', 'takeaways')
+			.distinct()
 		)
 		total_candidates = articles_qs.count()
 

--- a/django/gregory/management/commands/migrate_legacy_takeaways.py
+++ b/django/gregory/management/commands/migrate_legacy_takeaways.py
@@ -23,6 +23,7 @@ Removal is handled in a follow-up migration after a release of co-existence.
 """
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
+from django.db.models import Count, Q
 
 from gregory.models import Articles, ArticleOrgContent
 from organizations.models import Organization
@@ -63,21 +64,21 @@ class Command(BaseCommand):
 		"""Print a table of organisations with their article counts."""
 		orgs = (
 			Organization.objects
-			.prefetch_related('article_contents')
+			.annotate(
+				article_count=Count(
+					'teams__articles',
+					filter=Q(teams__articles__takeaways__isnull=False)
+					& ~Q(teams__articles__takeaways=''),
+					distinct=True,
+				)
+			)
 			.order_by('id')
 		)
 		self.stdout.write('\nAvailable organisations:\n')
 		self.stdout.write(f'  {"ID":>5}  {"Name":<40}  {"Articles with takeaways":>23}')
 		self.stdout.write('  ' + '-' * 72)
 		for org in orgs:
-			article_count = (
-				Articles.objects
-				.filter(teams__organization=org, takeaways__isnull=False)
-				.exclude(takeaways='')
-				.distinct()
-				.count()
-			)
-			self.stdout.write(f'  {org.id:>5}  {str(org.name):<40}  {article_count:>23}')
+			self.stdout.write(f'  {org.id:>5}  {str(org.name):<40}  {org.article_count:>23}')
 		self.stdout.write('')
 
 	def _prompt_org_id(self):

--- a/django/gregory/management/commands/migrate_legacy_takeaways.py
+++ b/django/gregory/management/commands/migrate_legacy_takeaways.py
@@ -1,0 +1,178 @@
+"""
+migrate_legacy_takeaways
+========================
+One-shot management command that copies existing ``Articles.takeaways`` values
+into ``ArticleOrgContent`` rows for a single designated organisation.
+
+Usage
+-----
+Interactive (prompts for target org)::
+
+    python manage.py migrate_legacy_takeaways
+
+Non-interactive (scripted / CI)::
+
+    python manage.py migrate_legacy_takeaways --org-id 3 --noinput
+
+Dry run (no writes)::
+
+    python manage.py migrate_legacy_takeaways --dry-run
+
+The source column (``Articles.takeaways``) is NOT dropped here.
+Removal is handled in a follow-up migration after a release of co-existence.
+"""
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from gregory.models import Articles, ArticleOrgContent
+from organizations.models import Organization
+
+
+class Command(BaseCommand):
+	help = (
+		'Copy Articles.takeaways into ArticleOrgContent for a chosen organisation. '
+		'Idempotent — rows that already exist are skipped.'
+	)
+
+	def add_arguments(self, parser):
+		parser.add_argument(
+			'--org-id',
+			type=int,
+			dest='org_id',
+			help='ID of the target organisation. Required when --noinput is set.',
+		)
+		parser.add_argument(
+			'--noinput',
+			'--no-input',
+			action='store_true',
+			dest='no_input',
+			help='Do not prompt for confirmation. Requires --org-id.',
+		)
+		parser.add_argument(
+			'--dry-run',
+			action='store_true',
+			dest='dry_run',
+			help='Report how many rows would be created without writing anything.',
+		)
+
+	# ------------------------------------------------------------------
+	# Helpers
+	# ------------------------------------------------------------------
+
+	def _list_organisations(self):
+		"""Print a table of organisations with their article counts."""
+		orgs = (
+			Organization.objects
+			.prefetch_related('article_contents')
+			.order_by('id')
+		)
+		self.stdout.write('\nAvailable organisations:\n')
+		self.stdout.write(f'  {"ID":>5}  {"Name":<40}  {"Articles with takeaways":>23}')
+		self.stdout.write('  ' + '-' * 72)
+		for org in orgs:
+			article_count = (
+				Articles.objects
+				.filter(teams__organization=org, takeaways__isnull=False)
+				.exclude(takeaways='')
+				.distinct()
+				.count()
+			)
+			self.stdout.write(f'  {org.id:>5}  {str(org.name):<40}  {article_count:>23}')
+		self.stdout.write('')
+
+	def _prompt_org_id(self):
+		"""Interactively ask the operator to choose an organisation."""
+		self._list_organisations()
+		while True:
+			raw = input('Enter the target organisation ID: ').strip()
+			if raw.isdigit():
+				return int(raw)
+			self.stderr.write('Please enter a numeric ID.\n')
+
+	def _resolve_org(self, org_id):
+		"""Return the Organisation for *org_id*, raising CommandError if not found."""
+		try:
+			return Organization.objects.get(pk=org_id)
+		except Organization.DoesNotExist:
+			raise CommandError(f'Organisation with id={org_id} does not exist.')
+
+	# ------------------------------------------------------------------
+	# Entry point
+	# ------------------------------------------------------------------
+
+	def handle(self, *args, **options):
+		org_id = options['org_id']
+		no_input = options['no_input']
+		dry_run = options['dry_run']
+
+		# --- resolve target organisation ---
+		if org_id is None:
+			if no_input:
+				raise CommandError(
+					'--org-id is required when --noinput is set.'
+				)
+			org_id = self._prompt_org_id()
+
+		org = self._resolve_org(org_id)
+
+		# --- confirmation (unless --noinput or --dry-run) ---
+		if not no_input and not dry_run:
+			confirm = input(
+				f'\nAbout to migrate Articles.takeaways → ArticleOrgContent '
+				f'for organisation "{org.name}" (id={org.id}).\n'
+				f'Continue? [y/N] '
+			).strip().lower()
+			if confirm not in ('y', 'yes'):
+				self.stdout.write('Aborted.')
+				return
+
+		# --- gather candidate articles ---
+		articles_qs = (
+			Articles.objects
+			.filter(takeaways__isnull=False)
+			.exclude(takeaways='')
+			.only('article_id', 'takeaways')
+		)
+		total_candidates = articles_qs.count()
+
+		if dry_run:
+			# Count how many would actually create a new row (skip existing).
+			existing_article_ids = set(
+				ArticleOrgContent.objects
+				.filter(organization=org, article_id__in=articles_qs.values('article_id'))
+				.values_list('article_id', flat=True)
+			)
+			would_create = total_candidates - len(existing_article_ids)
+			would_skip = len(existing_article_ids)
+			self.stdout.write(
+				self.style.WARNING(
+					f'[DRY RUN] Would create {would_create} ArticleOrgContent row(s), '
+					f'skip {would_skip} existing row(s) '
+					f'(out of {total_candidates} candidate article(s)).'
+				)
+			)
+			return
+
+		# --- migrate ---
+		created = 0
+		skipped = 0
+
+		with transaction.atomic():
+			for article in articles_qs.iterator(chunk_size=500):
+				_, was_created = ArticleOrgContent.objects.get_or_create(
+					article=article,
+					organization=org,
+					defaults={'takeaways': article.takeaways},
+				)
+				if was_created:
+					created += 1
+				else:
+					skipped += 1
+
+		self.stdout.write(
+			self.style.SUCCESS(
+				f'Done. Created {created} ArticleOrgContent row(s), '
+				f'skipped {skipped} existing row(s) '
+				f'(out of {total_candidates} candidate article(s)).'
+			)
+		)

--- a/django/gregory/migrations/0047_drop_authtoken_tables.py
+++ b/django/gregory/migrations/0047_drop_authtoken_tables.py
@@ -25,11 +25,5 @@ class Migration(migrations.Migration):
 				'DROP TABLE IF EXISTS authtoken_token CASCADE;',
 				'DROP TABLE IF EXISTS authtoken_tokenproxy CASCADE;',
 			],
-			reverse_sql=[
-				# Recreating authtoken tables by hand is impractical; mark as
-				# non-reversible so rollback fails fast rather than silently
-				# leaving the database in an inconsistent state.
-				migrations.RunSQL.noop,
-			],
 		),
 	]

--- a/django/gregory/migrations/0047_drop_authtoken_tables.py
+++ b/django/gregory/migrations/0047_drop_authtoken_tables.py
@@ -1,0 +1,35 @@
+"""
+Drop the authtoken tables left behind when rest_framework.authtoken is removed
+from INSTALLED_APPS.  Django does not auto-generate a migration for app removal,
+so we do it manually via RunSQL.
+
+The two tables are:
+  authtoken_token   — one token per user
+  authtoken_tokenproxy — Django content-type proxy table (may or may not exist)
+
+Both DROP statements use IF EXISTS so the migration is safe to run on databases
+that never had the authtoken app installed.
+"""
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		('gregory', '0046_historicalarticleorgcontent_api_access_scheme_label_and_more'),
+	]
+
+	operations = [
+		migrations.RunSQL(
+			sql=[
+				'DROP TABLE IF EXISTS authtoken_token CASCADE;',
+				'DROP TABLE IF EXISTS authtoken_tokenproxy CASCADE;',
+			],
+			reverse_sql=[
+				# Recreating authtoken tables by hand is impractical; mark as
+				# non-reversible so rollback fails fast rather than silently
+				# leaving the database in an inconsistent state.
+				migrations.RunSQL.noop,
+			],
+		),
+	]

--- a/django/gregory/migrations/0047_drop_authtoken_tables.py
+++ b/django/gregory/migrations/0047_drop_authtoken_tables.py
@@ -25,5 +25,11 @@ class Migration(migrations.Migration):
 				'DROP TABLE IF EXISTS authtoken_token CASCADE;',
 				'DROP TABLE IF EXISTS authtoken_tokenproxy CASCADE;',
 			],
+			# We can't recover the dropped rows, but make the migration
+			# reversible (no-op on the way back) so `manage.py migrate
+			# gregory 0046` doesn't fail with IrreversibleError.  Restoring
+			# the tables would require re-adding rest_framework.authtoken
+			# to INSTALLED_APPS, which is the deliberate way to roll back.
+			reverse_sql=migrations.RunSQL.noop,
 		),
 	]

--- a/django/gregory/tests/management/test_migrate_legacy_takeaways.py
+++ b/django/gregory/tests/management/test_migrate_legacy_takeaways.py
@@ -1,0 +1,156 @@
+"""
+Tests for the migrate_legacy_takeaways management command (Phase 7).
+
+These tests will FAIL until phase-7-migrate-legacy-takeaways is merged into
+api-improvements (the command does not exist on main yet).
+
+Covers spec §10.5:
+  - 2 articles (one with takeaways, one without) → exactly 1 ArticleOrgContent created
+  - Re-run is idempotent (no duplicate rows created)
+  - --dry-run reports counts and writes nothing
+  - --org-id <bad-id> exits non-zero with clear error
+  - --org-id <id> --noinput runs without prompting
+
+Run with:
+    docker exec gregory python manage.py test gregory.tests.management.test_migrate_legacy_takeaways
+"""
+from io import StringIO
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+from organizations.models import Organization
+
+from gregory.models import Articles, ArticleOrgContent, Team, OrganizationApiSettings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug=''):
+	slug = slug or name.lower().replace(' ', '-')
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=False)
+	return org
+
+
+def _make_team(org, name):
+	return Team.objects.create(organization=org, name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_article(team, title, link, takeaways=None):
+	article = Articles.objects.create(title=title, link=link, takeaways=takeaways)
+	article.teams.add(team)
+	return article
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class MigrateLegacyTakeawaysCommandTest(TestCase):
+	"""Core migration behaviour."""
+
+	def setUp(self):
+		self.org = _make_org('Migration Org')
+		self.team = _make_team(self.org, 'Migration Team')
+		# One article with takeaways, one without
+		self.article_with = _make_article(
+			self.team, 'Has Takeaways', 'https://example.com/with', takeaways='Some takeaways'
+		)
+		self.article_without = _make_article(
+			self.team, 'No Takeaways', 'https://example.com/without', takeaways=None
+		)
+
+	def test_creates_exactly_one_org_content_row(self):
+		"""Only the article with takeaways should produce an ArticleOrgContent row."""
+		out = StringIO()
+		call_command(
+			'migrate_legacy_takeaways',
+			org_id=self.org.pk,
+			noinput=True,
+			stdout=out,
+		)
+		self.assertEqual(ArticleOrgContent.objects.count(), 1)
+		content = ArticleOrgContent.objects.get()
+		self.assertEqual(content.article_id, self.article_with.article_id)
+		self.assertEqual(content.takeaways, 'Some takeaways')
+		self.assertEqual(content.organization_id, self.org.pk)
+
+	def test_idempotent_on_rerun(self):
+		"""Running the command twice does not create duplicate rows."""
+		for _ in range(2):
+			call_command(
+				'migrate_legacy_takeaways',
+				org_id=self.org.pk,
+				noinput=True,
+				stdout=StringIO(),
+			)
+		self.assertEqual(ArticleOrgContent.objects.count(), 1)
+
+	def test_dry_run_writes_nothing(self):
+		"""--dry-run reports counts but creates no database rows."""
+		out = StringIO()
+		call_command(
+			'migrate_legacy_takeaways',
+			org_id=self.org.pk,
+			noinput=True,
+			dry_run=True,
+			stdout=out,
+		)
+		self.assertEqual(ArticleOrgContent.objects.count(), 0)
+		output = out.getvalue()
+		# Should mention at least 1 article would be migrated
+		self.assertIn('1', output)
+
+	def test_invalid_org_id_raises_error(self):
+		"""--org-id with a nonexistent org should raise CommandError."""
+		with self.assertRaises((CommandError, SystemExit)):
+			call_command(
+				'migrate_legacy_takeaways',
+				org_id=99999,
+				noinput=True,
+				stdout=StringIO(),
+			)
+
+	def test_noinput_runs_without_prompting(self):
+		"""--org-id <id> --noinput should complete without stdin interaction."""
+		out = StringIO()
+		# Should not raise EOFError or similar (which would happen if it
+		# tried to read from stdin)
+		call_command(
+			'migrate_legacy_takeaways',
+			org_id=self.org.pk,
+			noinput=True,
+			stdout=out,
+		)
+		self.assertEqual(ArticleOrgContent.objects.count(), 1)
+
+
+class MigrateLegacyTakeawaysMultiOrgTest(TestCase):
+	"""Only articles belonging to the specified org are migrated."""
+
+	def setUp(self):
+		self.org_a = _make_org('Multi Org A')
+		self.org_b = _make_org('Multi Org B', 'multi-org-b')
+		self.team_a = _make_team(self.org_a, 'Multi Team A')
+		self.team_b = _make_team(self.org_b, 'Multi Team B')
+		self.article_a = _make_article(
+			self.team_a, 'Org A Article', 'https://example.com/a', takeaways='Org A takeaway'
+		)
+		self.article_b = _make_article(
+			self.team_b, 'Org B Article', 'https://example.com/b', takeaways='Org B takeaway'
+		)
+
+	def test_only_migrates_chosen_org_articles(self):
+		"""Migrating for Org A should not create content for Org B articles."""
+		call_command(
+			'migrate_legacy_takeaways',
+			org_id=self.org_a.pk,
+			noinput=True,
+			stdout=StringIO(),
+		)
+		self.assertEqual(ArticleOrgContent.objects.count(), 1)
+		content = ArticleOrgContent.objects.get()
+		self.assertEqual(content.organization_id, self.org_a.pk)

--- a/django/gregory/tests/management/test_migrate_legacy_takeaways.py
+++ b/django/gregory/tests/management/test_migrate_legacy_takeaways.py
@@ -1,8 +1,5 @@
 """
-Tests for the migrate_legacy_takeaways management command (Phase 7).
-
-These tests will FAIL until phase-7-migrate-legacy-takeaways is merged into
-api-improvements (the command does not exist on main yet).
+Tests for the migrate_legacy_takeaways management command.
 
 Covers spec §10.5:
   - 2 articles (one with takeaways, one without) → exactly 1 ArticleOrgContent created
@@ -10,6 +7,7 @@ Covers spec §10.5:
   - --dry-run reports counts and writes nothing
   - --org-id <bad-id> exits non-zero with clear error
   - --org-id <id> --noinput runs without prompting
+  - Articles outside the chosen org are not migrated.
 
 Run with:
     docker exec gregory python manage.py test gregory.tests.management.test_migrate_legacy_takeaways


### PR DESCRIPTION
## Summary

This PR completes the API improvements spec (`API_IMPROVEMENTS_SPEC.md`) by rolling the previously-merged phase branches (4–8) into `main` together with new admin-side support for per-organisation editorial content.

### API changes (Phases 4–8)
- **Read serialization (§6, Phase 4)**: `ArticleSerializer` / `TrialSerializer` now expose `takeaways` and `summary_plain_english` resolved against the caller's organisation (API key → org, or `?team_id=` of a `make_api_public=True` org). Anonymous requests get the fields **omitted** entirely.
- **Viewset lockdown (§5, Phase 5)**: `ArticleViewSet`, `TrialViewSet`, `AuthorsViewSet`, `SourceViewSet`, `CategoryViewSet`, `SubjectsViewSet`, `TeamsViewSet` switched to `ReadOnlyModelViewSet` — PUT/PATCH/DELETE now return `405 Method Not Allowed`. `post_article`, `edit_article`, `edit_trial` remain the only API write paths.
- **Auth cleanup (§8, Phase 6)**: removed the broken DRF Token endpoint (`POST /api/token/get/`), stripped `rest_framework.authtoken` from `INSTALLED_APPS`, and added migration `0047_drop_authtoken_tables` to clean the leftover tables.
- **Legacy data migration (§7, Phase 7)**: new `migrate_legacy_takeaways` management command copies legacy `Articles.takeaways` into `ArticleOrgContent` for a chosen organisation. Scoped to the org's teams so it never touches articles outside the target org.
- **Test coverage (§10, Phase 8)**: full matrix of edit/read/lockdown/migration tests under `django/api/tests/` and `django/gregory/tests/management/`.

### Admin changes (new in this PR)
- Wires `ArticleOrgContent` / `TrialOrgContent` into the article and trial change pages as a per-org inline. Staff see one inline row scoped (and locked) to their organisation; superusers see and can add rows for any organisation. Existing rows have their `organization` field disabled so content cannot be reassigned across orgs.
- Demotes the now-deprecated `Articles.takeaways` / `Articles.summary_plain_english` (and `Trials.summary_plain_english`) into a collapsed read-only "Legacy editorial fields" section, per spec §3.5. Columns are kept around until the follow-up migration drops them.
- Registers standalone `ArticleOrgContent` / `TrialOrgContent` admins (using `SimpleHistoryAdmin`) so the audit trail is browsable and superusers can clean up cross-org rows. Non-superuser access is filtered by `OrganizationFilterMixin`; the `organization` field is restricted to the user's own orgs.

Audit attribution is unchanged — admin saves go through the existing `stamp_api_access_scheme_on_history` signal, which sets `history_user = request.user` and leaves `api_access_scheme = NULL` for admin/shell edits (spec §9.2).

### Review feedback addressed (commit `f1ce77fb`)
- Scoped `migrate_legacy_takeaways` candidate articles to the chosen organisation's teams (no more cross-org pollution).
- Replaced the per-row `obj.org_contents.get(...)` N+1 in serializers with a per-request prefetch attached by the viewset's `get_queryset`; narrowed the blanket `except Exception` to the model-specific `DoesNotExist`.
- Narrowed the blanket `except Exception` in `_resolve_per_org_fields_org` to `(ValueError, TypeError, Team.DoesNotExist)`.
- Made `0047_drop_authtoken_tables` reversible (`reverse_sql=migrations.RunSQL.noop`).
- Cleaned stale "will FAIL until phase-X merges" docstrings in the test files.

## Test plan

### Admin
- [ ] As a staff user with one org, open an article and confirm exactly one inline row appears, pre-set to their org, with the org field locked.
- [ ] Save with takeaways/summary filled in — row is created; reopen the article and verify content is preserved.
- [ ] Save without typing anything — confirm no `ArticleOrgContent` row was created.
- [ ] As a superuser, open an article and confirm all existing org rows are visible, plus one empty extra with a free org dropdown.
- [ ] Confirm legacy `takeaways` / `summary_plain_english` are visible read-only in the collapsed "Legacy" section.
- [ ] Repeat the four checks above on a trial.
- [ ] Visit `/admin/gregory/articleorgcontent/` and `/admin/gregory/trialorgcontent/` as a staff user — only their org's rows are listed.

### API
- [ ] Hit `/articles/` with an Org A API key — response includes `takeaways` resolved to Org A's `ArticleOrgContent`.
- [ ] Hit `/articles/` anonymously — `takeaways` / `summary_plain_english` are absent from the payload.
- [ ] Hit `/articles/?team_id=<id>` for a team whose org has `make_api_public=True` — per-org fields present.
- [ ] `PATCH /articles/<id>/` returns 405. Same for `/trials/`, `/authors/`, `/sources/`, `/subjects/`, `/teams/`, `/categories/`.
- [ ] `POST /api/token/get/` returns 404 (route removed).

### Data migration
- [ ] Run `python manage.py migrate_legacy_takeaways --dry-run` and confirm reported counts match expectations for the target org only.
- [ ] Run with `--org-id <id> --noinput` and confirm only that org's articles get `ArticleOrgContent` rows.
- [ ] Re-run to confirm idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)