### PR TITLE
feat(trials): capture raw inbound trial streams to JSONL

### DIFF
--- a/django/gregory/management/commands/capture_trial_streams.py
+++ b/django/gregory/management/commands/capture_trial_streams.py
@@ -10,7 +10,7 @@ merge happens it is destructive — the second record's title/link is overwritte
 invisible afterwards.
 
 This command records what each *source* actually sent, as a second stream you can diff
-against the merged `Trials` rows to detect (and later audit) wrong merges. WHO ICTRP is
+against the merged ``Trials`` rows to detect (and later audit) wrong merges. WHO ICTRP is
 already a local XML file you can keep; this captures the two *live* streams:
 
   * ClinicalTrials.gov API  (Sources.method='ctgov_api')
@@ -19,10 +19,13 @@ already a local XML file you can keep; this captures the two *live* streams:
 How it stays safe on prod
 -------------------------
 It subclasses the real importer commands and reuses their fetch + parse verbatim, but
-overrides the persistence hooks: `find_existing_trial` always returns None and
-`create_new_trial` / `update_existing_trial` write a JSON line instead of touching the DB.
-The only database access is the read of `Sources` needed to know what to fetch. **No
-`Trials` rows are read or written.**
+overrides the persistence hooks: ``find_existing_trial`` always returns None and both
+``create_new_trial`` and ``update_existing_trial`` write a JSON line instead of touching the
+DB. The only database access is the read of ``Sources`` needed to know what to fetch. **No
+``Trials`` rows are read or written.**
+
+If any feed raises, the command still runs the other feed, then exits non-zero
+(``CommandError``) so a scheduler notices the partial failure.
 
 Output
 ------
@@ -47,7 +50,7 @@ import json
 import os
 from datetime import datetime, timezone as dt_timezone
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from gregory.classes import ClinicalTrialsGovAPI  # noqa: F401  (parity with importer env)
 from gregory.management.commands import feedreader_trials, feedreader_trials_ctgov
@@ -56,101 +59,109 @@ DEFAULT_DIR = "/code/trial_captures"
 
 
 def _serialize(clinical_trial, source, feed):
-    """Flatten an incoming ClinicalTrial into a JSON-able capture record."""
-    pub = getattr(clinical_trial, "published_date", None)
-    return {
-        "captured_at": datetime.now(dt_timezone.utc).isoformat(),
-        "feed": feed,
-        "source_id": getattr(source, "source_id", None),
-        "source_name": getattr(source, "name", None),
-        "title": getattr(clinical_trial, "title", None),
-        "summary": getattr(clinical_trial, "summary", None),
-        "link": getattr(clinical_trial, "link", None),
-        "published_date": pub.isoformat() if hasattr(pub, "isoformat") else pub,
-        "identifiers": getattr(clinical_trial, "identifiers", None),
-        "extra_fields": getattr(clinical_trial, "extra_fields", None),
-    }
+	"""Flatten an incoming ClinicalTrial into a JSON-able capture record."""
+	pub = getattr(clinical_trial, "published_date", None)
+	return {
+		"captured_at": datetime.now(dt_timezone.utc).isoformat(),
+		"feed": feed,
+		"source_id": getattr(source, "source_id", None),
+		"source_name": getattr(source, "name", None),
+		"title": getattr(clinical_trial, "title", None),
+		"summary": getattr(clinical_trial, "summary", None),
+		"link": getattr(clinical_trial, "link", None),
+		"published_date": pub.isoformat() if hasattr(pub, "isoformat") else pub,
+		"identifiers": getattr(clinical_trial, "identifiers", None),
+		"extra_fields": getattr(clinical_trial, "extra_fields", None),
+	}
 
 
 class _CaptureMixin:
-    """Neutralise every DB-write path; route each parsed record to the capture file."""
+	"""Neutralise every DB-write path; route each parsed record to the capture file."""
 
-    capture_fh = None
-    capture_feed = None
-    captured = 0
+	capture_fh = None
+	capture_feed = None
+	captured = 0
 
-    def find_existing_trial(self, clinical_trial):  # never read/match against the DB
-        return None
+	def find_existing_trial(self, clinical_trial):  # never read/match against the DB
+		return None
 
-    def _capture(self, clinical_trial, source):
-        self.capture_fh.write(
-            json.dumps(_serialize(clinical_trial, source, self.capture_feed),
-                       ensure_ascii=False, default=str) + "\n"
-        )
-        self.captured += 1
-        return None
+	def _capture(self, clinical_trial, source):
+		self.capture_fh.write(
+			json.dumps(_serialize(clinical_trial, source, self.capture_feed),
+					   ensure_ascii=False, default=str) + "\n"
+		)
+		self.captured += 1
+		return None
 
-    def create_new_trial(self, clinical_trial, source):
-        return self._capture(clinical_trial, source)
+	def create_new_trial(self, clinical_trial, source):
+		return self._capture(clinical_trial, source)
 
-    def update_existing_trial(self, *args, **kwargs):  # unreachable (find→None); belt & braces
-        return None
+	def update_existing_trial(self, existing_trial, clinical_trial, source):
+		# Capture on update too. find_existing_trial returns None so this is currently
+		# unreachable, but keeping create/update symmetric means a future change to the
+		# importer flow can't silently drop records (and matches the module docstring).
+		return self._capture(clinical_trial, source)
 
 
 class _CtgovCapture(_CaptureMixin, feedreader_trials_ctgov.Command):
-    capture_feed = "ctgov_api"
+	capture_feed = "ctgov_api"
 
 
 class _EuCapture(_CaptureMixin, feedreader_trials.Command):
-    capture_feed = "eu_rss"
+	capture_feed = "eu_rss"
 
 
 class Command(BaseCommand):
-    help = "Capture the raw inbound trial stream (CTgov API + EU RSS) to a JSONL file without writing to the DB."
+	help = "Capture the raw inbound trial stream (CTgov API + EU RSS) to a JSONL file without writing to the DB."
 
-    def add_arguments(self, parser):
-        parser.add_argument("--feed", choices=["ctgov", "eu", "both"], default="both",
-                            help="Which live stream(s) to capture (default: both).")
-        parser.add_argument("--output", help="Output JSONL path (default: a timestamped file under %s)." % DEFAULT_DIR)
-        parser.add_argument("--max-results", type=int, default=1000,
-                            help="Max results per CTgov source (default: 1000).")
-        parser.add_argument("--source-id", type=int, help="Restrict CTgov capture to one source id.")
+	def add_arguments(self, parser):
+		parser.add_argument("--feed", choices=["ctgov", "eu", "both"], default="both",
+							help="Which live stream(s) to capture (default: both).")
+		parser.add_argument("--output", help="Output JSONL path (default: a timestamped file under %s)." % DEFAULT_DIR)
+		parser.add_argument("--max-results", type=int, default=1000,
+							help="Max results per CTgov source (default: 1000).")
+		parser.add_argument("--source-id", type=int, help="Restrict CTgov capture to one source id.")
 
-    def handle(self, *args, **options):
-        verbosity = options.get("verbosity", 1)
-        feed = options["feed"]
+	def handle(self, *args, **options):
+		verbosity = options.get("verbosity", 1)
+		feed = options["feed"]
 
-        output = options.get("output")
-        if not output:
-            os.makedirs(DEFAULT_DIR, exist_ok=True)
-            stamp = datetime.now(dt_timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-            output = os.path.join(DEFAULT_DIR, f"trial_stream_{stamp}.jsonl")
-        else:
-            os.makedirs(os.path.dirname(output) or ".", exist_ok=True)
+		output = options.get("output")
+		if not output:
+			os.makedirs(DEFAULT_DIR, exist_ok=True)
+			stamp = datetime.now(dt_timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+			output = os.path.join(DEFAULT_DIR, f"trial_stream_{stamp}.jsonl")
+		else:
+			os.makedirs(os.path.dirname(output) or ".", exist_ok=True)
 
-        counts = {}
-        with open(output, "w", encoding="utf-8") as fh:
-            if feed in ("ctgov", "both"):
-                cmd = _CtgovCapture()
-                cmd.capture_fh, cmd.captured = fh, 0
-                try:
-                    cmd.handle(verbosity=verbosity, max_results=options["max_results"],
-                               source_id=options.get("source_id"), debug=False)
-                except Exception as e:  # keep the EU capture alive if CTgov fails
-                    self.stderr.write(self.style.ERROR(f"CTgov capture error: {e}"))
-                counts["ctgov_api"] = cmd.captured
+		counts = {}
+		errors = []
+		with open(output, "w", encoding="utf-8") as fh:
+			if feed in ("ctgov", "both"):
+				cmd = _CtgovCapture()
+				cmd.capture_fh, cmd.captured = fh, 0
+				try:
+					cmd.handle(verbosity=verbosity, max_results=options["max_results"],
+							   source_id=options.get("source_id"), debug=False)
+				except Exception as e:  # keep the EU capture alive if CTgov fails
+					errors.append(f"ctgov: {e}")
+					self.stderr.write(self.style.ERROR(f"CTgov capture error: {e}"))
+				counts["ctgov_api"] = cmd.captured
 
-            if feed in ("eu", "both"):
-                cmd = _EuCapture()
-                cmd.capture_fh, cmd.captured = fh, 0
-                try:
-                    cmd.handle(verbosity=verbosity)
-                except Exception as e:
-                    self.stderr.write(self.style.ERROR(f"EU capture error: {e}"))
-                counts["eu_rss"] = cmd.captured
+			if feed in ("eu", "both"):
+				cmd = _EuCapture()
+				cmd.capture_fh, cmd.captured = fh, 0
+				try:
+					cmd.handle(verbosity=verbosity)
+				except Exception as e:
+					errors.append(f"eu: {e}")
+					self.stderr.write(self.style.ERROR(f"EU capture error: {e}"))
+				counts["eu_rss"] = cmd.captured
 
-        total = sum(counts.values())
-        self.stdout.write(self.style.SUCCESS(
-            f"Captured {total} records to {output} "
-            f"({', '.join(f'{k}={v}' for k, v in counts.items())})"
-        ))
+		total = sum(counts.values())
+		summary = f"Captured {total} records to {output} ({', '.join(f'{k}={v}' for k, v in counts.items())})"
+		if errors:
+			# Surface the partial counts, then fail loudly so cron/ops see a non-zero exit.
+			self.stdout.write(summary)
+			raise CommandError(f"{len(errors)} feed(s) failed: " + "; ".join(errors))
+		self.stdout.write(self.style.SUCCESS(summary))

--- a/django/gregory/management/commands/capture_trial_streams.py
+++ b/django/gregory/management/commands/capture_trial_streams.py
@@ -1,0 +1,156 @@
+"""
+Capture the *raw inbound* clinical-trial stream BEFORE it reaches the database.
+
+Why this exists
+---------------
+Trial identity is resolved on ingest (identifier match, then a guarded title match).
+A residual risk remains until Phase C (corroboration) lands: two *different* trials that
+share a title but come from *different* registries can still be merged onto one row. Once a
+merge happens it is destructive — the second record's title/link is overwritten — so it is
+invisible afterwards.
+
+This command records what each *source* actually sent, as a second stream you can diff
+against the merged `Trials` rows to detect (and later audit) wrong merges. WHO ICTRP is
+already a local XML file you can keep; this captures the two *live* streams:
+
+  * ClinicalTrials.gov API  (Sources.method='ctgov_api')
+  * EU CTIS / EU-register RSS (Sources.method='rss', source_for='trials')
+
+How it stays safe on prod
+-------------------------
+It subclasses the real importer commands and reuses their fetch + parse verbatim, but
+overrides the persistence hooks: `find_existing_trial` always returns None and
+`create_new_trial` / `update_existing_trial` write a JSON line instead of touching the DB.
+The only database access is the read of `Sources` needed to know what to fetch. **No
+`Trials` rows are read or written.**
+
+Output
+------
+JSON Lines (one source record per line):
+  {captured_at, feed, source_id, source_name, title, summary, link,
+   published_date, identifiers, extra_fields}
+
+Usage (prod)
+------------
+  docker exec gregory python manage.py capture_trial_streams
+  docker exec gregory python manage.py capture_trial_streams --feed ctgov --max-results 1000
+  docker exec gregory python manage.py capture_trial_streams --output /code/trial_captures/run.jsonl
+
+Retrieve the file:
+  docker cp gregory:/code/trial_captures/<file>.jsonl ./
+
+Run it on the same schedule as (ideally just before) the pipeline so each capture lines up
+with what that pipeline run ingests.
+"""
+
+import json
+import os
+from datetime import datetime, timezone as dt_timezone
+
+from django.core.management.base import BaseCommand
+
+from gregory.classes import ClinicalTrialsGovAPI  # noqa: F401  (parity with importer env)
+from gregory.management.commands import feedreader_trials, feedreader_trials_ctgov
+
+DEFAULT_DIR = "/code/trial_captures"
+
+
+def _serialize(clinical_trial, source, feed):
+    """Flatten an incoming ClinicalTrial into a JSON-able capture record."""
+    pub = getattr(clinical_trial, "published_date", None)
+    return {
+        "captured_at": datetime.now(dt_timezone.utc).isoformat(),
+        "feed": feed,
+        "source_id": getattr(source, "source_id", None),
+        "source_name": getattr(source, "name", None),
+        "title": getattr(clinical_trial, "title", None),
+        "summary": getattr(clinical_trial, "summary", None),
+        "link": getattr(clinical_trial, "link", None),
+        "published_date": pub.isoformat() if hasattr(pub, "isoformat") else pub,
+        "identifiers": getattr(clinical_trial, "identifiers", None),
+        "extra_fields": getattr(clinical_trial, "extra_fields", None),
+    }
+
+
+class _CaptureMixin:
+    """Neutralise every DB-write path; route each parsed record to the capture file."""
+
+    capture_fh = None
+    capture_feed = None
+    captured = 0
+
+    def find_existing_trial(self, clinical_trial):  # never read/match against the DB
+        return None
+
+    def _capture(self, clinical_trial, source):
+        self.capture_fh.write(
+            json.dumps(_serialize(clinical_trial, source, self.capture_feed),
+                       ensure_ascii=False, default=str) + "\n"
+        )
+        self.captured += 1
+        return None
+
+    def create_new_trial(self, clinical_trial, source):
+        return self._capture(clinical_trial, source)
+
+    def update_existing_trial(self, *args, **kwargs):  # unreachable (find→None); belt & braces
+        return None
+
+
+class _CtgovCapture(_CaptureMixin, feedreader_trials_ctgov.Command):
+    capture_feed = "ctgov_api"
+
+
+class _EuCapture(_CaptureMixin, feedreader_trials.Command):
+    capture_feed = "eu_rss"
+
+
+class Command(BaseCommand):
+    help = "Capture the raw inbound trial stream (CTgov API + EU RSS) to a JSONL file without writing to the DB."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--feed", choices=["ctgov", "eu", "both"], default="both",
+                            help="Which live stream(s) to capture (default: both).")
+        parser.add_argument("--output", help="Output JSONL path (default: a timestamped file under %s)." % DEFAULT_DIR)
+        parser.add_argument("--max-results", type=int, default=1000,
+                            help="Max results per CTgov source (default: 1000).")
+        parser.add_argument("--source-id", type=int, help="Restrict CTgov capture to one source id.")
+
+    def handle(self, *args, **options):
+        verbosity = options.get("verbosity", 1)
+        feed = options["feed"]
+
+        output = options.get("output")
+        if not output:
+            os.makedirs(DEFAULT_DIR, exist_ok=True)
+            stamp = datetime.now(dt_timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            output = os.path.join(DEFAULT_DIR, f"trial_stream_{stamp}.jsonl")
+        else:
+            os.makedirs(os.path.dirname(output) or ".", exist_ok=True)
+
+        counts = {}
+        with open(output, "w", encoding="utf-8") as fh:
+            if feed in ("ctgov", "both"):
+                cmd = _CtgovCapture()
+                cmd.capture_fh, cmd.captured = fh, 0
+                try:
+                    cmd.handle(verbosity=verbosity, max_results=options["max_results"],
+                               source_id=options.get("source_id"), debug=False)
+                except Exception as e:  # keep the EU capture alive if CTgov fails
+                    self.stderr.write(self.style.ERROR(f"CTgov capture error: {e}"))
+                counts["ctgov_api"] = cmd.captured
+
+            if feed in ("eu", "both"):
+                cmd = _EuCapture()
+                cmd.capture_fh, cmd.captured = fh, 0
+                try:
+                    cmd.handle(verbosity=verbosity)
+                except Exception as e:
+                    self.stderr.write(self.style.ERROR(f"EU capture error: {e}"))
+                counts["eu_rss"] = cmd.captured
+
+        total = sum(counts.values())
+        self.stdout.write(self.style.SUCCESS(
+            f"Captured {total} records to {output} "
+            f"({', '.join(f'{k}={v}' for k, v in counts.items())})"
+        ))

--- a/django/gregory/tests/management/test_capture_trial_streams.py
+++ b/django/gregory/tests/management/test_capture_trial_streams.py
@@ -1,0 +1,105 @@
+"""
+Tests for the capture_trial_streams management command.
+
+The command must (1) write one JSONL line per inbound source record using mocked
+importer fetches, (2) emit the documented JSON schema, and (3) NEVER read or write the
+``Trials`` table — that no-DB-writes guarantee is the whole point of the command. A failing
+feed must surface as a non-zero exit (CommandError).
+
+Run:
+  docker exec gregory python manage.py test gregory.tests.management.test_capture_trial_streams
+"""
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
+django.setup()
+
+import json
+import tempfile
+from unittest.mock import patch, MagicMock
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from gregory.classes import ClinicalTrial
+from gregory.models import Sources, Trials
+
+
+class CaptureTrialStreamsTest(TestCase):
+	def _make_source(self, method, name):
+		return Sources.objects.create(
+			name=name,
+			link='https://feed.example/trials.rss',
+			method=method,
+			source_for='trials',
+			active=True,
+			ctgov_search_condition='multiple sclerosis',
+		)
+
+	def test_eu_capture_writes_jsonl_and_does_not_touch_db(self):
+		self._make_source('rss', 'EU Capture Source')
+		fake_feed = {'entries': [{
+			'title': 'Captured EU Trial',
+			'link': 'https://www.clinicaltrialsregister.eu/ctr-search/search?query=eudract_number:2021-000123-45',
+			'summary': 'A summary',
+			'guid': '',
+		}]}
+		with tempfile.TemporaryDirectory() as tmp:
+			out = os.path.join(tmp, 'cap.jsonl')
+			with patch('gregory.management.commands.feedreader_trials.feedparser.parse',
+					   return_value=fake_feed):
+				call_command('capture_trial_streams', feed='eu', output=out)
+			lines = [ln for ln in open(out, encoding='utf-8') if ln.strip()]
+
+		self.assertEqual(len(lines), 1)
+		rec = json.loads(lines[0])
+		self.assertEqual(rec['feed'], 'eu_rss')
+		self.assertEqual(rec['title'], 'Captured EU Trial')
+		# link is preserved (the colon may be URL-encoded to %3A by remove_utm)
+		self.assertIn('2021-000123-45', rec['link'])
+		self.assertIn('clinicaltrialsregister.eu', rec['link'])
+		# documented schema keys are present
+		for key in ('captured_at', 'source_name', 'identifiers', 'extra_fields', 'published_date'):
+			self.assertIn(key, rec)
+		# the guarantee: no Trials row was created (or read/matched) at any point
+		self.assertEqual(Trials.objects.count(), 0)
+
+	def test_ctgov_capture_writes_jsonl_and_does_not_touch_db(self):
+		self._make_source('ctgov_api', 'CTgov Capture Source')
+		fake_ct = ClinicalTrial(
+			title='Captured CTgov Trial',
+			summary='A summary',
+			link='https://clinicaltrials.gov/study/NCT00000001',
+			identifiers={'nct': 'NCT00000001'},
+			extra_fields={},
+		)
+		mock_api = MagicMock()
+		mock_api.get_version.return_value = {'dataTimestamp': 'x'}
+		mock_api.search_all.return_value = [{'protocolSection': {}}]
+		mock_api.parse_study_to_clinical_trial.return_value = fake_ct
+
+		with tempfile.TemporaryDirectory() as tmp:
+			out = os.path.join(tmp, 'cap.jsonl')
+			with patch('gregory.management.commands.feedreader_trials_ctgov.ClinicalTrialsGovAPI',
+					   return_value=mock_api):
+				call_command('capture_trial_streams', feed='ctgov', output=out, max_results=5)
+			lines = [ln for ln in open(out, encoding='utf-8') if ln.strip()]
+
+		self.assertEqual(len(lines), 1)
+		rec = json.loads(lines[0])
+		self.assertEqual(rec['feed'], 'ctgov_api')
+		self.assertEqual(rec['identifiers'], {'nct': 'NCT00000001'})
+		self.assertEqual(Trials.objects.count(), 0)
+
+	def test_feed_failure_raises_command_error(self):
+		"""A failing feed must exit non-zero so schedulers notice."""
+		self._make_source('rss', 'EU Capture Source')
+		with tempfile.TemporaryDirectory() as tmp:
+			out = os.path.join(tmp, 'cap.jsonl')
+			with patch('gregory.management.commands.feedreader_trials.feedparser.parse',
+					   side_effect=RuntimeError('feed boom')):
+				with self.assertRaises(CommandError):
+					call_command('capture_trial_streams', feed='eu', output=out)
+		self.assertEqual(Trials.objects.count(), 0)


### PR DESCRIPTION
## What

Adds a `capture_trial_streams` management command that records the **raw inbound** clinical-trial stream — from the ClinicalTrials.gov API and the EU CTIS/RSS feeds — to a JSON Lines file **before anything is written to the database**.

```bash
docker exec gregory python manage.py capture_trial_streams            # both streams
docker exec gregory python manage.py capture_trial_streams --feed ctgov --max-results 1000
```

Each line is one source record:
`{captured_at, feed, source_id, source_name, title, summary, link, published_date, identifiers, extra_fields}`.

## Why

Trial identity is resolved on ingest (identifier match, then a title fallback). Until the corroboration step of the trials-identity-dedup work lands, a residual risk remains: two **different** trials that share a title but come from **different** registries can be merged onto one row. A merge is destructive (the second record's title/link is overwritten), so it's invisible afterwards.

This command gives us a **second data stream** to reconcile against the merged `Trials` rows so wrong merges can be detected/audited after the fact. WHO ICTRP is already kept as local XML; this captures the two *live* streams that otherwise leave no trace.

## How it stays safe on prod

It subclasses the existing importer commands and **reuses their fetch + parse verbatim**, overriding only the persistence hooks:
- `find_existing_trial` → returns `None` (no `Trials` reads/matching)
- `create_new_trial` / `update_existing_trial` → write a JSON line instead of touching the DB

The only database access is the read of `Sources` needed to know what to fetch. **No `Trials` rows are read or written.**

## Reviewer notes

- **Standalone / deployable now.** Depends only on the importers (`feedreader_trials`, `feedreader_trials_ctgov`) and `ClinicalTrialsGovAPI`, all already on `main`. It does **not** depend on the un-merged `trials-identity-dedup` branch (no `trial_utils` / `identifiers_conflict` reference).
- Verified at runtime against `main`'s code: `manage.py help capture_trial_streams` loads cleanly (transitive imports resolve), and a small live `--feed ctgov --max-results 2` run produced well-formed JSONL.
- Suggested cron (just before the pipeline at `:25`):
  ```cron
  20 */12 * * * docker exec gregory python manage.py capture_trial_streams
  ```
- Output lands in `/code/trial_captures/*.jsonl`; retrieve with `docker cp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)