### PR TITLE
refactor(gregory): write get_takeaways output to ArticleOrgContent

### DIFF
--- a/django/gregory/management/commands/get_takeaways.py
+++ b/django/gregory/management/commands/get_takeaways.py
@@ -84,7 +84,7 @@ class Command(BaseCommand):
 			print(f"Summarizing abstract {article_id} with lengths [{min_length}, {max_length}]")
 			summary = summarizer(abstract, min_length=min_length, max_length=max_length, truncation=True)
 			end = time.time()
-			print(f" => Ellapsed time: {end - start} sec.")
+			print(f" => Elapsed time: {end - start} sec.")
 			return summary[0]['summary_text'] if summary else ""
 		return ""
 

--- a/django/gregory/management/commands/get_takeaways.py
+++ b/django/gregory/management/commands/get_takeaways.py
@@ -1,57 +1,227 @@
+"""
+get_takeaways
+=============
+Generate ML takeaways for science papers and store them in ``ArticleOrgContent``
+(one row per article × organisation).
+
+A single summariser call is made per article (since the abstract is identical
+regardless of organisation), and the resulting text is fanned out to every
+organisation the article belongs to via teams that does not already have a
+non-empty ``takeaways`` row.
+
+Usage
+-----
+Default (pipeline cron)::
+
+    python manage.py get_takeaways
+
+Scoped to one organisation::
+
+    python manage.py get_takeaways --org-id 3
+
+Bigger / smaller batch, dry run::
+
+    python manage.py get_takeaways --limit 50
+    python manage.py get_takeaways --dry-run
+"""
 from bs4 import BeautifulSoup
 import html
 import time
-from django.core.management.base import BaseCommand
+
+from django.core.management.base import BaseCommand, CommandError
 from django.db.models.functions import Length
-from gregory.models import Articles
+
+from gregory.models import Articles, ArticleOrgContent
 from transformers import pipeline
 
 
 class Command(BaseCommand):
+	help = (
+		'Summarise article abstracts and store the result in ArticleOrgContent '
+		'for every organisation the article belongs to (via teams).'
+	)
+
+	def add_arguments(self, parser):
+		parser.add_argument(
+			'--org-id',
+			type=int,
+			dest='org_id',
+			help='Restrict generation to a single organisation.',
+		)
+		parser.add_argument(
+			'--limit',
+			type=int,
+			default=20,
+			dest='limit',
+			help='Maximum number of articles to summarise in this run (default: 20).',
+		)
+		parser.add_argument(
+			'--dry-run',
+			action='store_true',
+			dest='dry_run',
+			help='Report what would be generated without loading the model or writing rows.',
+		)
+
+	# ------------------------------------------------------------------
+	# Helpers
+	# ------------------------------------------------------------------
+
 	@staticmethod
 	def clean_html(input_text):
-			return BeautifulSoup(input_text, 'html.parser').get_text()
+		return BeautifulSoup(input_text, 'html.parser').get_text()
 
 	@staticmethod
 	def get_summary_max_length(text):
-			nr_words = len(text.split())
-			max_length = 100
-			return min(max_length, int(nr_words / 2))
+		nr_words = len(text.split())
+		max_length = 100
+		return min(max_length, int(nr_words / 2))
 
 	@staticmethod
 	def summarize_abstract(article_id, abstract, summarizer, min_length=25):
-			start = time.time()
-			max_length = Command.get_summary_max_length(abstract)
-			if max_length > min_length:
-					print(f"Summarizing abstract {article_id} with lengths [{min_length}, {max_length}]")
-					summary = summarizer(abstract, min_length=min_length, max_length=max_length, truncation=True)
-					end = time.time()
-					print(f" => Ellapsed time: {end - start} sec.")
-					return summary[0]['summary_text'] if summary else ""
-			return ""
+		start = time.time()
+		max_length = Command.get_summary_max_length(abstract)
+		if max_length > min_length:
+			print(f"Summarizing abstract {article_id} with lengths [{min_length}, {max_length}]")
+			summary = summarizer(abstract, min_length=min_length, max_length=max_length, truncation=True)
+			end = time.time()
+			print(f" => Ellapsed time: {end - start} sec.")
+			return summary[0]['summary_text'] if summary else ""
+		return ""
+
+	@staticmethod
+	def _orgs_for_article(article, org_id=None):
+		"""Return organisations linked to *article* via its teams, optionally scoped."""
+		from django.apps import apps
+		Organization = apps.get_model('organizations', 'Organization')
+		qs = Organization.objects.filter(teams__articles=article).distinct()
+		if org_id is not None:
+			qs = qs.filter(pk=org_id)
+		return list(qs)
+
+	@staticmethod
+	def _orgs_missing_takeaways(article, orgs):
+		"""Of *orgs*, return the ones whose ArticleOrgContent row is missing or has empty takeaways."""
+		existing = (
+			ArticleOrgContent.objects
+			.filter(article=article, organization__in=orgs)
+			.exclude(takeaways__isnull=True)
+			.exclude(takeaways='')
+			.values_list('organization_id', flat=True)
+		)
+		filled = set(existing)
+		return [org for org in orgs if org.pk not in filled]
+
+	# ------------------------------------------------------------------
+	# Entry point
+	# ------------------------------------------------------------------
 
 	def handle(self, *args, **options):
-			queryset = Articles.objects.annotate(abstract_length=Length('summary')).filter(
-					abstract_length__gte=25,
-					abstract_length__lte=3000,
-					kind='science paper',
-					takeaways=None
-			)[:20]
+		org_id = options.get('org_id')
+		limit = options.get('limit') or 20
+		dry_run = options.get('dry_run')
 
-			if not queryset:
-					print('Nothing to analyse, queryset is empty.')
-					exit()
+		if limit <= 0:
+			raise CommandError('--limit must be a positive integer.')
 
-			self.stdout.write("Loading the model")
-			summarizer = pipeline("summarization", model='philschmid/bart-large-cnn-samsum')
-			summarizer.tokenizer.model_max_length = 1024
-			self.stdout.write("Summarizer model ready for use")
+		# Base candidate pool: science papers with an abstract in the usable length range.
+		# We order by newest first so each run prioritises recent ingestion.
+		base_qs = (
+			Articles.objects
+			.annotate(abstract_length=Length('summary'))
+			.filter(
+				abstract_length__gte=25,
+				abstract_length__lte=3000,
+				kind='science paper',
+			)
+			.order_by('-article_id')
+		)
 
-			for article in queryset:
-					try:
-							abstract = self.clean_html(html.unescape(article.summary)).replace('\n', ' ').replace('\r', ' ')
-							takeaways = self.summarize_abstract(article.article_id, abstract, summarizer)
-							article.takeaways = takeaways
-							article.save()
-					except Exception as e:
-							self.stderr.write(self.style.WARNING(f'Skipping article {article.article_id}: {e}'))
+		summarizer = None
+		processed = 0
+		created_rows = 0
+		updated_rows = 0
+		scanned = 0
+		orphans = 0
+
+		# Over-scan factor lets us skip articles whose org content is already
+		# filled without aborting the run prematurely.
+		scan_cap = max(limit * 10, 200)
+
+		for article in base_qs.iterator(chunk_size=100):
+			if processed >= limit:
+				break
+			if scanned >= scan_cap:
+				self.stdout.write(self.style.WARNING(
+					f'Reached scan cap of {scan_cap} articles without filling --limit; stopping.'
+				))
+				break
+			scanned += 1
+
+			orgs = self._orgs_for_article(article, org_id=org_id)
+			if not orgs:
+				if org_id is None:
+					orphans += 1
+					self.stderr.write(self.style.WARNING(
+						f'Skipping orphan article {article.article_id}: no organisations via teams.'
+					))
+				continue
+
+			missing_orgs = self._orgs_missing_takeaways(article, orgs)
+			if not missing_orgs:
+				continue
+
+			try:
+				abstract = self.clean_html(html.unescape(article.summary)).replace('\n', ' ').replace('\r', ' ')
+			except Exception as e:
+				self.stderr.write(self.style.WARNING(
+					f'Skipping article {article.article_id}: failed to clean abstract: {e}'
+				))
+				continue
+
+			if dry_run:
+				self.stdout.write(
+					f'[DRY RUN] Would summarise article {article.article_id} and fill '
+					f'{len(missing_orgs)} org row(s): {[o.pk for o in missing_orgs]}'
+				)
+				processed += 1
+				continue
+
+			if summarizer is None:
+				self.stdout.write('Loading the model')
+				summarizer = pipeline('summarization', model='philschmid/bart-large-cnn-samsum')
+				summarizer.tokenizer.model_max_length = 1024
+				self.stdout.write('Summarizer model ready for use')
+
+			try:
+				takeaways = self.summarize_abstract(article.article_id, abstract, summarizer)
+			except Exception as e:
+				self.stderr.write(self.style.WARNING(
+					f'Skipping article {article.article_id}: summariser failed: {e}'
+				))
+				continue
+
+			if not takeaways:
+				continue
+
+			for org in missing_orgs:
+				aoc, created = ArticleOrgContent.objects.get_or_create(
+					article=article,
+					organization=org,
+					defaults={'takeaways': takeaways},
+				)
+				if created:
+					created_rows += 1
+				else:
+					aoc.takeaways = takeaways
+					aoc.save(update_fields=['takeaways', 'updated_at'])
+					updated_rows += 1
+
+			processed += 1
+
+		summary_style = self.style.WARNING if dry_run else self.style.SUCCESS
+		self.stdout.write(summary_style(
+			f'{"[DRY RUN] " if dry_run else ""}'
+			f'Processed {processed} article(s) (scanned {scanned}, orphans skipped {orphans}). '
+			f'Created {created_rows} new ArticleOrgContent row(s), '
+			f'updated {updated_rows} existing row(s).'
+		))

--- a/django/gregory/management/commands/get_takeaways.py
+++ b/django/gregory/management/commands/get_takeaways.py
@@ -117,7 +117,9 @@ class Command(BaseCommand):
 
 	def handle(self, *args, **options):
 		org_id = options.get('org_id')
-		limit = options.get('limit') or 20
+		limit = options.get('limit')
+		if limit is None:
+			limit = 20
 		dry_run = options.get('dry_run')
 
 		if limit <= 0:

--- a/django/gregory/tests/management/test_get_takeaways_command.py
+++ b/django/gregory/tests/management/test_get_takeaways_command.py
@@ -1,15 +1,65 @@
+"""
+Tests for the get_takeaways management command.
+
+The command summarises article abstracts and writes the result into
+ArticleOrgContent for every organisation the article belongs to via teams.
+
+Run with:
+    docker exec gregory python manage.py test gregory.tests.management.test_get_takeaways_command
+"""
 import os
 import django
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
 django.setup()
 
+from io import StringIO
+from unittest.mock import patch, MagicMock
+
 from django.core.management import call_command
 from django.test import TestCase
-from unittest.mock import patch, MagicMock
-from gregory.management.commands.get_takeaways import Command
+from organizations.models import Organization
 
-class GetTakeawaysCommandTest(TestCase):
+from gregory.management.commands.get_takeaways import Command
+from gregory.models import Articles, ArticleOrgContent, OrganizationApiSettings, Team
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_org(name, slug=''):
+	slug = slug or name.lower().replace(' ', '-')
+	org = Organization.objects.create(name=name, slug=slug)
+	OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=False)
+	return org
+
+
+def _make_team(org, name):
+	return Team.objects.create(organization=org, name=name, slug=name.lower().replace(' ', '-'))
+
+
+def _make_article(teams, title, link, summary):
+	article = Articles.objects.create(
+		title=title,
+		link=link,
+		summary=summary,
+		kind='science paper',
+	)
+	for team in teams:
+		article.teams.add(team)
+	return article
+
+
+# A summary long enough for `get_summary_max_length` to return >25
+_LONG_ABSTRACT = ('word ' * 80).strip()
+
+
+# ---------------------------------------------------------------------------
+# Pure unit tests for static helpers
+# ---------------------------------------------------------------------------
+
+class GetTakeawaysHelpersTest(TestCase):
 	def test_clean_html(self):
 		self.assertEqual(Command.clean_html('<b>hi</b>'), 'hi')
 
@@ -23,11 +73,138 @@ class GetTakeawaysCommandTest(TestCase):
 		mock_summarizer.assert_called_once()
 		self.assertEqual(result, 'ok')
 
+
+# ---------------------------------------------------------------------------
+# Integration-style tests against the DB
+# ---------------------------------------------------------------------------
+
+class GetTakeawaysFanOutTest(TestCase):
+	"""Generating once per article should fan out to every linked org."""
+
+	def setUp(self):
+		self.org_a = _make_org('Takeaways Org A')
+		self.org_b = _make_org('Takeaways Org B', 'takeaways-org-b')
+		self.team_a = _make_team(self.org_a, 'Takeaways Team A')
+		self.team_b = _make_team(self.org_b, 'Takeaways Team B')
+		self.article = _make_article(
+			[self.team_a, self.team_b],
+			'Multi-org article',
+			'https://example.com/multi',
+			_LONG_ABSTRACT,
+		)
+
 	@patch('gregory.management.commands.get_takeaways.pipeline')
-	@patch('gregory.management.commands.get_takeaways.Articles')
-	def test_handle_processes_queryset(self, mock_articles, mock_pipeline):
-		qs = [MagicMock(summary='test', article_id=1, save=MagicMock(), takeaways=None)]
-		mock_articles.objects.annotate.return_value.filter.return_value = qs
-		mock_pipeline.return_value = MagicMock(return_value=[{'summary_text': 'x'}])
-		call_command('get_takeaways')
-		mock_pipeline.assert_called_once_with('summarization', model='philschmid/bart-large-cnn-samsum')
+	def test_fans_out_to_all_orgs_with_single_inference(self, mock_pipeline):
+		summarizer = MagicMock(return_value=[{'summary_text': 'GENERATED'}])
+		summarizer.tokenizer = MagicMock()
+		mock_pipeline.return_value = summarizer
+
+		call_command('get_takeaways', stdout=StringIO())
+
+		# Both orgs should now have rows with the generated takeaway.
+		self.assertEqual(ArticleOrgContent.objects.count(), 2)
+		for org in (self.org_a, self.org_b):
+			row = ArticleOrgContent.objects.get(article=self.article, organization=org)
+			self.assertEqual(row.takeaways, 'GENERATED')
+
+		# Crucially, the summariser ran exactly once even though we wrote two rows.
+		self.assertEqual(summarizer.call_count, 1)
+		# Model was loaded exactly once for the run.
+		mock_pipeline.assert_called_once_with(
+			'summarization', model='philschmid/bart-large-cnn-samsum'
+		)
+
+	@patch('gregory.management.commands.get_takeaways.pipeline')
+	def test_org_id_scopes_generation(self, mock_pipeline):
+		summarizer = MagicMock(return_value=[{'summary_text': 'SCOPED'}])
+		summarizer.tokenizer = MagicMock()
+		mock_pipeline.return_value = summarizer
+
+		call_command('get_takeaways', org_id=self.org_a.pk, stdout=StringIO())
+
+		self.assertEqual(ArticleOrgContent.objects.count(), 1)
+		row = ArticleOrgContent.objects.get()
+		self.assertEqual(row.organization_id, self.org_a.pk)
+		self.assertEqual(row.takeaways, 'SCOPED')
+
+	@patch('gregory.management.commands.get_takeaways.pipeline')
+	def test_skips_orgs_that_already_have_takeaways(self, mock_pipeline):
+		ArticleOrgContent.objects.create(
+			article=self.article,
+			organization=self.org_a,
+			takeaways='Editor wrote this',
+		)
+		summarizer = MagicMock(return_value=[{'summary_text': 'GENERATED'}])
+		summarizer.tokenizer = MagicMock()
+		mock_pipeline.return_value = summarizer
+
+		call_command('get_takeaways', stdout=StringIO())
+
+		# Org A row stays untouched, Org B gets a new row.
+		row_a = ArticleOrgContent.objects.get(article=self.article, organization=self.org_a)
+		row_b = ArticleOrgContent.objects.get(article=self.article, organization=self.org_b)
+		self.assertEqual(row_a.takeaways, 'Editor wrote this')
+		self.assertEqual(row_b.takeaways, 'GENERATED')
+
+	@patch('gregory.management.commands.get_takeaways.pipeline')
+	def test_fills_existing_row_with_empty_takeaways(self, mock_pipeline):
+		ArticleOrgContent.objects.create(
+			article=self.article,
+			organization=self.org_a,
+			takeaways='',
+			summary_plain_english='Pre-existing plain english',
+		)
+		summarizer = MagicMock(return_value=[{'summary_text': 'GENERATED'}])
+		summarizer.tokenizer = MagicMock()
+		mock_pipeline.return_value = summarizer
+
+		call_command('get_takeaways', stdout=StringIO())
+
+		row_a = ArticleOrgContent.objects.get(article=self.article, organization=self.org_a)
+		self.assertEqual(row_a.takeaways, 'GENERATED')
+		# The previously-set plain English text must not be wiped.
+		self.assertEqual(row_a.summary_plain_english, 'Pre-existing plain english')
+
+
+class GetTakeawaysOrphanTest(TestCase):
+	"""Articles with no linked organisation should be skipped with a warning."""
+
+	def setUp(self):
+		self.article = Articles.objects.create(
+			title='Orphan',
+			link='https://example.com/orphan',
+			summary=_LONG_ABSTRACT,
+			kind='science paper',
+		)
+
+	@patch('gregory.management.commands.get_takeaways.pipeline')
+	def test_orphan_is_skipped_with_warning(self, mock_pipeline):
+		summarizer = MagicMock(return_value=[{'summary_text': 'X'}])
+		summarizer.tokenizer = MagicMock()
+		mock_pipeline.return_value = summarizer
+
+		err = StringIO()
+		call_command('get_takeaways', stdout=StringIO(), stderr=err)
+
+		self.assertEqual(ArticleOrgContent.objects.count(), 0)
+		# Model is never loaded because no work was found.
+		mock_pipeline.assert_not_called()
+		self.assertIn('orphan', err.getvalue().lower())
+
+
+class GetTakeawaysDryRunTest(TestCase):
+	"""--dry-run must not load the model or write any rows."""
+
+	def setUp(self):
+		self.org = _make_org('Dry Run Org')
+		self.team = _make_team(self.org, 'Dry Run Team')
+		self.article = _make_article(
+			[self.team], 'Dry article', 'https://example.com/dry', _LONG_ABSTRACT
+		)
+
+	@patch('gregory.management.commands.get_takeaways.pipeline')
+	def test_dry_run_writes_nothing_and_skips_model(self, mock_pipeline):
+		call_command('get_takeaways', dry_run=True, stdout=StringIO())
+
+		self.assertEqual(ArticleOrgContent.objects.count(), 0)
+		mock_pipeline.assert_not_called()


### PR DESCRIPTION
## Summary

- Switches `get_takeaways` from writing the legacy `Articles.takeaways` column to populating per-organisation `ArticleOrgContent` rows.
- One summariser call per article, fanned out to every organisation the article belongs to via teams (skips rows that already have non-empty takeaways).
- Adds `--org-id`, `--limit`, and `--dry-run` flags; orphan articles (no orgs) are skipped with a warning; existing `summary_plain_english` content is preserved when filling an empty `takeaways` row.

## Test plan

- [ ] `docker exec gregory python manage.py test gregory.tests.management.test_get_takeaways_command`
- [ ] Spot-check with `docker exec gregory python manage.py get_takeaways --dry-run` on a populated DB — no rows should be written and no model loaded.
- [ ] Run `docker exec gregory python manage.py get_takeaways --limit 1` for one article, confirm an `ArticleOrgContent` row appears for every linked org of that article and the `Articles.takeaways` column is untouched.
- [ ] Run the full pipeline (`docker exec gregory python manage.py pipeline`) and confirm step 8 still completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)