### PR TITLE
fix(trials): 0054 dupe-check ignores NULLs + add merge_trials (follow-up to #681)

### DIFF
--- a/django/gregory/management/commands/audit_trial_merges.py
+++ b/django/gregory/management/commands/audit_trial_merges.py
@@ -99,11 +99,11 @@ class Command(BaseCommand):
 						"""
 						SELECT upper(identifiers->>'%s') AS val, count(*) AS cnt
 						FROM trials
-						WHERE identifiers ? '%s'
+						WHERE identifiers ? '%s' AND identifiers->>'%s' IS NOT NULL
 						GROUP BY upper(identifiers->>'%s')
 						HAVING count(*) > 1
 						ORDER BY cnt DESC
-						""" % (key, key, key)  # noqa: S608 – read-only, no user input
+						""" % (key, key, key, key)  # noqa: S608 – read-only, fixed keys
 					)
 					rows = cursor.fetchall()
 				if rows:

--- a/django/gregory/management/commands/merge_trials.py
+++ b/django/gregory/management/commands/merge_trials.py
@@ -1,0 +1,114 @@
+"""
+Merge duplicate ``Trials`` rows into one.
+
+Used to resolve pre-existing duplicates before applying migration 0054 (the partial
+unique indexes on registry identifiers) — see docs/trials-identity-dedup.md, Phase 0. The
+guarded-title matching added in this PR stops *new* duplicates, but rows that were already
+merged-by-title-then-split (or manually entered twice) must be reconciled by hand.
+
+For each removed trial it:
+  * adds the removed trial's M2M links (sources, teams, subjects, team_categories,
+    ml_predictions) to the kept trial,
+  * repoints every reverse-FK child (org_contents, article_references, sent notifications)
+    to the kept trial — dropping a child if the kept trial already has the equivalent row
+    (so a unique constraint isn't violated; nothing is CASCADE-deleted by accident),
+  * unions ``identifiers`` (the kept trial's values win on shared keys),
+  * deletes the removed trial.
+
+All work happens in one transaction; ``--dry-run`` rolls back.
+
+Usage:
+  docker exec gregory python manage.py merge_trials --keep 643 --remove 699
+  docker exec gregory python manage.py merge_trials --keep 3913 --remove 11915 --dry-run
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import IntegrityError, transaction
+
+from gregory.models import Trials
+
+
+class Command(BaseCommand):
+	help = 'Merge duplicate Trials rows into a kept trial, moving all relations, then deleting the duplicates.'
+
+	def add_arguments(self, parser):
+		parser.add_argument('--keep', type=int, required=True, help='trial_id to keep.')
+		parser.add_argument('--remove', type=int, nargs='+', required=True,
+							help='one or more trial_ids to merge into --keep and delete.')
+		parser.add_argument('--dry-run', action='store_true', help='roll back instead of committing.')
+
+	def handle(self, *args, **options):
+		keep_id = options['keep']
+		remove_ids = [r for r in options['remove'] if r != keep_id]
+		dry_run = options['dry_run']
+
+		if not remove_ids:
+			raise CommandError('--remove must contain at least one id different from --keep.')
+
+		try:
+			keep = Trials.objects.get(pk=keep_id)
+		except Trials.DoesNotExist:
+			raise CommandError(f'--keep trial {keep_id} does not exist.')
+
+		m2m_fields = [f.name for f in Trials._meta.get_fields()
+					  if f.many_to_many and not f.auto_created]
+		reverse_fks = [f for f in Trials._meta.get_fields() if f.one_to_many]
+
+		with transaction.atomic():
+			for rid in remove_ids:
+				try:
+					rem = Trials.objects.get(pk=rid)
+				except Trials.DoesNotExist:
+					self.stderr.write(self.style.WARNING(f'skip: trial {rid} does not exist.'))
+					continue
+
+				self.stdout.write(f'Merging trial {rid} into {keep_id} …')
+
+				# 1. M2M links → add removed trial's to the kept trial.
+				for fname in m2m_fields:
+					related = list(getattr(rem, fname).all())
+					if related:
+						getattr(keep, fname).add(*related)
+
+				# 2. Reverse-FK children → repoint to kept trial; drop on unique collision.
+				#    A nested atomic() per child gives a savepoint we can roll back cleanly
+				#    after an IntegrityError and keep using the outer transaction.
+				for rel in reverse_fks:
+					accessor = rel.get_accessor_name()
+					fk_name = rel.field.name
+					for child in list(getattr(rem, accessor).all()):
+						try:
+							with transaction.atomic():
+								setattr(child, fk_name, keep)
+								child.save(update_fields=[fk_name])
+						except IntegrityError:
+							dropped_pk = child.pk
+							child.delete()
+							self.stdout.write(
+								f'   dropped duplicate {rel.related_model.__name__} #{dropped_pk} '
+								f'(kept trial already has the equivalent row)'
+							)
+
+				# 3. Union identifiers (conservative: kept trial's values win, add missing keys).
+				merged = dict(keep.identifiers or {})
+				for k, v in (rem.identifiers or {}).items():
+					if v and (k not in merged or merged[k] is None):
+						merged[k] = v
+
+				# 4. Delete the removed trial FIRST so its registry ids are freed, THEN adopt
+				#    the unioned identifiers — otherwise both rows briefly share an id and trip
+				#    the partial unique indexes added in migration 0054.
+				rem.delete()
+				if merged != (keep.identifiers or {}):
+					keep.identifiers = merged
+					keep.save(update_fields=['identifiers'])
+				self.stdout.write(self.style.SUCCESS(f'   merged and deleted trial {rid}.'))
+
+			keep.refresh_from_db()
+			self.stdout.write(self.style.SUCCESS(
+				f'Done. Kept trial {keep_id} identifiers: {keep.identifiers}'
+			))
+
+			if dry_run:
+				transaction.set_rollback(True)
+				self.stdout.write(self.style.WARNING('DRY RUN — all changes rolled back.'))

--- a/django/gregory/migrations/0054_trials_swap_title_constraint_for_registry_unique_indexes.py
+++ b/django/gregory/migrations/0054_trials_swap_title_constraint_for_registry_unique_indexes.py
@@ -13,12 +13,17 @@ from django.db.models.functions import Upper, Lower
 
 
 def check_registry_duplicates(apps, schema_editor):
-	"""Pre-flight: fail loudly if any duplicate registry IDs exist.
+	"""Pre-flight: fail loudly if any *real* duplicate registry IDs exist.
 
-	The partial unique indexes will fail to create if duplicates are present.
-	Running this check first gives an actionable error message instead of a
-	cryptic DB error, and surfaces the offending values so they can be resolved
-	before the migration is re-run.
+	The partial unique indexes are built on ``upper(identifiers->>'<key>')`` for
+	rows where the key is present. NULL-valued keys are excluded here because
+	PostgreSQL treats NULLs as distinct in a unique index, so multiple rows with a
+	null (or absent) value never collide — only two rows sharing the *same
+	non-null* value would block index creation. Counting NULLs as a "duplicate"
+	group would be a false positive.
+
+	Running this first turns a cryptic DB error into an actionable list naming the
+	exact trial_ids to merge before the migration is re-run.
 	"""
 	from django.db import connection
 
@@ -29,26 +34,29 @@ def check_registry_duplicates(apps, schema_editor):
 		for key in registry_keys:
 			cursor.execute(
 				"""
-				SELECT upper(identifiers->>'%s') AS val, count(*) AS cnt
+				SELECT upper(identifiers->>'%s') AS val,
+				       count(*) AS cnt,
+				       array_agg(trial_id ORDER BY trial_id) AS ids
 				FROM trials
-				WHERE identifiers ? '%s'
+				WHERE identifiers ? '%s' AND identifiers->>'%s' IS NOT NULL
 				GROUP BY upper(identifiers->>'%s')
 				HAVING count(*) > 1
 				ORDER BY cnt DESC
-				""" % (key, key, key)  # noqa: S608 – read-only, no user input
+				""" % (key, key, key, key)  # noqa: S608 – read-only, fixed keys
 			)
 			rows = cursor.fetchall()
 			if rows:
-				duplicates_found[key] = [(r[0], r[1]) for r in rows]
+				duplicates_found[key] = [(r[0], r[1], r[2]) for r in rows]
 
 	if duplicates_found:
 		lines = [
 			'Cannot add partial unique indexes: duplicate registry IDs found.',
-			'Resolve these collisions before re-running the migration:',
+			'Merge these trials before re-running the migration:',
 		]
 		for key, rows in duplicates_found.items():
-			for val, cnt in rows:
-				lines.append(f'  {key} = {val!r}  ({cnt} rows)')
+			for val, cnt, ids in rows:
+				ids_str = ', '.join(str(i) for i in ids)
+				lines.append(f'  {key} = {val!r}  ({cnt} rows: trial_id {ids_str})')
 		raise Exception('\n'.join(lines))
 
 

--- a/django/gregory/tests/management/test_merge_trials.py
+++ b/django/gregory/tests/management/test_merge_trials.py
@@ -1,0 +1,74 @@
+"""
+Tests for the merge_trials management command (Phase-0 duplicate resolution).
+
+Verifies that merging a duplicate trial into a kept trial:
+  - unions identifiers (kept trial wins on shared keys, gains missing keys, skips nulls),
+  - moves M2M links (teams, subjects, …) to the kept trial,
+  - repoints reverse-FK children (e.g. TrialOrgContent) instead of CASCADE-deleting them,
+  - drops a child that would collide with an existing row on the kept trial,
+  - leaves everything untouched under --dry-run.
+
+Run:
+  docker exec gregory python manage.py test gregory.tests.management.test_merge_trials
+"""
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
+django.setup()
+
+from django.core.management import call_command
+from django.test import TestCase
+from organizations.models import Organization
+
+from gregory.models import Trials, Team, Subject, TrialOrgContent
+
+
+class MergeTrialsTest(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(name='Merge Org', slug='merge-org')
+		self.team = Team.objects.create(organization=self.org, name='Merge Team', slug='merge-team')
+		self.subject = Subject.objects.create(subject_name='MS', subject_slug='ms', team=self.team)
+
+	def _trial(self, title, identifiers, link='https://example.com/x'):
+		return Trials.objects.create(title=title, link=link, identifiers=identifiers)
+
+	def test_merge_unions_identifiers_moves_m2m_and_reverse_fk(self):
+		keep = self._trial('Keep One', {'nct': 'NCT00000001', 'ctis': 'CTIS-1'})
+		rem = self._trial('Rem One', {'nct': 'NCT00000001b', 'euctr': 'EUCTR-1', 'euct': None})
+		rem.teams.add(self.team)
+		rem.subjects.add(self.subject)
+		# reverse-FK child only on rem → must be repointed, not lost
+		TrialOrgContent.objects.create(trial=rem, organization=self.org, takeaways='keepme')
+
+		call_command('merge_trials', keep=keep.pk, remove=[rem.pk])
+
+		self.assertFalse(Trials.objects.filter(pk=rem.pk).exists())
+		keep.refresh_from_db()
+		# kept trial wins on 'nct', gains 'euctr', skips the null 'euct'
+		self.assertEqual(keep.identifiers, {'nct': 'NCT00000001', 'ctis': 'CTIS-1', 'euctr': 'EUCTR-1'})
+		self.assertTrue(keep.teams.filter(pk=self.team.pk).exists())
+		self.assertTrue(keep.subjects.filter(pk=self.subject.pk).exists())
+		self.assertEqual(keep.org_contents.count(), 1)
+		self.assertEqual(keep.org_contents.first().takeaways, 'keepme')
+
+	def test_merge_drops_colliding_reverse_fk_child(self):
+		keep = self._trial('Keep Two', {'nct': 'NCT00000002'})
+		rem = self._trial('Rem Two', {'nct': 'NCT00000002b'})
+		# both have org content for the SAME org → unique (trial, org) collision on repoint
+		TrialOrgContent.objects.create(trial=keep, organization=self.org, takeaways='keep-content')
+		TrialOrgContent.objects.create(trial=rem, organization=self.org, takeaways='rem-content')
+
+		call_command('merge_trials', keep=keep.pk, remove=[rem.pk])
+
+		self.assertFalse(Trials.objects.filter(pk=rem.pk).exists())
+		# kept trial retains exactly its own org content; rem's was dropped, not a crash
+		self.assertEqual(keep.org_contents.count(), 1)
+		self.assertEqual(keep.org_contents.first().takeaways, 'keep-content')
+
+	def test_dry_run_changes_nothing(self):
+		keep = self._trial('Keep Three', {'nct': 'NCT00000003'})
+		rem = self._trial('Rem Three', {'nct': 'NCT00000003b'})
+		call_command('merge_trials', keep=keep.pk, remove=[rem.pk], dry_run=True)
+		self.assertTrue(Trials.objects.filter(pk=rem.pk).exists())
+		self.assertTrue(Trials.objects.filter(pk=keep.pk).exists())


### PR DESCRIPTION
Follow-up to #681 (already merged). Two commits were pushed to that branch after it merged, so this brings them into `main`.

## Why

When running migration `0054` on prod it aborts with a long list of "duplicate" registry IDs that are mostly **false positives**:

```
nct = None  (312 rows)
eudract = None  (13571 rows)
nct = 'NCT00213135'  (2 rows)
nct = 'NCT04688788'  (2 rows)
```

The pre-flight check groups rows by `upper(identifiers->>'<key>')`, which collapses **every NULL-valued key into a single group** and flags it as a duplicate. But PostgreSQL treats NULLs as **distinct** in a unique index, so those rows never collide — verified by building the `eudract` index (all 13,571 NULL rows) inside a rolled-back transaction; it succeeds. Only the two `nct` pairs are real.

## What this PR does

- **Fix the 0054 pre-flight check**: add `AND identifiers->>'<key>' IS NOT NULL` so it reports only real collisions, and have it **name the exact `trial_id`s** to merge. (Same false-positive fix applied to the `audit_trial_merges` scan.)
- **Add `merge_trials`** management command (Phase-0 duplicate resolution): moves M2M links, repoints reverse-FK children (dropping ones that would collide rather than CASCADE-deleting), unions identifiers, deletes the duplicate. Transactional, `--dry-run`, tested.

Editing the migration (vs. a new one) is necessary: `0054` itself fails in its check, so a later migration can't rescue it. The failed run rolls back, so environments that hit the error have **not** recorded `0054` as applied.

## Resolving the two real duplicates

Both are one trial split across two rows by the old title-based identity:

```bash
docker exec gregory python manage.py merge_trials --keep 643  --remove 699   --dry-run
docker exec gregory python manage.py merge_trials --keep 643  --remove 699
docker exec gregory python manage.py merge_trials --keep 3913 --remove 11915 --dry-run
docker exec gregory python manage.py merge_trials --keep 3913 --remove 11915
docker exec gregory python manage.py migrate   # now passes
```

(After merging, re-running `migrate` applies the partial unique indexes cleanly. If prod ids differ, the fixed check prints the exact ids to merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)