### PR TITLE
docs(release): v24 release plan + prepare_v24_upgrade helper

### DIFF
--- a/django/gregory/management/commands/prepare_v24_upgrade.py
+++ b/django/gregory/management/commands/prepare_v24_upgrade.py
@@ -2,25 +2,38 @@
 prepare_v24_upgrade
 ===================
 Friendly, idempotent helper that de-risks the v24 upgrade. It handles the
-**critical** and **moderate** items flagged in docs/releases/v24/MIGRATION_SAFETY.md
-*before* you run ``python manage.py migrate``.
+**critical** and **moderate** items flagged in docs/releases/v24/MIGRATION_SAFETY.md.
+
+Where it fits in the upgrade
+----------------------------
+The per-org content tables (``ArticleOrgContent`` / ``TrialOrgContent``) are
+created by migration ``gregory/0045``, and the legacy columns are dropped by
+``gregory/0048``. So the backfill must run **between** those two migrations:
+
+    1. migrate gregory up to 0047   # creates per-org tables, keeps legacy columns
+    2. prepare_v24_upgrade --backfill --org-id <id>
+    3. migrate                       # applies 0048 (drops legacy columns) + the rest
+
+The command detects which of those states the database is in and guides you,
+rather than assuming the tables already exist.
 
 What it does
 ------------
 1. **Pre-flight check** (default, read-only): reports whether the legacy
-   takeaway columns still hold data, how much is already in the per-org
-   content tables, and how big the tables that migration ``0022`` will index
-   are (so you can judge the write-lock window).
+   takeaway columns still hold data, whether the per-org tables exist yet, how
+   much is already migrated, and the size of the tables that migration ``0022``
+   will lock while building indexes.
 
-2. **Backfill** (``--backfill``): copies the legacy
-   ``articles.takeaways`` / ``articles.summary_plain_english`` and
-   ``trials.summary_plain_english`` values into ``ArticleOrgContent`` /
-   ``TrialOrgContent`` for a chosen organisation, so that migration
-   ``0048`` (which *drops* those columns) cannot lose data.
+2. **Backfill** (``--backfill``): copies the legacy ``articles.takeaways`` /
+   ``articles.summary_plain_english`` and ``trials.summary_plain_english``
+   values into ``ArticleOrgContent`` / ``TrialOrgContent`` for a chosen
+   organisation, so migration ``0048`` cannot lose data. For rows that already
+   exist it fills **only** the per-org fields that are currently empty, so a
+   partial previous run can be safely re-run.
 
 The legacy columns are read with raw SQL on purpose: on the v24 code the model
-fields no longer exist, so this command keeps working whether it runs against a
-pre- or post-``0048`` database.
+fields no longer exist, so this command works whether it runs against a pre- or
+post-``0048`` database.
 
 Usage
 -----
@@ -54,6 +67,10 @@ LEGACY = {
 }
 # Tables whose write-lock during the 0022 index build is worth sizing up.
 INDEXED_TABLES = ['articles', 'trials', 'articles_team_categories', 'articles_authors']
+
+# Last gregory migration before 0048 drops the legacy columns. Migrating to this
+# creates the per-org tables (0045) while leaving the legacy columns intact.
+PRE_DROP_MIGRATION = '0047'
 
 
 class Command(BaseCommand):
@@ -102,6 +119,19 @@ class Command(BaseCommand):
 			)
 			return {row[0] for row in cur.fetchall()}
 
+	def _table_exists(self, table):
+		"""True if *table* exists in the current database."""
+		with connection.cursor() as cur:
+			cur.execute("SELECT to_regclass(%s)", [table])
+			return cur.fetchone()[0] is not None
+
+	def _orgcontent_ready(self):
+		"""True once both per-org content tables exist (created by 0045)."""
+		return (
+			self._table_exists(ArticleOrgContent._meta.db_table)
+			and self._table_exists(TrialOrgContent._meta.db_table)
+		)
+
 	def _rows_with_data(self, table, columns):
 		"""Count rows where any of *columns* is non-null and non-empty."""
 		if not columns:
@@ -141,38 +171,51 @@ class Command(BaseCommand):
 
 		state = self._legacy_state()
 		any_legacy_cols = any(present for present, _ in state.values())
+		pending = sum(rows for _, rows in state.values())
+		oc_ready = self._orgcontent_ready()
 
 		# --- Critical: legacy takeaway data ---
 		self.stdout.write('Critical — legacy takeaway/summary data (dropped by 0048):')
+		next_step = None
 		if not any_legacy_cols:
 			self.stdout.write(self.style.SUCCESS(
 				'  ✓ Legacy columns already removed. 0048 has run (or DB post-dates it). '
 				'Nothing to back up.'
 			))
 		else:
-			pending = 0
 			for table, (present, rows) in state.items():
-				if not present:
-					continue
-				self.stdout.write(
-					f'  • {table}: {rows} row(s) still hold data in '
-					f'{", ".join(sorted(present))}'
-				)
-				pending += rows
-			art_oc = ArticleOrgContent.objects.count()
-			trial_oc = TrialOrgContent.objects.count()
-			self.stdout.write(
-				f'  • already migrated: ArticleOrgContent={art_oc}, TrialOrgContent={trial_oc}'
-			)
-			if pending:
-				self.stdout.write(self.style.WARNING(
-					f'  ⚠ {pending} row(s) carry legacy data. Run '
-					f'`--backfill` BEFORE migrate, or 0048 will drop them.'
-				))
-			else:
+				if present:
+					self.stdout.write(
+						f'  • {table}: {rows} row(s) still hold data in '
+						f'{", ".join(sorted(present))}'
+					)
+			if not pending:
 				self.stdout.write(self.style.SUCCESS(
 					'  ✓ Columns exist but hold no data — safe to migrate.'
 				))
+			elif not oc_ready:
+				# Per-org tables (0045) don't exist yet — cannot back up safely.
+				self.stdout.write(self.style.WARNING(
+					f'  ⚠ {pending} row(s) carry legacy data, but the per-org tables '
+					f'do not exist yet (created by 0045).'
+				))
+				self.stdout.write(
+					f'    Apply schema up to {PRE_DROP_MIGRATION} first, then back up, '
+					f'then finish:'
+				)
+				self.stdout.write(f'      python manage.py migrate gregory {PRE_DROP_MIGRATION}')
+				self.stdout.write('      python manage.py prepare_v24_upgrade --backfill --org-id <id>')
+				next_step = 'split'
+			else:
+				art_oc = ArticleOrgContent.objects.count()
+				trial_oc = TrialOrgContent.objects.count()
+				self.stdout.write(
+					f'  • already migrated: ArticleOrgContent={art_oc}, TrialOrgContent={trial_oc}'
+				)
+				self.stdout.write(self.style.WARNING(
+					'  ⚠ Run `--backfill` BEFORE the final migrate, or 0048 will drop them.'
+				))
+				next_step = 'backfill'
 
 		# --- Moderate: index-build write lock (0022) ---
 		self.stdout.write('\nModerate — 0022 builds indexes with a plain CREATE INDEX')
@@ -186,7 +229,12 @@ class Command(BaseCommand):
 
 		# --- Verdict ---
 		self.stdout.write('')
-		if any_legacy_cols and any(rows for _, rows in state.values()):
+		if next_step == 'split':
+			self.stdout.write(self.style.NOTICE(
+				f'Next: python manage.py migrate gregory {PRE_DROP_MIGRATION}  →  '
+				f'--backfill  →  migrate'
+			))
+		elif next_step == 'backfill':
 			self.stdout.write(self.style.NOTICE(
 				'Next: python manage.py prepare_v24_upgrade --backfill --org-id <id>'
 			))
@@ -242,45 +290,61 @@ class Command(BaseCommand):
 			))
 			return
 
+		if not self._orgcontent_ready():
+			raise CommandError(
+				'Per-org tables (ArticleOrgContent/TrialOrgContent) do not exist yet. '
+				f'Run `python manage.py migrate gregory {PRE_DROP_MIGRATION}` first, '
+				'then re-run this backfill.'
+			)
+
 		plan = [
 			('articles', 'article_id', ArticleOrgContent, 'article_id'),
 			('trials', 'trial_id', TrialOrgContent, 'trial_id'),
 		]
-		created = skipped = 0
+		created = updated = skipped = 0
 
 		for table, pk, model, fk in plan:
-			present = state[table][0]
+			present = sorted(state[table][0])
 			if not present:
 				continue
-			rows = list(self._fetch_legacy(table, pk, sorted(present)))
-			existing = set(
-				model.objects
-				.filter(organization=org, **{f'{fk}__in': [r[0] for r in rows]})
-				.values_list(fk, flat=True)
-			)
-			for obj_id, values in rows:
-				if obj_id in existing:
-					skipped += 1
-					continue
-				if dry_run:
+			legacy = dict(self._fetch_legacy(table, pk, present))
+			if not legacy:
+				continue
+			# Existing per-org rows for this org, keyed by FK, with current field values.
+			existing = {
+				row[fk]: row
+				for row in model.objects
+				.filter(organization=org, **{f'{fk}__in': list(legacy)})
+				.values(fk, *present)
+			}
+			for obj_id, values in legacy.items():
+				row = existing.get(obj_id)
+				if row is None:
+					if not dry_run:
+						with transaction.atomic():
+							model.objects.create(organization=org, **{fk: obj_id}, **values)
 					created += 1
 					continue
-				with transaction.atomic():
-					model.objects.create(
-						organization=org,
-						**{fk: obj_id},
-						**values,
-					)
-				created += 1
+				# Existing row: fill only the fields that are currently empty,
+				# so a partial previous run can be re-run without losing data.
+				fills = {c: v for c, v in values.items() if v and not row.get(c)}
+				if not fills:
+					skipped += 1
+					continue
+				if not dry_run:
+					with transaction.atomic():
+						model.objects.filter(organization=org, **{fk: obj_id}).update(**fills)
+				updated += 1
 
 		verb = 'Would create' if dry_run else 'Created'
 		style = self.style.WARNING if dry_run else self.style.SUCCESS
 		self.stdout.write(style(
-			f'{verb} {created} per-org content row(s); skipped {skipped} existing.'
+			f'{verb} {created} new row(s), filled {updated} existing row(s); '
+			f'skipped {skipped} already-complete row(s).'
 		))
 		if not dry_run:
 			self.stdout.write(self.style.SUCCESS(
-				'✓ Legacy data preserved. Safe to run migrate.'
+				'✓ Legacy data preserved. Safe to run the final migrate.'
 			))
 
 	# ------------------------------------------------------------------

--- a/django/gregory/management/commands/prepare_v24_upgrade.py
+++ b/django/gregory/management/commands/prepare_v24_upgrade.py
@@ -1,0 +1,306 @@
+"""
+prepare_v24_upgrade
+===================
+Friendly, idempotent helper that de-risks the v24 upgrade. It handles the
+**critical** and **moderate** items flagged in docs/releases/v24/MIGRATION_SAFETY.md
+*before* you run ``python manage.py migrate``.
+
+What it does
+------------
+1. **Pre-flight check** (default, read-only): reports whether the legacy
+   takeaway columns still hold data, how much is already in the per-org
+   content tables, and how big the tables that migration ``0022`` will index
+   are (so you can judge the write-lock window).
+
+2. **Backfill** (``--backfill``): copies the legacy
+   ``articles.takeaways`` / ``articles.summary_plain_english`` and
+   ``trials.summary_plain_english`` values into ``ArticleOrgContent`` /
+   ``TrialOrgContent`` for a chosen organisation, so that migration
+   ``0048`` (which *drops* those columns) cannot lose data.
+
+The legacy columns are read with raw SQL on purpose: on the v24 code the model
+fields no longer exist, so this command keeps working whether it runs against a
+pre- or post-``0048`` database.
+
+Usage
+-----
+Read-only pre-flight (safe to run any time)::
+
+    python manage.py prepare_v24_upgrade
+
+Dry-run the backfill (no writes)::
+
+    python manage.py prepare_v24_upgrade --backfill --dry-run
+
+Backfill into a chosen org (interactive picker)::
+
+    python manage.py prepare_v24_upgrade --backfill
+
+Scripted / CI::
+
+    python manage.py prepare_v24_upgrade --backfill --org-id 3 --noinput
+"""
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connection, transaction
+
+from gregory.models import ArticleOrgContent, TrialOrgContent
+from organizations.models import Organization
+
+
+# (table, [legacy columns]) pairs that migration 0048 removes.
+LEGACY = {
+	'articles': ['takeaways', 'summary_plain_english'],
+	'trials': ['summary_plain_english'],
+}
+# Tables whose write-lock during the 0022 index build is worth sizing up.
+INDEXED_TABLES = ['articles', 'trials', 'articles_team_categories', 'articles_authors']
+
+
+class Command(BaseCommand):
+	help = (
+		'De-risk the v24 upgrade: pre-flight check (default) or back up legacy '
+		'takeaway data into per-org content tables before running migrate.'
+	)
+
+	def add_arguments(self, parser):
+		parser.add_argument(
+			'--backfill',
+			action='store_true',
+			help='Copy legacy takeaways/summaries into ArticleOrgContent/TrialOrgContent.',
+		)
+		parser.add_argument(
+			'--org-id',
+			type=int,
+			dest='org_id',
+			help='Target organisation ID for the backfill. Required with --noinput.',
+		)
+		parser.add_argument(
+			'--dry-run',
+			action='store_true',
+			dest='dry_run',
+			help='Report what the backfill would do without writing.',
+		)
+		parser.add_argument(
+			'--noinput',
+			'--no-input',
+			action='store_true',
+			dest='no_input',
+			help='Run non-interactively. Requires --org-id.',
+		)
+
+	# ------------------------------------------------------------------
+	# Low-level helpers
+	# ------------------------------------------------------------------
+
+	def _columns_present(self, table):
+		"""Return the subset of LEGACY[table] columns that still exist in the DB."""
+		with connection.cursor() as cur:
+			cur.execute(
+				"SELECT column_name FROM information_schema.columns "
+				"WHERE table_name = %s AND column_name = ANY(%s)",
+				[table, LEGACY[table]],
+			)
+			return {row[0] for row in cur.fetchall()}
+
+	def _rows_with_data(self, table, columns):
+		"""Count rows where any of *columns* is non-null and non-empty."""
+		if not columns:
+			return 0
+		where = ' OR '.join(
+			f"({c} IS NOT NULL AND {c} <> '')" for c in columns
+		)
+		with connection.cursor() as cur:
+			cur.execute(f"SELECT count(*) FROM {table} WHERE {where}")
+			return cur.fetchone()[0]
+
+	def _table_size(self, table):
+		with connection.cursor() as cur:
+			cur.execute(
+				"SELECT pg_size_pretty(pg_total_relation_size(%s)), "
+				"       (SELECT reltuples::bigint FROM pg_class WHERE relname = %s)",
+				[table, table],
+			)
+			row = cur.fetchone()
+			return row if row else ('n/a', 0)
+
+	def _legacy_state(self):
+		"""Return {table: (present_columns, rows_with_data)}."""
+		state = {}
+		for table in LEGACY:
+			present = self._columns_present(table)
+			rows = self._rows_with_data(table, present)
+			state[table] = (present, rows)
+		return state
+
+	# ------------------------------------------------------------------
+	# Pre-flight report
+	# ------------------------------------------------------------------
+
+	def _preflight(self):
+		self.stdout.write(self.style.MIGRATE_HEADING('\nv24 upgrade pre-flight\n'))
+
+		state = self._legacy_state()
+		any_legacy_cols = any(present for present, _ in state.values())
+
+		# --- Critical: legacy takeaway data ---
+		self.stdout.write('Critical — legacy takeaway/summary data (dropped by 0048):')
+		if not any_legacy_cols:
+			self.stdout.write(self.style.SUCCESS(
+				'  ✓ Legacy columns already removed. 0048 has run (or DB post-dates it). '
+				'Nothing to back up.'
+			))
+		else:
+			pending = 0
+			for table, (present, rows) in state.items():
+				if not present:
+					continue
+				self.stdout.write(
+					f'  • {table}: {rows} row(s) still hold data in '
+					f'{", ".join(sorted(present))}'
+				)
+				pending += rows
+			art_oc = ArticleOrgContent.objects.count()
+			trial_oc = TrialOrgContent.objects.count()
+			self.stdout.write(
+				f'  • already migrated: ArticleOrgContent={art_oc}, TrialOrgContent={trial_oc}'
+			)
+			if pending:
+				self.stdout.write(self.style.WARNING(
+					f'  ⚠ {pending} row(s) carry legacy data. Run '
+					f'`--backfill` BEFORE migrate, or 0048 will drop them.'
+				))
+			else:
+				self.stdout.write(self.style.SUCCESS(
+					'  ✓ Columns exist but hold no data — safe to migrate.'
+				))
+
+		# --- Moderate: index-build write lock (0022) ---
+		self.stdout.write('\nModerate — 0022 builds indexes with a plain CREATE INDEX')
+		self.stdout.write('(blocks writes on these tables for the build duration):')
+		for table in INDEXED_TABLES:
+			size, rows = self._table_size(table)
+			self.stdout.write(f'  • {table}: {size} (~{rows:,} rows)')
+		self.stdout.write(self.style.WARNING(
+			'  ⚠ Run migrate inside a maintenance window with writers paused.'
+		))
+
+		# --- Verdict ---
+		self.stdout.write('')
+		if any_legacy_cols and any(rows for _, rows in state.values()):
+			self.stdout.write(self.style.NOTICE(
+				'Next: python manage.py prepare_v24_upgrade --backfill --org-id <id>'
+			))
+		else:
+			self.stdout.write(self.style.SUCCESS(
+				'Next: pause writers, then python manage.py migrate '
+				'&& python manage.py createcachetable gregory_cache'
+			))
+		self.stdout.write('')
+
+	# ------------------------------------------------------------------
+	# Backfill
+	# ------------------------------------------------------------------
+
+	def _list_orgs(self):
+		self.stdout.write('\nOrganisations:')
+		self.stdout.write(f'  {"ID":>5}  {"Name":<40}')
+		self.stdout.write('  ' + '-' * 48)
+		for org in Organization.objects.order_by('id'):
+			self.stdout.write(f'  {org.id:>5}  {str(org.name):<40}')
+		self.stdout.write('')
+
+	def _resolve_org(self, org_id, no_input):
+		if org_id is None:
+			if no_input:
+				raise CommandError('--org-id is required with --noinput.')
+			self._list_orgs()
+			while True:
+				raw = input('Target organisation ID: ').strip()
+				if raw.isdigit():
+					org_id = int(raw)
+					break
+				self.stderr.write('Please enter a numeric ID.\n')
+		try:
+			return Organization.objects.get(pk=org_id)
+		except Organization.DoesNotExist:
+			raise CommandError(f'Organisation id={org_id} does not exist.')
+
+	def _fetch_legacy(self, table, pk, columns):
+		"""Yield (pk_value, {col: value}) for rows with any non-empty legacy column."""
+		where = ' OR '.join(f"({c} IS NOT NULL AND {c} <> '')" for c in columns)
+		cols_sql = ', '.join(columns)
+		with connection.cursor() as cur:
+			cur.execute(f"SELECT {pk}, {cols_sql} FROM {table} WHERE {where}")
+			for row in cur.fetchall():
+				yield row[0], dict(zip(columns, row[1:]))
+
+	def _backfill(self, org, dry_run):
+		state = self._legacy_state()
+		if not any(present for present, _ in state.values()):
+			self.stdout.write(self.style.SUCCESS(
+				'Legacy columns already removed — nothing to back up.'
+			))
+			return
+
+		plan = [
+			('articles', 'article_id', ArticleOrgContent, 'article_id'),
+			('trials', 'trial_id', TrialOrgContent, 'trial_id'),
+		]
+		created = skipped = 0
+
+		for table, pk, model, fk in plan:
+			present = state[table][0]
+			if not present:
+				continue
+			rows = list(self._fetch_legacy(table, pk, sorted(present)))
+			existing = set(
+				model.objects
+				.filter(organization=org, **{f'{fk}__in': [r[0] for r in rows]})
+				.values_list(fk, flat=True)
+			)
+			for obj_id, values in rows:
+				if obj_id in existing:
+					skipped += 1
+					continue
+				if dry_run:
+					created += 1
+					continue
+				with transaction.atomic():
+					model.objects.create(
+						organization=org,
+						**{fk: obj_id},
+						**values,
+					)
+				created += 1
+
+		verb = 'Would create' if dry_run else 'Created'
+		style = self.style.WARNING if dry_run else self.style.SUCCESS
+		self.stdout.write(style(
+			f'{verb} {created} per-org content row(s); skipped {skipped} existing.'
+		))
+		if not dry_run:
+			self.stdout.write(self.style.SUCCESS(
+				'✓ Legacy data preserved. Safe to run migrate.'
+			))
+
+	# ------------------------------------------------------------------
+	# Entry point
+	# ------------------------------------------------------------------
+
+	def handle(self, *args, **options):
+		if not options['backfill']:
+			self._preflight()
+			return
+
+		org = self._resolve_org(options['org_id'], options['no_input'])
+
+		if not options['no_input'] and not options['dry_run']:
+			confirm = input(
+				f'\nBack up legacy takeaways/summaries into per-org content for '
+				f'"{org.name}" (id={org.id})? [y/N] '
+			).strip().lower()
+			if confirm not in ('y', 'yes'):
+				self.stdout.write('Aborted.')
+				return
+
+		self._backfill(org, options['dry_run'])

--- a/docs/releases/v24/DEPLOYMENT_RUNBOOK.md
+++ b/docs/releases/v24/DEPLOYMENT_RUNBOOK.md
@@ -1,0 +1,99 @@
+# v24 Deployment Runbook
+
+Two high-risk changes drive this runbook: **Postgres 15 → 17** (major upgrade)
+and **74 migrations** (irreversible data migrations + write-blocking index build).
+Plan a **maintenance window** with writes paused.
+
+Read [`MIGRATION_SAFETY.md`](./MIGRATION_SAFETY.md) before starting.
+
+---
+
+## 0. Pre-flight (do not skip)
+
+- [ ] Announce maintenance window; pause cron (`pipeline`, `send_weekly_summary`,
+      `send_admin_summary`) so nothing writes mid-migration.
+- [ ] Confirm target version/SHA and tag it (`v24`).
+- [ ] **Run the upgrade helper (read-only) on each target DB:**
+      ```bash
+      docker exec gregory python manage.py prepare_v24_upgrade
+      ```
+      It reports the **critical** takeaways gate and the **moderate** index-lock
+      table sizes, and tells you the exact next command. Three outcomes:
+  - *"Legacy columns already removed … Nothing to back up"* → gate clear, go to step 1.
+  - *"Columns exist but hold no data"* → gate clear, go to step 1.
+  - *"⚠ N row(s) carry legacy data"* → **back them up first**, then migrate:
+      ```bash
+      docker exec -it gregory python manage.py prepare_v24_upgrade --backfill --org-id <id>
+      # or scripted:  --backfill --org-id <id> --noinput   (preview with --dry-run)
+      ```
+      This copies `articles.takeaways` / `summary_plain_english` and
+      `trials.summary_plain_english` into `ArticleOrgContent` / `TrialOrgContent`
+      (idempotent) so migration `0048` cannot drop live data.
+- [ ] Verify `requirements.txt` installs cleanly on Python 3.12 in a scratch build
+      (`pyproject.toml` was removed).
+
+## 1. Backup
+
+- [ ] Full logical dump from the **current PG15** instance:
+      `pg_dump -Fc -d <db> -f gregory_pre_v24_$(date +%F).dump`
+- [ ] Snapshot the droplet/volume as well (belt and suspenders).
+- [ ] Verify the dump restores into a throwaway PG17 container (this doubles as the
+      staging dry-run base, step 2).
+
+## 2. Staging dry-run (mandatory — this is where 74 migrations get proven)
+
+- [ ] Spin up **PG17** + the v24 image against the restored prod copy.
+- [ ] `python manage.py migrate` — time it, watch for lock waits on the
+      `0022` index build and the field-removal migrations.
+- [ ] `python manage.py createcachetable gregory_cache`
+- [ ] Smoke test:
+  - [ ] API: search, CSV export, `/stats/`, a private-org key, a public read.
+  - [ ] Admin: announcements (CKEditor image upload), per-org content inlines.
+  - [ ] Emails: `send_weekly_summary` + `send_admin_summary` to a test list
+        (check unsubscribe links use the API domain, images render).
+  - [ ] `pipeline` end-to-end (ingest → ML → categories).
+  - [ ] Per-org takeaways visible where legacy ones used to be.
+- [ ] Confirm no data loss: re-run the takeaways counts from step 0.
+
+## 3. Production deploy
+
+- [ ] Enter maintenance window; stop the app container (writers quiesced).
+- [ ] Take a final dump (state immediately pre-migrate).
+- [ ] **Postgres 15 → 17 upgrade** (dump/restore path):
+      - [ ] Stand up PG17, restore the final dump, repoint `DB_HOST`.
+      - [ ] (compose already pins `postgres:17`.)
+- [ ] Pull/​build the v24 image (Python 3.12, multi-arch).
+- [ ] `python manage.py migrate`
+- [ ] `python manage.py createcachetable gregory_cache`
+- [ ] `python manage.py collectstatic --noinput` if static changed.
+- [ ] Start the app; health-check API + admin login.
+
+## 4. Post-deploy verification
+
+- [ ] Re-run the step-2 smoke tests against production.
+- [ ] Re-enable cron jobs; confirm `pipeline` lock file is clear.
+- [ ] Watch logs for one full pipeline + one summary send.
+- [ ] Confirm `DEBUG` is off in prod (`DJANGO_DEBUG` unset / settings `DEBUG = False`).
+
+## 5. Publish the release
+
+- [ ] Push the `v24` tag.
+- [ ] Create the GitHub Release from `RELEASE_NOTES.md`, mark it **Latest**.
+- [ ] Fix the stale label: v22 currently still shows "Latest" — moving Latest to
+      v24 corrects it.
+
+---
+
+## Rollback
+
+Several migrations are irreversible (field/table drops, `noop`-reverse backfills),
+so **`migrate` is not cleanly reversible**. Rollback = **restore the pre-migrate
+dump** into PG15 and redeploy v23:
+
+- [ ] Stop v24 app.
+- [ ] Restore `gregory_pre_v24_*.dump` into the PG15 instance.
+- [ ] Redeploy the v23 image.
+- [ ] Re-enable cron.
+
+Decision point: if `migrate` fails partway, do **not** try to hand-fix forward —
+restore the dump. The window's backup is the rollback plan.

--- a/docs/releases/v24/DEPLOYMENT_RUNBOOK.md
+++ b/docs/releases/v24/DEPLOYMENT_RUNBOOK.md
@@ -18,17 +18,25 @@ Read [`MIGRATION_SAFETY.md`](./MIGRATION_SAFETY.md) before starting.
       docker exec gregory python manage.py prepare_v24_upgrade
       ```
       It reports the **critical** takeaways gate and the **moderate** index-lock
-      table sizes, and tells you the exact next command. Three outcomes:
+      table sizes, and tells you the exact next command. Possible outcomes:
   - *"Legacy columns already removed … Nothing to back up"* → gate clear, go to step 1.
   - *"Columns exist but hold no data"* → gate clear, go to step 1.
-  - *"⚠ N row(s) carry legacy data"* → **back them up first**, then migrate:
+  - *"⚠ N row(s) carry legacy data"* → **back them up between 0045 and 0048**
+      (the per-org tables don't exist until `gregory/0045`, and `0048` drops the
+      legacy columns). Use the split-migration flow below.
+- [ ] **If the helper flags pending legacy data, split the migration** so the
+      backfill runs after the per-org tables exist but before the drop:
       ```bash
+      # 1. create per-org tables, stop before 0048 drops the legacy columns
+      docker exec gregory python manage.py migrate gregory 0047
+      # 2. back up legacy data into the per-org tables (idempotent; fills empty
+      #    fields on existing rows). Preview with --dry-run first.
       docker exec -it gregory python manage.py prepare_v24_upgrade --backfill --org-id <id>
-      # or scripted:  --backfill --org-id <id> --noinput   (preview with --dry-run)
+      # 3. (the full `migrate` in step 3 then applies 0048 + everything else)
       ```
       This copies `articles.takeaways` / `summary_plain_english` and
       `trials.summary_plain_english` into `ArticleOrgContent` / `TrialOrgContent`
-      (idempotent) so migration `0048` cannot drop live data.
+      so migration `0048` cannot drop live data.
 - [ ] Verify `requirements.txt` installs cleanly on Python 3.12 in a scratch build
       (`pyproject.toml` was removed).
 
@@ -78,9 +86,8 @@ Read [`MIGRATION_SAFETY.md`](./MIGRATION_SAFETY.md) before starting.
 ## 5. Publish the release
 
 - [ ] Push the `v24` tag.
-- [ ] Create the GitHub Release from `RELEASE_NOTES.md`, mark it **Latest**.
-- [ ] Fix the stale label: v22 currently still shows "Latest" — moving Latest to
-      v24 corrects it.
+- [ ] Create the GitHub Release from `RELEASE_NOTES.md`, mark it **Latest**
+      (this moves the "Latest" label from v23 to v24 automatically).
 
 ---
 

--- a/docs/releases/v24/MIGRATION_SAFETY.md
+++ b/docs/releases/v24/MIGRATION_SAFETY.md
@@ -95,13 +95,22 @@ moderate checks above:
   pending, and the sizes of the tables `0022` will lock.
 - **`--backfill --org-id <id>`:** idempotently copies legacy
   takeaways/summaries into `ArticleOrgContent` / `TrialOrgContent` so `0048`
-  can't drop live data. Reads the legacy columns via raw SQL, so it works on
-  both pre- and post-`0048` databases. Supports `--dry-run` and `--noinput`.
+  can't drop live data. Reads the legacy columns via raw SQL; for existing
+  per-org rows it fills only the fields that are currently empty (safe to
+  re-run). Supports `--dry-run` and `--noinput`.
+
+The per-org tables are created by `0045` and the legacy columns dropped by
+`0048`, so the backfill must run **between** them via a split migration:
 
 ```bash
-docker exec gregory python manage.py prepare_v24_upgrade            # check
-docker exec -it gregory python manage.py prepare_v24_upgrade --backfill --org-id 3
+docker exec gregory python manage.py prepare_v24_upgrade            # 0. check
+docker exec gregory python manage.py migrate gregory 0047          # 1. create per-org tables
+docker exec -it gregory python manage.py prepare_v24_upgrade --backfill --org-id 3  # 2. back up
+docker exec gregory python manage.py migrate                       # 3. apply 0048 + rest
 ```
+
+The command detects this state and refuses to back up (with guidance) if the
+per-org tables don't exist yet, rather than erroring on a missing table.
 
 ## Summary checklist
 

--- a/docs/releases/v24/MIGRATION_SAFETY.md
+++ b/docs/releases/v24/MIGRATION_SAFETY.md
@@ -1,0 +1,112 @@
+# v24 Migration Safety Review
+
+Scope: every new migration on `main` since the **v23** tag (`cec3d65`, 2025-06-21).
+
+- **74 new migrations** — gregory 36, subscriptions 27, sitesettings 9, api 2.
+- **9 data migrations** (`RunPython`), **4 raw-SQL** (`RunSQL`), **10 field/model removals**.
+
+Run order is enforced by Django's dependency graph, so a single `migrate` applies
+everything in the correct sequence. The risks below are about **data loss**,
+**locking**, and **reversibility**, not ordering.
+
+---
+
+## 🔴 Critical — irreversible data loss if prerequisite was skipped
+
+### `gregory/0048_remove_legacy_takeaway_fields.py`
+Drops `Articles.takeaways`, `Articles.summary_plain_english`,
+`Trials.summary_plain_english` (+ the matching historical fields).
+
+- The migration is a **pure schema removal** — no data copy, no guard.
+- The data was meant to be moved into `ArticleOrgContent` first by the
+  `migrate_legacy_takeaways` management command (added in Phase 7, PR #650).
+- **That command was deleted** in commit `d482dfec` with the note
+  *"one-shot, done"* — i.e. it had already been run on the author's production.
+- **`ArticleOrgContent` (created in `0045`) is schema-only — there is no
+  data migration that copies the legacy columns into it.**
+
+**Implication:**
+- On **the production where the one-shot already ran** → safe, data already in `ArticleOrgContent`.
+- On **any instance that never ran `migrate_legacy_takeaways`** (fresh org
+  instance, a DB restored from before Phase 7, gregory-002, etc.) → applying
+  `0048` **permanently drops the takeaways/summaries with no in-tree recovery path.**
+
+**Action before deploy:** For each target DB, confirm `ArticleOrgContent` is
+populated **before** `0048` runs. If not, restore the deleted command from
+`git show b0973f5a:django/gregory/management/commands/migrate_legacy_takeaways.py`
+and run it first. See the runbook pre-flight gate.
+
+---
+
+## 🟠 Moderate — locking / write-blocking during migrate
+
+### `gregory/0022_add_category_performance_indexes.py`
+- `atomic = False` but uses **plain `CREATE INDEX ... IF NOT EXISTS`**, *not*
+  `CREATE INDEX CONCURRENTLY` (the module docstring says so explicitly).
+- Plain `CREATE INDEX` takes a lock that **blocks writes** on each target table
+  (`articles_team_categories`, `articles_authors`, `articles`, `trials`, …) for
+  the duration of the build.
+- On large `articles`/`trials` tables this can be a multi-second to multi-minute
+  write stall. **Fine inside a maintenance window; risky on a live writer.**
+
+### `gregory/0040_remove_teamcredentials.py` · `subscriptions/0008` · `subscriptions/0010_switch_subscriptions_to_through_model.py`
+- `DeleteModel` / through-model switch rewrite table structure. Backed by
+  backfill migrations (`subscriptions/0009`, `0013`) that must succeed first.
+- Verify the `0009`/`0013` backfills completed (they have reverse ops) — a
+  partial backfill before the structural change loses subscription links.
+
+---
+
+## 🟡 Low — irreversible but non-destructive
+
+`RunPython` migrations with **no reverse** (`migrations.RunPython.noop` only, or
+none). Forward-safe; a rollback past them silently does nothing (won't restore
+prior values). Acceptable for one-shot backfills, listed for completeness:
+
+| Migration | What it backfills |
+|---|---|
+| `gregory/0017_populate_full_name_field` | Author `full_name` |
+| `gregory/0026_normalize_orcid_values` | ORCID normalization (no reverse) |
+| `gregory/0043_organizationapisettings` | Org API settings |
+| `sitesettings/0006_backfill_credentials_from_team` | Team → CustomSetting creds |
+| `sitesettings/0010_copy_allowed_domains_from_lists` | Lists → CustomSetting domains |
+| `subscriptions/0009 / 0013` | Unsubscribe tokens + list subscriptions |
+| `subscriptions/0027_backfill_announcement_organization` | Announcement → org |
+| `api/0004_apiaccessscheme_organization_required` | API access org flag |
+
+`allowed_domains` path is two-step and order-dependent:
+`sitesettings/0010` **copies** Lists→CustomSetting, then
+`subscriptions/0020` **removes** `Lists.allowed_domains`. The copy depends-on
+correctly precedes the removal — safe as a single `migrate` run, **but do not
+run the apps' migrations separately/out of order.**
+
+### `gregory/0047_drop_authtoken_tables.py`
+Raw SQL `DROP TABLE` for the DRF authtoken tables, `reverse_sql=noop`.
+Irreversible but intended (the Token endpoint was removed). No app data lost.
+
+---
+
+## Helper command
+
+`gregory/management/commands/prepare_v24_upgrade.py` automates the critical and
+moderate checks above:
+
+- **Default (read-only):** reports the takeaways gate, how much legacy data is
+  pending, and the sizes of the tables `0022` will lock.
+- **`--backfill --org-id <id>`:** idempotently copies legacy
+  takeaways/summaries into `ArticleOrgContent` / `TrialOrgContent` so `0048`
+  can't drop live data. Reads the legacy columns via raw SQL, so it works on
+  both pre- and post-`0048` databases. Supports `--dry-run` and `--noinput`.
+
+```bash
+docker exec gregory python manage.py prepare_v24_upgrade            # check
+docker exec -it gregory python manage.py prepare_v24_upgrade --backfill --org-id 3
+```
+
+## Summary checklist
+
+- [ ] **Gate:** run `prepare_v24_upgrade`; back up legacy data if it flags pending rows.
+- [ ] Run `migrate` inside a **maintenance window** (index build in `0022` blocks writes).
+- [ ] Apply **all apps together** in one `migrate` (cross-app order matters: allowed_domains, subscriptions backfills).
+- [ ] Take a **full DB backup** immediately before `migrate` (several steps are irreversible).
+- [ ] After `migrate`, run `createcachetable gregory_cache` (new DB cache backend).

--- a/docs/releases/v24/RELEASE_NOTES.md
+++ b/docs/releases/v24/RELEASE_NOTES.md
@@ -1,0 +1,77 @@
+# Gregory AI v24
+
+_Range: v23 (2025-06-21) → main (2025-05-30). 113 merged PRs, ~717 commits._
+
+The multi-organization release: Gregory now runs as a true multi-tenant platform —
+API keys, ORCID credentials, content, and visibility are all scoped per
+organization. Plus a new email Announcements system, a much faster and search-capable
+API, new data sources (BioRxiv, MedRxiv, ClinicalTrials.gov, PNAS), and an
+infrastructure jump to Postgres 17 and Python 3.12.
+
+---
+
+## ⚠️ Breaking changes — read before upgrading
+
+- **Postgres 15 → 17.** Major version bump; requires a dump/restore or `pg_upgrade`,
+  not an in-place restart. See the deployment runbook.
+- **Python 3.12.** Rebuild the image; `pyproject.toml` was removed — deploys install
+  from `requirements.txt`.
+- **API is now read-only.** All ModelViewSets are locked to read-only (Phase 5).
+  External clients that POST/PUT must move to the org-scoped write path.
+- **DRF Token auth removed.** The `/api-token-auth/` endpoint and authtoken tables
+  are gone (Phase 6). Use JWT or per-organization API keys instead.
+- **Legacy article fields dropped.** `Articles.takeaways` and
+  `summary_plain_english` now live in `ArticleOrgContent` (per-org). ⚠️ See the
+  migration-safety note — confirm data was moved before deploying.
+- **`Team.organization` is now NOT NULL.** Defensive null-handling removed; every
+  team must belong to an organization.
+- **`allowed_domains` moved** from `Lists` to `CustomSetting`.
+- **`TeamCredentials` model removed** — ORCID/credentials are now per organization/team.
+- New DB cache backend: run `python manage.py createcachetable gregory_cache` after migrate.
+
+---
+
+## ✨ Highlights
+
+### Multi-organization / multi-site
+- API keys per organization and team; org-scoped POST enforcement.
+- Per-organization ORCID credentials (env-var dependency removed).
+- Flag to mark an organization's API **private**, with visibility middleware.
+- Multi-site support for subscription lists.
+
+### API
+- Full-text **search** endpoint (articles, trials, authors) with performance tuning.
+- **CSV export** + streaming responses for large downloads; full-results search export.
+- New **/stats/** aggregate endpoint with org filter, reduced joins, and caching.
+- Author endpoints: sort by article count, author statistics on `/categories/`.
+- New filters: intersection, `has_clinical_trials` (detects NCT IDs in abstracts),
+  case-insensitive trial status, ML-score threshold, date filters.
+- Per-org takeaways/summaries in serializers; read-only viewsets; Token endpoint removed.
+
+### Email & subscriptions
+- **Announcements**: CKEditor-authored emails with CTA buttons and inline images,
+  duplicate action, per-org ownership, image-quality + host-config safeguards.
+- Weekly digest: per-date or per-relevancy modes, article limits, threshold filtering.
+- Subscriber analytics: list distribution, historical active-subscriber chart.
+- Dark-mode / Outlook email rendering fixes; sender-name setting; API-domain
+  unsubscribe links; import / reconcile / prune subscriber commands.
+
+### Data sources & ML
+- **BioRxiv & MedRxiv** support; **ClinicalTrials.gov API**; **PNAS** RSS.
+- New RSS feeds for articles and clinical-trials-by-subject.
+- Better ML algorithms and category matching with batch processing.
+
+### Admin & ops
+- Richer admin: sources, subjects (with content analytics), teams (categories,
+  sources, subjects inlines), per-org editorial inlines, subject deletion.
+- Multi-arch Docker build & push; Makefile build commands.
+- DB pruning for notifications/history; orphan author/article cleanup commands.
+- Postgres 17, Python 3.12, codebase cleanup.
+
+---
+
+## Upgrade
+
+Follow [`DEPLOYMENT_RUNBOOK.md`](./DEPLOYMENT_RUNBOOK.md). Review
+[`MIGRATION_SAFETY.md`](./MIGRATION_SAFETY.md) first — there are 74 migrations
+including irreversible data migrations and a Postgres major-version upgrade.

--- a/docs/releases/v24/RELEASE_NOTES.md
+++ b/docs/releases/v24/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Gregory AI v24
 
-_Range: v23 (2025-06-21) → main (2025-05-30). 113 merged PRs, ~717 commits._
+_Range: v23 (2025-06-21) → main (2026-05-30). 113 merged PRs, ~717 commits._
 
 The multi-organization release: Gregory now runs as a true multi-tenant platform —
 API keys, ORCID credentials, content, and visibility are all scoped per


### PR DESCRIPTION
## Summary

Planning artifacts for the **v24** release — the first release since **v23** (2025-06-21), covering **717 commits / 113 merged PRs** (~11 months).

Adds:
- **`docs/releases/v24/RELEASE_NOTES.md`** — draft GitHub Release notes grouped by theme, with a breaking-changes section. (Intended as an editable draft to seed the GitHub Release; not an in-repo changelog convention.)
- **`docs/releases/v24/DEPLOYMENT_RUNBOOK.md`** — step-by-step upgrade + rollback runbook (Postgres 15→17, 74 migrations).
- **`docs/releases/v24/MIGRATION_SAFETY.md`** — risk review of all 74 new migrations.
- **`django/gregory/management/commands/prepare_v24_upgrade.py`** — a friendly, idempotent helper that de-risks the upgrade.

## Why

There was no release process doc and no record of what changed since v23. The migration set includes one irreversible data-loss trap worth surfacing.

### Key finding
`gregory/0048_remove_legacy_takeaway_fields.py` permanently drops `Articles.takeaways` / `summary_plain_english` and `Trials.summary_plain_english` with **no in-migration data copy** — the one-shot `migrate_legacy_takeaways` command that was meant to move the data into `ArticleOrgContent`/`TrialOrgContent` was deleted (commit note: "one-shot, done"). Safe on DBs where it already ran; destructive on any that skipped it.

### `prepare_v24_upgrade`
- **Default (read-only)** pre-flight: reports the takeaways data gate and the index-lock table sizes (migration `0022` builds indexes with plain `CREATE INDEX`).
- **`--backfill --org-id <id>`**: idempotently copies legacy takeaways/summaries into the per-org tables before `0048` drops them. Reads legacy columns via raw SQL (guarded by an `information_schema` check), so it works pre- and post-`0048`.

## Reviewer notes
- **For brunoamaral's own fleet this is informational only** — gregory-ms.com, brain-regeneration.com, encefalites, and clinicaltrialupdates already run the latest code, so `0048` is applied and the failsafe is a no-op there. Verified the read-only pre-flight and backfill dry-run against the live DB.
- The backfill is deliberately a standalone command, **not** an inserted data migration — inserting one before `0048` would cause `InconsistentMigrationHistory` on instances that already applied it.
- Release notes are meant to be edited before publishing the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)