### PR TITLE
feat(stats): add org filter, reduce joins, cache payload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ db-pull: | $(BACKUP_DIR)
 	docker exec -i db psql -U $(POSTGRES_USER) -d $(POSTGRES_DB) < $(DUMP_FILE)
 	@echo "==> Running Django migrations ..."
 	docker exec gregory python manage.py migrate --run-syncdb
-	docker exec gregory python manage.py createcachetable
+	docker exec gregory python manage.py createcachetable gregory_cache
 	@echo "==> Done. Local database is now a copy of production."
 
 ## Restore the most recently modified SQL file in $(BACKUP_DIR)/
@@ -137,7 +137,7 @@ db-upgrade-finish: | $(BACKUP_DIR)
 	docker compose up -d gregory
 	@echo "==> Running Django migrations"
 	docker exec gregory python manage.py migrate --run-syncdb
-	docker exec gregory python manage.py createcachetable
+	docker exec gregory python manage.py createcachetable gregory_cache
 	@echo "==> Done. Verify, then remove postgres-data.pre-upgrade.* once happy."
 
 $(BACKUP_DIR):

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ db-pull: | $(BACKUP_DIR)
 	docker exec -i db psql -U $(POSTGRES_USER) -d $(POSTGRES_DB) < $(DUMP_FILE)
 	@echo "==> Running Django migrations ..."
 	docker exec gregory python manage.py migrate --run-syncdb
+	docker exec gregory python manage.py createcachetable
 	@echo "==> Done. Local database is now a copy of production."
 
 ## Restore the most recently modified SQL file in $(BACKUP_DIR)/
@@ -136,6 +137,7 @@ db-upgrade-finish: | $(BACKUP_DIR)
 	docker compose up -d gregory
 	@echo "==> Running Django migrations"
 	docker exec gregory python manage.py migrate --run-syncdb
+	docker exec gregory python manage.py createcachetable
 	@echo "==> Done. Verify, then remove postgres-data.pre-upgrade.* once happy."
 
 $(BACKUP_DIR):

--- a/django/admin/settings.py
+++ b/django/admin/settings.py
@@ -136,7 +136,7 @@ DATABASES = {
 }
 
 # Cache backend — shared across gunicorn workers via the existing Postgres DB.
-# Run `python manage.py createcachetable` once after deploy to create the table.
+# Run `python manage.py createcachetable gregory_cache` once after deploy to create the table.
 CACHES = {
 	'default': {
 		'BACKEND': 'django.core.cache.backends.db.DatabaseCache',

--- a/django/admin/settings.py
+++ b/django/admin/settings.py
@@ -135,6 +135,18 @@ DATABASES = {
 	}
 }
 
+# Cache backend — shared across gunicorn workers via the existing Postgres DB.
+# Run `python manage.py createcachetable` once after deploy to create the table.
+CACHES = {
+	'default': {
+		'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+		'LOCATION': 'gregory_cache',
+	}
+}
+
+# TTL (seconds) for the /stats/ response cache. Override via STATS_CACHE_TTL env var.
+STATS_CACHE_TTL = int(os.environ.get('STATS_CACHE_TTL', '600'))
+
 # Password validation
 AUTH_PASSWORD_VALIDATORS = [
 	{'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},

--- a/django/api/tests/test_visibility_stats.py
+++ b/django/api/tests/test_visibility_stats.py
@@ -300,37 +300,47 @@ class OrgFilterStatsTest(StatsVisibilityBase):
 
 
 class OrgAndTeamIntersectionTest(StatsVisibilityBase):
-	"""?organization= + ?team= intersection semantics."""
+	"""?organization= + ?team= intersection semantics.
+
+	Uses an authenticated member of my_org with ?include_public=true so that
+	both my_org and pub_org are visible, allowing precise intersection tests.
+	"""
 
 	def setUp(self):
 		super().setUp()
 		from django.core.cache import cache
 		cache.clear()
+		self.user = User.objects.create_user(username='intersect-member', password='pw')
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
 
 	def test_team_in_org_returns_correct_count(self):
 		"""team belonging to the requested org → counts scoped to that team."""
 		resp = self.client.get(
 			'/stats/',
-			{'organization': self.pub_org.id, 'team': self.pub_team.id},
+			{'organization': self.pub_org.id, 'team': self.pub_team.id, 'include_public': 'true'},
 		)
 		self.assertEqual(resp.status_code, 200)
 		self.assertEqual(resp.data['articles'], 1)
 
 	def test_team_not_in_org_returns_zero_not_404(self):
-		"""team valid + org valid but team not in org → 200 with zero counts."""
+		"""Both team and org are visible but team belongs to a different org.
+
+		my_team (in my_org) + ?organization=pub_org → intersection empty
+		→ 200 with zero counts (both params individually valid, result is empty).
+		"""
 		resp = self.client.get(
 			'/stats/',
-			{'organization': self.pub_org.id, 'team': self.pub_team.id + 999},
+			{'organization': self.pub_org.id, 'team': self.my_team.id, 'include_public': 'true'},
 		)
-		# The team ID doesn't exist so it resolves to an empty team_id_list;
-		# that is a well-formed request that yields zero results, not 404.
-		self.assertIn(resp.status_code, (200, 404))
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 0)
 
 	def test_hidden_team_with_visible_org_returns_404(self):
 		"""A hidden team requested alongside a visible org is still 404."""
 		resp = self.client.get(
 			'/stats/',
-			{'organization': self.pub_org.id, 'team': self.priv_team.id},
+			{'organization': self.pub_org.id, 'team': self.priv_team.id, 'include_public': 'true'},
 		)
 		self.assertEqual(resp.status_code, 404)
 
@@ -346,6 +356,11 @@ class StatsCacheTest(StatsVisibilityBase):
 		super().setUp()
 		from django.core.cache import cache
 		cache.clear()
+		# Second public org/team so both cache entries can be populated by an
+		# anonymous caller (my_team is private; only public teams are visible).
+		self.pub_org2 = _make_org('Public Org 2', 'pub-org2-cache-stats', public=True)
+		self.pub_team2 = _make_team(self.pub_org2, 'Pub Team 2 Cache Stats')
+		_make_article('Pub Art 2 Cache', 'https://st.ex/cache/a2', teams=[self.pub_team2])
 
 	def test_second_request_served_from_cache(self):
 		"""Two identical requests issue DB count queries only on the first."""
@@ -370,15 +385,18 @@ class StatsCacheTest(StatsVisibilityBase):
 		self.assertLess(second_count, first_count)
 
 	def test_cache_key_differs_by_team(self):
-		"""Requests for different teams are cached independently."""
+		"""Requests for different visible teams are cached independently."""
 		from django.core.cache import cache as django_cache
 
 		self.client.get('/stats/', {'team': self.pub_team.id})
-		self.client.get('/stats/', {'team': self.my_team.id})
+		self.client.get('/stats/', {'team': self.pub_team2.id})
 
-		# Two distinct cache entries should exist (neither evicts the other).
-		pub_key = f'stats:{self.pub_team.id}'
-		self.assertIsNotNone(django_cache.get(pub_key))
+		# Both requests must produce distinct, non-None cache entries.
+		key1 = f'stats:{self.pub_team.id}'
+		key2 = f'stats:{self.pub_team2.id}'
+		self.assertIsNotNone(django_cache.get(key1))
+		self.assertIsNotNone(django_cache.get(key2))
+		self.assertNotEqual(key1, key2)
 
 	def test_cache_cleared_between_tests(self):
 		"""setUp.cache.clear() isolates test runs."""

--- a/django/api/tests/test_visibility_stats.py
+++ b/django/api/tests/test_visibility_stats.py
@@ -1,5 +1,5 @@
 """
-Tests for StatsView visibility enforcement (PR 6).
+Tests for StatsView visibility enforcement and filtering.
 
 Covers:
   - Anonymous caller: counts reflect public orgs only
@@ -8,6 +8,9 @@ Covers:
   - ?team=<id> for a hidden team → 404
   - ?team=<id> for a visible team → counts scoped to that team
   - ?include_public=true adds public org data for identified callers
+  - ?organization= / ?org= alias: scoping, visibility, intersection with ?team=
+  - Cache: second identical request served from cache (zero count queries)
+  - assertNumQueries: pins the query budget for a typical scoped call
 
 Run with:
     docker exec gregory python manage.py test api.tests.test_visibility_stats
@@ -251,3 +254,169 @@ class NullOrgAPIKeyStatsVisibilityTest(StatsVisibilityBase):
 		resp = self.client.get('/stats/', {'team': self.pub_team.id})
 		self.assertEqual(resp.status_code, 200)
 		self.assertEqual(resp.data['articles'], 1)
+
+
+# ---------------------------------------------------------------------------
+# ?organization= filter
+# ---------------------------------------------------------------------------
+
+class OrgFilterStatsTest(StatsVisibilityBase):
+	"""?organization= scopes counts and enforces visibility."""
+
+	def setUp(self):
+		super().setUp()
+		from django.core.cache import cache
+		cache.clear()
+
+	def test_org_filter_visible_org_scopes_counts(self):
+		"""?organization=<public org> returns only that org's counts."""
+		resp = self.client.get('/stats/', {'organization': self.pub_org.id})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 1)
+		self.assertEqual(resp.data['trials'], 1)
+
+	def test_org_filter_hidden_org_returns_404(self):
+		"""?organization=<private org> (not visible to anon) returns 404."""
+		resp = self.client.get('/stats/', {'organization': self.priv_org.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_org_filter_mixed_visible_hidden_returns_404(self):
+		"""Any hidden org in a comma-separated list returns 404."""
+		resp = self.client.get(
+			'/stats/',
+			{'organization': f'{self.pub_org.id},{self.priv_org.id}'},
+		)
+		self.assertEqual(resp.status_code, 404)
+
+	def test_org_filter_invalid_value_returns_400(self):
+		resp = self.client.get('/stats/', {'organization': 'abc'})
+		self.assertEqual(resp.status_code, 400)
+
+	def test_org_alias_param_accepted(self):
+		"""?org= is accepted as an alias for ?organization=."""
+		resp = self.client.get('/stats/', {'org': self.pub_org.id})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 1)
+
+
+class OrgAndTeamIntersectionTest(StatsVisibilityBase):
+	"""?organization= + ?team= intersection semantics."""
+
+	def setUp(self):
+		super().setUp()
+		from django.core.cache import cache
+		cache.clear()
+
+	def test_team_in_org_returns_correct_count(self):
+		"""team belonging to the requested org → counts scoped to that team."""
+		resp = self.client.get(
+			'/stats/',
+			{'organization': self.pub_org.id, 'team': self.pub_team.id},
+		)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data['articles'], 1)
+
+	def test_team_not_in_org_returns_zero_not_404(self):
+		"""team valid + org valid but team not in org → 200 with zero counts."""
+		resp = self.client.get(
+			'/stats/',
+			{'organization': self.pub_org.id, 'team': self.pub_team.id + 999},
+		)
+		# The team ID doesn't exist so it resolves to an empty team_id_list;
+		# that is a well-formed request that yields zero results, not 404.
+		self.assertIn(resp.status_code, (200, 404))
+
+	def test_hidden_team_with_visible_org_returns_404(self):
+		"""A hidden team requested alongside a visible org is still 404."""
+		resp = self.client.get(
+			'/stats/',
+			{'organization': self.pub_org.id, 'team': self.priv_team.id},
+		)
+		self.assertEqual(resp.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
+# Cache behaviour
+# ---------------------------------------------------------------------------
+
+class StatsCacheTest(StatsVisibilityBase):
+	"""The second identical request within the TTL is served from cache."""
+
+	def setUp(self):
+		super().setUp()
+		from django.core.cache import cache
+		cache.clear()
+
+	def test_second_request_served_from_cache(self):
+		"""Two identical requests issue DB count queries only on the first."""
+		from django.db import connection, reset_queries
+		from django.conf import settings as django_settings
+
+		orig_debug = django_settings.DEBUG
+		django_settings.DEBUG = True
+		try:
+			reset_queries()
+			self.client.get('/stats/', {'team': self.pub_team.id})
+			first_count = len(connection.queries)
+
+			reset_queries()
+			self.client.get('/stats/', {'team': self.pub_team.id})
+			second_count = len(connection.queries)
+		finally:
+			django_settings.DEBUG = orig_debug
+
+		# The second call must issue fewer queries than the first
+		# (cache hit replaces the four COUNT queries with one SELECT).
+		self.assertLess(second_count, first_count)
+
+	def test_cache_key_differs_by_team(self):
+		"""Requests for different teams are cached independently."""
+		from django.core.cache import cache as django_cache
+
+		self.client.get('/stats/', {'team': self.pub_team.id})
+		self.client.get('/stats/', {'team': self.my_team.id})
+
+		# Two distinct cache entries should exist (neither evicts the other).
+		pub_key = f'stats:{self.pub_team.id}'
+		self.assertIsNotNone(django_cache.get(pub_key))
+
+	def test_cache_cleared_between_tests(self):
+		"""setUp.cache.clear() isolates test runs."""
+		from django.core.cache import cache as django_cache
+		self.assertIsNone(django_cache.get('stats:all'))
+
+
+# ---------------------------------------------------------------------------
+# Query-count regression guard
+# ---------------------------------------------------------------------------
+
+class StatsQueryCountTest(StatsVisibilityBase):
+	"""assertNumQueries pins the query budget so regressions are caught."""
+
+	def setUp(self):
+		super().setUp()
+		from django.core.cache import cache
+		cache.clear()
+
+	def test_scoped_call_query_budget(self):
+		"""
+		A team-scoped /stats/ call must stay within a small query budget.
+
+		Budget breakdown (cold cache, 14 queries):
+		  1 — VisibleOrgMiddleware: OrganizationApiSettings lookup
+		  1 — team visibility check (Team.objects.filter COUNT)
+		  1 — resolve team_id_list (Team VALUES)
+		  1 — cache GET (miss)
+		  4 — articles, trials, authors, subscribers COUNT DISTINCT
+		  1 — sources VALUES
+		  4 — cache SET (COUNT + SAVEPOINT + key lookup + INSERT + RELEASE)
+		= 14 queries.
+		"""
+		with self.assertNumQueries(14, msg="StatsView exceeded the query budget"):
+			self.client.get('/stats/', {'team': self.pub_team.id})
+
+	def test_cached_call_query_budget(self):
+		"""A cache-warm call must issue far fewer queries than a cold one."""
+		self.client.get('/stats/', {'team': self.pub_team.id})  # warm the cache
+		with self.assertNumQueries(4, msg="Cache hit should eliminate the count queries"):
+			self.client.get('/stats/', {'team': self.pub_team.id})

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.core.cache import cache
 from api.serializers import (
 		ArticleSerializer, TrialSerializer, SourceSerializer, AuthorSerializer,
 		CategorySerializer, CategoryTopAuthorSerializer, TeamSerializer, SubjectsSerializer,
@@ -2150,14 +2152,24 @@ class AuthorSearchView(generics.ListAPIView):
 class StatsView(APIView):
 	"""
 	Returns aggregate statistics about the data in the system.
-	All counts can be optionally scoped to one or more teams via ?team=1 or ?team=1,2,3.
 
-	Counts are filtered to organisations visible to the caller when
-	``request.visible_org_ids`` is present (set by VisibleOrgMiddleware).
-	If the attribute is absent — e.g. in management commands or tests that
-	bypass middleware — the fallback is unscoped querysets that span all
-	organisations.  In production the middleware is always active, so callers
-	will always receive org-filtered results.
+	Filters
+	-------
+	?team=1,2,3
+	    Scope to one or more teams (comma-separated integer IDs).
+	?organization=1,2  (alias: ?org=)
+	    Scope to one or more organisations (comma-separated integer IDs).
+	    When combined with ?team=, the effective scope is the intersection:
+	    teams that belong to the requested org(s).
+
+	Both params are validated against ``request.visible_org_ids``
+	(set by VisibleOrgMiddleware).  A team or org that is not visible to the
+	caller returns 404 so that existence is not leaked.  When the middleware
+	attribute is absent (management commands, tests bypassing middleware) the
+	visibility check is skipped and the params still narrow the queryset.
+
+	Results are short-lived cached (STATS_CACHE_TTL seconds, default 600) using
+	Django's database cache so all gunicorn workers share the same value.
 	"""
 	permission_classes = [permissions.AllowAny]
 
@@ -2165,10 +2177,9 @@ class StatsView(APIView):
 		from urllib.parse import urlparse
 		from subscriptions.models import Subscribers
 
-		# --- Org visibility ------------------------------------------------
 		visible_org_ids = getattr(request, 'visible_org_ids', None)
 
-		# Parse team IDs from query params
+		# --- Parse ?team= -----------------------------------------------
 		team_param = request.query_params.get('team', None)
 		team_ids = None
 		if team_param:
@@ -2177,63 +2188,93 @@ class StatsView(APIView):
 			except ValueError:
 				return Response(
 					{'error': 'Invalid team parameter. Expected integer or comma-separated integers.'},
-					status=status.HTTP_400_BAD_REQUEST
+					status=status.HTTP_400_BAD_REQUEST,
 				)
-			# 404 if any requested team is not in a visible org
-			if visible_org_ids is not None:
-				visible = Team.objects.filter(id__in=team_ids, organization_id__in=visible_org_ids)
-				if visible.count() != len(set(team_ids)):
-					raise Http404
 
-		# Base querysets scoped to visible orgs (no-op when middleware absent)
-		if visible_org_ids is not None:
-			articles_base     = Articles.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
-			trials_base       = Trials.objects.filter(teams__organization_id__in=visible_org_ids).distinct()
-			authors_base      = Authors.objects.filter(articles__teams__organization_id__in=visible_org_ids).distinct()
-			sources_base      = Sources.objects.filter(team__organization_id__in=visible_org_ids)
-			subscribers_base  = Subscribers.objects.filter(subscriptions__team__organization_id__in=visible_org_ids)
+		# --- Parse ?organization= (alias ?org=) -------------------------
+		org_param = request.query_params.get('organization') or request.query_params.get('org')
+		org_ids = None
+		if org_param:
+			try:
+				org_ids = [int(o.strip()) for o in org_param.split(',') if o.strip()]
+			except ValueError:
+				return Response(
+					{'error': 'Invalid organization parameter. Expected integer or comma-separated integers.'},
+					status=status.HTTP_400_BAD_REQUEST,
+				)
+
+		# --- Visibility validation (no extra DB queries for org check) --
+		if org_ids and visible_org_ids is not None:
+			if not set(org_ids).issubset(visible_org_ids):
+				raise Http404
+
+		if team_ids and visible_org_ids is not None:
+			visible = Team.objects.filter(id__in=team_ids, organization_id__in=visible_org_ids)
+			if visible.count() != len(set(team_ids)):
+				raise Http404
+
+		# --- Resolve effective org scope --------------------------------
+		# org_ids already validated as a subset of visible_org_ids above,
+		# so the effective set is exactly org_ids when given.
+		if org_ids is not None:
+			effective_org_ids = set(org_ids)
 		else:
-			articles_base     = Articles.objects.all()
-			trials_base       = Trials.objects.all()
-			authors_base      = Authors.objects.all()
-			sources_base      = Sources.objects.all()
-			subscribers_base  = Subscribers.objects.all()
+			effective_org_ids = visible_org_ids  # may be None (middleware absent)
 
-		# Articles count
-		if team_ids:
-			articles_count = articles_base.filter(teams__in=team_ids).distinct().count()
+		# --- Resolve in-scope team IDs (one query, reused for all counts)
+		# When there is no scoping at all, fall through to .objects.all()
+		# to preserve teamless articles/trials in the unscoped count.
+		fully_unscoped = effective_org_ids is None and not team_ids
+
+		if not fully_unscoped:
+			teams_qs = Team.objects.all()
+			if effective_org_ids is not None:
+				teams_qs = teams_qs.filter(organization_id__in=effective_org_ids)
+			if team_ids:
+				teams_qs = teams_qs.filter(id__in=team_ids)
+			team_id_list = list(teams_qs.values_list('id', flat=True))
 		else:
-			articles_count = articles_base.count()
+			team_id_list = None
 
-		# Trials count
-		if team_ids:
-			trials_count = trials_base.filter(teams__in=team_ids).distinct().count()
+		# --- Cache lookup -----------------------------------------------
+		cache_key = 'stats:' + (
+			'all' if team_id_list is None
+			else ','.join(str(i) for i in sorted(team_id_list))
+		)
+		cached = cache.get(cache_key)
+		if cached is not None:
+			return Response(cached)
+
+		# --- Counts (single join per queryset) --------------------------
+		if fully_unscoped:
+			articles_count    = Articles.objects.count()
+			trials_count      = Trials.objects.count()
+			authors_count     = Authors.objects.count()
+			subscribers_count = Subscribers.objects.filter(active=True).distinct().count()
+			sources_qs        = Sources.objects.all()
 		else:
-			trials_count = trials_base.count()
+			articles_count = (
+				Articles.objects.filter(teams__in=team_id_list).distinct().count()
+			)
+			trials_count = (
+				Trials.objects.filter(teams__in=team_id_list).distinct().count()
+			)
+			authors_count = (
+				Authors.objects
+				.filter(articles__teams__in=team_id_list)
+				.distinct()
+				.count()
+			)
+			subscribers_count = (
+				Subscribers.objects
+				.filter(active=True, subscriptions__team__in=team_id_list)
+				.distinct()
+				.count()
+			)
+			# Sources has a direct FK to Team — no distinct needed.
+			sources_qs = Sources.objects.filter(team_id__in=team_id_list)
 
-		# Subscribers count (active only)
-		if team_ids:
-			subscribers_count = subscribers_base.filter(
-				active=True,
-				subscriptions__team__in=team_ids
-			).distinct().count()
-		else:
-			subscribers_count = subscribers_base.filter(active=True).distinct().count()
-
-		# Authors count (distinct authors linked to articles in scope)
-		if team_ids:
-			authors_count = authors_base.filter(
-				articles__teams__in=team_ids
-			).distinct().count()
-		else:
-			authors_count = authors_base.count()
-
-		# Sources queryset scoped to team(s)
-		if team_ids:
-			sources_qs = sources_base.filter(team__in=team_ids)
-		else:
-			sources_qs = sources_base
-
+		# --- Sources domain aggregation (single pass) -------------------
 		def extract_domain(url):
 			if not url:
 				return None
@@ -2244,34 +2285,24 @@ class StatsView(APIView):
 
 		source_data = list(sources_qs.values('link', 'source_for'))
 
-		# sources.total = number of unique domains
 		all_domains = set()
-		for s in source_data:
-			d = extract_domain(s['link'])
-			if d:
-				all_domains.add(d)
-
-		# sources.by_type = unique domain count per source type
 		type_domains = {}
-		for s in source_data:
-			d = extract_domain(s['link'])
-			if d:
-				type_domains.setdefault(s['source_for'], set()).add(d)
-		sources_by_type = {k: len(v) for k, v in type_domains.items()}
-
-		# sources.by_domain = each unique domain with count of individual feeds
 		domain_feed_count = {}
 		for s in source_data:
 			d = extract_domain(s['link'])
 			if d:
+				all_domains.add(d)
+				type_domains.setdefault(s['source_for'], set()).add(d)
 				domain_feed_count[d] = domain_feed_count.get(d, 0) + 1
+
+		sources_by_type = {k: len(v) for k, v in type_domains.items()}
 		sources_by_domain = sorted(
 			[{'domain': d, 'count': c} for d, c in domain_feed_count.items()],
 			key=lambda x: x['count'],
-			reverse=True
+			reverse=True,
 		)
 
-		return Response({
+		payload = {
 			'articles': articles_count,
 			'trials': trials_count,
 			'subscribers': subscribers_count,
@@ -2280,5 +2311,7 @@ class StatsView(APIView):
 				'total': len(all_domains),
 				'by_type': sources_by_type,
 				'by_domain': sources_by_domain,
-			}
-		})
+			},
+		}
+		cache.set(cache_key, payload, settings.STATS_CACHE_TTL)
+		return Response(payload)

--- a/docs/01-install.md
+++ b/docs/01-install.md
@@ -62,7 +62,7 @@ This starts the Django application, PostgreSQL, and any supporting services defi
 
 ```bash
 docker exec gregory python manage.py migrate
-docker exec gregory python manage.py createcachetable
+docker exec gregory python manage.py createcachetable gregory_cache
 docker exec gregory python manage.py createsuperuser
 ```
 

--- a/docs/01-install.md
+++ b/docs/01-install.md
@@ -62,6 +62,7 @@ This starts the Django application, PostgreSQL, and any supporting services defi
 
 ```bash
 docker exec gregory python manage.py migrate
+docker exec gregory python manage.py createcachetable
 docker exec gregory python manage.py createsuperuser
 ```
 

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -169,7 +169,61 @@ GET /articles/?has_clinical_trials=true
 | Email templates | `GET /emails/context/{template_name}/` | `template_name` (path) | |
 | RSS feeds | `GET /feed/author/{orcid}/` | `orcid` (path) | |
 | RSS feeds | `GET /feed/trials/subject/{subject_slug}/` | `subject_slug` (path) | |
+| Stats | `GET /stats/` | `team`, `organization` (alias `org`), `include_public` | See [Stats endpoint](#stats-endpoint) below |
 | Subscriptions | `POST /subscriptions/new/` | `first_name`, `last_name`, `email`, `profile`, `list` | |
+
+### Stats endpoint
+
+`GET /stats/` returns aggregate counts for the data visible to the caller.
+
+```
+GET /stats/
+GET /stats/?organization=3
+GET /stats/?organization=3,7
+GET /stats/?team=12
+GET /stats/?organization=3&team=12
+GET /stats/?include_public=true
+```
+
+Response shape (unchanged across all filter combinations):
+
+```json
+{
+  "articles": 1234,
+  "trials": 56,
+  "subscribers": 78,
+  "authors": 910,
+  "sources": {
+    "total": 42,
+    "by_type": { "science paper": 35, "clinical trial": 7 },
+    "by_domain": [
+      { "domain": "pubmed.ncbi.nlm.nih.gov", "count": 12 },
+      ...
+    ]
+  }
+}
+```
+
+#### Filter parameters
+
+| Parameter | Type | Behaviour |
+|:----------|:-----|:----------|
+| `organization` | int or CSV of ints | Scope counts to one or more organisations. Alias `org` is accepted. |
+| `team` | int or CSV of ints | Scope counts to one or more teams. |
+| `include_public` | bool (`true`/`false`) | Handled by the visibility layer — adds public-org data for identified callers. |
+
+When both `organization` and `team` are given the effective scope is their **intersection**: teams that belong to the requested org(s).
+
+#### Error responses
+
+| Status | Condition |
+|:-------|:----------|
+| `400 Bad Request` | Non-integer value in `team` or `organization`. |
+| `404 Not Found` | Any requested `team` or `organization` is not visible to the caller (hidden org — existence is not leaked). |
+
+#### Caching
+
+Results are cached for `STATS_CACHE_TTL` seconds (default 600 s / 10 min) using Django's database cache. All gunicorn workers share the same cached value. The cache key encodes the resolved set of in-scope team IDs, so different filter combinations are cached independently.
 
 ### Trials-specific filter parameters
 

--- a/example.env
+++ b/example.env
@@ -35,6 +35,10 @@ EMAIL_USE_TLS='True'
 EMAIL_POSTMARK_API_KEY=''
 EMAIL_POSTMARK_API_URL='https://api.postmarkapp.com/email'
 
+# Stats endpoint cache TTL in seconds. Default: 600 (10 minutes).
+# Increase for lower DB load; decrease for fresher counts after pipeline runs.
+STATS_CACHE_TTL=600
+
 # --- ORCID API ---
 # ORCID credentials are no longer configured here.
 # Set orcid_client_id and orcid_client_secret per organisation in the Django admin


### PR DESCRIPTION
## Summary

- **New `?organization=` filter** (alias `?org=`) scopes `/stats/` counts to one or more organisations, with the same visibility enforcement as `?team=` (hidden org → 404, malformed value → 400). When combined with `?team=`, the effective scope is the intersection.
- **Single-join counts** — previously the view built a base queryset filtered by `teams__organization_id__in` and then re-filtered by `teams__in`, producing a double join on the `articles_teams` / `trials_teams` through tables. Now in-scope team IDs are resolved once and reused across all four counts.
- **Single-pass source aggregation** — replaced three separate Python loops over the source rows with one.
- **Response caching** — payload cached for `STATS_CACHE_TTL` seconds (default 600 s) using Django's `DatabaseCache`, backed by the existing PostgreSQL database (no Redis). All gunicorn workers share the same value. Cache key encodes the resolved team-ID list.

## Commits (one per spec task)

1. `feat(cache)` — add `DatabaseCache` backend and `STATS_CACHE_TTL` setting to `django/admin/settings.py` + `example.env`
2. `chore(deploy)` — add `createcachetable` after `migrate` in `Makefile` and `docs/01-install.md`
3. `feat(stats)` — refactor `StatsView.get()` in `django/api/views.py`
4. `test(stats)` — extend `test_visibility_stats.py` with org filter, intersection, cache, and `assertNumQueries` budget tests
5. `docs(stats)` — document the endpoint in `docs/03-api-and-rss-feeds.md`

## Query budget (verified against test DB)

| Call | Queries |
|:-----|:--------|
| Cold cache (team-scoped) | **14** (was N×joins per param combo) |
| Warm cache (same params) | **4** (visibility checks + cache GET) |

## Pre-existing test failures

`NullOrgAPIKeyStatsVisibilityTest` (2 tests) errors with `IntegrityError: null value in organization_id` — these broke in PR #657 when the `NOT NULL` constraint was enforced on `api_apiaccessscheme.organization_id`. Unrelated to this branch.

## Test plan

- [ ] `docker exec gregory python manage.py createcachetable` — creates `gregory_cache` table
- [ ] `docker exec gregory python manage.py test api.tests.test_visibility_stats` — 28/30 pass (2 pre-existing errors noted above)
- [ ] Manual: `GET /stats/?organization=<id>` returns scoped counts
- [ ] Manual: `GET /stats/?organization=<hidden>` returns 404
- [ ] Manual: `GET /stats/?organization=abc` returns 400
- [ ] Manual: two identical requests within 10 min return the same value faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)