### PR TITLE
feat(trials): one-time acronym backfill from ClinicalTrials.gov

### DIFF
--- a/django/gregory/management/commands/backfill_trial_acronyms.py
+++ b/django/gregory/management/commands/backfill_trial_acronyms.py
@@ -74,7 +74,7 @@ class Command(BaseCommand):
 
 		nct_ids = sorted(trials_by_nct)
 		total = len(nct_ids)
-		self.stdout.write(f'{total} trials with an NCT id and no acronym ({invalid} skipped as invalid).')
+		self.stdout.write(f'{total} NCT ids with no acronym ({invalid} skipped as invalid).')
 		if not total:
 			return
 
@@ -113,14 +113,14 @@ class Command(BaseCommand):
 						self.stdout.write(f'{nct}: {acronym}')
 
 			done = min(start + batch_size, total)
-			self.stdout.write(f'Processed {done}/{total} (updated {updated}).')
+			self.stdout.write(f'Processed {done}/{total} NCT ids (updated {updated} trial rows).')
 			if sleep and done < total:
 				time.sleep(sleep)
 
 		prefix = 'Would update' if dry_run else 'Updated'
 		self.stdout.write(self.style.SUCCESS(
-			f'{prefix} {updated} trials. '
-			f'No acronym on registry: {no_acronym}. Not returned by API: {not_in_response}.'))
+			f'{prefix} {updated} trial rows. '
+			f'No acronym on registry: {no_acronym} NCT ids. Not returned by API: {not_in_response} NCT ids.'))
 		if failed_batches:
 			self.stdout.write(self.style.ERROR(
 				f'{len(failed_batches)} batch(es) failed and were skipped — rerun to retry: '
@@ -141,7 +141,7 @@ class Command(BaseCommand):
 				if attempt == 1:
 					self.stderr.write(self.style.WARNING(
 						f'Batch {batch[0]}–{batch[-1]} failed ({exc}); retrying.'))
-					time.sleep(max(sleep, 1) * 4)
+					time.sleep(sleep * 4)
 				else:
 					self.stderr.write(self.style.ERROR(
 						f'Batch {batch[0]}–{batch[-1]} failed twice ({exc}); skipping.'))

--- a/django/gregory/management/commands/backfill_trial_acronyms.py
+++ b/django/gregory/management/commands/backfill_trial_acronyms.py
@@ -1,0 +1,149 @@
+"""One-time backfill of Trials.acronym from the ClinicalTrials.gov API.
+
+The CTgov ingester predates the acronym field, so trials sourced from
+ClinicalTrials.gov have no acronym even when the registry publishes one.
+This command fetches acronyms in bulk (filter.ids batches) for every trial
+that has an NCT identifier and an empty acronym, and never overwrites an
+existing value — WHO/ICTRP imports remain the authority for what they set.
+
+Idempotent and resumable: rerunning only targets rows still missing an
+acronym, so an interrupted run can simply be started again.
+"""
+
+import re
+import time
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from gregory.classes import ClinicalTrialsGovAPI
+from gregory.models import Trials
+
+NCT_RE = re.compile(r'^NCT\d{8}$')
+ACRONYM_FIELDS = [
+	'protocolSection.identificationModule.nctId',
+	'protocolSection.identificationModule.acronym',
+]
+ACRONYM_MAX_LENGTH = Trials._meta.get_field('acronym').max_length
+CHANGE_REASON = 'Backfilled acronym from ClinicalTrials.gov API'
+
+
+class Command(BaseCommand):
+	help = 'Backfill empty Trials.acronym values from the ClinicalTrials.gov API for trials with an NCT identifier.'
+
+	def add_arguments(self, parser):
+		parser.add_argument('--batch-size', type=int, default=100,
+							help='NCT ids per API request (default: 100, max: 1000).')
+		parser.add_argument('--limit', type=int,
+							help='Stop after this many candidate trials (useful for a smoke test).')
+		parser.add_argument('--sleep', type=float, default=1.0,
+							help='Seconds to wait between API requests (default: 1.0).')
+		parser.add_argument('--dry-run', action='store_true',
+							help='Report what would be updated without saving.')
+
+	def handle(self, *args, **options):
+		batch_size = min(max(options['batch_size'], 1), 1000)
+		limit = options.get('limit')
+		sleep = max(options['sleep'], 0)
+		dry_run = options['dry_run']
+		verbosity = options.get('verbosity', 1)
+
+		candidates = (
+			Trials.objects
+			.filter(identifiers__has_key='nct')
+			.filter(Q(acronym__isnull=True) | Q(acronym=''))
+			.order_by('trial_id')
+			.only('trial_id', 'acronym', 'identifiers')
+		)
+		if limit:
+			candidates = candidates[:limit]
+
+		# NCT ids carry a per-registry unique index, but normalise and map
+		# defensively: pre-0054 rows may hold stray casing or whitespace.
+		trials_by_nct = {}
+		invalid = 0
+		for trial in candidates:
+			nct = (trial.identifiers.get('nct') or '').strip().upper()
+			if not NCT_RE.match(nct):
+				invalid += 1
+				if verbosity >= 2:
+					self.stdout.write(self.style.WARNING(
+						f'Skipping trial {trial.trial_id}: invalid NCT id {trial.identifiers.get("nct")!r}'))
+				continue
+			trials_by_nct.setdefault(nct, []).append(trial)
+
+		nct_ids = sorted(trials_by_nct)
+		total = len(nct_ids)
+		self.stdout.write(f'{total} trials with an NCT id and no acronym ({invalid} skipped as invalid).')
+		if not total:
+			return
+
+		api = ClinicalTrialsGovAPI()
+		updated = no_acronym = not_in_response = 0
+		failed_batches = []
+
+		for start in range(0, total, batch_size):
+			batch = nct_ids[start:start + batch_size]
+			studies = self._fetch_batch(api, batch, sleep, failed_batches)
+			if studies is None:
+				continue
+
+			acronyms = {}
+			for study in studies:
+				ident = study.get('protocolSection', {}).get('identificationModule', {})
+				nct = (ident.get('nctId') or '').strip().upper()
+				if nct:
+					acronyms[nct] = (ident.get('acronym') or '').strip()
+
+			for nct in batch:
+				if nct not in acronyms:
+					not_in_response += 1
+					continue
+				acronym = acronyms[nct][:ACRONYM_MAX_LENGTH]
+				if not acronym:
+					no_acronym += 1
+					continue
+				for trial in trials_by_nct[nct]:
+					if not dry_run:
+						trial.acronym = acronym
+						trial._change_reason = CHANGE_REASON
+						trial.save(update_fields=['acronym'])
+					updated += 1
+					if verbosity >= 2:
+						self.stdout.write(f'{nct}: {acronym}')
+
+			done = min(start + batch_size, total)
+			self.stdout.write(f'Processed {done}/{total} (updated {updated}).')
+			if sleep and done < total:
+				time.sleep(sleep)
+
+		prefix = 'Would update' if dry_run else 'Updated'
+		self.stdout.write(self.style.SUCCESS(
+			f'{prefix} {updated} trials. '
+			f'No acronym on registry: {no_acronym}. Not returned by API: {not_in_response}.'))
+		if failed_batches:
+			self.stdout.write(self.style.ERROR(
+				f'{len(failed_batches)} batch(es) failed and were skipped — rerun to retry: '
+				f'{", ".join(failed_batches[:5])}{"…" if len(failed_batches) > 5 else ""}'))
+
+	def _fetch_batch(self, api, batch, sleep, failed_batches):
+		"""Fetch one filter.ids batch, retrying once before skipping it."""
+		for attempt in (1, 2):
+			try:
+				response = api.search(
+					filter_ids=batch,
+					fields=ACRONYM_FIELDS,
+					page_size=len(batch),
+					count_total=False,
+				)
+				return response.get('studies', [])
+			except Exception as exc:
+				if attempt == 1:
+					self.stderr.write(self.style.WARNING(
+						f'Batch {batch[0]}–{batch[-1]} failed ({exc}); retrying.'))
+					time.sleep(max(sleep, 1) * 4)
+				else:
+					self.stderr.write(self.style.ERROR(
+						f'Batch {batch[0]}–{batch[-1]} failed twice ({exc}); skipping.'))
+					failed_batches.append(f'{batch[0]}–{batch[-1]}')
+		return None

--- a/django/gregory/tests/test_backfill_trial_acronyms.py
+++ b/django/gregory/tests/test_backfill_trial_acronyms.py
@@ -60,7 +60,7 @@ class BackfillTrialAcronymsTest(TestCase):
 		trial.refresh_from_db()
 		self.assertEqual(trial.acronym, 'OPERA')
 		self.assertEqual(trial.history.first().history_change_reason, CHANGE_REASON)
-		self.assertIn('Updated 1 trials', out)
+		self.assertIn('Updated 1 trial rows', out)
 
 	def test_skips_trials_with_acronym_or_without_nct(self):
 		self.make_trial('NCT00000001', acronym='KEEP')
@@ -70,7 +70,7 @@ class BackfillTrialAcronymsTest(TestCase):
 		out, _ = self.run_command()
 
 		self.assertEqual(FakeAPI.calls, [])
-		self.assertIn('0 trials with an NCT id and no acronym', out)
+		self.assertIn('0 NCT ids with no acronym', out)
 		self.assertEqual(Trials.objects.get(identifiers__nct='NCT00000001').acronym, 'KEEP')
 
 	def test_registry_without_acronym_leaves_trial_untouched(self):
@@ -81,7 +81,7 @@ class BackfillTrialAcronymsTest(TestCase):
 
 		trial.refresh_from_db()
 		self.assertIsNone(trial.acronym)
-		self.assertIn('No acronym on registry: 1', out)
+		self.assertIn('No acronym on registry: 1 NCT ids', out)
 
 	def test_nct_missing_from_response_is_counted(self):
 		trial = self.make_trial('NCT00000001')
@@ -90,7 +90,7 @@ class BackfillTrialAcronymsTest(TestCase):
 
 		trial.refresh_from_db()
 		self.assertIsNone(trial.acronym)
-		self.assertIn('Not returned by API: 1', out)
+		self.assertIn('Not returned by API: 1 NCT ids', out)
 
 	def test_dry_run_saves_nothing(self):
 		trial = self.make_trial('NCT00000001')
@@ -100,7 +100,7 @@ class BackfillTrialAcronymsTest(TestCase):
 
 		trial.refresh_from_db()
 		self.assertIsNone(trial.acronym)
-		self.assertIn('Would update 1 trials', out)
+		self.assertIn('Would update 1 trial rows', out)
 
 	def test_batches_requests_by_batch_size(self):
 		for i in range(1, 6):
@@ -158,5 +158,5 @@ class BackfillTrialAcronymsTest(TestCase):
 
 		out, _ = self.run_command(limit=2)
 
-		self.assertIn('2 trials with an NCT id and no acronym', out)
-		self.assertIn('Updated 2 trials', out)
+		self.assertIn('2 NCT ids with no acronym', out)
+		self.assertIn('Updated 2 trial rows', out)

--- a/django/gregory/tests/test_backfill_trial_acronyms.py
+++ b/django/gregory/tests/test_backfill_trial_acronyms.py
@@ -1,0 +1,162 @@
+"""Tests for the backfill_trial_acronyms management command."""
+
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from gregory.management.commands.backfill_trial_acronyms import CHANGE_REASON
+from gregory.models import Trials
+
+
+def _study(nct_id, acronym=None):
+	ident = {'nctId': nct_id}
+	if acronym is not None:
+		ident['acronym'] = acronym
+	return {'protocolSection': {'identificationModule': ident}}
+
+
+class FakeAPI:
+	"""Stand-in for ClinicalTrialsGovAPI returning canned studies."""
+
+	studies_by_nct = {}
+	calls = []
+
+	def __init__(self):
+		pass
+
+	def search(self, filter_ids=None, **kwargs):
+		type(self).calls.append(list(filter_ids))
+		return {'studies': [self.studies_by_nct[nct] for nct in filter_ids if nct in self.studies_by_nct]}
+
+
+@patch('gregory.management.commands.backfill_trial_acronyms.ClinicalTrialsGovAPI', FakeAPI)
+class BackfillTrialAcronymsTest(TestCase):
+	def setUp(self):
+		FakeAPI.studies_by_nct = {}
+		FakeAPI.calls = []
+
+	def run_command(self, **kwargs):
+		out, err = StringIO(), StringIO()
+		call_command('backfill_trial_acronyms', sleep=0, stdout=out, stderr=err, **kwargs)
+		return out.getvalue(), err.getvalue()
+
+	def make_trial(self, nct, acronym=None, identifiers=None, n=None):
+		n = n if n is not None else (nct or 'X')
+		return Trials.objects.create(
+			title=f'Trial {n}',
+			link=f'https://clinicaltrials.gov/study/{n}',
+			identifiers=identifiers if identifiers is not None else {'nct': nct},
+			acronym=acronym,
+		)
+
+	def test_fills_empty_acronyms_and_records_change_reason(self):
+		trial = self.make_trial('NCT00000001')
+		FakeAPI.studies_by_nct = {'NCT00000001': _study('NCT00000001', '  OPERA ')}
+
+		out, _ = self.run_command()
+
+		trial.refresh_from_db()
+		self.assertEqual(trial.acronym, 'OPERA')
+		self.assertEqual(trial.history.first().history_change_reason, CHANGE_REASON)
+		self.assertIn('Updated 1 trials', out)
+
+	def test_skips_trials_with_acronym_or_without_nct(self):
+		self.make_trial('NCT00000001', acronym='KEEP')
+		self.make_trial(None, identifiers={'euctr': '2016-001005-36'}, n='EUCTR1')
+		FakeAPI.studies_by_nct = {'NCT00000001': _study('NCT00000001', 'CLOBBER')}
+
+		out, _ = self.run_command()
+
+		self.assertEqual(FakeAPI.calls, [])
+		self.assertIn('0 trials with an NCT id and no acronym', out)
+		self.assertEqual(Trials.objects.get(identifiers__nct='NCT00000001').acronym, 'KEEP')
+
+	def test_registry_without_acronym_leaves_trial_untouched(self):
+		trial = self.make_trial('NCT00000001')
+		FakeAPI.studies_by_nct = {'NCT00000001': _study('NCT00000001')}
+
+		out, _ = self.run_command()
+
+		trial.refresh_from_db()
+		self.assertIsNone(trial.acronym)
+		self.assertIn('No acronym on registry: 1', out)
+
+	def test_nct_missing_from_response_is_counted(self):
+		trial = self.make_trial('NCT00000001')
+
+		out, _ = self.run_command()
+
+		trial.refresh_from_db()
+		self.assertIsNone(trial.acronym)
+		self.assertIn('Not returned by API: 1', out)
+
+	def test_dry_run_saves_nothing(self):
+		trial = self.make_trial('NCT00000001')
+		FakeAPI.studies_by_nct = {'NCT00000001': _study('NCT00000001', 'OPERA')}
+
+		out, _ = self.run_command(dry_run=True)
+
+		trial.refresh_from_db()
+		self.assertIsNone(trial.acronym)
+		self.assertIn('Would update 1 trials', out)
+
+	def test_batches_requests_by_batch_size(self):
+		for i in range(1, 6):
+			self.make_trial(f'NCT0000000{i}')
+
+		self.run_command(batch_size=2)
+
+		self.assertEqual([len(c) for c in FakeAPI.calls], [2, 2, 1])
+
+	def test_normalises_nct_case_and_truncates_acronym(self):
+		trial = self.make_trial(None, identifiers={'nct': ' nct00000001 '}, n='NCT00000001')
+		FakeAPI.studies_by_nct = {'NCT00000001': _study('NCT00000001', 'A' * 250)}
+
+		self.run_command()
+
+		trial.refresh_from_db()
+		self.assertEqual(trial.acronym, 'A' * 200)
+		self.assertEqual(FakeAPI.calls, [['NCT00000001']])
+
+	def test_invalid_nct_ids_are_skipped(self):
+		self.make_trial(None, identifiers={'nct': 'not-an-id'}, n='BAD1')
+
+		out, _ = self.run_command()
+
+		self.assertEqual(FakeAPI.calls, [])
+		self.assertIn('1 skipped as invalid', out)
+
+	def test_failed_batch_is_retried_then_skipped_and_others_continue(self):
+		self.make_trial('NCT00000001')
+		self.make_trial('NCT00000002')
+		FakeAPI.studies_by_nct = {
+			'NCT00000001': _study('NCT00000001', 'FIRST'),
+			'NCT00000002': _study('NCT00000002', 'SECOND'),
+		}
+		original_search = FakeAPI.search
+
+		def flaky_search(self, filter_ids=None, **kwargs):
+			if 'NCT00000001' in filter_ids:
+				type(self).calls.append(list(filter_ids))
+				raise RuntimeError('boom')
+			return original_search(self, filter_ids=filter_ids, **kwargs)
+
+		with patch.object(FakeAPI, 'search', flaky_search):
+			out, err = self.run_command(batch_size=1)
+
+		self.assertEqual(Trials.objects.get(identifiers__nct='NCT00000001').acronym, None)
+		self.assertEqual(Trials.objects.get(identifiers__nct='NCT00000002').acronym, 'SECOND')
+		self.assertIn('failed twice', err)
+		self.assertIn('rerun to retry', out)
+
+	def test_limit_caps_candidates(self):
+		for i in range(1, 4):
+			self.make_trial(f'NCT0000000{i}')
+		FakeAPI.studies_by_nct = {f'NCT0000000{i}': _study(f'NCT0000000{i}', f'ACR{i}') for i in range(1, 4)}
+
+		out, _ = self.run_command(limit=2)
+
+		self.assertIn('2 trials with an NCT id and no acronym', out)
+		self.assertIn('Updated 2 trials', out)


### PR DESCRIPTION
## What

New `backfill_trial_acronyms` management command. The CTgov ingester predates the `Trials.acronym` field (added in #675), so trials sourced from ClinicalTrials.gov have no acronym even when the registry publishes one — which left the new `?acronym=` API filter (#684) with almost nothing to match.

## How

- Selects trials with an NCT identifier and an empty acronym.
- Queries the CTgov v2 API in `filter.ids` batches (default 100, 1s pause between requests), requesting only the identification module fields.
- Fills empty acronyms only — never overwrites; WHO/ICTRP imports stay authoritative for what they set.
- Records `Backfilled acronym from ClinicalTrials.gov API` as the history change reason.
- Idempotent and resumable: reruns only target rows still missing a value. Failed batches retry once, then are skipped and reported.
- Flags: `--batch-size`, `--limit`, `--sleep`, `--dry-run`.

## Results (local 19.5k-trial DB)

- 15,794 NCT ids queried, all batches succeeded.
- 5,165 acronyms filled (e.g. ENFORCE, AMA-VACC, ESPOIR2); 10,617 trials have no acronym on the registry; 12 ids not returned by the API; 319 rows skipped (`nct: null` in identifiers).

## Tests

10 new tests covering fill + change reason, dry run, batching, normalisation/truncation, invalid ids, retry-then-skip, and `--limit`. `docker exec gregory python manage.py test gregory.tests.test_backfill_trial_acronyms` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)