### PR TITLE
fix(subscriptions): improve announcement image quality on upload

### DIFF
--- a/django/subscriptions/views.py
+++ b/django/subscriptions/views.py
@@ -522,13 +522,26 @@ def ckeditor_upload(request):
 
 		buf = io.BytesIO()
 		image.save(buf, **save_kwargs)
+		encoded_size = buf.getbuffer().nbytes
+		if encoded_size > _UPLOAD_MAX_SIZE:
+			# The re-encoded output is larger than the original upload cap
+			# (possible when a heavily-compressed original is re-saved at a
+			# higher quality for EXIF-orientation baking).  We proceed rather
+			# than reject — the user already passed validation and a post-
+			# processing rejection would be confusing UX.  Log so operators
+			# can monitor and adjust _JPEG_QUALITY / _UPLOAD_MAX_SIZE if needed.
+			logger.warning(
+				'ckeditor_upload: re-encoded %s (%s) grew from %d to %d bytes '
+				'(exceeds _UPLOAD_MAX_SIZE=%d); storing anyway.',
+				upload.name, canonical_fmt, upload.size, encoded_size, _UPLOAD_MAX_SIZE,
+			)
 		buf.seek(0)
 		upload = InMemoryUploadedFile(
 			file=buf,
 			field_name='upload',
 			name=upload.name,
 			content_type=canonical_content_type,
-			size=buf.getbuffer().nbytes,
+			size=encoded_size,
 			charset=None,
 		)
 

--- a/django/subscriptions/views.py
+++ b/django/subscriptions/views.py
@@ -485,8 +485,23 @@ def ckeditor_upload(request):
 	needs_resize = image.width > _UPLOAD_MAX_WIDTH
 
 	if not needs_resize and not needs_orient_fix:
-		# Pass through original bytes unchanged.
+		# Pass through original bytes unchanged, but normalise content_type to
+		# the Pillow-detected canonical value.  A client could legally declare
+		# 'image/jpeg' while uploading a PNG (both are in _UPLOAD_ALLOWED_TYPES)
+		# and the user-supplied content_type would otherwise be forwarded to
+		# handle_uploaded_file(), causing the stored file's metadata to lie
+		# about its format.
 		upload.seek(0)
+		if upload.content_type != canonical_content_type:
+			raw = upload.read()
+			upload = InMemoryUploadedFile(
+				file=io.BytesIO(raw),
+				field_name='upload',
+				name=upload.name,
+				content_type=canonical_content_type,
+				size=len(raw),
+				charset=None,
+			)
 	else:
 		if needs_resize:
 			image.thumbnail((_UPLOAD_MAX_WIDTH, 10_000), Image.LANCZOS)

--- a/django/subscriptions/views.py
+++ b/django/subscriptions/views.py
@@ -10,7 +10,7 @@ from django.shortcuts import render, get_object_or_404
 from django.utils.timezone import now as tz_now
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
-from PIL import Image
+from PIL import Image, ImageOps
 from urllib.parse import urlparse
 
 from sitesettings.models import CustomSetting
@@ -369,7 +369,16 @@ def unsubscribe_all(request, token):
 # ---------------------------------------------------------------------------
 
 _UPLOAD_MAX_SIZE = 2 * 1024 * 1024  # 2 MB
-_UPLOAD_MAX_WIDTH = 600
+# 1 200 px — 2× the standard 600 px email body width, so images stay sharp
+# on retina / HiDPI mail clients when the browser scales them to 600 css px.
+_UPLOAD_MAX_WIDTH = 1200
+# Per-format save quality settings (used only when a resize or EXIF-orient
+# correction is needed; images already ≤ _UPLOAD_MAX_WIDTH pass through
+# byte-for-byte unchanged).
+_JPEG_QUALITY = 88        # above the ringing threshold on screenshots/text
+_WEBP_QUALITY = 90        # WebP scale ≠ JPEG scale; ~90 gives visual parity
+_PNG_COMPRESS_LEVEL = 9   # PNG is lossless — max zlib effort is safe
+
 # User-controlled content_type is the first gate; Pillow-detected format is
 # the authoritative second gate (see comment in the view).
 _UPLOAD_ALLOWED_TYPES = frozenset({'image/jpeg', 'image/png', 'image/gif', 'image/webp'})
@@ -389,11 +398,18 @@ def ckeditor_upload(request):
 	Hardened CKEditor 5 image upload endpoint.
 
 	Validates file size (≤ 2 MB), MIME type (JPEG / PNG / GIF / WebP),
-	and Pillow readability.  Images wider than 600 px are resized
-	(LANCZOS, aspect ratio preserved) before storage.
+	and Pillow readability.  Images wider than 1 200 px are resized
+	(LANCZOS, aspect ratio preserved) before storage.  1 200 px is 2× the
+	standard 600 px email body width, which keeps images sharp on retina /
+	HiDPI mail clients.
+
+	Images already ≤ 1 200 px wide are passed through byte-for-byte
+	unchanged *unless* they carry a non-default EXIF orientation tag, in
+	which case the orientation is baked in and the image is re-saved at
+	high quality.
 
 	Animated GIFs are flattened to their first frame when resizing is
-	required; GIFs already ≤ 600 px wide pass through unchanged.
+	required; GIFs already ≤ 1 200 px wide pass through unchanged.
 
 	Delegates storage to ``django_ckeditor_5.views.handle_uploaded_file``
 	so the file ends up in the same place as a native CKEditor upload.
@@ -453,14 +469,58 @@ def ckeditor_upload(request):
 		)
 	canonical_content_type = _FORMAT_TO_CONTENT_TYPE[canonical_fmt]
 
-	# ---- resize if necessary ----------------------------------------------
-	if image.width > _UPLOAD_MAX_WIDTH:
-		image.thumbnail((_UPLOAD_MAX_WIDTH, 10_000), Image.LANCZOS)
-		buf = io.BytesIO()
+	# ---- EXIF orientation --------------------------------------------------
+	# Bake in the EXIF orientation tag (e.g. portrait phone photos stored
+	# rotated).  This is a no-op for images without an orientation tag.
+	# We detect whether a correction was actually needed so we can decide
+	# whether to pass small images through unchanged.
+	exif_orientation = image.getexif().get(0x0112, 1)  # tag 274 = Orientation
+	needs_orient_fix = exif_orientation != 1
+	image = ImageOps.exif_transpose(image)
+
+	# ---- resize / re-encode if necessary ----------------------------------
+	# If the image is already ≤ max width AND no EXIF fix was needed, send
+	# the original bytes straight to storage without re-encoding, so there
+	# is zero quality loss.
+	needs_resize = image.width > _UPLOAD_MAX_WIDTH
+
+	if not needs_resize and not needs_orient_fix:
+		# Pass through original bytes unchanged.
+		upload.seek(0)
+	else:
+		if needs_resize:
+			image.thumbnail((_UPLOAD_MAX_WIDTH, 10_000), Image.LANCZOS)
+
+		# Build per-format save kwargs with quality-preserving settings.
 		save_kwargs = {'format': canonical_fmt}
-		if canonical_fmt == 'GIF':
+
+		# Preserve ICC colour profile so colours don't shift.
+		icc = image.info.get('icc_profile')
+		if icc:
+			save_kwargs['icc_profile'] = icc
+
+		if canonical_fmt == 'JPEG':
+			save_kwargs.update(
+				quality=_JPEG_QUALITY,
+				optimize=True,
+				progressive=True,
+				subsampling=2,  # 4:2:0 — Pillow default; keeps files small
+			)
+		elif canonical_fmt == 'WEBP':
+			save_kwargs.update(
+				quality=_WEBP_QUALITY,
+				method=6,  # slower encoder pass, better compression ratio
+			)
+		elif canonical_fmt == 'PNG':
+			save_kwargs.update(
+				optimize=True,
+				compress_level=_PNG_COMPRESS_LEVEL,
+			)
+		elif canonical_fmt == 'GIF':
 			# Animated GIFs are flattened to the first frame on resize.
 			save_kwargs['save_all'] = False
+
+		buf = io.BytesIO()
 		image.save(buf, **save_kwargs)
 		buf.seek(0)
 		upload = InMemoryUploadedFile(


### PR DESCRIPTION
## Problem

Images uploaded to announcements via the CKEditor 5 endpoint were coming out unreadable in delivered emails. Two issues compounded:

1. **Quality loss on save**: `image.save(buf, format=…)` was called with no `quality` argument, falling back to Pillow's defaults (JPEG ≈ 75, WebP ≈ 80, no `optimize`, no `progressive`). This causes visible ringing and banding on screenshots and text.
2. **600 px max width**: This is the CSS display width, not the physical pixel width. On retina/HiDPI mail clients the image is upscaled 2×, doubling every JPEG artifact.

## Changes

- **Max stored width: 600 → 1 200 px** — 2× the standard 600 px email body width, so images stay sharp at native resolution on retina mail clients (Apple Mail, Gmail web, Outlook web).
- **Pass-through for small images**: Images already ≤ 1 200 px wide with no EXIF quirks are forwarded byte-for-byte unchanged — zero re-encode, zero quality loss.
- **EXIF orientation fix** (`ImageOps.exif_transpose`): Portrait phone photos stored rotated in EXIF now render upright. Applied before the width check so the orientation decision and resize decision are independent.
- **Per-format quality settings** (only applied when resize or orientation fix is needed):
  | Format | Settings |
  |--------|----------|
  | JPEG | q=88, `optimize=True`, `progressive=True`, subsampling 4:2:0 |
  | WebP | q=90, `method=6` |
  | PNG | `optimize=True`, `compress_level=9` (lossless — no quality change) |
  | GIF | first-frame flatten preserved (existing behaviour) |
- **ICC colour profile preserved** on re-save to avoid colour shifts between design tools and email clients.
- Format policy unchanged — original format preserved (no silent JPEG/WebP conversion).
- Upload size cap unchanged — 2 MB.

## Email best practices addressed

- Width chosen for retina rendering (physical 2×), not just CSS width.
- JPEG saved as progressive for better perceived load on slow connections.
- EXIF orientation baked in (many email clients ignore the EXIF rotation tag).
- ICC profile preserved for colour accuracy.
- Small images left byte-identical — no quality tax for correctly-sized assets.

## Test plan

Manual (visual regression):
1. Re-upload both failing sample images through the announcement editor — confirm sharpness in browser and in a test newsletter.
2. Send test email to Gmail and Outlook accounts; confirm text in images is readable on retina and non-retina.
3. Upload a portrait phone photo with EXIF orientation 6 — confirm it renders upright.
4. Upload an image already ≤ 1 200 px wide — confirm byte-identical pass-through.
5. Upload an animated GIF > 1 200 px — confirm it flattens to first frame (existing behaviour, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)