### PR TITLE
feat(trials): capture acronym in live ClinicalTrials.gov ingestion

### DIFF
--- a/django/gregory/classes.py
+++ b/django/gregory/classes.py
@@ -448,6 +448,9 @@ class ClinicalTrialsGovAPI:
 		
 		# Extract title (prefer official, fallback to brief)
 		title = identification.get('officialTitle') or identification.get('briefTitle', '')
+
+		# Extract acronym (Trials.acronym is capped at 200 chars)
+		acronym = (identification.get('acronym') or '').strip()[:200] or None
 		
 		# Build link
 		link = f"https://clinicaltrials.gov/study/{nct_id}" if nct_id else None
@@ -562,6 +565,7 @@ class ClinicalTrialsGovAPI:
 		# Build extra_fields for ClinicalTrial object
 		extra_fields = {
 			'scientific_title': identification.get('officialTitle'),
+			'acronym': acronym,
 			'recruitment_status': recruitment_status,
 			'date_registration': self._parse_date(status_module.get('studyFirstSubmitDate')),
 			'study_type': study_type,

--- a/django/gregory/management/commands/feedreader_trials_ctgov.py
+++ b/django/gregory/management/commands/feedreader_trials_ctgov.py
@@ -274,6 +274,7 @@ class Command(BaseCommand):
 				identifiers=clinical_trial.identifiers,
 				# WHO-style fields
 				scientific_title=extras.get('scientific_title'),
+				acronym=extras.get('acronym'),
 				primary_sponsor=extras.get('primary_sponsor'),
 				recruitment_status=extras.get('recruitment_status'),
 				date_registration=extras.get('date_registration'),
@@ -389,6 +390,14 @@ class Command(BaseCommand):
 				setattr(existing_trial, field, new_value)
 				has_changes = True
 				updated_fields.append(field)
+
+		# Acronym is fill-once: a value set by an earlier import (e.g. WHO ICTRP)
+		# is never replaced, mirroring the first-seen-wins rule for links.
+		new_acronym = extras.get('acronym')
+		if new_acronym and not existing_trial.acronym:
+			existing_trial.acronym = new_acronym
+			has_changes = True
+			updated_fields.append('acronym')
 
 		# Save if changes were detected
 		if has_changes:

--- a/django/gregory/tests/test_ctgov_acronym.py
+++ b/django/gregory/tests/test_ctgov_acronym.py
@@ -1,0 +1,117 @@
+"""
+Tests for acronym capture in the ClinicalTrials.gov ingestion path.
+
+Covers:
+  - parse_study_to_clinical_trial extracts, strips, and truncates the acronym
+  - create_new_trial stores the acronym on new trials
+  - update_existing_trial fills an empty acronym but never replaces one set
+    by an earlier import (e.g. WHO ICTRP) — fill-once, like links
+
+Run:
+  docker exec gregory python manage.py test gregory.tests.test_ctgov_acronym
+"""
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
+django.setup()
+
+from django.test import SimpleTestCase, TestCase
+from organizations.models import Organization
+
+from gregory.models import Trials, Sources, Subject, Team
+from gregory.classes import ClinicalTrial, ClinicalTrialsGovAPI
+from gregory.management.commands.feedreader_trials_ctgov import Command as CTGovCommand
+
+
+def _study(acronym=None):
+	identification = {
+		'nctId': 'NCT00000001',
+		'officialTitle': 'A Study of Acronym Capture',
+	}
+	if acronym is not None:
+		identification['acronym'] = acronym
+	return {'protocolSection': {'identificationModule': identification}}
+
+
+def _ctgov_trial(acronym=None):
+	return ClinicalTrial(
+		title='A Study of Acronym Capture',
+		summary='Summary from ClinicalTrials.gov',
+		link='https://clinicaltrials.gov/study/NCT00000001',
+		published_date=None,
+		identifiers={'nct': 'NCT00000001'},
+		extra_fields={'acronym': acronym} if acronym else {},
+	)
+
+
+def _ctgov_cmd():
+	cmd = CTGovCommand()
+	cmd.verbosity = 0
+	return cmd
+
+
+class ParseStudyAcronymTest(SimpleTestCase):
+	def setUp(self):
+		self.api = ClinicalTrialsGovAPI()
+
+	def test_extracts_and_strips_acronym(self):
+		trial = self.api.parse_study_to_clinical_trial(_study('  OPERA '))
+		self.assertEqual(trial.extra_fields['acronym'], 'OPERA')
+
+	def test_missing_acronym_is_none(self):
+		trial = self.api.parse_study_to_clinical_trial(_study())
+		self.assertIsNone(trial.extra_fields['acronym'])
+
+	def test_blank_acronym_is_none(self):
+		trial = self.api.parse_study_to_clinical_trial(_study('   '))
+		self.assertIsNone(trial.extra_fields['acronym'])
+
+	def test_long_acronym_is_truncated_to_field_limit(self):
+		trial = self.api.parse_study_to_clinical_trial(_study('A' * 250))
+		self.assertEqual(trial.extra_fields['acronym'], 'A' * 200)
+		self.assertEqual(len(trial.extra_fields['acronym']), Trials._meta.get_field('acronym').max_length)
+
+
+class ImporterAcronymTest(TestCase):
+	def setUp(self):
+		org = Organization.objects.create(name='Test Org')
+		team = Team.objects.create(organization=org, name='Test Team', slug='test-team')
+		subject = Subject.objects.create(subject_name='MS', subject_slug='ms')
+		self.source = Sources.objects.create(
+			name='CTGov API',
+			source_for='trials',
+			method='ctgov_api',
+			subject=subject,
+			team=team,
+		)
+		self.cmd = _ctgov_cmd()
+
+	def test_create_new_trial_stores_acronym(self):
+		self.cmd.create_new_trial(_ctgov_trial('OPERA'), self.source)
+		self.assertEqual(Trials.objects.get(identifiers__nct='NCT00000001').acronym, 'OPERA')
+
+	def test_update_fills_empty_acronym(self):
+		trial = self.cmd.create_new_trial(_ctgov_trial(), self.source)
+		self.assertIsNone(trial.acronym)
+
+		self.cmd.update_existing_trial(trial, _ctgov_trial('OPERA'), self.source)
+
+		trial.refresh_from_db()
+		self.assertEqual(trial.acronym, 'OPERA')
+
+	def test_update_never_replaces_existing_acronym(self):
+		trial = self.cmd.create_new_trial(_ctgov_trial('FROM-WHO'), self.source)
+
+		self.cmd.update_existing_trial(trial, _ctgov_trial('FROM-CTGOV'), self.source)
+
+		trial.refresh_from_db()
+		self.assertEqual(trial.acronym, 'FROM-WHO')
+
+	def test_update_without_acronym_leaves_field_alone(self):
+		trial = self.cmd.create_new_trial(_ctgov_trial('OPERA'), self.source)
+
+		self.cmd.update_existing_trial(trial, _ctgov_trial(), self.source)
+
+		trial.refresh_from_db()
+		self.assertEqual(trial.acronym, 'OPERA')


### PR DESCRIPTION
## What

Closes the gap left open after #688: the live CTgov ingestion path never captured the trial acronym, so newly ingested trials always arrived with `Trials.acronym` empty and depended on the one-time `backfill_trial_acronyms` command being rerun.

## How

- `parse_study_to_clinical_trial` (django/gregory/classes.py) now extracts `protocolSection.identificationModule.acronym`, stripped and truncated to the 200-char field limit, and passes it through `extra_fields`.
- `create_new_trial` stores it on new trials.
- `update_existing_trial` treats acronym as **fill-once**: an empty field is populated, but a value set by an earlier import (e.g. WHO ICTRP) is never replaced — deliberately stricter than the generic extra-fields loop, mirroring the first-seen-wins rule for links.

## Tests

8 new tests in `gregory.tests.test_ctgov_acronym` (parser extraction/strip/truncate, creation, fill-once update semantics). Related suites `test_trial_links`, `test_trial_identity`, and `test_capture_trial_streams` all pass (34 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)