### PR TITLE
Fix subscriber analytics: true historical active-subscribers chart + hardening

### DIFF
--- a/django/subscriptions/admin.py
+++ b/django/subscriptions/admin.py
@@ -375,46 +375,62 @@ class SubscriberAdmin(admin.ModelAdmin):
 		labels = [p.strftime(date_fmt) for p in period_range]
 
 		# ── Active subscribers over time ───────────────────────────────────────
-		# Counts currently-active subscribers by when they joined, building a
-		# cumulative total at each period point.  This approximation tracks the
-		# growth trajectory of the current active base; subscribers who churned
-		# between their join date and now are not included.
-		# Mirror the KPI scorecard definition: active account + at least one active
-		# list subscription, so the final data point matches the scorecard value.
-		active_subs_qs = Subscribers.objects.filter(
-			active=True,
-			list_subscriptions__is_active=True,
-		).distinct()
+		# True historical headcount: at each period point we count the distinct
+		# subscribers who had at least one active list subscription on that date,
+		# reconstructed from each subscription's active interval. Unlike a cumulative
+		# join-date count, this can rise *and* fall, so past peaks (e.g. 190 → 187)
+		# are visible. Subscription churn (unsubscribed_at) is the dominant signal.
+		#
+		# Subscribers are gated by their *current* account-active flag (active=True),
+		# mirroring the KPI scorecard so the final data point equals the "Total Active
+		# Subscribers" card. We do not replay Subscribers.history, so an account
+		# deactivated today is excluded from earlier points too; subscription opt-outs
+		# (unsubscribed_at) remain the dominant churn signal that makes the line dip.
+		from collections import defaultdict
+
+		# As-of date for each bucket = last day of the bucket, clamped to end_date.
+		# For preset ranges the final bucket's as-of date is today, so the last
+		# data point matches the "Total Active Subscribers" KPI card.
+		as_of_dates = []
+		for i, p in enumerate(period_range):
+			if i + 1 < len(period_range):
+				as_of_dates.append(min(period_range[i + 1] - timedelta(days=1), end_date))
+			else:
+				as_of_dates.append(end_date)
+
+		sub_rows = ListSubscription.objects.filter(subscriber__active=True)
 		if org_ids is not None:
-			active_subs_qs = active_subs_qs.filter(
-				list_subscriptions__list__team__organization__id__in=org_ids
-			).distinct()
-
-		pre_existing = active_subs_qs.filter(created_at__date__lt=start_date).count()
-		creation_rows = (
-			active_subs_qs
-			.filter(
-				created_at__date__gte=start_date,
-				created_at__date__lte=end_date,
-			)
-			.annotate(period=trunc_fn('created_at'))
-			.values('period')
-			.annotate(count=Count('subscriber_id', distinct=True))
-			.order_by('period')
+			sub_rows = sub_rows.filter(list__team__organization__id__in=org_ids)
+		sub_rows = sub_rows.values_list(
+			'subscriber_id', 'subscribed_at', 'unsubscribed_at', 'is_active'
 		)
-		creation_by_period = {}
-		for row in creation_rows:
-			pk = row['period']
-			if pk:
-				if hasattr(pk, 'date'):
-					pk = pk.date()
-				creation_by_period[pk] = row['count']
 
-		cumulative = pre_existing
+		# Build each subscriber's active intervals as (start_date, end_date_or_None).
+		# Trust is_active over a possibly-stale unsubscribed_at (re-subscription reuses
+		# the same row). An inactive row with no unsubscribed_at can't be placed in time,
+		# so it is skipped (rare).
+		intervals_by_sub = defaultdict(list)
+		for sub_id, sub_at, unsub_at, is_active in sub_rows:
+			if not sub_at:
+				continue
+			start = timezone.localtime(sub_at).date()
+			if is_active:
+				end = None
+			elif unsub_at is not None:
+				end = timezone.localtime(unsub_at).date()
+			else:
+				continue
+			intervals_by_sub[sub_id].append((start, end))
+
 		active_subscribers_series = []
-		for p in period_range:
-			cumulative += creation_by_period.get(p, 0)
-			active_subscribers_series.append(cumulative)
+		for as_of in as_of_dates:
+			count = 0
+			for intervals in intervals_by_sub.values():
+				for start, end in intervals:
+					if start <= as_of and (end is None or end > as_of):
+						count += 1
+						break
+			active_subscribers_series.append(count)
 
 		return JsonResponse({
 			'labels': labels,

--- a/django/templates/admin/subscriptions/subscribers/analytics.html
+++ b/django/templates/admin/subscriptions/subscribers/analytics.html
@@ -218,7 +218,7 @@
 	color: #aaa;
 	padding: 24px;
 	font-size: 13px;
-	italic;
+	font-style: italic;
 }
 .global-filter-bar {
 	display: flex;
@@ -492,12 +492,14 @@
 					<option value="">All Teams</option>
 				</select>
 			</div>
-			<canvas id="listDistributionChart"></canvas>
+			<div style="height: 300px;">
+				<canvas id="listDistributionChart"></canvas>
+			</div>
 		</div>
 		<div class="pie-chart-container">
 			<div class="chart-filter-bar">
 				<div>
-					<label style="font-weight:600;color:#555;font-size:13px;">Filter by list:</label><br style="margin-bottom:4px">
+					<label style="font-weight:600;color:#555;font-size:13px;display:block;margin-bottom:4px;">Filter by list:</label>
 					<div class="multiselect-wrap" id="profile-list-wrap">
 						<div class="multiselect-trigger" id="profile-list-trigger" role="button" tabindex="0" aria-haspopup="listbox" aria-expanded="false">
 							<span class="multiselect-placeholder" id="profile-list-label">All lists</span>
@@ -513,7 +515,9 @@
 					</div>
 				</div>
 			</div>
-			<canvas id="profileDistributionChart"></canvas>
+			<div style="height: 300px;">
+				<canvas id="profileDistributionChart"></canvas>
+			</div>
 		</div>
 	</div>
 </div>
@@ -527,6 +531,13 @@ var activeTeam = '';   // '' = all; set by team dropdown on list chart
 var activeProfileLists = []; // list IDs selected on profile chart
 var customStart = '';  // YYYY-MM-DD; set when custom range is active
 var customEnd   = '';  // YYYY-MM-DD; set when custom range is active
+
+// ── HTML escaping for values injected via innerHTML ─────────────────────────
+function escapeHtml(s) {
+	return String(s == null ? '' : s)
+		.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
 
 // ── Endpoint URLs ──────────────────────────────────────────────────────────
 var URLS = {
@@ -917,6 +928,7 @@ document.querySelectorAll('.period-btn').forEach(function(btn) {
 			customEnd   = '';
 			fetchAndRender(activeRange);
 			fetchListActivity();
+			fetchRecentActivity();
 		}
 	});
 });
@@ -936,6 +948,10 @@ document.addEventListener('DOMContentLoaded', function() {
 		if (!endInput.value) {
 			var today = new Date().toISOString().slice(0, 10);
 			endInput.value = today;
+		}
+		if (endInput.value < startInput.value) {
+			alert('The end date cannot be before the start date.');
+			return;
 		}
 		customStart = startInput.value;
 		customEnd   = endInput.value;
@@ -990,6 +1006,7 @@ function fetchDistribution() {
 					},
 					options: {
 						responsive: true,
+						maintainAspectRatio: false,
 						plugins: {
 							legend: {
 								position: 'bottom',
@@ -1057,6 +1074,7 @@ function fetchProfileDistribution() {
 					},
 					options: {
 						responsive: true,
+						maintainAspectRatio: false,
 						plugins: {
 							legend: {
 								position: 'bottom',
@@ -1101,7 +1119,7 @@ function fetchListActivity() {
 			}
 			tbody.innerHTML = data.lists.map(function(row) {
 				return '<tr>'
-					+ '<td>' + row.name + '</td>'
+					+ '<td>' + escapeHtml(row.name) + '</td>'
 					+ '<td style="text-align:right;color:#16a34a;font-weight:600">' + row.new + '</td>'
 					+ '<td style="text-align:right;color:#dc2626;font-weight:600">' + row.unsubs + '</td>'
 					+ '</tr>';
@@ -1120,7 +1138,7 @@ function fetchRecentActivity() {
 	var qs = params.toString() ? '?' + params.toString() : '';
 
 	function tag(text, cls) {
-		return '<span class="tag ' + cls + '">' + text + '</span>';
+		return '<span class="tag ' + cls + '">' + escapeHtml(text) + '</span>';
 	}
 
 	fetch(URLS.recentSubs + qs)
@@ -1139,10 +1157,10 @@ function fetchRecentActivity() {
 					? s.lists.map(function(l) { return tag(l, 'tag-list'); }).join('')
 					: '<span style="color:#bbb">—</span>';
 				return '<tr>'
-					+ '<td>' + s.name + '</td>'
+					+ '<td>' + escapeHtml(s.name) + '</td>'
 					+ '<td>' + profiles + '</td>'
 					+ '<td>' + lists + '</td>'
-					+ '<td class="date-cell">' + s.subscribed_at + '</td>'
+					+ '<td class="date-cell">' + escapeHtml(s.subscribed_at) + '</td>'
 					+ '</tr>';
 			}).join('');
 		})
@@ -1171,11 +1189,11 @@ function fetchRecentActivity() {
 					? u.kept_lists.map(function(l) { return tag(l, 'tag-kept'); }).join('')
 					: '<span style="color:#bbb">none</span>';
 				return '<tr>'
-					+ '<td>' + u.name + '</td>'
+					+ '<td>' + escapeHtml(u.name) + '</td>'
 					+ '<td>' + profiles + '</td>'
 					+ '<td>' + removed + '</td>'
 					+ '<td>' + kept + '</td>'
-					+ '<td class="date-cell">' + u.unsubscribed_at + '</td>'
+					+ '<td class="date-cell">' + escapeHtml(u.unsubscribed_at) + '</td>'
 					+ '</tr>';
 			}).join('');
 		})
@@ -1187,13 +1205,8 @@ function fetchRecentActivity() {
 }
 
 // ── Initial page load ──────────────────────────────────────────────────────
-reloadTeams();
-reloadAvailableLists();
-fetchAndRender(activeRange);
-fetchDistribution();
-fetchProfileDistribution();
-fetchRecentActivity();
-fetchListActivity();
+// Wait for the DOM so the activity-table bodies (declared after this script) exist.
+document.addEventListener('DOMContentLoaded', reloadAll);
 </script>
 
 <div class="activity-table-card" style="margin-top:32px;margin-bottom:24px">
@@ -1270,7 +1283,7 @@ fetchListActivity();
 		<dd style="margin: 0; color: #444;">Subscribers who transitioned to an inactive state during the selected period: either their account was explicitly deactivated, or they unsubscribed from all lists leaving them with no active list subscriptions.</dd>
 
 		<dt style="font-weight: 600; color: #1a1a1a;">Active Subscribers</dt>
-		<dd style="margin: 0; color: #444;">Distinct subscribers currently marked active who have at least one active list subscription.</dd>
+		<dd style="margin: 0; color: #444;">Distinct subscribers currently marked active who have at least one active list subscription. The "Total Active Subscribers" chart reconstructs this headcount at each point in the selected period from each subscription's active interval (subscribe → unsubscribe), so it can rise and fall and reflect past peaks — not just current totals.</dd>
 
 		<dt style="font-weight: 600; color: #1a1a1a;">Active Subscriptions</dt>
 		<dd style="margin: 0; color: #444;">Total active subscriber–list links right now. This is the denominator used for percentages in the pie chart.</dd>


### PR DESCRIPTION
## What & why

Reworks the **Subscriber Analytics** admin page (`analytics.html` and the `SubscriberAdmin` analytics endpoints) to fix a misleading chart, an XSS hole, and several smaller issues found during an audit.

### Backend — true historical "Active Subscribers" chart
The "Total Active Subscribers over time" line was built only from subscribers active *today*, distributed by their join date. That made it monotonic, always ending at the current total, and **unable to show past peaks** (e.g. 190 active in the past, 187 now — the 190 was invisible).

It now reconstructs each subscription's active interval from `subscribed_at` / `unsubscribed_at` (`ListSubscription`) and counts the distinct subscribers active at each period point, so the line can **rise and fall**. The count is gated on `subscriber.active=True` so the final data point still equals the "Total Active Subscribers" KPI card.

> Note: account-level deactivation history is not replayed (a currently-inactive account is excluded from earlier points too). Subscription opt-outs remain the dominant churn signal. Documented in code.

### Template fixes
- **Security**: escape all user-supplied strings before `innerHTML` in the activity-table builders — closes a stored-XSS vector via subscriber names.
- Fix invalid CSS (`italic;` → `font-style: italic;`).
- Refresh the Recent tables when leaving Custom-range mode (were showing stale data).
- Run init inside `DOMContentLoaded` via the existing `reloadAll()` so the table bodies exist first.
- Validate custom range (reject end-before-start).
- Cosmetics: drop an ineffective `<br>` margin; give the pie charts bounded height with `maintainAspectRatio:false`.
- Update Metric Definitions to describe the chart's new historical meaning.

## Verification
- `docker exec gregory python manage.py test subscriptions` → **229/230 pass**. The one failure (`test_oversized_jpeg_is_resized`) is a pre-existing CKEditor image-resize test unrelated to these changes.
- Exercised `analytics_data` end-to-end via the actual view: final point = **214** for 7d/30d/90d/365d, matching the scorecard (214); the series now varies (30d: 183 → 214).
- Confirmed the `0 → 214` rise on 90d/365d is real (all subscriptions imported 2026-04-17 → 2026-05-04; `subscribed_at` is `auto_now_add`).

## Reviewer notes
- Because `subscribed_at` is `auto_now_add`, the recent bulk import stamped subscriptions with import-time dates, so the early part of the historical curve reflects import dates rather than original signups. Real `unsubscribed_at` events will produce genuine dips going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)