### PR TITLE
fix(subscriptions): guard announcement form init when org/lists are readonly

### DIFF
--- a/django/subscriptions/forms.py
+++ b/django/subscriptions/forms.py
@@ -55,34 +55,39 @@ class AnnouncementAdminForm(ModelForm):
             ).order_by('pk')
             default_org = org_qs.first()
 
-        self.fields['organization'].queryset = org_qs
-        if not self.instance.pk and default_org is not None:
-            self.fields['organization'].initial = default_org
-        # Lock the field when the user has only one valid choice.
-        if org_qs.count() <= 1:
-            self.fields['organization'].disabled = True
+        # Sent announcements get organization/lists moved to readonly by the
+        # admin, which removes them from self.fields. Skip the scoping logic
+        # in that case — there's nothing editable to scope.
+        if 'organization' in self.fields:
+            self.fields['organization'].queryset = org_qs
+            if not self.instance.pk and default_org is not None:
+                self.fields['organization'].initial = default_org
+            # Lock the field when the user has only one valid choice.
+            if org_qs.count() <= 1:
+                self.fields['organization'].disabled = True
 
-        # Lock the field post-send (defence in depth — admin also gates it).
-        if self.instance.pk and self.instance.status == 'sent':
-            self.fields['organization'].disabled = True
+            # Lock the field post-send (defence in depth — admin also gates it).
+            if self.instance.pk and self.instance.status == 'sent':
+                self.fields['organization'].disabled = True
 
-        # Scope list choices to the currently selected (or saved) org.
-        # Priority: (1) POSTed org value, (2) saved instance org on edit,
-        # (3) default org for new announcements.
-        current_org = (
-            self.data.get('organization')
-            or (self.instance.organization_id if self.instance.pk else None)
-            or (default_org.pk if default_org else None)
-        )
-        if current_org:
-            self.fields['lists'].queryset = Lists.objects.filter(
-                team__organization_id=current_org
+        if 'lists' in self.fields:
+            # Scope list choices to the currently selected (or saved) org.
+            # Priority: (1) POSTed org value, (2) saved instance org on edit,
+            # (3) default org for new announcements.
+            current_org = (
+                self.data.get('organization')
+                or (self.instance.organization_id if self.instance.pk else None)
+                or (default_org.pk if default_org else None)
             )
-        elif user_org_ids is not None:
-            # Non-superuser with no org yet picked: limit to their orgs.
-            self.fields['lists'].queryset = Lists.objects.filter(
-                team__organization__id__in=user_org_ids
-            )
+            if current_org:
+                self.fields['lists'].queryset = Lists.objects.filter(
+                    team__organization_id=current_org
+                )
+            elif user_org_ids is not None:
+                # Non-superuser with no org yet picked: limit to their orgs.
+                self.fields['lists'].queryset = Lists.objects.filter(
+                    team__organization__id__in=user_org_ids
+                )
 
     def clean(self):
         cleaned = super().clean()

--- a/django/subscriptions/tests/test_announcement_organization.py
+++ b/django/subscriptions/tests/test_announcement_organization.py
@@ -514,3 +514,56 @@ class TestSaveModelFallbackForMissingOrganization(TestCase):
 
 		obj.refresh_from_db()
 		self.assertEqual(obj.organization, self.org)
+
+
+# ---------------------------------------------------------------------------
+# Form init must not KeyError when organization/lists are readonly (sent)
+# ---------------------------------------------------------------------------
+
+class TestFormInitHandlesReadonlyOrgAndLists(TestCase):
+	"""When status='sent', the admin moves 'organization' and 'lists' into
+	readonly_fields, which removes them from the ModelForm's fields. The
+	form's __init__ must not blow up trying to scope queryset/initial on
+	those missing fields."""
+
+	def setUp(self):
+		self.org = Organization.objects.create(name='Readonly Init Org')
+		team = Team.objects.create(organization=self.org, name='RI', slug='ri-team')
+		self.lst = Lists.objects.create(list_name='RI List', team=team)
+		self.admin = AnnouncementAdmin(Announcement, admin_site)
+		self.superuser = User.objects.create_superuser(
+			username='ri_su', password='pass', email='ri_su@example.com'
+		)
+		self.ann = Announcement.objects.create(
+			subject='Sent Init Ann', body='<p>x</p>', status='sent',
+			organization=self.org,
+		)
+
+	def test_form_init_does_not_keyerror_on_sent(self):
+		req = MagicMock()
+		req.user = self.superuser
+		req.data = {}
+		# Mirror how AnnouncementAdmin.get_form builds the ModelForm — Django
+		# strips readonly fields from the form via fields/exclude.
+		form_class = self.admin.get_form(req, obj=self.ann)
+		form = form_class(instance=self.ann, request=req)
+		# organization and lists must be excluded (moved to readonly).
+		self.assertNotIn('organization', form.fields)
+		self.assertNotIn('lists', form.fields)
+		# subject should still be editable on a sent announcement? No — the
+		# admin readonly-locks it too. So just confirm subject is also gone,
+		# which proves the readonly-field stripping is in effect.
+		self.assertNotIn('subject', form.fields)
+
+	def test_form_init_still_works_on_draft(self):
+		draft = Announcement.objects.create(
+			subject='Draft Init Ann', body='<p>x</p>', status='draft',
+			organization=self.org,
+		)
+		req = MagicMock()
+		req.user = self.superuser
+		req.data = {}
+		form_class = self.admin.get_form(req, obj=draft)
+		form = form_class(instance=draft, request=req)
+		self.assertIn('organization', form.fields)
+		self.assertIn('lists', form.fields)

--- a/django/subscriptions/tests/test_announcement_organization.py
+++ b/django/subscriptions/tests/test_announcement_organization.py
@@ -547,13 +547,11 @@ class TestFormInitHandlesReadonlyOrgAndLists(TestCase):
 		# strips readonly fields from the form via fields/exclude.
 		form_class = self.admin.get_form(req, obj=self.ann)
 		form = form_class(instance=self.ann, request=req)
-		# organization and lists must be excluded (moved to readonly).
+		# organization and lists must be excluded (moved to readonly) — that
+		# is what triggered the original KeyError. Reaching this line at all
+		# proves __init__ did not crash.
 		self.assertNotIn('organization', form.fields)
 		self.assertNotIn('lists', form.fields)
-		# subject should still be editable on a sent announcement? No — the
-		# admin readonly-locks it too. So just confirm subject is also gone,
-		# which proves the readonly-field stripping is in effect.
-		self.assertNotIn('subject', form.fields)
 
 	def test_form_init_still_works_on_draft(self):
 		draft = Announcement.objects.create(


### PR DESCRIPTION
## Summary

- Fixes `KeyError: 'organization'` at `subscriptions/forms.py:58` when opening the change page of a sent announcement.
- `AnnouncementAdmin.get_readonly_fields` moves `organization` and `lists` into `readonly_fields` for sent announcements. Django strips readonly fields from the ModelForm's `self.fields`, so the form's `__init__` then blew up trying to scope queryset/initial on missing fields.
- Guards the queryset/initial/disabled assignments behind `if 'organization' in self.fields` / `if 'lists' in self.fields`.

## Repro

`GET /admin/subscriptions/announcement/<id>/change/` for any announcement with `status='sent'`.

## Test plan

- [x] New regression tests in `subscriptions/tests/test_announcement_organization.py::TestFormInitHandlesReadonlyOrgAndLists` — covers sent (fields absent) and draft (fields present) paths
- [x] Full `test_announcement_organization` suite still passes (20/20)
- [ ] Open the change page of announcement 11 in admin and confirm no 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)