### PR TITLE
Add reconcile_inactive_subscriptions cleanup command

### DIFF
--- a/django/subscriptions/management/commands/reconcile_inactive_subscriptions.py
+++ b/django/subscriptions/management/commands/reconcile_inactive_subscriptions.py
@@ -1,0 +1,80 @@
+"""Reconcile list subscriptions for globally-inactive subscribers.
+
+A subscriber's ``active`` flag is a global email switch: when ``active=False`` they
+receive no email from any list (see Subscribers.active help text). That flag can be
+set without touching their per-list ``ListSubscription`` rows — e.g. via the admin
+"Disable all emails" bulk action, which uses ``queryset.update(active=False)``. The
+result is "drift": an inactive account that still holds ``is_active=True``
+subscriptions. Those subscriptions are stale (the person is already suppressed from
+all email) and cause analytics to over-count active subscribers.
+
+This command brings subscription state in line with the global opt-out: for every
+active subscription belonging to an inactive account, it sets ``is_active=False`` and
+stamps ``unsubscribed_at`` (preserving any existing timestamp). It never re-enables
+email for anyone, so it is GDPR-safe.
+
+Dry-run by default; pass ``--apply`` to write changes. The command is idempotent.
+"""
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone
+
+from subscriptions.models import ListSubscription
+
+
+class Command(BaseCommand):
+	help = (
+		"Opt out stale active subscriptions held by globally-inactive subscribers "
+		"(active=False). Dry-run by default; pass --apply to write changes."
+	)
+
+	def add_arguments(self, parser):
+		parser.add_argument(
+			'--apply',
+			action='store_true',
+			help='Write the changes. Without this flag the command only reports (dry run).',
+		)
+
+	def handle(self, *args, **options):
+		apply_changes = options['apply']
+
+		# Active subscriptions belonging to a globally-inactive account.
+		stale_qs = ListSubscription.objects.filter(
+			is_active=True,
+			subscriber__active=False,
+		)
+
+		affected_rows = stale_qs.count()
+		affected_subscribers = stale_qs.values('subscriber_id').distinct().count()
+
+		if affected_rows == 0:
+			self.stdout.write(self.style.SUCCESS(
+				'Nothing to reconcile — no active subscriptions on inactive accounts.'
+			))
+			return
+
+		self.stdout.write(
+			f'Found {affected_rows} active subscription(s) across {affected_subscribers} '
+			f'inactive subscriber account(s).'
+		)
+
+		if not apply_changes:
+			for ls in stale_qs.select_related('subscriber', 'list')[:10]:
+				self.stdout.write(f'  would opt-out: {ls.subscriber.email} → {ls.list.list_name}')
+			if affected_rows > 10:
+				self.stdout.write(f'  … and {affected_rows - 10} more')
+			self.stdout.write(self.style.WARNING(
+				'Dry run — no changes written. Re-run with --apply to commit.'
+			))
+			return
+
+		now = timezone.now()
+		with transaction.atomic():
+			# Stamp unsubscribed_at only where missing, then flip is_active.
+			stale_qs.filter(unsubscribed_at__isnull=True).update(unsubscribed_at=now)
+			updated = stale_qs.update(is_active=False)
+
+		self.stdout.write(self.style.SUCCESS(
+			f'Reconciled {updated} subscription(s) across {affected_subscribers} account(s): '
+			f'set is_active=False and stamped unsubscribed_at where missing.'
+		))

--- a/django/subscriptions/tests/test_reconcile_inactive_subscriptions.py
+++ b/django/subscriptions/tests/test_reconcile_inactive_subscriptions.py
@@ -1,0 +1,96 @@
+"""Tests for the reconcile_inactive_subscriptions management command."""
+import os
+import django
+from datetime import timedelta
+from io import StringIO
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
+django.setup()
+
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from gregory.models import Team
+from organizations.models import Organization
+from subscriptions.models import Lists, Subscribers, ListSubscription
+
+
+class ReconcileInactiveSubscriptionsTests(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(name="Recon Org", slug="recon-org")
+		self.team = Team.objects.create(name="Recon Team", organization=self.org, slug="recon-team")
+		self.site, _ = Site.objects.get_or_create(
+			id=1, defaults={"domain": "testserver.example.com", "name": "Test Site"},
+		)
+		self.list_a = Lists.objects.create(list_name="List A", team=self.team)
+		self.list_b = Lists.objects.create(list_name="List B", team=self.team)
+
+		# Drifted: inactive account still holding active subscriptions.
+		self.inactive_sub = Subscribers.objects.create(
+			first_name="In", last_name="Active", email="inactive@example.com", active=False,
+		)
+		self.drift_a = ListSubscription.objects.create(
+			subscriber=self.inactive_sub, list=self.list_a, is_active=True,
+		)
+		self.drift_b = ListSubscription.objects.create(
+			subscriber=self.inactive_sub, list=self.list_b, is_active=True,
+		)
+
+		# Healthy: active account with an active subscription — must be untouched.
+		self.active_sub = Subscribers.objects.create(
+			first_name="Act", last_name="Ive", email="active@example.com", active=True,
+		)
+		self.healthy = ListSubscription.objects.create(
+			subscriber=self.active_sub, list=self.list_a, is_active=True,
+		)
+
+	def _run(self, *args):
+		out = StringIO()
+		call_command('reconcile_inactive_subscriptions', *args, stdout=out)
+		return out.getvalue()
+
+	def test_dry_run_reports_but_does_not_change(self):
+		output = self._run()  # no --apply
+		self.assertIn('Found 2 active subscription(s) across 1', output)
+		self.assertIn('Dry run', output)
+		# Nothing changed.
+		self.drift_a.refresh_from_db()
+		self.drift_b.refresh_from_db()
+		self.assertTrue(self.drift_a.is_active)
+		self.assertTrue(self.drift_b.is_active)
+		self.assertIsNone(self.drift_a.unsubscribed_at)
+
+	def test_apply_opts_out_drifted_subscriptions(self):
+		output = self._run('--apply')
+		self.assertIn('Reconciled 2 subscription(s)', output)
+
+		self.drift_a.refresh_from_db()
+		self.drift_b.refresh_from_db()
+		self.assertFalse(self.drift_a.is_active)
+		self.assertFalse(self.drift_b.is_active)
+		self.assertIsNotNone(self.drift_a.unsubscribed_at)
+		self.assertIsNotNone(self.drift_b.unsubscribed_at)
+
+	def test_apply_leaves_healthy_subscription_untouched(self):
+		self._run('--apply')
+		self.healthy.refresh_from_db()
+		self.assertTrue(self.healthy.is_active)
+		self.assertIsNone(self.healthy.unsubscribed_at)
+
+	def test_existing_unsubscribed_at_is_preserved(self):
+		stamp = timezone.now() - timedelta(days=400)
+		# An active row that already carries a (stale) unsubscribed_at.
+		self.drift_a.unsubscribed_at = stamp
+		self.drift_a.save(update_fields=['unsubscribed_at'])
+
+		self._run('--apply')
+		self.drift_a.refresh_from_db()
+		self.assertFalse(self.drift_a.is_active)
+		self.assertEqual(self.drift_a.unsubscribed_at, stamp)
+
+	def test_idempotent_second_run_finds_nothing(self):
+		self._run('--apply')
+		output = self._run('--apply')
+		self.assertIn('Nothing to reconcile', output)


### PR DESCRIPTION
## What & why

Follow-up to the subscriber-analytics work. We found **55 accounts marked `active=False` while still holding 62 active list subscriptions** — "drift" caused by the admin *"Disable all emails"* bulk action, which sets `active=False` via `queryset.update()` without touching the per-list `ListSubscription` rows. Those subscriptions are stale (the account is already suppressed from all email) and make analytics over-count active subscribers.

Per the chosen direction (**respect the opt-out**), this adds a management command that brings subscription state in line with the global flag.

## Command

`python manage.py reconcile_inactive_subscriptions [--apply]`

- Finds active subscriptions (`is_active=True`) on inactive accounts (`subscriber.active=False`).
- **Dry-run by default** — reports the count and a sample, writes nothing.
- `--apply` sets those rows `is_active=False` and stamps `unsubscribed_at` (preserving any existing timestamp), inside a transaction.
- **Never re-enables email for anyone** → GDPR-safe. Zero email-delivery change (these accounts are already suppressed).
- Idempotent — a second run finds nothing.

## Verification

- 5 unit tests cover: dry-run is read-only, `--apply` opts out drifted rows, healthy active-account subscriptions are untouched, an existing `unsubscribed_at` is preserved, and idempotency. All pass.
- Dry-run against synced production data reports exactly **62 subscriptions across 55 accounts**, matching the investigation.

## Impact when applied on prod

- The 62 stale subscriptions become opted-out; analytics "active subscribers" drops from 242 toward 187 (the account-consistent number). Expect a one-time dip on the run date (that's when `unsubscribed_at` is stamped for rows that lacked one).
- No emails change — affected accounts were already `active=False`.

## Notes / follow-ups
- Does **not** change the admin bulk action, so drift can recur if "Disable all emails" is used again. Options to prevent recurrence (left for a separate decision because of a reversibility trade-off): make that action also deactivate subscriptions, or schedule this command periodically.
- Unrelated local `DEBUG=True` toggle in `django/admin/settings.py` was intentionally left out of this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)