### PR TITLE
feat(sitesettings): add sender_name field for email From display

### DIFF
--- a/django/sitesettings/admin.py
+++ b/django/sitesettings/admin.py
@@ -15,7 +15,7 @@ class CustomSettingInline(admin.StackedInline):
 			'fields': ['title'],
 		}),
 		('Email', {
-			'fields': ['admin_email', 'sender_email_prefix'],
+			'fields': ['admin_email', 'sender_name', 'sender_email_prefix'],
 		}),
 		('API & Domain', {
 			'fields': ['api_domain', 'allowed_domains'],

--- a/django/sitesettings/migrations/0011_customsetting_sender_name.py
+++ b/django/sitesettings/migrations/0011_customsetting_sender_name.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sitesettings', '0010_copy_allowed_domains_from_lists'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='customsetting',
+            name='sender_name',
+            field=models.CharField(
+                blank=True,
+                default='',
+                help_text="Display name shown in the email From header (e.g. 'Gregory AI'). Leave blank to fall back to the site title.",
+                max_length=100,
+            ),
+        ),
+    ]

--- a/django/sitesettings/models.py
+++ b/django/sitesettings/models.py
@@ -7,6 +7,12 @@ class CustomSetting(models.Model):
 	site = models.ForeignKey(Site, on_delete=models.PROTECT)
 	title = models.CharField(max_length=280,blank=False, null=False, unique=True)
 	admin_email = models.EmailField(max_length=254, unique=False, null=True,blank=True)
+	sender_name = models.CharField(
+		max_length=100,
+		blank=True,
+		default='',
+		help_text="Display name shown in the email From header (e.g. 'Gregory AI'). Leave blank to fall back to the site title."
+	)
 	sender_email_prefix = models.CharField(
 		max_length=64,
 		default='gregory',

--- a/django/sitesettings/tests.py
+++ b/django/sitesettings/tests.py
@@ -1,3 +1,33 @@
+from django.contrib.sites.models import Site
 from django.test import TestCase
 
-# Create your tests here.
+from .models import CustomSetting
+
+
+class SenderNameFallbackTests(TestCase):
+	"""The senders use `customsettings.sender_name or customsettings.title` as
+	the From display name. These tests pin that fallback contract so the field
+	stays backwards-compatible for sites that never set sender_name."""
+
+	def setUp(self):
+		self.site = Site.objects.create(domain='example.test', name='Example')
+
+	def _make(self, **kwargs):
+		defaults = {'site': self.site, 'title': 'Fallback Title'}
+		defaults.update(kwargs)
+		# title is unique=True, ensure each instance has a distinct one
+		return CustomSetting.objects.create(**defaults)
+
+	def test_sender_name_defaults_to_blank(self):
+		cs = self._make(title='Blank Default Site')
+		self.assertEqual(cs.sender_name, '')
+
+	def test_blank_sender_name_falls_back_to_title(self):
+		cs = self._make(title='My Project')
+		resolved = cs.sender_name or cs.title
+		self.assertEqual(resolved, 'My Project')
+
+	def test_set_sender_name_overrides_title(self):
+		cs = self._make(title='Internal Project Name', sender_name='Public Brand')
+		resolved = cs.sender_name or cs.title
+		self.assertEqual(resolved, 'Public Brand')

--- a/django/subscriptions/admin.py
+++ b/django/subscriptions/admin.py
@@ -1399,6 +1399,10 @@ class AnnouncementAdmin(admin.ModelAdmin):
 			html = self._render_announcement_email(announcement, site=site, custom_settings=custom_settings)
 			text = self._render_announcement_text(announcement)
 
+			sender_name = (
+				(custom_settings.sender_name or custom_settings.title)
+				if custom_settings else None
+			) or 'Gregory AI'
 			try:
 				response = send_email(
 					to=request.user.email,
@@ -1406,6 +1410,7 @@ class AnnouncementAdmin(admin.ModelAdmin):
 					html=html,
 					text=text,
 					site=site,
+					sender_name=sender_name,
 					api_token=api_token,
 					api_url=api_url,
 				)
@@ -1564,12 +1569,17 @@ class AnnouncementAdmin(admin.ModelAdmin):
 					live_subject = announcement.subject
 					if live_subject.startswith('[TEST] '):
 						live_subject = live_subject[7:]
+					_sender_name = (
+						(custom_settings.sender_name or custom_settings.title)
+						if custom_settings else None
+					) or 'Gregory AI'
 					response = send_email(
 						to=subscriber.email,
 						subject=live_subject,
 						html=html,
 						text=text,
 						site=site,
+						sender_name=_sender_name,
 						api_token=api_token,
 						api_url=api_url,
 					)

--- a/django/subscriptions/admin.py
+++ b/django/subscriptions/admin.py
@@ -1451,7 +1451,7 @@ class AnnouncementAdmin(admin.ModelAdmin):
 				'site_domain': _site.domain if _site else '',
 				'api_domain': _api_domain,
 				'sender_addr': _sender_addr,
-				'sender_name': 'Gregory AI',
+				'sender_name': (getattr(_cs, 'sender_name', '') or getattr(_cs, 'title', '') or 'Gregory AI'),
 				'image_rewrites': image_rewrites,
 				'list_name': first_list.list_name,
 			}

--- a/django/subscriptions/management/commands/send_admin_summary.py
+++ b/django/subscriptions/management/commands/send_admin_summary.py
@@ -131,7 +131,7 @@ class Command(BaseCommand):
 					html=html_content,
 					text=text_content,
 					site=site,
-					sender_name=customsettings.title,
+					sender_name=customsettings.sender_name or customsettings.title,
 					api_token=postmark_api_token,
 					api_url=api_url,
 					sender_prefix=customsettings.sender_email_prefix,

--- a/django/subscriptions/management/commands/send_trials_notification.py
+++ b/django/subscriptions/management/commands/send_trials_notification.py
@@ -122,7 +122,7 @@ class Command(BaseCommand):
 					html=html_content,
 					text=text_content,
 					site=site,
-					sender_name=customsettings.title,
+					sender_name=customsettings.sender_name or customsettings.title,
 					api_token=postmark_api_token,
 					api_url=api_url,
 					sender_prefix=customsettings.sender_email_prefix,

--- a/django/subscriptions/management/commands/send_weekly_summary.py
+++ b/django/subscriptions/management/commands/send_weekly_summary.py
@@ -525,7 +525,7 @@ class Command(BaseCommand):
 					html=html_content,
 					text=text_content,
 					site=site,
-					sender_name=customsettings.title,
+					sender_name=customsettings.sender_name or customsettings.title,
 					api_token=postmark_api_token,
 					api_url=api_url,
 					sender_prefix=customsettings.sender_email_prefix,


### PR DESCRIPTION
## Summary

- Adds `sender_name` (CharField, max 100) on `CustomSetting` so each site can configure the display name shown in the email "From" header independently of `title`.
- All three senders (`send_weekly_summary`, `send_admin_summary`, `send_trials_notification`) now use `customsettings.sender_name or customsettings.title`, so sites that don't set the new field keep their current behavior.
- Admin "Send Test" preview shows the configured value instead of a hardcoded "Gregory AI".

## Why

Today the From line is `<title> <prefix@domain>`, where `title` is also reused as the in-email header. Sites need to brand the in-email header and the sender display name independently (e.g. show "Brain Regeneration Research" as the sender while keeping a separate header title).

## Test plan

- [x] `docker exec gregory python manage.py test sitesettings.tests` — new fallback tests pass
- [x] `python manage.py makemigrations --check sitesettings` — clean
- [ ] Set `sender_name` in admin on a site and verify a real send shows the new name in the recipient's inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)