### PR TITLE
Export clinical trials to XLSX and complete trials API fields

### DIFF
--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -353,7 +353,7 @@ class ArticleSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSe
 		return content.summary_plain_english if content else None
 
 class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSerializer):
-	source = serializers.SlugRelatedField(read_only=True, slug_field='name')
+	sources = serializers.SlugRelatedField(many=True, read_only=True, slug_field='name')
 	team_categories = TeamCategorySerializer(many=True, read_only=True)
 	articles = serializers.SerializerMethodField()
 	takeaways = serializers.SerializerMethodField()
@@ -366,7 +366,7 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 		model = Trials
 		fields = [
 			'trial_id', 'title', 'summary', 'summary_plain_english', 'ctg_detailed_description',
-			'published_date', 'discovery_date', 'last_updated', 'link', 'source',
+			'published_date', 'discovery_date', 'last_updated', 'link', 'sources',
 			'identifiers', 'team_categories', 'export_date', 'internal_number', 'last_refreshed_on',
 			'acronym', 'scientific_title', 'primary_sponsor', 'secondary_sponsor', 'sponsor_type',
 			'prospective_registration', 'date_registration',

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -365,9 +365,10 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 	class Meta:
 		model = Trials
 		fields = [
-			'trial_id', 'title', 'summary', 'summary_plain_english', 'published_date', 'discovery_date', 'link', 'source',
+			'trial_id', 'title', 'summary', 'summary_plain_english', 'ctg_detailed_description',
+			'published_date', 'discovery_date', 'last_updated', 'link', 'source',
 			'identifiers', 'team_categories', 'export_date', 'internal_number', 'last_refreshed_on',
-			'acronym', 'scientific_title', 'primary_sponsor', 'secondary_sponsor',
+			'acronym', 'scientific_title', 'primary_sponsor', 'secondary_sponsor', 'sponsor_type',
 			'prospective_registration', 'date_registration',
 			'source_register', 'recruitment_status', 'other_records', 'inclusion_agemin',
 			'inclusion_agemax', 'inclusion_gender', 'date_enrollement', 'target_size',
@@ -379,6 +380,9 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 			'ethics_review_contact_name', 'ethics_review_contact_address', 'ethics_review_contact_phone',
 			'ethics_review_contact_email', 'results_date_completed', 'results_url_link',
 			'results_yes_no', 'results_ipd_plan', 'results_ipd_description',
+			# EU Clinical Trials (CTIS) fields
+			'therapeutic_areas', 'country_status', 'trial_region', 'results_posted',
+			'overall_decision_date', 'countries_decision_date',
 			'takeaways', 'articles'
 		]
 		read_only_fields = ('discovery_date', 'articles')

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -388,8 +388,13 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 		read_only_fields = ('discovery_date', 'articles')
 
 	def get_articles(self, obj):
-		"""Get articles that reference this trial"""
-		references = ArticleTrialReference.objects.filter(trial=obj)
+		"""Get articles that reference this trial.
+
+		Uses the prefetched ``article_references`` cache when available (populated
+		by TrialViewSet/AllTrialViewSet via prefetch_related('article_references__article'))
+		to avoid one query per trial on list responses.
+		"""
+		references = obj.article_references.all()
 		articles = [ref.article for ref in references]
 		return ArticleReferenceSerializer(articles, many=True).data
 

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1071,7 +1071,9 @@ class TrialViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 		``_prefetched_org_contents`` so the serializer can resolve per-org
 		fields without issuing one query per trial.
 		"""
-		qs = super().get_queryset()
+		# Prefetch m2m relations the serializer reads (sources, team_categories)
+		# so list/CSV-export responses don't issue one query per trial.
+		qs = super().get_queryset().prefetch_related('sources', 'team_categories')
 		org = _resolve_per_org_fields_org(self.request)
 		if org is not None:
 			qs = qs.prefetch_related(
@@ -1121,7 +1123,7 @@ class AllTrialViewSet(generics.ListAPIView):
 	List all clinical trials by discovery date
 	"""
 	pagination_class = None
-	queryset = Trials.objects.all().order_by('-discovery_date')
+	queryset = Trials.objects.all().order_by('-discovery_date').prefetch_related('sources', 'team_categories')
 	serializer_class = TrialSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1071,9 +1071,9 @@ class TrialViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 		``_prefetched_org_contents`` so the serializer can resolve per-org
 		fields without issuing one query per trial.
 		"""
-		# Prefetch m2m relations the serializer reads (sources, team_categories)
-		# so list/CSV-export responses don't issue one query per trial.
-		qs = super().get_queryset().prefetch_related('sources', 'team_categories')
+		# Prefetch m2m/reverse-FK relations the serializer reads (sources, team_categories,
+		# article_references) so list/CSV-export responses don't issue one query per trial.
+		qs = super().get_queryset().prefetch_related('sources', 'team_categories', 'article_references__article')
 		org = _resolve_per_org_fields_org(self.request)
 		if org is not None:
 			qs = qs.prefetch_related(
@@ -1123,7 +1123,7 @@ class AllTrialViewSet(generics.ListAPIView):
 	List all clinical trials by discovery date
 	"""
 	pagination_class = None
-	queryset = Trials.objects.all().order_by('-discovery_date').prefetch_related('sources', 'team_categories')
+	queryset = Trials.objects.all().order_by('-discovery_date').prefetch_related('sources', 'team_categories', 'article_references__article')
 	serializer_class = TrialSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 

--- a/django/gregory/management/commands/export_trials_xlsx.py
+++ b/django/gregory/management/commands/export_trials_xlsx.py
@@ -363,17 +363,20 @@ class Command(BaseCommand):
 				ids = [int(x.strip()) for x in raw.split(',') if x.strip()]
 			except ValueError:
 				raise CommandError('--subjects must be comma-separated integers.')
+			subject_qs = Subject.objects.all()
+			if options['team']:
+				subject_qs = subject_qs.filter(team_id=options['team'])
 			valid_ids = set(
-				Subject.objects.filter(pk__in=ids).values_list('pk', flat=True)
+				subject_qs.filter(pk__in=ids).values_list('pk', flat=True)
 			)
 			missing = set(ids) - valid_ids
 			if missing:
-				all_subs = Subject.objects.values_list('pk', 'subject_name')
+				all_subs = subject_qs.values_list('pk', 'subject_name')
 				valid_list = ', '.join(f'{pk} ({name})' for pk, name in all_subs)
 				raise CommandError(
 					f'Subject ID(s) not found: {sorted(missing)}. Valid IDs: {valid_list}'
 				)
-			subjects = list(Subject.objects.filter(pk__in=ids).order_by('subject_name'))
+			subjects = list(subject_qs.filter(pk__in=ids).order_by('subject_name'))
 
 		if not subjects:
 			raise CommandError('No subjects found.')

--- a/django/gregory/management/commands/export_trials_xlsx.py
+++ b/django/gregory/management/commands/export_trials_xlsx.py
@@ -1,0 +1,490 @@
+import json
+import re
+from datetime import datetime, date, timezone as dt_timezone
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import GeneratedField
+from openpyxl import Workbook
+from openpyxl.styles import Font, PatternFill, Alignment
+from openpyxl.utils import get_column_letter
+
+from gregory.models import Trials, Subject
+
+
+EXCLUDED_SCALARS = frozenset({'utitle', 'usummary'})
+EXCLUDED_M2M    = frozenset({'ml_predictions'})
+
+# Ordered column groups for data sheets
+IDENTITY_COLS = [
+	'trial_id', 'title', 'acronym', 'scientific_title', 'link',
+	'discovery_date', 'last_updated', 'published_date', 'date_registration',
+	'last_refreshed_on', 'export_date',
+]
+
+SCALAR_ORDER = [
+	'summary',
+	'internal_number', 'secondary_id', 'source_register', 'other_records',
+	'prospective_registration', 'study_type', 'study_design', 'phase',
+	'recruitment_status', 'target_size', 'date_enrollement', 'countries',
+	'condition', 'intervention', 'primary_outcome', 'secondary_outcome',
+	'inclusion_criteria', 'exclusion_criteria',
+	'inclusion_agemin', 'inclusion_agemax', 'inclusion_gender',
+	'primary_sponsor', 'secondary_sponsor', 'source_support', 'sponsor_type',
+	'contact_firstname', 'contact_lastname', 'contact_address',
+	'contact_email', 'contact_tel', 'contact_affiliation',
+	'ethics_review_status', 'ethics_review_approval_date',
+	'ethics_review_contact_name', 'ethics_review_contact_address',
+	'ethics_review_contact_phone', 'ethics_review_contact_email',
+	'results_posted', 'results_date_completed', 'results_url_link',
+	'results_yes_no', 'results_ipd_plan', 'results_ipd_description',
+	'therapeutic_areas', 'country_status', 'trial_region',
+	'overall_decision_date', 'countries_decision_date',
+	'ctg_detailed_description',
+]
+
+RELATION_COLS = ['subjects', 'teams', 'sources', 'team_categories', 'articles']
+
+# Descriptions for exported columns absent from TrialAdminForm.Meta.help_texts.
+# Format: field_name → (label, description, source_registries)
+EXTRA_GLOSSARY = {
+	'trial_id':   ('Trial ID', 'Internal Gregory database identifier for this trial record.', ''),
+	'summary':    ('Summary',  'Plain-language summary of the trial.', 'WHO ICTRP, ClinicalTrials.gov, EU CTIS'),
+	'discovery_date':  ('Discovery date', 'Date this trial was first added to Gregory.', ''),
+	'last_updated':    ('Last updated',   'Date and time this record was last modified in Gregory.', ''),
+	'identifiers_json': ('Identifiers (raw JSON)', 'Raw JSON dict of all registry identifiers for this trial.', 'WHO ICTRP, ClinicalTrials.gov, EU CTIS'),
+	'subjects':         ('Subjects',       'Research subjects this trial is assigned to in Gregory (semicolon-separated).', ''),
+	'teams':            ('Teams',          'Teams this trial is assigned to in Gregory (semicolon-separated).', ''),
+	'sources':          ('Sources',        'Registry sources that provided data for this trial (semicolon-separated).', ''),
+	'team_categories':  ('Categories',     'Team categories assigned to this trial (semicolon-separated).', ''),
+	'articles':         ('Related articles', 'Count of articles that reference this trial, followed by their URLs.', ''),
+	'therapeutic_areas': ('Therapeutic areas', 'Therapeutic areas covered by the trial.', 'EU CTIS'),
+	'country_status':    ('Country status', 'Authorisation status of the trial in each participating country.', 'EU CTIS'),
+	'trial_region':      ('Trial region', 'Geographic region of the trial.', 'EU CTIS'),
+	'overall_decision_date':   ('Overall decision date', 'Date of the overall regulatory decision for the trial.', 'EU CTIS'),
+	'countries_decision_date': ('Countries decision dates', 'JSON map of per-country regulatory decision dates.', 'EU CTIS'),
+	'sponsor_type':            ('Sponsor type', 'Whether the sponsor is commercial or non-commercial.', 'EU CTIS'),
+	'ctg_detailed_description': ('Detailed description', 'Extended description from ClinicalTrials.gov.', 'ClinicalTrials.gov'),
+}
+
+REGISTRIES_OVERVIEW = [
+	(
+		'WHO ICTRP',
+		'Varies (nct, euctr, chictr, nl, …)',
+		'Aggregator of national/regional registries worldwide',
+		'Richest field coverage: ethics review, IPD plans, enrolment dates, full sponsor '
+		'info. May lag primary registries; can overwrite a field with an empty value on '
+		're-import.',
+	),
+	(
+		'ClinicalTrials.gov',
+		'nct',
+		'US-hosted global registry',
+		'Provides ctg_detailed_description and results_url_link. Combines exclusion into '
+		'inclusion criteria. Never blanks a field on update (non-destructive).',
+	),
+	(
+		'EU Clinical Trials (CTIS)',
+		'euctr / eudract / ctis',
+		'EU trials register',
+		'Provides therapeutic_areas, country_status, trial_region, overall_decision_date, '
+		'countries_decision_date, sponsor_type. Does not provide date_registration. '
+		'May overwrite fields with empty values on re-import.',
+	),
+]
+
+MERGE_PROSE = (
+	'A single trial can be ingested from more than one source registry. Gregory stores '
+	'one row per trial and merges data on re-import using a last-write-wins strategy. '
+	'ClinicalTrials.gov never blanks a field it previously populated; WHO ICTRP and EU '
+	'CTIS may overwrite existing values — including with empty ones — if the incoming '
+	'record omits a field. The identifiers column is always merged non-destructively: '
+	'keys are added, never removed. Fields produced by only one registry (e.g. EU CTIS '
+	'therapeutic_areas or CT.gov ctg_detailed_description) are set only by their '
+	'respective importer and are never in conflict.'
+)
+
+REGISTRY_NAMES = ['WHO ICTRP', 'ClinicalTrials.gov', 'EU CTIS']
+
+# Column widths for data sheets
+_WIDE_COLS = {
+	'title', 'scientific_title', 'summary', 'ctg_detailed_description',
+	'inclusion_criteria', 'exclusion_criteria', 'intervention',
+	'primary_outcome', 'secondary_outcome', 'study_design', 'condition',
+	'results_ipd_description', 'therapeutic_areas', 'country_status', 'articles',
+}
+_URL_COLS = {'link', 'results_url_link', 'identifiers_json'}
+
+
+def _sanitise_sheet_name(name, used):
+	"""Return a valid, unique Excel sheet name (≤31 chars, no illegal characters)."""
+	name = re.sub(r'[\\/*?\[\]:]', '_', name)[:31]
+	base, suffix = name, 1
+	while name in used:
+		suffix += 1
+		name = base[:28] + f'_{suffix}'
+	used.add(name)
+	return name
+
+
+def _cell_value(value):
+	"""Convert a Python value to an Excel-safe type (None → empty string)."""
+	if value is None:
+		return ''
+	if isinstance(value, datetime):
+		if value.tzinfo is not None:
+			value = value.astimezone(dt_timezone.utc).replace(tzinfo=None)
+		return value
+	if isinstance(value, date):
+		return value
+	if isinstance(value, dict):
+		return json.dumps(value, ensure_ascii=False)
+	if isinstance(value, bool):
+		return value
+	if isinstance(value, (int, float)):
+		return value
+	return str(value)
+
+
+def _apply_header(ws, columns):
+	"""Write a bold, coloured header row and return the cell count."""
+	hdr_font = Font(bold=True, color='FFFFFF')
+	hdr_fill = PatternFill(fill_type='solid', fgColor='2F4F8F')
+	hdr_align = Alignment(vertical='center')
+	for col_idx, name in enumerate(columns, 1):
+		cell = ws.cell(row=1, column=col_idx, value=name)
+		cell.font = hdr_font
+		cell.fill = hdr_fill
+		cell.alignment = hdr_align
+	return len(columns)
+
+
+def _set_column_widths(ws, columns):
+	for col_idx, name in enumerate(columns, 1):
+		letter = get_column_letter(col_idx)
+		if name in _WIDE_COLS:
+			ws.column_dimensions[letter].width = 50
+		elif name in _URL_COLS:
+			ws.column_dimensions[letter].width = 40
+		elif name.startswith('id_'):
+			ws.column_dimensions[letter].width = 20
+		else:
+			ws.column_dimensions[letter].width = max(12, min(40, len(name) + 4))
+
+
+def _build_scalar_columns():
+	"""
+	Return an ordered list of scalar Trials column names for export.
+	Known columns follow IDENTITY_COLS + SCALAR_ORDER; unrecognised columns are appended.
+	Excludes: GeneratedField columns, m2m/relation fields, and 'identifiers' (expanded
+	separately into id_* columns and identifiers_json).
+	"""
+	known_order = IDENTITY_COLS + SCALAR_ORDER
+	# 'identifiers' is handled separately; EXCLUDED_* are never exported
+	known_set = set(known_order) | {'identifiers'} | EXCLUDED_SCALARS | EXCLUDED_M2M
+	unknown = []
+	for f in Trials._meta.get_fields():
+		if f.is_relation:
+			continue
+		if isinstance(f, GeneratedField):
+			continue
+		if f.name in known_set:
+			continue
+		unknown.append(f.name)
+	return known_order + sorted(unknown)
+
+
+def _parse_help_text(text):
+	"""
+	Split a help_text string into (description, source_registries_string).
+	Looks for a trailing 'Sources?: …' clause.
+	"""
+	match = re.search(r'\s+Sources?:\s*(.+?)\.?\s*$', text, re.IGNORECASE)
+	if match:
+		return text[:match.start()].strip(), match.group(1).strip().rstrip('.')
+	return text.strip(), ''
+
+
+def _sources_for(col_name, admin_labels, admin_help, model_help):
+	"""Return (label, description, source_str) for one exported column."""
+	if col_name.startswith('id_'):
+		key = col_name[3:]
+		return (
+			f'Identifier: {key.upper()}',
+			f'Registry identifier key "{key}" extracted from the identifiers JSON.',
+			'WHO ICTRP, ClinicalTrials.gov, EU CTIS',
+		)
+	if col_name in EXTRA_GLOSSARY:
+		return EXTRA_GLOSSARY[col_name]
+	if col_name in admin_help:
+		label = admin_labels.get(col_name, col_name)
+		desc, sources = _parse_help_text(admin_help[col_name])
+		return label, desc, sources
+	if col_name in model_help:
+		label = admin_labels.get(col_name, col_name)
+		desc, sources = _parse_help_text(model_help[col_name])
+		return label, desc, sources
+	return admin_labels.get(col_name, col_name), '', ''
+
+
+def _build_glossary_sheet(wb, all_data_cols):
+	"""Add a Glossary sheet — one row per exported column."""
+	from gregory.admin import TrialAdminForm
+
+	admin_labels = TrialAdminForm.Meta.labels
+	admin_help   = TrialAdminForm.Meta.help_texts
+	model_help   = {
+		f.name: f.help_text
+		for f in Trials._meta.get_fields()
+		if not f.is_relation and hasattr(f, 'help_text') and f.help_text
+	}
+
+	ws = wb.create_sheet(title='Glossary')
+	headers = ['Field', 'Label', 'Description', 'Source registries']
+	_apply_header(ws, headers)
+	ws.freeze_panes = 'A2'
+	ws.column_dimensions['A'].width = 32
+	ws.column_dimensions['B'].width = 32
+	ws.column_dimensions['C'].width = 65
+	ws.column_dimensions['D'].width = 32
+
+	for row_idx, col_name in enumerate(all_data_cols, 2):
+		label, desc, sources = _sources_for(col_name, admin_labels, admin_help, model_help)
+		ws.cell(row=row_idx, column=1, value=col_name)
+		ws.cell(row=row_idx, column=2, value=label)
+		cell_desc = ws.cell(row=row_idx, column=3, value=desc)
+		cell_desc.alignment = Alignment(wrap_text=True)
+		ws.cell(row=row_idx, column=4, value=sources)
+
+
+def _build_registries_sheet(wb, all_data_cols):
+	"""Add a Registries sheet with a prose overview, registry table, and field matrix."""
+	from gregory.admin import TrialAdminForm
+
+	admin_labels = TrialAdminForm.Meta.labels
+	admin_help   = TrialAdminForm.Meta.help_texts
+	model_help   = {
+		f.name: f.help_text
+		for f in Trials._meta.get_fields()
+		if not f.is_relation and hasattr(f, 'help_text') and f.help_text
+	}
+
+	ws = wb.create_sheet(title='Registries')
+	hdr_font = Font(bold=True, color='FFFFFF')
+	hdr_fill = PatternFill(fill_type='solid', fgColor='2F4F8F')
+	hdr_align = Alignment(vertical='center')
+	section_font = Font(bold=True, size=13)
+
+	# --- Part A: prose overview ---
+	ws.cell(row=1, column=1, value='Registry overview').font = section_font
+	prose_cell = ws.cell(row=2, column=1, value=MERGE_PROSE)
+	prose_cell.alignment = Alignment(wrap_text=True)
+	ws.merge_cells('A2:D2')
+	ws.row_dimensions[2].height = 90
+
+	# Overview table header (row 4)
+	for col_idx, h in enumerate(['Registry', 'Identifier key(s)', 'What it is', 'Notes on coverage'], 1):
+		c = ws.cell(row=4, column=col_idx, value=h)
+		c.font = hdr_font; c.fill = hdr_fill; c.alignment = hdr_align
+
+	for row_offset, (reg_name, id_keys_str, what, notes) in enumerate(REGISTRIES_OVERVIEW, 5):
+		ws.cell(row=row_offset, column=1, value=reg_name)
+		ws.cell(row=row_offset, column=2, value=id_keys_str)
+		ws.cell(row=row_offset, column=3, value=what)
+		ws.cell(row=row_offset, column=4, value=notes).alignment = Alignment(wrap_text=True)
+
+	# --- Part B: field-by-registry matrix ---
+	matrix_start = 10
+	ws.cell(row=matrix_start, column=1, value='Field coverage by registry').font = section_font
+
+	for col_idx, h in enumerate(['Field', 'Label'] + REGISTRY_NAMES, 1):
+		c = ws.cell(row=matrix_start + 1, column=col_idx, value=h)
+		c.font = hdr_font; c.fill = hdr_fill; c.alignment = hdr_align
+
+	for row_offset, col_name in enumerate(all_data_cols, matrix_start + 2):
+		label, _, sources_str = _sources_for(col_name, admin_labels, admin_help, model_help)
+		ws.cell(row=row_offset, column=1, value=col_name)
+		ws.cell(row=row_offset, column=2, value=label)
+		for reg_col, reg_name in enumerate(REGISTRY_NAMES, 3):
+			# Normalise for matching: "EU CTIS" matches "EU CTIS" or "EU Clinical"
+			src_lower = sources_str.lower()
+			reg_lower = reg_name.lower()
+			tick = '✓' if reg_lower in src_lower else ''
+			if not tick and reg_name == 'EU CTIS' and 'eu ctis' not in src_lower:
+				if 'eu clinical' in src_lower:
+					tick = '✓'
+			ws.cell(row=row_offset, column=reg_col, value=tick)
+
+	# Column widths
+	for letter, width in zip('ABCDE', [32, 32, 22, 22, 22]):
+		ws.column_dimensions[letter].width = width
+
+
+class Command(BaseCommand):
+	help = 'Export clinical-trial data to an XLSX workbook, one sheet per subject.'
+
+	def add_arguments(self, parser):
+		parser.add_argument(
+			'--subjects',
+			type=str,
+			default='',
+			help='Comma-separated subject IDs to export.',
+		)
+		parser.add_argument(
+			'--all-subjects',
+			action='store_true',
+			default=False,
+			help='Export every subject (one sheet each).',
+		)
+		parser.add_argument(
+			'--output',
+			type=str,
+			default='',
+			help='Output file path (default: trials_export_YYYYMMDD.xlsx in current directory).',
+		)
+		parser.add_argument(
+			'--team',
+			type=int,
+			default=None,
+			help='Optional team ID; filters which subjects are exported.',
+		)
+
+	def handle(self, *args, **options):
+		# --- Resolve subjects ---
+		if options['all_subjects']:
+			qs = Subject.objects.all()
+			if options['team']:
+				qs = qs.filter(team_id=options['team'])
+			subjects = list(qs.order_by('subject_name'))
+		else:
+			raw = options['subjects'].strip()
+			if not raw:
+				raise CommandError('Provide --subjects <ids> or --all-subjects.')
+			try:
+				ids = [int(x.strip()) for x in raw.split(',') if x.strip()]
+			except ValueError:
+				raise CommandError('--subjects must be comma-separated integers.')
+			valid_ids = set(
+				Subject.objects.filter(pk__in=ids).values_list('pk', flat=True)
+			)
+			missing = set(ids) - valid_ids
+			if missing:
+				all_subs = Subject.objects.values_list('pk', 'subject_name')
+				valid_list = ', '.join(f'{pk} ({name})' for pk, name in all_subs)
+				raise CommandError(
+					f'Subject ID(s) not found: {sorted(missing)}. Valid IDs: {valid_list}'
+				)
+			subjects = list(Subject.objects.filter(pk__in=ids).order_by('subject_name'))
+
+		if not subjects:
+			raise CommandError('No subjects found.')
+
+		output_path = options['output'] or f'trials_export_{datetime.now().strftime("%Y%m%d")}.xlsx'
+
+		# --- Build column plan ---
+		scalar_cols = _build_scalar_columns()
+		remaining_scalars = [
+			c for c in scalar_cols
+			if c not in set(IDENTITY_COLS) and c != 'identifiers'
+		]
+
+		# Discover all identifier keys across every exported subject (preserves first-seen order)
+		all_subject_ids = [s.pk for s in subjects]
+		id_key_order, seen_keys = [], set()
+		for identifiers in (
+			Trials.objects
+			.filter(subjects__in=all_subject_ids)
+			.exclude(identifiers=None)
+			.values_list('identifiers', flat=True)
+		):
+			if isinstance(identifiers, dict):
+				for k in identifiers:
+					if k not in seen_keys:
+						id_key_order.append(k)
+						seen_keys.add(k)
+
+		id_cols = [f'id_{k}' for k in id_key_order]
+		all_data_cols = IDENTITY_COLS + id_cols + ['identifiers_json'] + remaining_scalars + RELATION_COLS
+
+		self.stdout.write(f'Exporting {len(subjects)} subject(s) → {output_path}')
+
+		# --- Build workbook ---
+		wb = Workbook()
+		wb.remove(wb.active)  # remove the default blank sheet
+		used_sheet_names: set = set()
+
+		for subject in subjects:
+			sheet_name = _sanitise_sheet_name(subject.subject_name, used_sheet_names)
+			ws = wb.create_sheet(title=sheet_name)
+
+			qs = (
+				Trials.objects.filter(subjects=subject)
+				.distinct()
+				.order_by('-discovery_date')
+				.prefetch_related(
+					'subjects',
+					'teams',
+					'sources',
+					'team_categories',
+					'article_references__article',
+				)
+			)
+
+			count = qs.count()
+			self.stdout.write(f'  Sheet "{sheet_name}": {count} trial(s)')
+
+			_apply_header(ws, all_data_cols)
+			ws.freeze_panes = 'A2'
+			ws.auto_filter.ref = f'A1:{get_column_letter(len(all_data_cols))}1'
+
+			if count == 0:
+				ws.cell(row=2, column=1, value='No trials found for this subject.')
+			else:
+				scalar_set = set(IDENTITY_COLS) | set(remaining_scalars)
+				for row_idx, trial in enumerate(qs, 2):
+					identifiers = trial.identifiers or {}
+					row_data = []
+					for col_name in all_data_cols:
+						if col_name in scalar_set:
+							row_data.append(_cell_value(getattr(trial, col_name, None)))
+						elif col_name.startswith('id_'):
+							row_data.append(_cell_value(identifiers.get(col_name[3:])))
+						elif col_name == 'identifiers_json':
+							row_data.append(
+								json.dumps(identifiers, ensure_ascii=False) if identifiers else ''
+							)
+						elif col_name == 'subjects':
+							row_data.append(
+								'; '.join(s.subject_name for s in trial.subjects.all())
+							)
+						elif col_name == 'teams':
+							row_data.append(
+								'; '.join(t.name for t in trial.teams.all())
+							)
+						elif col_name == 'sources':
+							row_data.append(
+								'; '.join(src.name or '' for src in trial.sources.all())
+							)
+						elif col_name == 'team_categories':
+							row_data.append(
+								'; '.join(tc.category_name for tc in trial.team_categories.all())
+							)
+						elif col_name == 'articles':
+							refs = list(trial.article_references.all())
+							if refs:
+								links = '; '.join(r.article.link for r in refs)
+								row_data.append(f'{len(refs)}: {links}')
+							else:
+								row_data.append('')
+						else:
+							row_data.append('')
+
+					for col_idx, value in enumerate(row_data, 1):
+						ws.cell(row=row_idx, column=col_idx, value=value)
+
+			_set_column_widths(ws, all_data_cols)
+
+		_build_glossary_sheet(wb, all_data_cols)
+		_build_registries_sheet(wb, all_data_cols)
+
+		wb.save(output_path)
+		self.stdout.write(self.style.SUCCESS(f'Saved: {output_path}'))

--- a/django/gregory/tests/test_export_trials_xlsx.py
+++ b/django/gregory/tests/test_export_trials_xlsx.py
@@ -1,0 +1,329 @@
+"""
+Tests for the export_trials_xlsx management command.
+Run in the gregory Docker container:
+    python manage.py test gregory.tests.test_export_trials_xlsx
+"""
+import os
+import tempfile
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+from organizations.models import Organization
+
+import openpyxl
+
+from gregory.models import Articles, ArticleTrialReference, Sources, Subject, Team, Trials
+from gregory.management.commands.export_trials_xlsx import (
+	IDENTITY_COLS,
+	RELATION_COLS,
+	SCALAR_ORDER,
+	REGISTRY_NAMES,
+	_build_scalar_columns,
+	_sanitise_sheet_name,
+)
+
+
+class ExportTrialsXlsxTests(TestCase):
+
+	def setUp(self):
+		self.org  = Organization.objects.create(name='Test Org', slug='test-org')
+		self.team = Team.objects.create(name='Team A', organization=self.org, slug='team-a')
+
+		self.subject_ms     = Subject.objects.create(subject_name='Multiple Sclerosis', subject_slug='ms', team=self.team)
+		self.subject_cancer = Subject.objects.create(subject_name='Cancer', subject_slug='cancer', team=self.team)
+
+		self.source_ctg = Sources.objects.create(name='ClinicalTrials.gov', source_for='trials')
+		self.source_who = Sources.objects.create(name='WHO ICTRP', source_for='trials')
+
+		# Trial assigned to MS subject — NCT identifier
+		self.trial_ms = Trials.objects.create(
+			title='A randomised trial of natalizumab in MS',
+			link='https://clinicaltrials.gov/ct2/show/NCT00111111',
+			identifiers={'nct': 'NCT00111111'},
+			recruitment_status='Completed',
+			phase='Phase 3',
+		)
+		self.trial_ms.subjects.add(self.subject_ms)
+		self.trial_ms.sources.add(self.source_ctg)
+
+		# Trial assigned to MS subject — EUCTR identifier
+		self.trial_ms2 = Trials.objects.create(
+			title='An EU trial on ocrelizumab in MS',
+			link='https://www.clinicaltrialsregister.eu/ctr-search/trial/2016-001005-36/ES',
+			identifiers={'euctr': '2016-001005-36'},
+			recruitment_status='Ongoing',
+			therapeutic_areas='Neurology',
+		)
+		self.trial_ms2.subjects.add(self.subject_ms)
+		self.trial_ms2.sources.add(self.source_who)
+
+		# Trial assigned to Cancer subject only
+		self.trial_cancer = Trials.objects.create(
+			title='A trial for pancreatic cancer',
+			link='https://clinicaltrials.gov/ct2/show/NCT00999999',
+			identifiers={'nct': 'NCT00999999'},
+			recruitment_status='Recruiting',
+		)
+		self.trial_cancer.subjects.add(self.subject_cancer)
+		self.trial_cancer.sources.add(self.source_ctg)
+
+		# Article referencing the MS trial
+		self.article = Articles.objects.create(
+			title='Natalizumab review',
+			link='https://pubmed.ncbi.nlm.nih.gov/12345678/',
+		)
+		ArticleTrialReference.objects.create(
+			article=self.article,
+			trial=self.trial_ms,
+			identifier_type='nct',
+			identifier_value='NCT00111111',
+		)
+
+	def _export(self, **kwargs):
+		"""Run the command into a temp file; return (path, workbook)."""
+		fd, path = tempfile.mkstemp(suffix='.xlsx')
+		os.close(fd)
+		call_command('export_trials_xlsx', output=path, **kwargs)
+		wb = openpyxl.load_workbook(path)
+		return path, wb
+
+	def tearDown(self):
+		pass  # temp files cleaned up by individual tests
+
+	# ------------------------------------------------------------------
+	# Sheet structure
+	# ------------------------------------------------------------------
+
+	def test_one_sheet_per_subject_plus_glossary_and_registries(self):
+		path, wb = self._export(subjects=f'{self.subject_ms.pk},{self.subject_cancer.pk}')
+		try:
+			sheet_names = wb.sheetnames
+			self.assertIn('Multiple Sclerosis', sheet_names)
+			self.assertIn('Cancer', sheet_names)
+			self.assertIn('Glossary', sheet_names)
+			self.assertIn('Registries', sheet_names)
+		finally:
+			os.unlink(path)
+
+	def test_all_subjects_flag(self):
+		path, wb = self._export(all_subjects=True)
+		try:
+			sheet_names = wb.sheetnames
+			self.assertIn('Multiple Sclerosis', sheet_names)
+			self.assertIn('Cancer', sheet_names)
+		finally:
+			os.unlink(path)
+
+	def test_subject_not_found_raises(self):
+		with self.assertRaises(CommandError):
+			call_command('export_trials_xlsx', subjects='99999', output='/tmp/noop.xlsx')
+
+	def test_no_args_raises(self):
+		with self.assertRaises(CommandError):
+			call_command('export_trials_xlsx', output='/tmp/noop.xlsx')
+
+	# ------------------------------------------------------------------
+	# Data sheet headers
+	# ------------------------------------------------------------------
+
+	def test_identity_columns_present(self):
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb['Multiple Sclerosis']
+			headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+			for col in IDENTITY_COLS:
+				self.assertIn(col, headers, f'Identity column "{col}" missing from header row')
+		finally:
+			os.unlink(path)
+
+	def test_id_columns_created_from_identifier_keys(self):
+		"""id_nct and id_euctr must appear as explicit columns."""
+		path, wb = self._export(subjects=f'{self.subject_ms.pk},{self.subject_cancer.pk}')
+		try:
+			ws = wb['Multiple Sclerosis']
+			headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+			self.assertIn('id_nct',   headers)
+			self.assertIn('id_euctr', headers)
+			self.assertIn('identifiers_json', headers)
+		finally:
+			os.unlink(path)
+
+	def test_relation_columns_present(self):
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb['Multiple Sclerosis']
+			headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+			for col in RELATION_COLS:
+				self.assertIn(col, headers, f'Relation column "{col}" missing from header row')
+		finally:
+			os.unlink(path)
+
+	# ------------------------------------------------------------------
+	# Data values
+	# ------------------------------------------------------------------
+
+	def test_trial_data_written_correctly(self):
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb['Multiple Sclerosis']
+			headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+			# Find the title column
+			title_col = headers.index('title') + 1
+			titles = [
+				ws.cell(row=r, column=title_col).value
+				for r in range(2, ws.max_row + 1)
+			]
+			self.assertIn('A randomised trial of natalizumab in MS', titles)
+			self.assertIn('An EU trial on ocrelizumab in MS', titles)
+		finally:
+			os.unlink(path)
+
+	def test_identifier_expansion(self):
+		"""id_nct column should hold the NCT number; id_euctr should hold the EUCTR number."""
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb['Multiple Sclerosis']
+			headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+			nct_col   = headers.index('id_nct') + 1
+			euctr_col = headers.index('id_euctr') + 1
+			title_col = headers.index('title') + 1
+
+			nct_values   = {}
+			euctr_values = {}
+			for r in range(2, ws.max_row + 1):
+				title = ws.cell(row=r, column=title_col).value
+				nct_values[title]   = ws.cell(row=r, column=nct_col).value
+				euctr_values[title] = ws.cell(row=r, column=euctr_col).value
+
+			self.assertEqual(nct_values.get('A randomised trial of natalizumab in MS'), 'NCT00111111')
+			self.assertEqual(euctr_values.get('An EU trial on ocrelizumab in MS'), '2016-001005-36')
+		finally:
+			os.unlink(path)
+
+	def test_articles_column_shows_link(self):
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb['Multiple Sclerosis']
+			headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+			articles_col = headers.index('articles') + 1
+			title_col    = headers.index('title') + 1
+
+			for r in range(2, ws.max_row + 1):
+				if ws.cell(row=r, column=title_col).value == 'A randomised trial of natalizumab in MS':
+					cell_val = ws.cell(row=r, column=articles_col).value
+					self.assertIn('pubmed.ncbi.nlm.nih.gov', cell_val or '')
+					break
+			else:
+				self.fail('MS trial row not found')
+		finally:
+			os.unlink(path)
+
+	def test_empty_subject_still_has_header(self):
+		"""A subject with no trials must still produce a headed (non-crashing) sheet."""
+		empty_subject = Subject.objects.create(subject_name='Empty Subject', subject_slug='empty-subject', team=self.team)
+		path, wb = self._export(subjects=str(empty_subject.pk))
+		try:
+			ws = wb['Empty Subject']
+			headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+			self.assertIn('trial_id', headers)
+		finally:
+			os.unlink(path)
+
+	# ------------------------------------------------------------------
+	# Glossary sheet
+	# ------------------------------------------------------------------
+
+	def test_glossary_row_count_matches_data_columns(self):
+		"""Every exported column must have exactly one Glossary row."""
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws_data     = wb['Multiple Sclerosis']
+			ws_glossary = wb['Glossary']
+			data_col_count = ws_data.max_column
+			# Glossary row 1 is the header; rows 2..N are one per column
+			glossary_data_rows = ws_glossary.max_row - 1
+			self.assertEqual(data_col_count, glossary_data_rows)
+		finally:
+			os.unlink(path)
+
+	def test_glossary_has_field_and_label_columns(self):
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb['Glossary']
+			self.assertEqual(ws.cell(row=1, column=1).value, 'Field')
+			self.assertEqual(ws.cell(row=1, column=2).value, 'Label')
+		finally:
+			os.unlink(path)
+
+	# ------------------------------------------------------------------
+	# Registries sheet
+	# ------------------------------------------------------------------
+
+	def test_registries_sheet_has_three_registries(self):
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb['Registries']
+			# Read all text in the sheet
+			all_values = set()
+			for row in ws.iter_rows(values_only=True):
+				for v in row:
+					if v:
+						all_values.add(str(v))
+			for reg in REGISTRY_NAMES:
+				found = any(reg in v for v in all_values)
+				self.assertTrue(found, f'Registry "{reg}" not found in Registries sheet')
+		finally:
+			os.unlink(path)
+
+	def test_registries_sheet_has_field_matrix(self):
+		"""The field matrix header row must contain the registry names."""
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb['Registries']
+			all_values = []
+			for row in ws.iter_rows(values_only=True):
+				all_values.extend(v for v in row if v)
+			for reg in REGISTRY_NAMES:
+				self.assertIn(reg, all_values, f'Registry column "{reg}" not in field matrix')
+		finally:
+			os.unlink(path)
+
+	# ------------------------------------------------------------------
+	# Helper / utility unit tests
+	# ------------------------------------------------------------------
+
+	def test_sanitise_sheet_name_strips_illegal_chars(self):
+		used = set()
+		name = _sanitise_sheet_name('Trial/Results [2024]', used)
+		self.assertNotIn('/', name)
+		self.assertNotIn('[', name)
+		self.assertNotIn(']', name)
+
+	def test_sanitise_sheet_name_truncates_to_31(self):
+		used = set()
+		long_name = 'A' * 50
+		result = _sanitise_sheet_name(long_name, used)
+		self.assertLessEqual(len(result), 31)
+
+	def test_sanitise_sheet_name_deduplicates(self):
+		used = set()
+		name1 = _sanitise_sheet_name('Duplicate', used)
+		name2 = _sanitise_sheet_name('Duplicate', used)
+		self.assertNotEqual(name1, name2)
+
+	def test_build_scalar_columns_excludes_generated_fields(self):
+		scalar_cols = _build_scalar_columns()
+		self.assertNotIn('utitle',   scalar_cols)
+		self.assertNotIn('usummary', scalar_cols)
+
+	def test_build_scalar_columns_excludes_identifiers(self):
+		scalar_cols = _build_scalar_columns()
+		self.assertNotIn('identifiers', scalar_cols)
+
+	def test_build_scalar_columns_includes_all_scalar_fields(self):
+		scalar_cols = _build_scalar_columns()
+		# Spot-check a broad cross-section of known fields
+		for col in ['title', 'summary', 'phase', 'condition', 'ctg_detailed_description',
+		            'therapeutic_areas', 'sponsor_type', 'ethics_review_status']:
+			self.assertIn(col, scalar_cols, f'Expected column "{col}" in scalar list')

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -65,6 +65,7 @@ nltk==3.9.1
 numexpr==2.8.7
 numpy==1.26.3
 oauthlib==3.2.2
+openpyxl>=3.1.0
 opt_einsum==3.4.0
 optree==0.15.0
 orcid==1.0.3


### PR DESCRIPTION
## Summary

- **New management command** `export_trials_xlsx` generates a multi-sheet `.xlsx` workbook with all trial data filtered by subject. One data sheet per subject, plus shared **Glossary** and **Registries** sheets.
- **Trials API serializer**: replaced the dead singular `source` field with `sources` (many=True), and added the missing EU CTIS fields (`therapeutic_areas`, `country_status`, `trial_region`, `results_posted`, `overall_decision_date`, `countries_decision_date`) plus `ctg_detailed_description`, `last_updated`, and `sponsor_type` — bringing the public API to full field coverage.
- **Performance**: added `prefetch_related('sources', 'team_categories')` to `TrialViewSet` and `AllTrialViewSet` to avoid N+1 queries on list and CSV-export paths.

## Usage

```bash
# Export specific subjects (by ID)
python manage.py export_trials_xlsx --subjects 1,2 --output trials.xlsx

# Export all subjects
python manage.py export_trials_xlsx --all-subjects

# Filter by team
python manage.py export_trials_xlsx --all-subjects --team 3
```

## Workbook structure

| Sheet | Contents |
|---|---|
| `<Subject name>` | All scalar columns + dynamic `id_*` columns from `identifiers` JSON + relation columns (sources, teams, categories, articles) |
| Glossary | One row per exported column: field name, plain-language label, description, source registries — sourced from `TrialAdminForm.Meta.help_texts` |
| Registries | Prose merge-behaviour overview + per-registry overview table + field-by-registry ✓ matrix |

## Test plan

- [ ] `python manage.py test gregory.tests.test_export_trials_xlsx` — 21 tests pass (run in the `gregory` container)
- [ ] `python manage.py export_trials_xlsx --subjects 1 --output /tmp/ms.xlsx` — verify workbook opens with correct sheets, headers, and data rows
- [ ] Check that `/api/trials/` response now includes `sources`, `therapeutic_areas`, `sponsor_type`, and other previously-missing fields
- [ ] Confirm no N+1 warnings in Django debug toolbar on the trials list endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)