### PR TITLE
feat(trials): fill Tier-1 field gaps in CTGov and WHO importers

### DIFF
--- a/django/gregory/classes.py
+++ b/django/gregory/classes.py
@@ -544,7 +544,7 @@ class ClinicalTrialsGovAPI:
 		
 		# Extract locations/countries
 		locations = contacts_module.get('locations', [])
-		countries = list(set(loc.get('country', '') for loc in locations if loc.get('country')))
+		countries = sorted(set(loc.get('country', '') for loc in locations if loc.get('country')))
 		
 		# Extract contact information
 		central_contacts = contacts_module.get('centralContacts', [])
@@ -561,6 +561,48 @@ class ClinicalTrialsGovAPI:
 		has_results = bool(study_data.get('hasResults', False))
 		results_url_link = f"https://clinicaltrials.gov/study/{nct_id}?tab=results" if (has_results and nct_id) else None
 		results_date_completed = self._parse_date(status_module.get('resultsFirstPostDateStruct', {}).get('date'))
+
+		# study_design — compose human-readable string from designInfo
+		design_info = design_module.get('designInfo', {})
+		study_design = None
+		if design_info:
+			parts = []
+			if design_info.get('allocation'):
+				parts.append(f"Allocation: {design_info['allocation']}")
+			if design_info.get('interventionModel'):
+				parts.append(f"Intervention model: {design_info['interventionModel']}")
+			masking_info = design_info.get('maskingInfo', {})
+			if masking_info.get('masking'):
+				who_masked = masking_info.get('whoMasked', [])
+				masking_str = masking_info['masking']
+				if who_masked:
+					masking_str += f" ({', '.join(sorted(who_masked))})"
+				parts.append(f"Masking: {masking_str}")
+			if design_info.get('primaryPurpose'):
+				parts.append(f"Primary purpose: {design_info['primaryPurpose']}")
+			if design_info.get('observationalModel'):
+				parts.append(f"Observational model: {design_info['observationalModel']}")
+			if design_info.get('timePerspective'):
+				parts.append(f"Time perspective: {design_info['timePerspective']}")
+			study_design = '. '.join(parts) if parts else None
+
+		# results_ipd_plan / results_ipd_description
+		ipd_module = protocol.get('ipdSharingStatementModule', {})
+		results_ipd_plan = (ipd_module.get('ipdSharing') or '')[:10] or None
+		results_ipd_description = ipd_module.get('description') or None
+
+		# secondary_sponsor — collaborators are already collected above
+		secondary_sponsor = '; '.join(collaborators) if collaborators else None
+
+		# last_refreshed_on
+		last_refreshed_on = self._parse_date(status_module.get('lastUpdatePostDateStruct', {}).get('date'))
+
+		# date_enrollement — same start date already used for published_date
+		date_enrollement = self._parse_date(start_date_struct.get('date'))
+
+		# contact_affiliation — first overall official's affiliation
+		overall_officials = contacts_module.get('overallOfficials', [])
+		contact_affiliation = overall_officials[0].get('affiliation') if overall_officials else None
 
 		# Build extra_fields for ClinicalTrial object
 		extra_fields = {
@@ -592,6 +634,13 @@ class ClinicalTrialsGovAPI:
 			'results_posted': has_results,
 			'results_url_link': results_url_link,
 			'results_date_completed': results_date_completed,
+			'study_design': study_design,
+			'results_ipd_plan': results_ipd_plan,
+			'results_ipd_description': results_ipd_description,
+			'secondary_sponsor': secondary_sponsor,
+			'last_refreshed_on': last_refreshed_on,
+			'date_enrollement': date_enrollement,
+			'contact_affiliation': contact_affiliation,
 		}
 		
 		return ClinicalTrial(

--- a/django/gregory/classes.py
+++ b/django/gregory/classes.py
@@ -588,11 +588,13 @@ class ClinicalTrialsGovAPI:
 
 		# results_ipd_plan / results_ipd_description
 		ipd_module = protocol.get('ipdSharingStatementModule', {})
-		results_ipd_plan = (ipd_module.get('ipdSharing') or '')[:10] or None
-		results_ipd_description = ipd_module.get('description') or None
+		results_ipd_plan = ((ipd_module.get('ipdSharing') or '').strip()[:10]) or None
+		_ipd_desc = (ipd_module.get('description') or '').strip()
+		results_ipd_description = _ipd_desc or None
 
 		# secondary_sponsor — collaborators are already collected above
-		secondary_sponsor = '; '.join(collaborators) if collaborators else None
+		_clean_collabs = [c.strip() for c in collaborators if c.strip()]
+		secondary_sponsor = '; '.join(_clean_collabs) if _clean_collabs else None
 
 		# last_refreshed_on
 		last_refreshed_on = self._parse_date(status_module.get('lastUpdatePostDateStruct', {}).get('date'))
@@ -602,7 +604,8 @@ class ClinicalTrialsGovAPI:
 
 		# contact_affiliation — first overall official's affiliation
 		overall_officials = contacts_module.get('overallOfficials', [])
-		contact_affiliation = overall_officials[0].get('affiliation') if overall_officials else None
+		_raw_affiliation = overall_officials[0].get('affiliation', '') if overall_officials else ''
+		contact_affiliation = _raw_affiliation.strip() or None
 
 		# Build extra_fields for ClinicalTrial object
 		extra_fields = {

--- a/django/gregory/management/commands/feedreader_trials_ctgov.py
+++ b/django/gregory/management/commands/feedreader_trials_ctgov.py
@@ -301,6 +301,13 @@ class Command(BaseCommand):
 				results_posted=extras.get('results_posted', False),
 				results_url_link=extras.get('results_url_link'),
 				results_date_completed=extras.get('results_date_completed'),
+				study_design=extras.get('study_design'),
+				results_ipd_plan=extras.get('results_ipd_plan'),
+				results_ipd_description=extras.get('results_ipd_description'),
+				secondary_sponsor=extras.get('secondary_sponsor'),
+				last_refreshed_on=extras.get('last_refreshed_on'),
+				date_enrollement=extras.get('date_enrollement'),
+				contact_affiliation=extras.get('contact_affiliation'),
 			)
 			
 			if trial:
@@ -379,7 +386,10 @@ class Command(BaseCommand):
 			'inclusion_agemin', 'inclusion_agemax', 'inclusion_gender', 'target_size',
 			'contact_firstname', 'contact_lastname', 'contact_email', 'contact_tel',
 			'source_register', 'ctg_detailed_description',
-			'results_posted', 'results_url_link', 'results_date_completed'
+			'results_posted', 'results_url_link', 'results_date_completed',
+			'study_design', 'results_ipd_plan', 'results_ipd_description',
+			'secondary_sponsor', 'last_refreshed_on', 'date_enrollement',
+			'contact_affiliation',
 		]
 
 		for field in extra_field_mapping:

--- a/django/gregory/management/commands/importWHOXML.py
+++ b/django/gregory/management/commands/importWHOXML.py
@@ -231,7 +231,8 @@ class Command(BaseCommand):
 				'Intervention', 'Primary_outcome', 'Secondary_outcome', 'Secondary_ID',
 				'Source_Support', 'Ethics_review_status', 'Ethics_review_contact_name',
 				'Ethics_review_contact_address', 'Ethics_review_contact_phone', 'Ethics_review_contact_email',
-				'Acronym', 'Secondary_Sponsor', 'results_yes_no', 'results_ipd_plan', 'results_ipd_description'
+				'Acronym', 'Secondary_Sponsor', 'results_yes_no', 'results_ipd_plan', 'results_ipd_description',
+				'results_url_link'
 			]:
 				trial_data[field.lower()] = self.get_text(trial, field)
 

--- a/django/gregory/tests/management/test_ctgov_tier1_fields.py
+++ b/django/gregory/tests/management/test_ctgov_tier1_fields.py
@@ -1,0 +1,157 @@
+"""
+Command-level tests for Tier-1 field gap fixes in the CTGov importer.
+
+Verifies that new fields persist on create and that the non-destructive
+update guard applies: an existing non-empty value is replaced by a new
+non-empty value, but never blanked by an empty/None incoming one.
+
+Run:
+  docker exec gregory python manage.py test gregory.tests.management.test_ctgov_tier1_fields
+"""
+import datetime
+import os
+
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
+django.setup()
+
+from django.test import TestCase
+from organizations.models import Organization
+
+from gregory.classes import ClinicalTrial
+from gregory.management.commands.feedreader_trials_ctgov import Command as CTGovCommand
+from gregory.models import Sources, Subject, Team, Trials
+
+
+def _source():
+	org = Organization.objects.create(name='Test Org Tier1')
+	team = Team.objects.create(organization=org, name='Test Team Tier1', slug='test-team-tier1')
+	subject = Subject.objects.create(subject_name='MS Tier1', subject_slug='ms-tier1')
+	return Sources.objects.create(
+		name='CTGov Tier1',
+		source_for='trials',
+		method='ctgov_api',
+		subject=subject,
+		team=team,
+	)
+
+
+def _trial(nct='NCT88880001', **extra):
+	return ClinicalTrial(
+		title='Tier-1 Command Test Trial',
+		summary='Summary text.',
+		link=f'https://clinicaltrials.gov/study/{nct}',
+		published_date=None,
+		identifiers={'nct': nct},
+		extra_fields=extra,
+	)
+
+
+def _cmd():
+	cmd = CTGovCommand()
+	cmd.verbosity = 0
+	return cmd
+
+
+class Tier1CreateTest(TestCase):
+	def setUp(self):
+		self.source = _source()
+		self.cmd = _cmd()
+
+	def test_create_stores_study_design(self):
+		self.cmd.create_new_trial(_trial(study_design='Allocation: RANDOMIZED'), self.source)
+		t = Trials.objects.get(identifiers__nct='NCT88880001')
+		self.assertEqual(t.study_design, 'Allocation: RANDOMIZED')
+
+	def test_create_stores_results_ipd_fields(self):
+		self.cmd.create_new_trial(_trial(
+			nct='NCT88880002',
+			results_ipd_plan='YES',
+			results_ipd_description='After 2 years',
+		), self.source)
+		t = Trials.objects.get(identifiers__nct='NCT88880002')
+		self.assertEqual(t.results_ipd_plan, 'YES')
+		self.assertEqual(t.results_ipd_description, 'After 2 years')
+
+	def test_create_stores_secondary_sponsor(self):
+		self.cmd.create_new_trial(_trial(nct='NCT88880003', secondary_sponsor='Org A; Org B'), self.source)
+		t = Trials.objects.get(identifiers__nct='NCT88880003')
+		self.assertEqual(t.secondary_sponsor, 'Org A; Org B')
+
+	def test_create_stores_last_refreshed_on(self):
+		d = datetime.date(2024, 5, 10)
+		self.cmd.create_new_trial(_trial(nct='NCT88880004', last_refreshed_on=d), self.source)
+		t = Trials.objects.get(identifiers__nct='NCT88880004')
+		self.assertEqual(t.last_refreshed_on, d)
+
+	def test_create_stores_date_enrollement(self):
+		d = datetime.date(2023, 1, 1)
+		self.cmd.create_new_trial(_trial(nct='NCT88880005', date_enrollement=d), self.source)
+		t = Trials.objects.get(identifiers__nct='NCT88880005')
+		self.assertEqual(t.date_enrollement, d)
+
+	def test_create_stores_contact_affiliation(self):
+		self.cmd.create_new_trial(_trial(nct='NCT88880006', contact_affiliation='University Hospital'), self.source)
+		t = Trials.objects.get(identifiers__nct='NCT88880006')
+		self.assertEqual(t.contact_affiliation, 'University Hospital')
+
+
+class Tier1UpdateGuardTest(TestCase):
+	def setUp(self):
+		self.source = _source()
+		self.cmd = _cmd()
+
+	def _create(self, nct, **extra):
+		return self.cmd.create_new_trial(_trial(nct=nct, **extra), self.source)
+
+	def test_update_replaces_study_design_with_new_value(self):
+		t = self._create('NCT88881001', study_design='Old design')
+		self.cmd.update_existing_trial(t, _trial(nct='NCT88881001', study_design='New design'), self.source)
+		t.refresh_from_db()
+		self.assertEqual(t.study_design, 'New design')
+
+	def test_update_does_not_blank_study_design(self):
+		t = self._create('NCT88881002', study_design='Existing design')
+		self.cmd.update_existing_trial(t, _trial(nct='NCT88881002'), self.source)
+		t.refresh_from_db()
+		self.assertEqual(t.study_design, 'Existing design')
+
+	def test_update_replaces_secondary_sponsor(self):
+		t = self._create('NCT88881003', secondary_sponsor='Old Org')
+		self.cmd.update_existing_trial(t, _trial(nct='NCT88881003', secondary_sponsor='New Org'), self.source)
+		t.refresh_from_db()
+		self.assertEqual(t.secondary_sponsor, 'New Org')
+
+	def test_update_does_not_blank_secondary_sponsor(self):
+		t = self._create('NCT88881004', secondary_sponsor='Preserved Org')
+		self.cmd.update_existing_trial(t, _trial(nct='NCT88881004', secondary_sponsor=None), self.source)
+		t.refresh_from_db()
+		self.assertEqual(t.secondary_sponsor, 'Preserved Org')
+
+	def test_update_replaces_contact_affiliation(self):
+		t = self._create('NCT88881005', contact_affiliation='Old Hospital')
+		self.cmd.update_existing_trial(t, _trial(nct='NCT88881005', contact_affiliation='New Hospital'), self.source)
+		t.refresh_from_db()
+		self.assertEqual(t.contact_affiliation, 'New Hospital')
+
+	def test_update_does_not_blank_contact_affiliation(self):
+		t = self._create('NCT88881006', contact_affiliation='Existing Hospital')
+		self.cmd.update_existing_trial(t, _trial(nct='NCT88881006'), self.source)
+		t.refresh_from_db()
+		self.assertEqual(t.contact_affiliation, 'Existing Hospital')
+
+	def test_update_replaces_last_refreshed_on(self):
+		old_date = datetime.date(2023, 1, 1)
+		new_date = datetime.date(2024, 6, 15)
+		t = self._create('NCT88881007', last_refreshed_on=old_date)
+		self.cmd.update_existing_trial(t, _trial(nct='NCT88881007', last_refreshed_on=new_date), self.source)
+		t.refresh_from_db()
+		self.assertEqual(t.last_refreshed_on, new_date)
+
+	def test_update_does_not_blank_last_refreshed_on(self):
+		d = datetime.date(2024, 1, 1)
+		t = self._create('NCT88881008', last_refreshed_on=d)
+		self.cmd.update_existing_trial(t, _trial(nct='NCT88881008', last_refreshed_on=None), self.source)
+		t.refresh_from_db()
+		self.assertEqual(t.last_refreshed_on, d)

--- a/django/gregory/tests/test_ctgov_tier1_fields.py
+++ b/django/gregory/tests/test_ctgov_tier1_fields.py
@@ -1,0 +1,243 @@
+"""
+Tests for Tier-1 field gap fixes in the ClinicalTrials.gov parser.
+
+Covers parse_study_to_clinical_trial producing:
+  - study_design (interventional, observational, absent designInfo → None)
+  - results_ipd_plan (truncated to ≤10 chars), results_ipd_description, absent module → None
+  - secondary_sponsor joined from collaborators; none → None
+  - last_refreshed_on and date_enrollement as date objects (including partial date)
+  - contact_affiliation from first overall official; empty/absent → None
+  - countries string is deterministically sorted
+
+Run:
+  docker exec gregory python manage.py test gregory.tests.test_ctgov_tier1_fields
+"""
+import datetime
+import os
+
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
+django.setup()
+
+from django.test import SimpleTestCase
+
+from gregory.classes import ClinicalTrialsGovAPI
+
+
+def _base_study(**overrides):
+	"""Minimal study dict; caller can override any top-level protocolSection key."""
+	study = {
+		'protocolSection': {
+			'identificationModule': {
+				'nctId': 'NCT99999999',
+				'officialTitle': 'Tier-1 Test Study',
+			},
+			'statusModule': {
+				'overallStatus': 'RECRUITING',
+			},
+			'designModule': {},
+			'sponsorCollaboratorsModule': {'leadSponsor': {'name': 'Lead Corp'}},
+			'conditionsModule': {},
+			'eligibilityModule': {},
+			'outcomesModule': {},
+			'contactsLocationsModule': {},
+			'descriptionModule': {},
+			'armsInterventionsModule': {},
+		}
+	}
+	study['protocolSection'].update(overrides)
+	return study
+
+
+class StudyDesignTest(SimpleTestCase):
+	def setUp(self):
+		self.api = ClinicalTrialsGovAPI()
+
+	def _parse(self, design_module):
+		study = _base_study(designModule=design_module)
+		trial = self.api.parse_study_to_clinical_trial(study)
+		return trial.extra_fields.get('study_design')
+
+	def test_interventional_full(self):
+		result = self._parse({
+			'studyType': 'INTERVENTIONAL',
+			'designInfo': {
+				'allocation': 'RANDOMIZED',
+				'interventionModel': 'PARALLEL',
+				'maskingInfo': {
+					'masking': 'QUADRUPLE',
+					'whoMasked': ['PARTICIPANT', 'INVESTIGATOR', 'CARE_PROVIDER', 'OUTCOMES_ASSESSOR'],
+				},
+				'primaryPurpose': 'TREATMENT',
+			},
+		})
+		self.assertIn('Allocation: RANDOMIZED', result)
+		self.assertIn('Intervention model: PARALLEL', result)
+		self.assertIn('Masking: QUADRUPLE', result)
+		self.assertIn('Primary purpose: TREATMENT', result)
+		# whoMasked must be sorted for determinism
+		who_section = result[result.index('Masking:'):]
+		paren_content = who_section[who_section.index('(') + 1:who_section.index(')')]
+		names = [n.strip() for n in paren_content.split(',')]
+		self.assertEqual(names, sorted(names))
+
+	def test_observational(self):
+		result = self._parse({
+			'studyType': 'OBSERVATIONAL',
+			'designInfo': {
+				'observationalModel': 'COHORT',
+				'timePerspective': 'PROSPECTIVE',
+			},
+		})
+		self.assertIn('Observational model: COHORT', result)
+		self.assertIn('Time perspective: PROSPECTIVE', result)
+
+	def test_absent_design_info_returns_none(self):
+		result = self._parse({'studyType': 'INTERVENTIONAL'})
+		self.assertIsNone(result)
+
+	def test_empty_design_info_returns_none(self):
+		result = self._parse({'studyType': 'INTERVENTIONAL', 'designInfo': {}})
+		self.assertIsNone(result)
+
+	def test_deterministic_repeated_call(self):
+		dm = {
+			'studyType': 'INTERVENTIONAL',
+			'designInfo': {
+				'allocation': 'RANDOMIZED',
+				'maskingInfo': {'masking': 'DOUBLE', 'whoMasked': ['PARTICIPANT', 'CARE_PROVIDER']},
+				'primaryPurpose': 'PREVENTION',
+			},
+		}
+		first = self._parse(dm)
+		second = self._parse(dm)
+		self.assertEqual(first, second)
+
+
+class IpdFieldsTest(SimpleTestCase):
+	def setUp(self):
+		self.api = ClinicalTrialsGovAPI()
+
+	def _parse(self, ipd_module=None):
+		overrides = {}
+		if ipd_module is not None:
+			overrides['ipdSharingStatementModule'] = ipd_module
+		study = _base_study(**overrides)
+		trial = self.api.parse_study_to_clinical_trial(study)
+		return trial.extra_fields
+
+	def test_yes_plan_and_description(self):
+		ef = self._parse({'ipdSharing': 'YES', 'description': 'Available after 2 years'})
+		self.assertEqual(ef['results_ipd_plan'], 'YES')
+		self.assertEqual(ef['results_ipd_description'], 'Available after 2 years')
+
+	def test_plan_truncated_to_10_chars(self):
+		ef = self._parse({'ipdSharing': 'UNDECIDEDX_TOOLONG'})
+		self.assertLessEqual(len(ef['results_ipd_plan']), 10)
+
+	def test_absent_module_both_none(self):
+		ef = self._parse()
+		self.assertIsNone(ef['results_ipd_plan'])
+		self.assertIsNone(ef['results_ipd_description'])
+
+	def test_empty_ipd_sharing_is_none(self):
+		ef = self._parse({'ipdSharing': ''})
+		self.assertIsNone(ef['results_ipd_plan'])
+
+
+class SecondarySponsorTest(SimpleTestCase):
+	def setUp(self):
+		self.api = ClinicalTrialsGovAPI()
+
+	def _parse(self, collaborators):
+		study = _base_study(sponsorCollaboratorsModule={
+			'leadSponsor': {'name': 'Lead Corp'},
+			'collaborators': [{'name': c} for c in collaborators],
+		})
+		return self.api.parse_study_to_clinical_trial(study).extra_fields.get('secondary_sponsor')
+
+	def test_multiple_collaborators_joined(self):
+		result = self._parse(['Org A', 'Org B', 'Org C'])
+		self.assertEqual(result, 'Org A; Org B; Org C')
+
+	def test_no_collaborators_is_none(self):
+		self.assertIsNone(self._parse([]))
+
+	def test_api_order_preserved(self):
+		result = self._parse(['Z Corp', 'A Corp'])
+		self.assertEqual(result, 'Z Corp; A Corp')
+
+
+class LastRefreshedAndEnrollementTest(SimpleTestCase):
+	def setUp(self):
+		self.api = ClinicalTrialsGovAPI()
+
+	def _parse(self, last_update_date=None, start_date=None):
+		status = {'overallStatus': 'RECRUITING'}
+		if last_update_date:
+			status['lastUpdatePostDateStruct'] = {'date': last_update_date}
+		if start_date:
+			status['startDateStruct'] = {'date': start_date}
+		study = _base_study(statusModule=status)
+		return self.api.parse_study_to_clinical_trial(study).extra_fields
+
+	def test_full_date(self):
+		ef = self._parse(last_update_date='2024-03-15', start_date='2023-06-01')
+		self.assertEqual(ef['last_refreshed_on'], datetime.date(2024, 3, 15))
+		self.assertEqual(ef['date_enrollement'], datetime.date(2023, 6, 1))
+
+	def test_partial_year_month(self):
+		ef = self._parse(start_date='2022-09')
+		self.assertEqual(ef['date_enrollement'], datetime.date(2022, 9, 1))
+
+	def test_partial_year_only(self):
+		ef = self._parse(start_date='2021')
+		self.assertEqual(ef['date_enrollement'], datetime.date(2021, 1, 1))
+
+	def test_absent_dates_are_none(self):
+		ef = self._parse()
+		self.assertIsNone(ef['last_refreshed_on'])
+		self.assertIsNone(ef['date_enrollement'])
+
+
+class ContactAffiliationTest(SimpleTestCase):
+	def setUp(self):
+		self.api = ClinicalTrialsGovAPI()
+
+	def _parse(self, officials):
+		study = _base_study(contactsLocationsModule={'overallOfficials': officials})
+		return self.api.parse_study_to_clinical_trial(study).extra_fields.get('contact_affiliation')
+
+	def test_first_official_affiliation(self):
+		result = self._parse([
+			{'affiliation': 'University Hospital', 'name': 'Dr. Smith'},
+			{'affiliation': 'Other Institute', 'name': 'Dr. Jones'},
+		])
+		self.assertEqual(result, 'University Hospital')
+
+	def test_empty_officials_list_is_none(self):
+		self.assertIsNone(self._parse([]))
+
+	def test_absent_officials_key_is_none(self):
+		study = _base_study(contactsLocationsModule={})
+		result = self.api.parse_study_to_clinical_trial(study).extra_fields.get('contact_affiliation')
+		self.assertIsNone(result)
+
+
+class CountriesDeterminismTest(SimpleTestCase):
+	def setUp(self):
+		self.api = ClinicalTrialsGovAPI()
+
+	def test_countries_sorted(self):
+		study = _base_study(contactsLocationsModule={
+			'locations': [
+				{'country': 'Zimbabwe'},
+				{'country': 'Argentina'},
+				{'country': 'France'},
+			]
+		})
+		ef = self.api.parse_study_to_clinical_trial(study).extra_fields
+		countries = ef['countries']
+		parts = [c.strip() for c in countries.split(',')]
+		self.assertEqual(parts, sorted(parts))

--- a/django/gregory/tests/test_who_importer.py
+++ b/django/gregory/tests/test_who_importer.py
@@ -1,0 +1,113 @@
+"""
+Tests for the WHO ICTRP XML importer (importWHOXML).
+
+Verifies that results_url_link is captured from the XML and persists on
+both create and update paths.
+
+Run:
+  docker exec gregory python manage.py test gregory.tests.test_who_importer
+"""
+import os
+import tempfile
+
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gregory.tests.test_settings')
+django.setup()
+
+from django.test import TestCase
+from organizations.models import Organization
+
+from gregory.management.commands.importWHOXML import Command as WHOCommand
+from gregory.models import Sources, Subject, Team, Trials
+
+
+_WHO_XML_TEMPLATE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<Trials_central>
+  <Trial>
+    <TrialID>{trial_id}</TrialID>
+    <Public_title>Test Trial Results URL</Public_title>
+    <Scientific_title>Scientific Test Trial</Scientific_title>
+    <Primary_sponsor>Test Sponsor</Primary_sponsor>
+    <Date_registration>2023-01-15</Date_registration>
+    <web_address>https://trialsearch.who.int/Trial2.aspx?TrialID={trial_id}</web_address>
+    <results_url_link>{results_url_link}</results_url_link>
+    <results_yes_no>Yes</results_yes_no>
+  </Trial>
+</Trials_central>
+"""
+
+
+def _who_source():
+	org = Organization.objects.create(name='WHO Test Org')
+	team = Team.objects.create(organization=org, name='WHO Test Team', slug='who-test-team')
+	subject = Subject.objects.create(subject_name='WHO MS', subject_slug='who-ms')
+	return Sources.objects.create(
+		name='WHO ICTRP',
+		source_for='trials',
+		method='xml',
+		subject=subject,
+		team=team,
+	)
+
+
+def _run_import(xml_content, source_id):
+	with tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False) as f:
+		f.write(xml_content)
+		path = f.name
+	try:
+		cmd = WHOCommand()
+		cmd.stdout = open(os.devnull, 'w')
+		cmd.parse_xml(path, source_id)
+	finally:
+		os.unlink(path)
+		cmd.stdout.close()
+
+
+class WHOResultsUrlLinkTest(TestCase):
+	def setUp(self):
+		self.source = _who_source()
+
+	def test_create_stores_results_url_link(self):
+		xml = _WHO_XML_TEMPLATE.format(
+			trial_id='ISRCTN12345678',
+			results_url_link='https://www.isrctn.com/ISRCTN12345678#results',
+		)
+		_run_import(xml, self.source.source_id)
+		t = Trials.objects.get(identifiers__isrctn='ISRCTN12345678')
+		self.assertEqual(t.results_url_link, 'https://www.isrctn.com/ISRCTN12345678#results')
+
+	def test_update_fills_empty_results_url_link(self):
+		xml_no_url = _WHO_XML_TEMPLATE.format(
+			trial_id='ISRCTN11111111',
+			results_url_link='',
+		)
+		_run_import(xml_no_url, self.source.source_id)
+		t = Trials.objects.get(identifiers__isrctn='ISRCTN11111111')
+		self.assertFalse(t.results_url_link)
+
+		xml_with_url = _WHO_XML_TEMPLATE.format(
+			trial_id='ISRCTN11111111',
+			results_url_link='https://www.isrctn.com/ISRCTN11111111#results',
+		)
+		_run_import(xml_with_url, self.source.source_id)
+		t.refresh_from_db()
+		self.assertEqual(t.results_url_link, 'https://www.isrctn.com/ISRCTN11111111#results')
+
+	def test_update_does_not_blank_results_url_link(self):
+		xml_with_url = _WHO_XML_TEMPLATE.format(
+			trial_id='ISRCTN22222222',
+			results_url_link='https://www.isrctn.com/ISRCTN22222222#results',
+		)
+		_run_import(xml_with_url, self.source.source_id)
+		t = Trials.objects.get(identifiers__isrctn='ISRCTN22222222')
+		self.assertEqual(t.results_url_link, 'https://www.isrctn.com/ISRCTN22222222#results')
+
+		xml_no_url = _WHO_XML_TEMPLATE.format(
+			trial_id='ISRCTN22222222',
+			results_url_link='',
+		)
+		_run_import(xml_no_url, self.source.source_id)
+		t.refresh_from_db()
+		self.assertEqual(t.results_url_link, 'https://www.isrctn.com/ISRCTN22222222#results')

--- a/django/gregory/tests/test_who_importer.py
+++ b/django/gregory/tests/test_who_importer.py
@@ -57,12 +57,12 @@ def _run_import(xml_content, source_id):
 		f.write(xml_content)
 		path = f.name
 	try:
-		cmd = WHOCommand()
-		cmd.stdout = open(os.devnull, 'w')
-		cmd.parse_xml(path, source_id)
+		with open(os.devnull, 'w') as devnull:
+			cmd = WHOCommand()
+			cmd.stdout = devnull
+			cmd.parse_xml(path, source_id)
 	finally:
 		os.unlink(path)
-		cmd.stdout.close()
 
 
 class WHOResultsUrlLinkTest(TestCase):


### PR DESCRIPTION
## Summary

Wires up six `Trials` columns that the importers were already receiving from upstream but silently dropping — pure importer changes, **no model changes, no migrations**.

| # | Field(s) | Source | Gap |
|---|---|---|---|
| 1 | `results_url_link` | WHO ICTRP XML | Tag present in export, missing from plain-field list |
| 2 | `study_design` | ClinicalTrials.gov API | WHO-only; now composed from `designModule.designInfo` |
| 3 | `results_ipd_plan`, `results_ipd_description` | ClinicalTrials.gov API | WHO-only; now from `ipdSharingStatementModule` |
| 4 | `secondary_sponsor` | ClinicalTrials.gov API | Collaborators were parsed but then discarded |
| 5 | `last_refreshed_on` | ClinicalTrials.gov API | WHO + EUCTIS only; now from `lastUpdatePostDateStruct` |
| 6 | `date_enrollement`, `contact_affiliation` | ClinicalTrials.gov API | WHO-only; enrollment from `startDateStruct`, affiliation from `overallOfficials[0]` |

**Bonus:** `countries` string is now built with `sorted(set(...))` instead of `list(set(...))`, making it deterministic and preventing spurious `HistoricalRecords` rows on repeated pipeline runs with identical data.

## What changed

- **`django/gregory/management/commands/importWHOXML.py`** — added `results_url_link` to the plain-field list; flows through the existing non-destructive update path unchanged.
- **`django/gregory/classes.py`** (`parse_study_to_clinical_trial`) — extracts and exposes the six new keys in `extra_fields`; `study_design` is a deterministic human-readable string (parts joined with `. `); `whoMasked` list is sorted; `results_ipd_plan` truncated to 10 chars to fit `CharField(max_length=10)`; `contact_affiliation` guards against absent/empty `overallOfficials`.
- **`django/gregory/management/commands/feedreader_trials_ctgov.py`** — each new key added in both `create_new_trial` kwargs **and** `extra_field_mapping` in `update_existing_trial` (the two-place rule from the plan; this is exactly the gap that caused `secondary_sponsor` to be lost).

## Update semantics

All new fields use the existing **non-destructive merge**: only overwrite when the incoming value is non-empty, so a missing field never blanks data a previous source populated (matches `docs/trials-multi-source-merge.md`).

## Tests

Three new test modules, 37 new tests — all green:

- `gregory/tests/test_ctgov_tier1_fields.py` — parser unit tests (20 tests): each new field, edge cases (absent module → `None`, partial dates, sorted `whoMasked`, determinism).
- `gregory/tests/management/test_ctgov_tier1_fields.py` — command integration tests (14 tests): create stores each field; update replaces non-empty values but never blanks existing ones.
- `gregory/tests/test_who_importer.py` — WHO importer integration tests (3 tests): `results_url_link` on create, fill-empty update, and non-blank guard.

Full suite: **467/467 pass**. `makemigrations --check --dry-run` confirms no schema changes.

## Test plan

- [ ] `docker exec gregory python manage.py test gregory.tests.test_ctgov_tier1_fields` — 20 tests
- [ ] `docker exec gregory python manage.py test gregory.tests.management.test_ctgov_tier1_fields` — 14 tests
- [ ] `docker exec gregory python manage.py test gregory.tests.test_who_importer` — 3 tests
- [ ] `docker exec gregory python manage.py test gregory.tests` — full suite (467 tests)
- [ ] `docker exec gregory python manage.py makemigrations --check --dry-run` — no changes
- [ ] After merging, run the one-time `backfill_trial_acronyms` command on prod if not yet done (see memory note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)