### PR TITLE
Fix trial false-merges and link flip-flop (Phase 0 + Phase 1)

### DIFF
--- a/django/api/tests/test_edit_trial.py
+++ b/django/api/tests/test_edit_trial.py
@@ -20,6 +20,7 @@ import json
 from datetime import timedelta
 
 from django.test import TestCase, Client
+from django.db import IntegrityError, transaction
 from django.utils.timezone import now
 from organizations.models import Organization
 
@@ -168,23 +169,50 @@ class EditTrialErrorsTest(TestCase):
 		})
 		self.assertEqual(resp.status_code, 404)
 
-	def test_duplicate_nct_returns_409_with_ids(self):
-		"""Two trials with same NCT id → 409 with both ids."""
-		dup = Trials.objects.create(
-			title='Duplicate Trial',
-			link='https://example.com/dup-trial',
-			identifiers={'nct': 'NCT0000002'},
+	def test_duplicate_identifier_returns_409_with_ids(self):
+		"""Two trials sharing a non-unique identifier (euct) → 409 with both ids.
+
+		nct/euctr/eudract/ctis are now protected by partial unique indexes, so a
+		duplicate can only arise on an unconstrained key such as ``euct`` — which
+		``find_trial_by_identifier`` still matches on, keeping the 409 'multiple
+		match' path reachable.
+		"""
+		dup_euct = '2021-000123-45'
+		t1 = Trials.objects.create(
+			title='Duplicate Trial One',
+			link='https://example.com/dup-trial-1',
+			identifiers={'euct': dup_euct},
 		)
-		dup.teams.add(self.team)
+		t1.teams.add(self.team)
+		t2 = Trials.objects.create(
+			title='Duplicate Trial Two',
+			link='https://example.com/dup-trial-2',
+			identifiers={'euct': dup_euct},
+		)
+		t2.teams.add(self.team)
 		resp = _edit(self.client, self.scheme.api_key, {
-			'identifiers': {'nct': 'NCT0000002'},
+			'identifiers': {'euct': dup_euct},
 		})
 		self.assertEqual(resp.status_code, 409)
 		data = resp.json()
 		self.assertIn('trial_ids', data['extra_data'])
-		self.assertIn(self.trial.trial_id, data['extra_data']['trial_ids'])
-		self.assertIn(dup.trial_id, data['extra_data']['trial_ids'])
+		self.assertIn(t1.trial_id, data['extra_data']['trial_ids'])
+		self.assertIn(t2.trial_id, data['extra_data']['trial_ids'])
 		self.assertEqual(TrialOrgContent.objects.count(), 0)
+
+	def test_duplicate_nct_blocked_by_unique_constraint(self):
+		"""NCT is the primary identifier and must stay unique: migration 0054's
+		partial unique index rejects a second trial that reuses self.trial's nct
+		(NCT0000002), so duplicate-NCT rows can never exist in the first place.
+		This is the Postgres-only guarantee that test_trial_identity (SQLite)
+		cannot cover."""
+		with self.assertRaises(IntegrityError):
+			with transaction.atomic():
+				Trials.objects.create(
+					title='Second NCT0000002 Trial',
+					link='https://example.com/second-nct',
+					identifiers={'nct': 'NCT0000002'},
+				)
 
 	def test_cross_org_trial_returns_403(self):
 		"""Trial belongs to other_org only → 403."""

--- a/django/gregory/management/commands/audit_trial_merges.py
+++ b/django/gregory/management/commands/audit_trial_merges.py
@@ -19,7 +19,6 @@ import re
 
 from django.core.management.base import BaseCommand
 from django.db import connection
-from django.db.models import Count
 
 from gregory.models import Trials
 

--- a/django/gregory/management/commands/audit_trial_merges.py
+++ b/django/gregory/management/commands/audit_trial_merges.py
@@ -67,11 +67,8 @@ class Command(BaseCommand):
 		#    identifiers['nct'].
 		# ------------------------------------------------------------------
 		mismatches = []
-		qs = Trials.objects.exclude(identifiers__has_key='nct').union(
-			Trials.objects.filter(identifiers__has_key='nct')
-		)
-		# We need the full queryset; use filter to narrow to rows that have an
-		# NCT-looking link so we're not scanning all 19 k rows in Python.
+		# Narrow to rows that have an NCT and an NCT-looking link, so we scan only
+		# candidate rows in Python rather than all ~19k trials.
 		nct_rows = Trials.objects.filter(
 			identifiers__has_key='nct',
 			link__icontains='NCT',

--- a/django/gregory/management/commands/audit_trial_merges.py
+++ b/django/gregory/management/commands/audit_trial_merges.py
@@ -1,0 +1,152 @@
+"""
+Read-only management command: list suspected false-merges in the Trials table.
+
+Reports:
+  1. Rows where the link's NCT ID ≠ identifiers['nct']  (link/NCT mismatch)
+  2. Duplicate NCT/EUCTR/EUDRACT/CTIS values across rows  (constraint pre-flight check)
+
+Usage:
+  python manage.py audit_trial_merges
+  python manage.py audit_trial_merges --check-dupes  # also run per-key dupe scan
+  python manage.py audit_trial_merges --json          # machine-readable output
+
+Run this BEFORE applying the migration that adds the partial unique indexes to
+confirm no existing rows would collide on the new constraints.
+"""
+
+import json
+import re
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+from django.db.models import Count
+
+from gregory.models import Trials
+
+
+# Pattern to extract an NCT ID from a ClinicalTrials.gov URL
+_NCT_FROM_LINK_RE = re.compile(r'/(NCT\d{8})', re.IGNORECASE)
+
+
+def _nct_from_link(link: str | None) -> str | None:
+	"""Extract a normalised NCT ID from a CT.gov URL, or None."""
+	if not link:
+		return None
+	m = _NCT_FROM_LINK_RE.search(link)
+	return m.group(1).upper() if m else None
+
+
+class Command(BaseCommand):
+	help = (
+		'Read-only audit: list Trials rows with suspected link/NCT mismatches '
+		'and (optionally) per-registry-key duplicate values.'
+	)
+
+	def add_arguments(self, parser):
+		parser.add_argument(
+			'--check-dupes',
+			action='store_true',
+			default=False,
+			help='Also scan for rows that would collide under the new partial unique indexes.',
+		)
+		parser.add_argument(
+			'--json',
+			dest='output_json',
+			action='store_true',
+			default=False,
+			help='Emit results as a JSON object instead of human-readable text.',
+		)
+
+	def handle(self, *args, **options):
+		check_dupes = options['check_dupes']
+		output_json = options['output_json']
+
+		report = {}
+
+		# ------------------------------------------------------------------
+		# 1. Link/NCT mismatch: stored link points to a different NCT than
+		#    identifiers['nct'].
+		# ------------------------------------------------------------------
+		mismatches = []
+		qs = Trials.objects.exclude(identifiers__has_key='nct').union(
+			Trials.objects.filter(identifiers__has_key='nct')
+		)
+		# We need the full queryset; use filter to narrow to rows that have an
+		# NCT-looking link so we're not scanning all 19 k rows in Python.
+		nct_rows = Trials.objects.filter(
+			identifiers__has_key='nct',
+			link__icontains='NCT',
+		).values('trial_id', 'link', 'identifiers')
+
+		for row in nct_rows:
+			stored_nct = (row['identifiers'].get('nct') or '').strip().upper()
+			link_nct = _nct_from_link(row['link'])
+			if link_nct and stored_nct and link_nct != stored_nct:
+				mismatches.append({
+					'trial_id': row['trial_id'],
+					'identifiers_nct': stored_nct,
+					'link_nct': link_nct,
+					'link': row['link'],
+				})
+
+		report['link_nct_mismatches'] = mismatches
+
+		# ------------------------------------------------------------------
+		# 2. Per-registry duplicate scan (pre-flight for the migration).
+		# ------------------------------------------------------------------
+		dupes_report = {}
+		if check_dupes:
+			registry_keys = ['nct', 'euctr', 'eudract', 'ctis']
+			for key in registry_keys:
+				with connection.cursor() as cursor:
+					cursor.execute(
+						"""
+						SELECT upper(identifiers->>'%s') AS val, count(*) AS cnt
+						FROM trials
+						WHERE identifiers ? '%s'
+						GROUP BY upper(identifiers->>'%s')
+						HAVING count(*) > 1
+						ORDER BY cnt DESC
+						""" % (key, key, key)  # noqa: S608 – read-only, no user input
+					)
+					rows = cursor.fetchall()
+				if rows:
+					dupes_report[key] = [{'value': r[0], 'count': r[1]} for r in rows]
+			report['duplicate_registry_ids'] = dupes_report
+
+		# ------------------------------------------------------------------
+		# Output
+		# ------------------------------------------------------------------
+		if output_json:
+			self.stdout.write(json.dumps(report, indent=2))
+			return
+
+		# Human-readable
+		self.stdout.write(self.style.MIGRATE_HEADING('\n=== Link / NCT mismatch ==='))
+		if mismatches:
+			self.stdout.write(
+				self.style.WARNING(f'{len(mismatches)} row(s) where link NCT ≠ identifiers[\'nct\']:')
+			)
+			for m in mismatches:
+				self.stdout.write(
+					f"  trial_id={m['trial_id']}  "
+					f"identifiers.nct={m['identifiers_nct']}  "
+					f"link_nct={m['link_nct']}  "
+					f"link={m['link']}"
+				)
+		else:
+			self.stdout.write(self.style.SUCCESS('No link/NCT mismatches found.'))
+
+		if check_dupes:
+			self.stdout.write(self.style.MIGRATE_HEADING('\n=== Duplicate registry IDs ==='))
+			if dupes_report:
+				for key, entries in dupes_report.items():
+					self.stdout.write(self.style.WARNING(f'{key}:'))
+					for e in entries:
+						self.stdout.write(f"  {e['value']}  ({e['count']} rows)")
+			else:
+				self.stdout.write(
+					self.style.SUCCESS(
+						'No duplicate registry IDs found — safe to apply the partial unique indexes.'
+					)
+				)

--- a/django/gregory/management/commands/feedreader_trials.py
+++ b/django/gregory/management/commands/feedreader_trials.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from gregory.classes import ClinicalTrial, EUTrialParser
 from gregory.functions import remove_utm
 from gregory.models import Trials, Sources
+from gregory.utils.trial_utils import identifiers_conflict
 import feedparser
 import pytz
 import requests
@@ -125,11 +126,13 @@ class Command(BaseCommand):
 			if trial:
 				return trial
 
+		# Fallback to title match (case-insensitive) — only merge when the candidate
+		# does not conflict on a shared registry key (Option B guard).
 		if title:
-			trial = Trials.objects.filter(title__iexact=title).first()
-			if trial:
-				self.log(f"Found trial by title: {trial.title}", level=3)
-				return trial
+			candidate = Trials.objects.filter(title__iexact=title).first()
+			if candidate and not identifiers_conflict(candidate.identifiers, clinical_trial.identifiers):
+				self.log(f"Found trial by title: {candidate.title}", level=3)
+				return candidate
 
 	def create_new_trial(self, clinical_trial: ClinicalTrial, source):
 		"""Create a new trial in the database."""

--- a/django/gregory/management/commands/feedreader_trials_ctgov.py
+++ b/django/gregory/management/commands/feedreader_trials_ctgov.py
@@ -24,6 +24,7 @@ from django.db.models import Q
 from django.utils import timezone
 from gregory.classes import ClinicalTrialsGovAPI, ClinicalTrial
 from gregory.models import Trials, Sources
+from gregory.utils.trial_utils import identifiers_conflict
 import pytz
 
 
@@ -248,12 +249,13 @@ class Command(BaseCommand):
 			if trial:
 				return trial
 
-		# Fallback to title match (case-insensitive)
+		# Fallback to title match (case-insensitive) — only merge when the candidate
+		# does not conflict on a shared registry key (Option B guard).
 		if title:
-			trial = Trials.objects.filter(title__iexact=clinical_trial.title).first()
-			if trial:
-				self.log(f"Found trial by title: {trial.title[:50]}...", level=3)
-				return trial
+			candidate = Trials.objects.filter(title__iexact=clinical_trial.title).first()
+			if candidate and not identifiers_conflict(candidate.identifiers, clinical_trial.identifiers):
+				self.log(f"Found trial by title: {candidate.title[:50]}...", level=3)
+				return candidate
 
 		return None
 

--- a/django/gregory/management/commands/importWHOXML.py
+++ b/django/gregory/management/commands/importWHOXML.py
@@ -3,6 +3,7 @@ from django.core.management.base import BaseCommand
 from django.db import IntegrityError
 from django.utils import timezone
 from gregory.models import Trials, Sources
+from gregory.utils.trial_utils import identifiers_conflict
 import datetime
 import re
 import xml.etree.ElementTree as ET
@@ -73,10 +74,16 @@ class Command(BaseCommand):
 
 			# Handle other fields
 			elif key == 'identifiers':
-				# Check for existing identifiers and merge with the one in trial_data
+				# Conservative merge: preserve existing keys; only add keys that are
+				# absent or null.  {**current, **value} would overwrite stored IDs on
+				# every re-ingest (the "flip-flop" described in
+				# docs/trials-identity-dedup.md).
 				if isinstance(current_value, dict) and isinstance(value, dict):
-					merged_identifiers = {**current_value, **value}  # Merge dictionaries
-					if merged_identifiers != current_value:  # Check if the merge changed anything
+					merged_identifiers = current_value.copy()
+					for k, v in value.items():
+						if v and (k not in merged_identifiers or merged_identifiers[k] is None):
+							merged_identifiers[k] = v
+					if merged_identifiers != current_value:
 						trial.identifiers = merged_identifiers
 						has_changes = True
 						updated_fields.append(key)
@@ -131,17 +138,25 @@ class Command(BaseCommand):
 				existing_trial = Trials.objects.filter(
 					identifiers__contains={identifier_key: trial_id_value}
 				).first()
+				# Apply conflict guard: a value-level match under a different key should
+				# not merge records that disagree on a shared registry key.
+				if existing_trial and identifiers_conflict(existing_trial.identifiers, trial_data.get('identifiers')):
+					existing_trial = None
 			
 			# Fallback to a broader search if no specific key match
 			if not existing_trial:
 				existing_trial = Trials.objects.filter(
 					identifiers__contains=trial_id_value
 				).first()
-
-		# Step 2: Fallback to matching by title (case-insensitive)
+				# Apply conflict guard to the broad fallback as well.
+				if existing_trial and identifiers_conflict(existing_trial.identifiers, trial_data.get('identifiers')):
+					existing_trial = None
+		# Step 2: Fallback to matching by title (case-insensitive) — only merge when
+		# the candidate does not conflict on a shared registry key (Option B guard).
 		if not existing_trial and 'title' in trial_data:
-			existing_trial = Trials.objects.filter(title__iexact=trial_data['title']).first()
-			# print(f"Existing trial by title: {existing_trial}")
+			candidate = Trials.objects.filter(title__iexact=trial_data['title']).first()
+			if candidate and not identifiers_conflict(candidate.identifiers, trial_data.get('identifiers')):
+				existing_trial = candidate
 		# Step 3: Handle trial creation or update
 		try:
 			if existing_trial:

--- a/django/gregory/management/commands/importWHOXML.py
+++ b/django/gregory/management/commands/importWHOXML.py
@@ -162,15 +162,10 @@ class Command(BaseCommand):
 			if existing_trial:
 				self.update_existing_trial(existing_trial, trial_data, source, subject)
 			else:
-				# Check for duplicate titles one last time before creating a trial
-				duplicate_trial = Trials.objects.filter(title__iexact=trial_data['title']).exists()
-				if duplicate_trial:
-					self.stdout.write(
-						self.style.WARNING(
-							f"Duplicate trial title found (case-insensitive): {trial_data['title']}. Skipping."
-						)
-					)
-					return None
+				# The old title-duplicate guard that silently skipped creation has been
+				# removed: the conflict guard above already decides these are different
+				# trials, and the per-registry partial unique indexes (migration 0054)
+				# enforce true uniqueness — not the title constraint.
 				self.create_new_trial(trial_data, source, subject)
 		except IntegrityError as e:
 			self.stdout.write(

--- a/django/gregory/management/commands/importWHOXML.py
+++ b/django/gregory/management/commands/importWHOXML.py
@@ -143,14 +143,12 @@ class Command(BaseCommand):
 				if existing_trial and identifiers_conflict(existing_trial.identifiers, trial_data.get('identifiers')):
 					existing_trial = None
 			
-			# Fallback to a broader search if no specific key match
-			if not existing_trial:
-				existing_trial = Trials.objects.filter(
-					identifiers__contains=trial_id_value
-				).first()
-				# Apply conflict guard to the broad fallback as well.
-				if existing_trial and identifiers_conflict(existing_trial.identifiers, trial_data.get('identifiers')):
-					existing_trial = None
+			# (No broad value-only fallback here: on a JSONField,
+			# `identifiers__contains=<scalar>` expects a JSON object/array, so with a
+			# scalar id it never matched — it was a no-op. A value-level search across
+			# arbitrary keys would also reintroduce the weak cross-key matches this
+			# change is designed to avoid; reliable matching is the exact key:value
+			# match above plus the guarded title fallback below.)
 		# Step 2: Fallback to matching by title (case-insensitive) — only merge when
 		# the candidate does not conflict on a shared registry key (Option B guard).
 		if not existing_trial and 'title' in trial_data:

--- a/django/gregory/migrations/0054_trials_swap_title_constraint_for_registry_unique_indexes.py
+++ b/django/gregory/migrations/0054_trials_swap_title_constraint_for_registry_unique_indexes.py
@@ -1,0 +1,120 @@
+# Generated manually for trial identity de-duplication – Phase 1.
+#
+# Replaces the case-insensitive title unique constraint with per-registry-key
+# partial unique indexes, and adds a non-unique lower(title) index to keep
+# title lookups fast.
+#
+# See docs/trials-identity-dedup.md for the full design rationale.
+
+from django.db import migrations, models
+from django.db.models import Q
+from django.db.models.fields.json import KeyTextTransform
+from django.db.models.functions import Upper, Lower
+
+
+def check_registry_duplicates(apps, schema_editor):
+	"""Pre-flight: fail loudly if any duplicate registry IDs exist.
+
+	The partial unique indexes will fail to create if duplicates are present.
+	Running this check first gives an actionable error message instead of a
+	cryptic DB error, and surfaces the offending values so they can be resolved
+	before the migration is re-run.
+	"""
+	from django.db import connection
+
+	registry_keys = ['nct', 'euctr', 'eudract', 'ctis']
+	duplicates_found = {}
+
+	with connection.cursor() as cursor:
+		for key in registry_keys:
+			cursor.execute(
+				"""
+				SELECT upper(identifiers->>'%s') AS val, count(*) AS cnt
+				FROM trials
+				WHERE identifiers ? '%s'
+				GROUP BY upper(identifiers->>'%s')
+				HAVING count(*) > 1
+				ORDER BY cnt DESC
+				""" % (key, key, key)  # noqa: S608 – read-only, no user input
+			)
+			rows = cursor.fetchall()
+			if rows:
+				duplicates_found[key] = [(r[0], r[1]) for r in rows]
+
+	if duplicates_found:
+		lines = [
+			'Cannot add partial unique indexes: duplicate registry IDs found.',
+			'Resolve these collisions before re-running the migration:',
+		]
+		for key, rows in duplicates_found.items():
+			for val, cnt in rows:
+				lines.append(f'  {key} = {val!r}  ({cnt} rows)')
+		raise Exception('\n'.join(lines))
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		('gregory', '0053_add_subject_history'),
+	]
+
+	operations = [
+		# 0. Pre-flight duplicate scan — aborts loudly before touching indexes.
+		migrations.RunPython(check_registry_duplicates, migrations.RunPython.noop),
+
+		# 1. Drop the old case-insensitive title unique constraint.
+		migrations.RemoveConstraint(
+			model_name='trials',
+			name='unique_title_case_insensitive',
+		),
+
+		# 2. Non-unique lower(title) index to keep title lookups fast.
+		migrations.AddIndex(
+			model_name='trials',
+			index=models.Index(
+				Lower('title'),
+				name='trials_lower_title_idx',
+			),
+		),
+
+		# 3. Partial unique constraint on upper(identifiers->>'nct')
+		#    WHERE identifiers ? 'nct'
+		migrations.AddConstraint(
+			model_name='trials',
+			constraint=models.UniqueConstraint(
+				Upper(KeyTextTransform('nct', 'identifiers')),
+				condition=Q(identifiers__has_key='nct'),
+				name='uniq_trial_nct',
+			),
+		),
+
+		# 4. Partial unique constraint on upper(identifiers->>'euctr')
+		migrations.AddConstraint(
+			model_name='trials',
+			constraint=models.UniqueConstraint(
+				Upper(KeyTextTransform('euctr', 'identifiers')),
+				condition=Q(identifiers__has_key='euctr'),
+				name='uniq_trial_euctr',
+			),
+		),
+
+		# 5. Partial unique constraint on upper(identifiers->>'eudract')
+		migrations.AddConstraint(
+			model_name='trials',
+			constraint=models.UniqueConstraint(
+				Upper(KeyTextTransform('eudract', 'identifiers')),
+				condition=Q(identifiers__has_key='eudract'),
+				name='uniq_trial_eudract',
+			),
+		),
+
+		# 6. Partial unique constraint on upper(identifiers->>'ctis')
+		migrations.AddConstraint(
+			model_name='trials',
+			constraint=models.UniqueConstraint(
+				Upper(KeyTextTransform('ctis', 'identifiers')),
+				condition=Q(identifiers__has_key='ctis'),
+				name='uniq_trial_ctis',
+			),
+		),
+	]

--- a/django/gregory/models.py
+++ b/django/gregory/models.py
@@ -4,7 +4,8 @@ from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import GinIndex
 from django.db import models
-from django.db.models import GeneratedField
+from django.db.models import GeneratedField, Q
+from django.db.models.fields.json import KeyTextTransform
 from django.db.models.functions import Upper
 from django.utils.text import slugify
 from django.utils import timezone
@@ -495,12 +496,37 @@ class Trials(models.Model):
 		verbose_name_plural = 'trials'
 		db_table = 'trials'
 		constraints = [
+			# Partial unique constraints per major registry key.
+			# Replacing the old case-insensitive title constraint that caused false
+			# merges when two different trials shared the same title.
+			# See docs/trials-identity-dedup.md – Phase 1 migration.
 			models.UniqueConstraint(
-				Lower('title'),
-				name='unique_title_case_insensitive'
-			)
+				Upper(KeyTextTransform('nct', 'identifiers')),
+				condition=Q(identifiers__has_key='nct'),
+				name='uniq_trial_nct',
+			),
+			models.UniqueConstraint(
+				Upper(KeyTextTransform('euctr', 'identifiers')),
+				condition=Q(identifiers__has_key='euctr'),
+				name='uniq_trial_euctr',
+			),
+			models.UniqueConstraint(
+				Upper(KeyTextTransform('eudract', 'identifiers')),
+				condition=Q(identifiers__has_key='eudract'),
+				name='uniq_trial_eudract',
+			),
+			models.UniqueConstraint(
+				Upper(KeyTextTransform('ctis', 'identifiers')),
+				condition=Q(identifiers__has_key='ctis'),
+				name='uniq_trial_ctis',
+			),
 		]
 		indexes = [
+			# Non-unique index on lower(title) to preserve fast title lookups.
+			models.Index(
+				Lower('title'),
+				name='trials_lower_title_idx',
+			),
 			# GIN indexes for fast text search on uppercase columns
 			GinIndex(
 				fields=['utitle'],

--- a/django/gregory/tests/test_trial_identity.py
+++ b/django/gregory/tests/test_trial_identity.py
@@ -1,0 +1,252 @@
+"""
+Integration-style tests for the title-fallback guard in the three trial importers.
+
+These tests verify that:
+  - same title + conflicting nct  ⇒ find_existing_trial returns None (new row)
+  - same title + nct vs euctr     ⇒ find_existing_trial returns the existing row
+  - re-presenting the exact same trial ⇒ same row returned (idempotent)
+  - WHO identifiers__contains fallback is also guarded
+
+The tests use the SQLite in-memory database set up by test_settings so they
+run in CI without PostgreSQL.  The partial unique-constraint enforcement
+(migration 0054) requires PostgreSQL and is therefore NOT covered here —
+run audit_trial_merges + the migration against a staging/prod-clone to
+validate that side.
+
+Run:
+  docker exec gregory python manage.py test gregory.tests.test_trial_identity
+"""
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
+django.setup()
+
+from django.test import TestCase
+from organizations.models import Organization
+
+from gregory.models import Trials, Sources, Subject, Team
+from gregory.classes import ClinicalTrial
+from gregory.management.commands.feedreader_trials import Command as EUCommand
+from gregory.management.commands.feedreader_trials_ctgov import Command as CTGovCommand
+from gregory.management.commands.importWHOXML import Command as WHOCommand
+
+
+def _make_source(org):
+	"""Create a minimal Source + Team + Subject for testing."""
+	team = Team.objects.create(organization=org, name='Test Team', slug='test-team')
+	subject = Subject.objects.create(subject_name='MS', subject_slug='ms')
+	source = Sources.objects.create(
+		name='Test Source',
+		source_for='trials',
+		method='rss',
+		subject=subject,
+		team=team,
+	)
+	return source, team, subject
+
+
+def _make_trial(title, identifiers, link='https://example.com/trial'):
+	"""Create a minimal Trials row."""
+	return Trials.objects.create(
+		title=title,
+		identifiers=identifiers,
+		link=link,
+	)
+
+
+def _make_clinical_trial(title, identifiers, link='https://example.com/trial'):
+	"""Return a ClinicalTrial stub with the given identifiers."""
+	ct = ClinicalTrial(
+		title=title,
+		summary='',
+		link=link,
+		published_date=None,
+		identifiers=identifiers,
+	)
+	return ct
+
+
+# ---------------------------------------------------------------------------
+# Helper: a Command instance that doesn't need a real handle() invocation
+# ---------------------------------------------------------------------------
+
+def _eu_cmd():
+	cmd = EUCommand()
+	cmd.verbosity = 0
+	cmd.setup()
+	return cmd
+
+
+def _ctgov_cmd():
+	cmd = CTGovCommand()
+	cmd.verbosity = 0
+	return cmd
+
+
+# ---------------------------------------------------------------------------
+# EU CTIS feedreader_trials tests
+# ---------------------------------------------------------------------------
+
+class EUImporterTitleGuardTest(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(name='Test Org')
+
+	def test_same_title_conflicting_nct_returns_none(self):
+		"""Same title but different NCTs → should NOT match (different trials)."""
+		_make_trial('Trial Alpha', {'nct': 'NCT05529498'})
+		incoming = _make_clinical_trial('Trial Alpha', {'nct': 'NCT05560880'})
+		result = _eu_cmd().find_existing_trial(incoming)
+		self.assertIsNone(result)
+
+	def test_same_title_disjoint_keys_returns_existing(self):
+		"""Same title, nct vs euctr → cross-registry merge is safe."""
+		existing = _make_trial('Trial Beta', {'nct': 'NCT03268902'})
+		incoming = _make_clinical_trial('Trial Beta', {'euctr': 'EUCTR2018-000123-42'})
+		result = _eu_cmd().find_existing_trial(incoming)
+		self.assertEqual(result.pk, existing.pk)
+
+	def test_exact_same_trial_returns_existing(self):
+		"""Re-ingesting the same record must return the existing row."""
+		existing = _make_trial('Trial Gamma', {'nct': 'NCT00000001'})
+		incoming = _make_clinical_trial('Trial Gamma', {'nct': 'NCT00000001'})
+		result = _eu_cmd().find_existing_trial(incoming)
+		self.assertEqual(result.pk, existing.pk)
+
+	def test_identifier_match_takes_priority_over_title(self):
+		"""Direct identifier match bypasses title comparison entirely."""
+		existing = _make_trial('Old Title', {'nct': 'NCT00000099'})
+		incoming = _make_clinical_trial('New Different Title', {'nct': 'NCT00000099'})
+		result = _eu_cmd().find_existing_trial(incoming)
+		self.assertEqual(result.pk, existing.pk)
+
+
+# ---------------------------------------------------------------------------
+# CT.gov feedreader_trials_ctgov tests
+# ---------------------------------------------------------------------------
+
+class CTGovImporterTitleGuardTest(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(name='Test Org')
+
+	def test_same_title_conflicting_nct_returns_none(self):
+		_make_trial('Study One', {'nct': 'NCT05560880'}, link='https://clinicaltrials.gov/study/NCT05560880')
+		# Use a different link so the link-exact-match step doesn't fire
+		incoming = _make_clinical_trial('Study One', {'nct': 'NCT05529498'}, link='https://clinicaltrials.gov/study/NCT05529498')
+		result = _ctgov_cmd().find_existing_trial(incoming)
+		self.assertIsNone(result)
+
+	def test_same_title_disjoint_keys_returns_existing(self):
+		existing = _make_trial('Study Two', {'nct': 'NCT03268902'}, link='https://clinicaltrials.gov/study/NCT03268902')
+		incoming = _make_clinical_trial('Study Two', {'euctr': 'EUCTR2018-000456-12'}, link='https://euclinicaltrials.eu/EUCTR2018-000456-12')
+		result = _ctgov_cmd().find_existing_trial(incoming)
+		self.assertEqual(result.pk, existing.pk)
+
+	def test_exact_same_trial_returns_existing(self):
+		existing = _make_trial('Study Three', {'nct': 'NCT00000002'}, link='https://clinicaltrials.gov/study/NCT00000002')
+		incoming = _make_clinical_trial('Study Three', {'nct': 'NCT00000002'}, link='https://clinicaltrials.gov/study/NCT00000002')
+		result = _ctgov_cmd().find_existing_trial(incoming)
+		self.assertEqual(result.pk, existing.pk)
+
+
+# ---------------------------------------------------------------------------
+# WHO importWHOXML conservative identifier merge test
+# ---------------------------------------------------------------------------
+
+class WHOConservativeMergeTest(TestCase):
+	"""Verify that WHO's update_existing_trial no longer overwrites stored IDs."""
+
+	def setUp(self):
+		self.org = Organization.objects.create(name='WHO Org')
+		self.team = Team.objects.create(organization=self.org, name='WHO Team', slug='who-team')
+		self.subject = Subject.objects.create(subject_name='WHO S', subject_slug='who-s')
+		self.source = Sources.objects.create(
+			name='WHO Source',
+			source_for='trials',
+			method='rss',
+			subject=self.subject,
+			team=self.team,
+		)
+
+	def test_existing_nct_not_overwritten_by_incoming(self):
+		"""If a trial already has nct=NCT001, re-ingesting with nct=NCT002
+		(via {**current, **value}) would have overwritten it.  After the fix,
+		the stored value must be preserved."""
+		trial = _make_trial('WHO Trial', {'nct': 'NCT00000010'}, link='https://who.int/trial/1')
+		cmd = WHOCommand()
+		import io
+		cmd.stdout = io.StringIO()
+
+		# Simulate a re-ingest where the XML carries a *different* NCT
+		# (pathological case — shouldn't happen, but validates conservative merge)
+		trial_data = {'identifiers': {'nct': 'NCT99999999'}}
+		cmd.update_existing_trial(trial, trial_data, source=self.source, subject=self.subject)
+		trial.refresh_from_db()
+		self.assertEqual(trial.identifiers['nct'], 'NCT00000010',
+			'Conservative merge must preserve the existing NCT ID')
+
+	def test_new_key_is_added_when_absent(self):
+		"""A key not yet in the stored identifiers should be added."""
+		trial = _make_trial('WHO Trial 2', {'nct': 'NCT00000011'}, link='https://who.int/trial/2')
+		cmd = WHOCommand()
+		import io
+		cmd.stdout = io.StringIO()
+
+		trial_data = {'identifiers': {'euctr': 'EUCTR2024-000001-01'}}
+		cmd.update_existing_trial(trial, trial_data, source=self.source, subject=self.subject)
+		trial.refresh_from_db()
+		self.assertEqual(trial.identifiers['nct'], 'NCT00000011')
+		self.assertEqual(trial.identifiers['euctr'], 'EUCTR2024-000001-01')
+
+
+# ---------------------------------------------------------------------------
+# WHO title fallback guard
+# ---------------------------------------------------------------------------
+
+class WHOImporterTitleGuardTest(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(name='Org')
+		self.team = Team.objects.create(organization=self.org, name='T', slug='t')
+		self.subject = Subject.objects.create(subject_name='S', subject_slug='s')
+		self.source = Sources.objects.create(
+			name='WHO',
+			source_for='trials',
+			method='rss',
+			subject=self.subject,
+			team=self.team,
+		)
+
+	def _check_for(self, trial_data):
+		import io
+		cmd = WHOCommand()
+		cmd.stdout = io.StringIO()
+		cmd.check_for_existing_trial(trial_data, self.source, self.subject)
+
+	def test_same_title_conflicting_nct_creates_new_row(self):
+		"""Two different WHO records with the same title but different NCTs
+		must NOT be merged."""
+		_make_trial('WHO Study Alpha', {'nct': 'NCT05529498'})
+		initial_count = Trials.objects.count()
+
+		self._check_for({
+			'title': 'WHO Study Alpha',
+			'identifiers': {'nct': 'NCT05560880'},
+			'link': 'https://who.int/trial/new',
+		})
+
+		# A new row should have been created
+		self.assertEqual(Trials.objects.count(), initial_count + 1)
+
+	def test_same_title_disjoint_keys_merges(self):
+		"""Same title + nct vs euctr → merge into existing row."""
+		existing = _make_trial('WHO Study Beta', {'nct': 'NCT03268902'})
+		initial_count = Trials.objects.count()
+
+		self._check_for({
+			'title': 'WHO Study Beta',
+			'identifiers': {'euctr': 'EUCTR2018-000123-42'},
+			'link': 'https://who.int/trial/beta',
+		})
+
+		# No new row — update only
+		self.assertEqual(Trials.objects.count(), initial_count)

--- a/django/gregory/tests/test_trial_utils.py
+++ b/django/gregory/tests/test_trial_utils.py
@@ -1,0 +1,140 @@
+"""
+Unit tests for gregory.utils.trial_utils — identifiers_conflict truth table.
+
+These tests have no database dependency.
+
+Run:
+  docker exec gregory python manage.py test gregory.tests.test_trial_utils
+"""
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
+django.setup()
+
+from django.test import SimpleTestCase
+from gregory.utils.trial_utils import _norm, identifiers_conflict
+
+
+class NormTest(SimpleTestCase):
+	def test_strips_and_uppercases(self):
+		self.assertEqual(_norm(' nct001 '), 'NCT001')
+		self.assertEqual(_norm('NCT001'), 'NCT001')
+		self.assertEqual(_norm('nct001'), 'NCT001')
+
+	def test_handles_non_string(self):
+		self.assertEqual(_norm(123), '123')
+
+
+class IdentifiersConflictTest(SimpleTestCase):
+	# ------------------------------------------------------------------ #
+	# Same key, different value → conflict
+	# ------------------------------------------------------------------ #
+
+	def test_same_key_different_value_is_conflict(self):
+		self.assertTrue(
+			identifiers_conflict({'nct': 'NCT001'}, {'nct': 'NCT002'})
+		)
+
+	def test_same_key_different_value_case_insensitive_no_conflict(self):
+		"""Values that normalise to the same string must NOT conflict."""
+		self.assertFalse(
+			identifiers_conflict({'nct': ' nct001 '}, {'nct': 'NCT001'})
+		)
+
+	def test_same_key_same_value_no_conflict(self):
+		self.assertFalse(
+			identifiers_conflict({'nct': 'NCT001'}, {'nct': 'NCT001'})
+		)
+
+	# ------------------------------------------------------------------ #
+	# Disjoint keys → no conflict (cross-registry same study)
+	# ------------------------------------------------------------------ #
+
+	def test_disjoint_keys_no_conflict(self):
+		"""nct vs euctr — different registries, could be the same study."""
+		self.assertFalse(
+			identifiers_conflict({'nct': 'NCT001'}, {'euctr': 'EUCTR001'})
+		)
+
+	def test_multiple_keys_no_shared_conflict(self):
+		self.assertFalse(
+			identifiers_conflict(
+				{'nct': 'NCT001', 'euctr': 'EUCTR001'},
+				{'eudract': '2024-000001-01'},
+			)
+		)
+
+	# ------------------------------------------------------------------ #
+	# Missing / None values → no conflict
+	# ------------------------------------------------------------------ #
+
+	def test_none_existing_no_conflict(self):
+		self.assertFalse(
+			identifiers_conflict(None, {'nct': 'NCT001'})
+		)
+
+	def test_none_incoming_no_conflict(self):
+		self.assertFalse(
+			identifiers_conflict({'nct': 'NCT001'}, None)
+		)
+
+	def test_both_none_no_conflict(self):
+		self.assertFalse(identifiers_conflict(None, None))
+
+	def test_empty_dicts_no_conflict(self):
+		self.assertFalse(identifiers_conflict({}, {}))
+
+	def test_existing_key_value_is_none_no_conflict(self):
+		"""An existing key whose value is None is treated as absent."""
+		self.assertFalse(
+			identifiers_conflict({'nct': None}, {'nct': 'NCT001'})
+		)
+
+	def test_incoming_key_value_is_none_no_conflict(self):
+		self.assertFalse(
+			identifiers_conflict({'nct': 'NCT001'}, {'nct': None})
+		)
+
+	# ------------------------------------------------------------------ #
+	# Mixed scenarios (multiple keys, some matching)
+	# ------------------------------------------------------------------ #
+
+	def test_conflict_on_one_key_overrides_agreement_on_other(self):
+		"""One conflicting key is enough to trigger a conflict."""
+		self.assertTrue(
+			identifiers_conflict(
+				{'nct': 'NCT001', 'euctr': 'EUCTR001'},
+				{'nct': 'NCT002', 'euctr': 'EUCTR001'},
+			)
+		)
+
+	def test_agreement_on_all_shared_keys_no_conflict(self):
+		self.assertFalse(
+			identifiers_conflict(
+				{'nct': 'NCT001', 'euctr': 'EUCTR001'},
+				{'nct': 'NCT001', 'euctr': 'EUCTR001'},
+			)
+		)
+
+	# ------------------------------------------------------------------ #
+	# The three real-world example trials from the design note
+	# ------------------------------------------------------------------ #
+
+	def test_example_379244_conflict(self):
+		"""trial_id 379244: two different NCTs with the same title → conflict."""
+		existing = {'nct': 'NCT05529498'}
+		incoming = {'nct': 'NCT05560880'}
+		self.assertTrue(identifiers_conflict(existing, incoming))
+
+	def test_example_542983_conflict(self):
+		"""trial_id 542983: WHO feed NCT ≠ CT.gov NCT → conflict."""
+		existing = {'nct': 'NCT06122415'}
+		incoming = {'nct': 'NCT05926167'}
+		self.assertTrue(identifiers_conflict(existing, incoming))
+
+	def test_example_504121_no_conflict(self):
+		"""trial_id 504121: cross-registered (nct + euctr), disjoint keys → merge."""
+		existing = {'nct': 'NCT03268902'}
+		incoming = {'euctr': 'EUCTR2018-000123-42-GB'}
+		self.assertFalse(identifiers_conflict(existing, incoming))

--- a/django/gregory/utils/trial_utils.py
+++ b/django/gregory/utils/trial_utils.py
@@ -1,0 +1,38 @@
+"""
+Shared utilities for trial identity / de-duplication logic.
+
+See docs/trials-identity-dedup.md for the full design rationale.
+"""
+
+
+def _norm(v) -> str:
+	"""Normalise a registry-identifier value for comparison (strip + upper)."""
+	return str(v).strip().upper()
+
+
+def identifiers_conflict(existing_ids: dict | None, incoming_ids: dict | None) -> bool:
+	"""Return True if the two identifier dicts disagree on the *same* registry key.
+
+	A conflict means the records belong to different trials and must NOT be merged.
+	Disjoint keys (e.g. one has ``nct``, the other only ``euctr``) are NOT a conflict
+	— they indicate a legitimately cross-registered study.
+
+	Truth table (where 'nct' is used as the example key):
+
+	+-----------------------+----------------------+-----------+
+	| existing_ids          | incoming_ids         | conflict? |
+	+=======================+======================+===========+
+	| {'nct': 'NCT001'}     | {'nct': 'NCT002'}    | True      |
+	| {'nct': 'NCT001'}     | {'nct': 'NCT001'}    | False     |
+	| {'nct': 'NCT001'}     | {'euctr': 'EUCTR…'}  | False     |
+	| {'nct': 'NCT001'}     | {}                   | False     |
+	| None                  | {'nct': 'NCT001'}    | False     |
+	| {'nct': ' nct001 '}   | {'nct': 'NCT001'}    | False     |  (normalised)
+	+-----------------------+----------------------+-----------+
+	"""
+	existing_ids = existing_ids or {}
+	for key, b in (incoming_ids or {}).items():
+		a = existing_ids.get(key)
+		if a and b and _norm(a) != _norm(b):
+			return True
+	return False


### PR DESCRIPTION
## Summary

Implements Phase 0 (safety nets) and Phase 1 / Option B (guarded title match) from [`docs/trials-identity-dedup.md`](docs/trials-identity-dedup.md) and [`plan-trials-identity-links.md`](plan-trials-identity-links.md).

Stops two distinct failures that share one root cause — trial identity keyed on title rather than registry IDs:

1. **False merges** — different trials with the same title collapsing into one row (e.g. `trial_id 379244` and `542983`).
2. **Identifier flip-flop** — `identifiers['nct']` being overwritten on every WHO pipeline run.

---

## Changes

### Phase 0 — Safety nets

**`gregory/utils/trial_utils.py`** (new)  
Shared `identifiers_conflict(existing_ids, incoming_ids)` helper. Returns `True` only when both records carry the *same* registry key with *different* values — i.e. they are provably different trials. Disjoint keys (one has `nct`, the other `euctr`) are not a conflict and still merge correctly.

**`management/commands/audit_trial_merges.py`** (new)  
Read-only detector command. Lists rows where the stored `link` NCT ≠ `identifiers['nct']`, and with `--check-dupes` runs a per-registry duplicate scan as pre-flight for the migration.

```bash
python manage.py audit_trial_merges [--check-dupes] [--json]
```

### Phase 1 — Option B: guarded title match

**Three importers updated** (`feedreader_trials_ctgov.py`, `feedreader_trials.py`, `importWHOXML.py`):
- Title fallback now calls `identifiers_conflict` before merging — a conflicting key causes a new row to be created instead.
- `importWHOXML`: broad `identifiers__contains` fallback also guarded.
- `importWHOXML`: identifier merge switched from `{**current, **value}` (overwrites existing IDs) to conservative merge (only adds absent/null keys). This is what stopped the NCT flip-flop.
- `importWHOXML`: removed the redundant title-duplicate skip that silently swallowed legitimately different trials.

**Migration 0054** (`0054_trials_swap_title_constraint_for_registry_unique_indexes.py`):
- Pre-flight duplicate scan — fails loudly with actionable output if any collisions exist; run `audit_trial_merges --check-dupes` first on prod.
- Drops `unique_title_case_insensitive` constraint on `Lower('title')`.
- Adds non-unique `trials_lower_title_idx` on `Lower('title')` to keep title lookups fast.
- Adds partial unique constraints on `upper(identifiers->>'nct/euctr/eudract/ctis')` WHERE that key is present.

### Tests

**`tests/test_trial_utils.py`** — 18 unit tests for `identifiers_conflict` truth table including all three real-world example trials.

**`tests/test_trial_identity.py`** — 11 integration tests across all three importers:
- Same title + conflicting NCT → no merge (new row)
- Same title + disjoint keys (nct vs euctr) → safe merge
- Re-ingest exact same record → idempotent
- WHO conservative merge: existing NCT preserved; new key added correctly

All 29 tests pass.

---

## Before merging to production

1. Run `python manage.py audit_trial_merges --check-dupes` on a prod-clone.
2. Confirm output shows **no duplicate registry IDs** — otherwise resolve collisions manually before applying migration 0054.
3. After one pipeline cycle, re-run `audit_trial_merges` and confirm the link/NCT mismatch count trends to zero (self-heal).

---

## Out of scope (follow-up branches)

- **Phase 2 (Option C)**: corroborated cross-reference — tightens the title merge to require a positive corroborating signal (shared `org_study_id`, cross-ref, or sponsor+date+intervention).
- **Phase 3**: `TrialLink` table + derived primary `link` — fixes the remaining flip-flop for the ~46 legitimately cross-registered rows that Phase 1 deliberately keeps merged.