### PR TITLE
perf(ci): parallel tests + faster Docker builds

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -14,9 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -31,10 +28,15 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          # CI builds amd64 only (production servers are amd64).
+          # For a local arm64 image (Apple Silicon) run:
+          #   docker buildx build --platform linux/arm64 -t gregory-ai:local .
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Registry cache avoids the 10 GB cap of type=gha, which was being
+          # exceeded by the torch/tensorflow wheels and causing full rebuilds.
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -12,19 +12,19 @@ jobs:
   build-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Stopgap until the base image is rebuilt from this PR's requirements.txt
+      # (which adds pytest-django and pytest-xdist). Remove once merged.
+      - name: Install test dependencies
+        run: pip install --no-cache-dir "pytest-django>=4.9.0" "pytest-xdist>=3.6.0"
+
       - name: Run pytest
         working-directory: django
         # SECRET_KEY / FERNET_SECRET_KEY are generated per-run so no secrets

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,10 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # pytest-django is new; install it until it lands in the base image.
-      - name: Install pytest-django and pytest-xdist
-        run: pip install --no-cache-dir "pytest-django>=4.9.0" "pytest-xdist>=3.6.0"
-
       - name: Run pytest
         working-directory: django
         # SECRET_KEY / FERNET_SECRET_KEY are generated per-run so no secrets

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,8 +37,8 @@ jobs:
       - uses: actions/checkout@v4
 
       # pytest-django is new; install it until it lands in the base image.
-      - name: Install pytest-django
-        run: pip install --no-cache-dir "pytest-django>=4.9.0"
+      - name: Install pytest-django and pytest-xdist
+        run: pip install --no-cache-dir "pytest-django>=4.9.0" "pytest-xdist>=3.6.0"
 
       - name: Run pytest
         working-directory: django

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,7 +34,7 @@ jobs:
       POSTGRES_USER: postgres
       DB_HOST: postgres
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run pytest
         working-directory: django

--- a/django/api/tests/test_filter_error_fix.py
+++ b/django/api/tests/test_filter_error_fix.py
@@ -33,7 +33,7 @@ class FilterErrorHandlingTest(TestCase):
 		]
 		
 		for test_value, description in test_cases:
-			with self.subTest(msg=description):
+			with self.subTest(msg=f"{description} (value={repr(test_value)})"):
 				try:
 					# This should NOT raise a TypeError anymore
 					result = filter_instance.filter_last_days(queryset, 'last_days', test_value)

--- a/django/api/tests/test_filter_error_fix.py
+++ b/django/api/tests/test_filter_error_fix.py
@@ -33,7 +33,7 @@ class FilterErrorHandlingTest(TestCase):
 		]
 		
 		for test_value, description in test_cases:
-			with self.subTest(value=test_value, description=description):
+			with self.subTest(msg=description):
 				try:
 					# This should NOT raise a TypeError anymore
 					result = filter_instance.filter_last_days(queryset, 'last_days', test_value)

--- a/django/pytest.ini
+++ b/django/pytest.ini
@@ -4,4 +4,4 @@ python_files = test_*.py tests.py
 python_classes = Test*
 python_functions = test_*
 testpaths = api gregory subscriptions indexers rss sitesettings
-addopts = --reuse-db
+addopts = --reuse-db --dist loadfile -n auto

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -78,6 +78,7 @@ psutil==5.9.0
 psycopg==3.2.9
 pytest==9.0.3
 pytest-django>=4.9.0
+pytest-xdist>=3.6.0
 psycopg-binary==3.2.9
 pyasn1==0.6.1
 pyasn1_modules==0.4.2


### PR DESCRIPTION
## Summary

- **pytest-xdist**: run the 1008-test suite in parallel with `--dist loadfile -n auto`; measured **56 s** locally vs 97 s serial (~42 % faster). On GitHub's 4-vCPU Linux runners the test step should drop from ~2 min to ~40–50 s.
- **Drop arm64 from CI build**: production servers are amd64-only; arm64 (Apple Silicon) images can be built locally with `docker buildx build --platform linux/arm64`. Removes QEMU emulation, the primary cause of 20-min build times.
- **Switch Docker cache from `type=gha` to `type=registry`**: `type=gha` has a 10 GB cap that torch + tensorflow wheels overflow, causing full rebuilds every run. Registry cache (stored as `amaralbruno/gregory-ai:buildcache`) has no size limit; subsequent builds after the first will be fast cache hits.
- **Fix xdist subtest serialisation**: `self.subTest(value=object())` passes a non-picklable object as the subtest identifier; xdist's execnet layer fails to send the worker report to the controller. Changed to `self.subTest(msg=description)`.

## Expected CI impact

| | Before | After (est.) |
|---|---|---|
| Tests workflow | ~3 m 30 s | ~90 s |
| Build & push (cold) | ~20 min | ~6–8 min |
| Build & push (warm cache) | ~20 min | ~3–4 min |

## Test plan

- [x] Full suite run locally with `--create-db` (fresh DB): **1008 passed, 0 failed**
- [x] Full suite run with `--reuse-db`: **1008 passed in 56 s**
- [x] `test_filter_error_fix.py` passes in isolation and in full parallel run
- [ ] Verify first CI run primes the Docker registry cache (expected ~6–8 min)
- [ ] Verify second CI run uses cache (expected ~3–4 min)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)