### PR TITLE
fix(admin): show per-org editorial inline expanded by default

### DIFF
--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -341,7 +341,6 @@ class _BaseOrgContentInline(admin.StackedInline):
 	  opening an article without typing anything does not pollute the table.
 	"""
 	extra = 0
-	classes = ('collapse',)
 	fields = ('organization', 'takeaways', 'summary_plain_english', 'updated_at')
 	readonly_fields = ('updated_at',)
 


### PR DESCRIPTION
## Summary

The per-organisation editorial inline added in #652 had `classes=('collapse',)`, so on `/admin/gregory/articles/<id>/change/` it rendered as an "Editorial content (per organisation) — Show" link instead of an open form. Reported by Bruno: the takeaways field appeared to be missing entirely.

Removing the `collapse` class so the inline is expanded on page load — editing takeaways is the primary reason to open the change page, so the form should be visible without an extra click.

The "Legacy editorial fields (read-only)" fieldset stays collapsed, since those columns are deprecated read-only data.

## Test plan

- [ ] Open `/admin/gregory/articles/316078/change/` as a superuser — confirm the "Editorial content (per organisation)" section is expanded with one empty form (organization dropdown + takeaways + summary_plain_english textareas).
- [ ] Repeat as a staff user with one org — confirm the inline shows one row pre-set (and locked) to their org.
- [ ] Open a trial change page and confirm the same expanded behaviour for `TrialOrgContent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)