### PR TITLE
fix(subscriptions): use api_domain for unsubscribe links

### DIFF
--- a/django/subscriptions/admin.py
+++ b/django/subscriptions/admin.py
@@ -17,6 +17,7 @@ import bleach
 from .models import Subscribers, Lists, FailedNotification, ListSubscription, SubscriberSiteProfile, Announcement, AnnouncementRecipient
 from .forms import ListsAdminForm, AnnouncementAdminForm
 from gregory.models import Team
+from subscriptions.management.commands.utils.get_credentials import build_unsubscribe_base_url
 
 # Allowlist for announcement body HTML (used by bleach sanitization)
 _ANNOUNCEMENT_ALLOWED_TAGS = [
@@ -1183,12 +1184,7 @@ class AnnouncementAdmin(admin.ModelAdmin):
 		if subscriber:
 			context['subscriber'] = subscriber
 		if site:
-			# Always use site.domain (the domain the list is linked to) so that
-			# all footer links are consistent with Lists.site.
-			# Strip whitespace to guard against accidental spaces in Site.domain.
-			_domain = site.domain.strip()
-			_scheme = 'https' if _domain not in ('localhost', '127.0.0.1') else 'http'
-			context['unsubscribe_base_url'] = f"{_scheme}://{_domain}"
+			context['unsubscribe_base_url'] = build_unsubscribe_base_url(site, custom_settings)
 			context['site'] = site
 		if list_id:
 			context['list_id'] = list_id

--- a/django/subscriptions/management/commands/send_admin_summary.py
+++ b/django/subscriptions/management/commands/send_admin_summary.py
@@ -114,10 +114,10 @@ class Command(BaseCommand):
 					organization=organization,
 				)
 				# Inject unsubscribe context for the footer template
-				# Always use site.domain (the domain the list is linked to) so that
-				# all footer links are consistent with Lists.site.
-				# Strip whitespace to guard against accidental spaces in Site.domain.
-				_domain = site.domain.strip()
+				# Prefer CustomSetting.api_domain (the backend-reachable domain) for
+				# unsubscribe links; fall back to site.domain when api_domain is unset.
+				_api_domain = customsettings.api_domain.strip() if customsettings and customsettings.api_domain else ''
+				_domain = _api_domain or site.domain.strip()
 				_scheme = 'https' if _domain not in ('localhost', '127.0.0.1') else 'http'
 				summary_context['list_id'] = admin_list.list_id
 				summary_context['unsubscribe_base_url'] = f"{_scheme}://{_domain}"

--- a/django/subscriptions/management/commands/send_admin_summary.py
+++ b/django/subscriptions/management/commands/send_admin_summary.py
@@ -3,7 +3,7 @@ from django.core.management.base import BaseCommand
 from django.template.loader import get_template
 from django.utils.html import strip_tags
 from gregory.models import Articles, Trials, MLPredictions
-from subscriptions.management.commands.utils.get_credentials import get_postmark_credentials, get_site_and_settings
+from subscriptions.management.commands.utils.get_credentials import build_unsubscribe_base_url, get_postmark_credentials, get_site_and_settings
 from subscriptions.management.commands.utils.send_email import send_email
 from subscriptions.management.commands.utils.subscription import get_trials_for_list, get_articles_for_list
 from subscriptions.models import Lists, Subscribers, SentArticleNotification, SentTrialNotification, FailedNotification
@@ -114,13 +114,8 @@ class Command(BaseCommand):
 					organization=organization,
 				)
 				# Inject unsubscribe context for the footer template
-				# Prefer CustomSetting.api_domain (the backend-reachable domain) for
-				# unsubscribe links; fall back to site.domain when api_domain is unset.
-				_api_domain = customsettings.api_domain.strip() if customsettings and customsettings.api_domain else ''
-				_domain = _api_domain or site.domain.strip()
-				_scheme = 'https' if _domain not in ('localhost', '127.0.0.1') else 'http'
 				summary_context['list_id'] = admin_list.list_id
-				summary_context['unsubscribe_base_url'] = f"{_scheme}://{_domain}"
+				summary_context['unsubscribe_base_url'] = build_unsubscribe_base_url(site, customsettings)
 				summary_context['header_title'] = admin_list.header_title or ''
 				summary_context['header_tagline'] = admin_list.header_tagline or ''
 				summary_context['show_header_tagline'] = admin_list.show_header_tagline

--- a/django/subscriptions/management/commands/send_trials_notification.py
+++ b/django/subscriptions/management/commands/send_trials_notification.py
@@ -7,7 +7,7 @@ from subscriptions.management.commands.utils.send_email import send_email
 from subscriptions.management.commands.utils.subscription import get_trials_for_list
 from subscriptions.models import Lists, Subscribers, SentTrialNotification, FailedNotification
 
-from subscriptions.management.commands.utils.get_credentials import get_postmark_credentials, get_site_and_settings
+from subscriptions.management.commands.utils.get_credentials import build_unsubscribe_base_url, get_postmark_credentials, get_site_and_settings
 from templates.emails.components.content_organizer import get_optimized_email_context
 
 
@@ -98,13 +98,8 @@ class Command(BaseCommand):
 					custom_settings=customsettings
 				)
 				# Inject unsubscribe context for the footer template
-				# Always use site.domain (the domain the list is linked to) so that
-				# all footer links are consistent with Lists.site.
-				# Strip whitespace to guard against accidental spaces in Site.domain.
-				_domain = site.domain.strip()
-				_scheme = 'https' if _domain not in ('localhost', '127.0.0.1') else 'http'
 				summary_context['list_id'] = lst.list_id
-				summary_context['unsubscribe_base_url'] = f"{_scheme}://{_domain}"
+				summary_context['unsubscribe_base_url'] = build_unsubscribe_base_url(site, customsettings)
 				summary_context['header_title'] = lst.header_title or ''
 				summary_context['header_tagline'] = lst.header_tagline or ''
 				summary_context['show_header_tagline'] = lst.show_header_tagline

--- a/django/subscriptions/management/commands/send_weekly_summary.py
+++ b/django/subscriptions/management/commands/send_weekly_summary.py
@@ -10,7 +10,7 @@ from subscriptions.management.commands.utils.subscription import (
 	get_latest_research_by_category,
 )
 from gregory.models import Articles, Authors, Trials, MLPredictions
-from subscriptions.management.commands.utils.get_credentials import get_postmark_credentials, get_site_and_settings
+from subscriptions.management.commands.utils.get_credentials import build_unsubscribe_base_url, get_postmark_credentials, get_site_and_settings
 from subscriptions.models import (
 	Lists,
 	Subscribers,
@@ -402,13 +402,8 @@ class Command(BaseCommand):
 				)
 
 				# Inject unsubscribe context for the footer template
-				# Prefer CustomSetting.api_domain (the backend-reachable domain) for
-				# unsubscribe links; fall back to site.domain when api_domain is unset.
-				_api_domain = customsettings.api_domain.strip() if customsettings and customsettings.api_domain else ''
-				_domain = _api_domain or site.domain.strip()
-				_scheme = 'https' if _domain not in ('localhost', '127.0.0.1') else 'http'
 				summary_context['list_id'] = digest_list.list_id
-				summary_context['unsubscribe_base_url'] = f"{_scheme}://{_domain}"
+				summary_context['unsubscribe_base_url'] = build_unsubscribe_base_url(site, customsettings)
 				summary_context['header_title'] = digest_list.header_title or ''
 				summary_context['header_tagline'] = digest_list.header_tagline or ''
 				summary_context['show_header_tagline'] = digest_list.show_header_tagline

--- a/django/subscriptions/management/commands/send_weekly_summary.py
+++ b/django/subscriptions/management/commands/send_weekly_summary.py
@@ -402,10 +402,10 @@ class Command(BaseCommand):
 				)
 
 				# Inject unsubscribe context for the footer template
-				# Always use site.domain (the domain the list is linked to) so that
-				# all footer links are consistent with Lists.site.
-				# Strip whitespace to guard against accidental spaces in Site.domain.
-				_domain = site.domain.strip()
+				# Prefer CustomSetting.api_domain (the backend-reachable domain) for
+				# unsubscribe links; fall back to site.domain when api_domain is unset.
+				_api_domain = customsettings.api_domain.strip() if customsettings and customsettings.api_domain else ''
+				_domain = _api_domain or site.domain.strip()
 				_scheme = 'https' if _domain not in ('localhost', '127.0.0.1') else 'http'
 				summary_context['list_id'] = digest_list.list_id
 				summary_context['unsubscribe_base_url'] = f"{_scheme}://{_domain}"

--- a/django/subscriptions/management/commands/utils/get_credentials.py
+++ b/django/subscriptions/management/commands/utils/get_credentials.py
@@ -1,8 +1,34 @@
+import re
+
 from django.conf import settings
 from django.contrib.sites.models import Site
 
 from gregory.models import OrganizationCredentials, OrganizationSite
 from sitesettings.models import CustomSetting
+
+_SCHEME_RE = re.compile(r'^https?://', re.IGNORECASE)
+
+
+def build_unsubscribe_base_url(site, customsettings=None):
+	"""
+	Return the base URL (scheme + host) used for unsubscribe links.
+
+	Prefers CustomSetting.api_domain when non-empty; falls back to site.domain.
+	Strips any scheme prefix an admin may have pasted into api_domain (e.g.
+	"https://api.example.com" → "api.example.com") to prevent double-scheme URLs.
+	"""
+	raw = ''
+	if customsettings and customsettings.api_domain:
+		raw = customsettings.api_domain.strip()
+	if not raw:
+		raw = (site.domain.strip() if site and site.domain else '')
+
+	domain = _SCHEME_RE.sub('', raw).rstrip('/')
+	if not domain:
+		return ''
+
+	scheme = 'http' if domain in ('localhost', '127.0.0.1') else 'https'
+	return f"{scheme}://{domain}"
 
 
 def get_orcid_credentials(organization):

--- a/django/subscriptions/tests/test_unsubscribe_url.py
+++ b/django/subscriptions/tests/test_unsubscribe_url.py
@@ -3,16 +3,14 @@ Tests for the unsubscribe_base_url logic in send_weekly_summary.
 
 The command derives the URL as:
 
-    scheme               = 'http' if site.domain in ('localhost', '127.0.0.1') else 'https'
-    unsubscribe_base_url = f"{scheme}://{site.domain}"
-
-The footer always uses the domain from Lists.site, ensuring consistency with
-the domain the distribution list is explicitly linked to. The CustomSetting
-api_domain field is no longer used for unsubscribe links.
+    api_domain           = CustomSetting.api_domain (stripped) if non-empty
+    domain               = api_domain or site.domain (stripped)
+    scheme               = 'http' if domain in ('localhost', '127.0.0.1') else 'https'
+    unsubscribe_base_url = f"{scheme}://{domain}"
 
 Scenarios:
-1. api_domain set on CustomSetting  → ignored; site.domain is used
-2. api_domain empty / not set       → site.domain used (same as before)
+1. api_domain set on CustomSetting  → api_domain is used
+2. api_domain empty / not set       → site.domain used as fallback
 3. site.domain == 'localhost'       → http:// scheme
 4. site.domain == '127.0.0.1'      → http:// scheme
 """
@@ -130,8 +128,8 @@ class TestUnsubscribeBaseUrl(TestCase):
 		return_value=("test-token", "https://api.postmarkapp.com/email"),
 	)
 	@patch("subscriptions.management.commands.send_weekly_summary.send_email")
-	def test_api_domain_ignored_site_domain_always_used(self, mock_send_email, _mock_creds):
-		"""api_domain is no longer used for unsubscribe links; site.domain is always used."""
+	def test_api_domain_used_when_set(self, mock_send_email, _mock_creds):
+		"""When api_domain is set on CustomSetting, unsubscribe links use it."""
 		self.custom_settings.api_domain = "api.example.com"
 		self.custom_settings.save()
 
@@ -139,14 +137,14 @@ class TestUnsubscribeBaseUrl(TestCase):
 
 		html = self._captured_html(mock_send_email)
 		self.assertIn(
-			"https://testserver.example.com/subscriptions/unsubscribe/",
-			html,
-			"Unsubscribe link should always use site.domain, not api_domain",
-		)
-		self.assertNotIn(
 			"https://api.example.com/subscriptions/unsubscribe/",
 			html,
-			"Unsubscribe link must NOT use api_domain",
+			"Unsubscribe link should use CustomSetting.api_domain when set",
+		)
+		self.assertNotIn(
+			"https://testserver.example.com/subscriptions/unsubscribe/",
+			html,
+			"Unsubscribe link must NOT use site.domain when api_domain is set",
 		)
 
 	@patch(
@@ -155,7 +153,7 @@ class TestUnsubscribeBaseUrl(TestCase):
 	)
 	@patch("subscriptions.management.commands.send_weekly_summary.send_email")
 	def test_site_domain_used_when_api_domain_empty(self, mock_send_email, _mock_creds):
-		"""When api_domain is empty, unsubscribe links use site.domain."""
+		"""When api_domain is empty, unsubscribe links fall back to site.domain."""
 		self.custom_settings.api_domain = ""
 		self.custom_settings.save()
 
@@ -165,7 +163,7 @@ class TestUnsubscribeBaseUrl(TestCase):
 		self.assertIn(
 			"https://testserver.example.com/subscriptions/unsubscribe/",
 			html,
-			"Unsubscribe link should use site.domain",
+			"Unsubscribe link should fall back to site.domain when api_domain is empty",
 		)
 
 	@patch(
@@ -174,9 +172,11 @@ class TestUnsubscribeBaseUrl(TestCase):
 	)
 	@patch("subscriptions.management.commands.send_weekly_summary.send_email")
 	def test_http_scheme_for_localhost(self, mock_send_email, _mock_creds):
-		"""When site.domain is 'localhost', the scheme must be http://."""
+		"""When the resolved domain is 'localhost', the scheme must be http://."""
 		self.site.domain = "localhost"
 		self.site.save()
+		self.custom_settings.api_domain = ""
+		self.custom_settings.save()
 
 		self._run(mock_send_email)
 
@@ -198,9 +198,11 @@ class TestUnsubscribeBaseUrl(TestCase):
 	)
 	@patch("subscriptions.management.commands.send_weekly_summary.send_email")
 	def test_http_scheme_for_loopback_ip(self, mock_send_email, _mock_creds):
-		"""When site.domain is '127.0.0.1', the scheme must be http://."""
+		"""When the resolved domain is '127.0.0.1', the scheme must be http://."""
 		self.site.domain = "127.0.0.1"
 		self.site.save()
+		self.custom_settings.api_domain = ""
+		self.custom_settings.save()
 
 		self._run(mock_send_email)
 

--- a/django/subscriptions/tests/test_unsubscribe_url.py
+++ b/django/subscriptions/tests/test_unsubscribe_url.py
@@ -1,18 +1,24 @@
 """
-Tests for the unsubscribe_base_url logic in send_weekly_summary.
+Tests for unsubscribe_base_url logic.
 
-The command derives the URL as:
+Covers two layers:
+  1. build_unsubscribe_base_url() unit tests — scheme selection, api_domain
+     precedence, whitespace stripping, and scheme-prefix normalisation.
+  2. send_weekly_summary integration tests — end-to-end email output.
 
-    api_domain           = CustomSetting.api_domain (stripped) if non-empty
-    domain               = api_domain or site.domain (stripped)
-    scheme               = 'http' if domain in ('localhost', '127.0.0.1') else 'https'
-    unsubscribe_base_url = f"{scheme}://{domain}"
+Resolution order:
+    api_domain  = CustomSetting.api_domain stripped, scheme-prefix removed
+    domain      = api_domain if non-empty, else site.domain stripped
+    scheme      = 'http' if domain in ('localhost', '127.0.0.1') else 'https'
+    base_url    = f"{scheme}://{domain}"
 
 Scenarios:
-1. api_domain set on CustomSetting  → api_domain is used
-2. api_domain empty / not set       → site.domain used as fallback
-3. site.domain == 'localhost'       → http:// scheme
-4. site.domain == '127.0.0.1'      → http:// scheme
+1. api_domain set                              → api_domain used
+2. api_domain empty / whitespace-only          → site.domain fallback
+3. api_domain with leading scheme prefix       → prefix stripped
+4. api_domain with leading/trailing whitespace → whitespace stripped
+5. site.domain == 'localhost'                  → http:// scheme
+6. site.domain == '127.0.0.1'                 → http:// scheme
 """
 import os
 import django
@@ -30,6 +36,7 @@ from django.utils.timezone import now
 from gregory.models import Subject, Articles, Team
 from organizations.models import Organization
 from sitesettings.models import CustomSetting
+from subscriptions.management.commands.utils.get_credentials import build_unsubscribe_base_url
 from subscriptions.models import Lists, Subscribers, ListSubscription
 
 
@@ -40,6 +47,84 @@ def _ok_response():
 	mock.json.return_value = {"ErrorCode": 0, "Message": "OK"}
 	return mock
 
+
+# ── Unit tests for the helper ─────────────────────────────────────────────────
+
+class TestBuildUnsubscribeBaseUrl(TestCase):
+	"""Unit tests for build_unsubscribe_base_url()."""
+
+	def _site(self, domain):
+		site = MagicMock()
+		site.domain = domain
+		return site
+
+	def _cs(self, api_domain):
+		cs = MagicMock(spec=CustomSetting)
+		cs.api_domain = api_domain
+		return cs
+
+	def test_api_domain_preferred_over_site_domain(self):
+		self.assertEqual(
+			build_unsubscribe_base_url(self._site('site.example.com'), self._cs('api.example.com')),
+			'https://api.example.com',
+		)
+
+	def test_fallback_to_site_domain_when_api_domain_empty(self):
+		self.assertEqual(
+			build_unsubscribe_base_url(self._site('site.example.com'), self._cs('')),
+			'https://site.example.com',
+		)
+
+	def test_fallback_to_site_domain_when_api_domain_whitespace_only(self):
+		self.assertEqual(
+			build_unsubscribe_base_url(self._site('site.example.com'), self._cs('   ')),
+			'https://site.example.com',
+		)
+
+	def test_whitespace_stripped_from_api_domain(self):
+		self.assertEqual(
+			build_unsubscribe_base_url(self._site('site.example.com'), self._cs('  api.example.com  ')),
+			'https://api.example.com',
+		)
+
+	def test_https_scheme_prefix_stripped_from_api_domain(self):
+		self.assertEqual(
+			build_unsubscribe_base_url(self._site('site.example.com'), self._cs('https://api.example.com')),
+			'https://api.example.com',
+		)
+
+	def test_http_scheme_prefix_stripped_from_api_domain(self):
+		self.assertEqual(
+			build_unsubscribe_base_url(self._site('site.example.com'), self._cs('http://api.example.com')),
+			'https://api.example.com',
+		)
+
+	def test_http_scheme_for_localhost(self):
+		self.assertEqual(
+			build_unsubscribe_base_url(self._site('localhost'), None),
+			'http://localhost',
+		)
+
+	def test_http_scheme_for_loopback_ip(self):
+		self.assertEqual(
+			build_unsubscribe_base_url(self._site('127.0.0.1'), None),
+			'http://127.0.0.1',
+		)
+
+	def test_no_customsettings(self):
+		self.assertEqual(
+			build_unsubscribe_base_url(self._site('site.example.com'), None),
+			'https://site.example.com',
+		)
+
+	def test_empty_site_domain_returns_empty(self):
+		self.assertEqual(
+			build_unsubscribe_base_url(self._site(''), self._cs('')),
+			'',
+		)
+
+
+# ── Integration tests via send_weekly_summary ─────────────────────────────────
 
 class TestUnsubscribeBaseUrl(TestCase):
 	"""Ensure send_weekly_summary injects the correct unsubscribe_base_url."""
@@ -145,6 +230,49 @@ class TestUnsubscribeBaseUrl(TestCase):
 			"https://testserver.example.com/subscriptions/unsubscribe/",
 			html,
 			"Unsubscribe link must NOT use site.domain when api_domain is set",
+		)
+
+	@patch(
+		"subscriptions.management.commands.send_weekly_summary.get_postmark_credentials",
+		return_value=("test-token", "https://api.postmarkapp.com/email"),
+	)
+	@patch("subscriptions.management.commands.send_weekly_summary.send_email")
+	def test_api_domain_with_scheme_prefix(self, mock_send_email, _mock_creds):
+		"""api_domain containing a scheme prefix must not produce a double-scheme URL."""
+		self.custom_settings.api_domain = "https://api.example.com"
+		self.custom_settings.save()
+
+		self._run(mock_send_email)
+
+		html = self._captured_html(mock_send_email)
+		self.assertIn(
+			"https://api.example.com/subscriptions/unsubscribe/",
+			html,
+			"Scheme prefix in api_domain should be stripped before building the URL",
+		)
+		self.assertNotIn(
+			"https://https://",
+			html,
+			"Double-scheme must never appear in the unsubscribe URL",
+		)
+
+	@patch(
+		"subscriptions.management.commands.send_weekly_summary.get_postmark_credentials",
+		return_value=("test-token", "https://api.postmarkapp.com/email"),
+	)
+	@patch("subscriptions.management.commands.send_weekly_summary.send_email")
+	def test_whitespace_only_api_domain_falls_back_to_site_domain(self, mock_send_email, _mock_creds):
+		"""Whitespace-only api_domain is treated as unset; site.domain is used."""
+		self.custom_settings.api_domain = "   "
+		self.custom_settings.save()
+
+		self._run(mock_send_email)
+
+		html = self._captured_html(mock_send_email)
+		self.assertIn(
+			"https://testserver.example.com/subscriptions/unsubscribe/",
+			html,
+			"Whitespace-only api_domain should fall back to site.domain",
 		)
 
 	@patch(

--- a/django/templates/emails/views.py
+++ b/django/templates/emails/views.py
@@ -18,6 +18,7 @@ from django.views.decorators.http import require_http_methods
 
 from gregory.models import Articles, Trials
 from sitesettings.models import CustomSetting
+from subscriptions.management.commands.utils.get_credentials import build_unsubscribe_base_url
 from subscriptions.models import Lists, Subscribers
 from templates.emails.components.content_organizer import get_optimized_email_context
 
@@ -157,9 +158,7 @@ def _build_preview_context(request, template_name):
 		context['header_title'] = list_obj.header_title or ''
 		context['header_tagline'] = list_obj.header_tagline or ''
 		context['show_header_tagline'] = list_obj.show_header_tagline
-	_domain = (getattr(site, 'domain', '') or '').strip()
-	_scheme = 'https' if _domain not in ('localhost', '127.0.0.1') else 'http'
-	context['unsubscribe_base_url'] = f"{_scheme}://{_domain}" if _domain else ''
+	context['unsubscribe_base_url'] = build_unsubscribe_base_url(site, custom_settings)
 	context['subscriber'] = subscriber
 
 	return context


### PR DESCRIPTION
## Summary

- `CustomSetting.api_domain` already existed with help_text *"Used for unsubscribe links"*, but the code was ignoring it and always using `site.domain` instead.
- `send_weekly_summary` and `send_admin_summary` now prefer `api_domain` (stripped) when set, falling back to `site.domain` when empty.
- Updated `test_unsubscribe_url.py` to assert the correct behaviour (the old tests were explicitly asserting the wrong behaviour).

## Test plan

- [ ] `test_api_domain_used_when_set` — api_domain present → used in unsubscribe URL
- [ ] `test_site_domain_used_when_api_domain_empty` — api_domain empty → falls back to site.domain
- [ ] `test_http_scheme_for_localhost` — localhost resolves to http://
- [ ] `test_http_scheme_for_loopback_ip` — 127.0.0.1 resolves to http://

All 4 tests pass locally (`docker exec gregory python manage.py test subscriptions.tests.test_unsubscribe_url`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)