### PR TITLE
Make "Disable all emails" action also unsubscribe from all lists

### DIFF
--- a/django/subscriptions/admin.py
+++ b/django/subscriptions/admin.py
@@ -4,6 +4,7 @@ from django.urls import path, reverse
 from django.shortcuts import render, redirect, get_object_or_404
 from django.http import JsonResponse, HttpResponse
 import csv
+from django.db import transaction
 from django.db.models import Count, Q
 from django.db.models.functions import TruncDate, TruncWeek, TruncMonth
 from django.utils import timezone
@@ -779,8 +780,13 @@ class SubscriberAdmin(admin.ModelAdmin):
 
 	# The `active` flag is a GLOBAL email switch (see Subscribers.active help text):
 	# active=False suppresses all email for the subscriber regardless of their list
-	# subscriptions. These actions only flip that flag — they do NOT change the
-	# per-list ListSubscription.is_active opt-outs.
+	# subscriptions.
+	#
+	# make_active only clears that flag — it does NOT re-subscribe anyone to lists
+	# (re-subscription is an opt-in and must be done explicitly). make_inactive mirrors
+	# the "unsubscribe from everything" flow: it sets the flag AND opts the subscriber
+	# out of every list, so the global switch and per-list state stay consistent and the
+	# subscription-based analytics agree with the account flag (no drift).
 	def make_active(self, request, queryset):
 		updated_count = queryset.update(active=True)
 		self.message_user(
@@ -792,11 +798,23 @@ class SubscriberAdmin(admin.ModelAdmin):
 	make_active.short_description = "Enable all emails (mark as active)"
 
 	def make_inactive(self, request, queryset):
-		updated_count = queryset.update(active=False)
+		now = timezone.now()
+		# Materialise the selected IDs: get_queryset() is annotated/distinct, which makes
+		# it unreliable as an `__in` subquery.
+		subscriber_ids = list(queryset.values_list('pk', flat=True))
+		with transaction.atomic():
+			updated_count = Subscribers.objects.filter(pk__in=subscriber_ids).update(active=False)
+			# Opt the selected subscribers out of every list they are still on, mirroring
+			# the global "unsubscribe from everything" flow. Preserve any existing
+			# unsubscribed_at; only stamp the rows that lack one.
+			stale_subs = ListSubscription.objects.filter(subscriber_id__in=subscriber_ids, is_active=True)
+			stale_subs.filter(unsubscribed_at__isnull=True).update(unsubscribed_at=now)
+			unsubscribed = stale_subs.update(is_active=False)
 		self.message_user(
 			request,
 			f"{updated_count} subscriber(s) marked inactive — they will receive no emails from any "
-			f"list. This is a global opt-out; their individual list subscriptions were not changed.",
+			f"list. Also opted them out of {unsubscribed} active list subscription(s) so their list "
+			f"state matches this global opt-out.",
 		)
 	make_inactive.short_description = "Disable all emails (mark as inactive)"
 

--- a/django/subscriptions/tests/test_subscriber_admin_actions.py
+++ b/django/subscriptions/tests/test_subscriber_admin_actions.py
@@ -1,0 +1,89 @@
+"""Tests for the make_active / make_inactive bulk actions on SubscriberAdmin.
+
+make_inactive is the "Disable all emails" action: it must set the global account
+flag AND opt the subscriber out of every list, so the global switch and per-list
+state stay consistent (no drift). make_active only clears the flag — it must NOT
+re-subscribe anyone.
+"""
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.utils import timezone
+
+from organizations.models import Organization
+from gregory.models import Team
+from subscriptions.models import Lists, Subscribers, ListSubscription
+
+CHANGELIST_URL = reverse('admin:subscriptions_subscribers_changelist')
+
+
+def _post_action(client, action, pks):
+	return client.post(CHANGELIST_URL, {
+		'action': action,
+		'_selected_action': [str(pk) for pk in pks],
+	}, follow=False)
+
+
+class SubscriberAdminActionTests(TestCase):
+	def setUp(self):
+		self.superuser = User.objects.create_superuser('super', 'super@example.com', 'pass')
+		self.org = Organization.objects.create(name='Org')
+		self.team = Team.objects.create(organization=self.org, name='Team', slug='team')
+		self.list_a = Lists.objects.create(list_name='List A', team=self.team)
+		self.list_b = Lists.objects.create(list_name='List B', team=self.team)
+		self.client = Client()
+		self.client.force_login(self.superuser)
+
+		self.sub = Subscribers.objects.create(
+			first_name='J', last_name='D', email='j@example.com', active=True,
+		)
+		self.ls_a = ListSubscription.objects.create(subscriber=self.sub, list=self.list_a, is_active=True)
+		self.ls_b = ListSubscription.objects.create(subscriber=self.sub, list=self.list_b, is_active=True)
+
+	def test_make_inactive_sets_flag_and_unsubscribes_all_lists(self):
+		_post_action(self.client, 'make_inactive', [self.sub.pk])
+
+		self.sub.refresh_from_db()
+		self.ls_a.refresh_from_db()
+		self.ls_b.refresh_from_db()
+		self.assertFalse(self.sub.active)
+		self.assertFalse(self.ls_a.is_active)
+		self.assertFalse(self.ls_b.is_active)
+		self.assertIsNotNone(self.ls_a.unsubscribed_at)
+		self.assertIsNotNone(self.ls_b.unsubscribed_at)
+
+	def test_make_inactive_preserves_existing_unsubscribed_at(self):
+		stamp = timezone.now() - timedelta(days=100)
+		self.ls_a.unsubscribed_at = stamp
+		self.ls_a.save(update_fields=['unsubscribed_at'])
+
+		_post_action(self.client, 'make_inactive', [self.sub.pk])
+
+		self.ls_a.refresh_from_db()
+		self.assertFalse(self.ls_a.is_active)
+		self.assertEqual(self.ls_a.unsubscribed_at, stamp)
+
+	def test_make_inactive_only_affects_selected_subscribers(self):
+		other = Subscribers.objects.create(
+			first_name='K', last_name='E', email='k@example.com', active=True,
+		)
+		other_ls = ListSubscription.objects.create(subscriber=other, list=self.list_a, is_active=True)
+
+		_post_action(self.client, 'make_inactive', [self.sub.pk])
+
+		other.refresh_from_db()
+		other_ls.refresh_from_db()
+		self.assertTrue(other.active)
+		self.assertTrue(other_ls.is_active)
+
+	def test_make_active_does_not_resubscribe(self):
+		_post_action(self.client, 'make_inactive', [self.sub.pk])
+		_post_action(self.client, 'make_active', [self.sub.pk])
+
+		self.sub.refresh_from_db()
+		self.ls_a.refresh_from_db()
+		self.assertTrue(self.sub.active)
+		# Re-activation clears the global flag but must NOT re-subscribe to lists.
+		self.assertFalse(self.ls_a.is_active)


### PR DESCRIPTION
## What & why

Follow-up to the subscriber-analytics cleanup: prevent the **drift** at its source.

The admin **"Disable all emails"** bulk action (`make_inactive`) previously only flipped the global `Subscribers.active` flag via `queryset.update(active=False)`, leaving the per-list `ListSubscription` rows `is_active=True`. That's exactly what created the 55 drifted accounts that PR #671's `reconcile_inactive_subscriptions` command had to clean up — and it would keep recurring every time the action was used.

## Change

`make_inactive` now mirrors the "unsubscribe from everything" flow (`views.py` `scope='all'`): inside a transaction it sets `active=False` **and** opts the selected subscribers out of every active list (`is_active=False`, stamping `unsubscribed_at` where missing, preserving any existing timestamp).

- Selected IDs are materialised first, since `SubscriberAdmin.get_queryset()` is annotated/`distinct()` and unreliable as an `__in` subquery.
- The success message now reports how many list subscriptions were opted out.
- `make_active` is **unchanged** — it only clears the flag and deliberately does **not** re-subscribe (re-subscription is opt-in).

Result: the global switch and per-list state stay consistent, so subscription-based analytics agree with the account flag and drift no longer accumulates.

## Tests

New `test_subscriber_admin_actions.py` (4 tests, all pass):
- make_inactive sets the flag and deactivates all lists with `unsubscribed_at`
- existing `unsubscribed_at` is preserved
- only the selected subscribers are affected
- make_active clears the flag but does not re-subscribe

Full `subscriptions` suite: 238/239 pass (the one failure is the pre-existing, unrelated `test_oversized_jpeg_is_resized`). No model/migration change.

## Relationship to the one-off cleanup
- This stops *future* drift. The existing rows are still cleaned up by running `reconcile_inactive_subscriptions --apply` on prod (not yet done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)