### PR TITLE
fix(api): stop search views swallowing all errors as empty results

### DIFF
--- a/django/api/views.py
+++ b/django/api/views.py
@@ -21,6 +21,7 @@ from django.http import Http404, StreamingHttpResponse
 from rest_framework.views import APIView
 from rest_framework_simplejwt.views import TokenObtainPairView
 import json
+import logging
 import traceback
 from django.utils.dateparse import parse_date
 
@@ -1776,7 +1777,13 @@ class ArticleSearchView(generics.ListAPIView):
                 )
                 
             return queryset
-        except:  # noqa: E722
+        except (AttributeError, TypeError, ValueError) as e:
+            # Malformed search params (e.g. a non-string title/summary/search
+            # from a JSON POST body): return no matches, but log it so a genuine
+            # bug can't hide as an empty result. Anything unexpected propagates.
+            logging.getLogger(__name__).warning(
+                "ArticleSearchView: ignoring malformed search params (%s)", e
+            )
             return Articles.objects.none()
     
     def filter_queryset(self, queryset):
@@ -2095,11 +2102,13 @@ class AuthorSearchView(generics.ListAPIView):
                 queryset = queryset.filter(full_name__icontains=full_name)
 
             return queryset
-        except Exception as e:
-            # Log the exception for debugging
-            import logging
-            logger = logging.getLogger(__name__)
-            logger.error(f"Error in AuthorSearchView.get_queryset: {str(e)}")
+        except (AttributeError, TypeError, ValueError) as e:
+            # Malformed search params (e.g. a non-string full_name from a JSON
+            # POST body): return no matches, but log it so a genuine bug can't
+            # hide as an empty result. Anything unexpected propagates.
+            logging.getLogger(__name__).warning(
+                "AuthorSearchView: ignoring malformed search params (%s)", e
+            )
             return Authors.objects.none()
 
     def post(self, request, *args, **kwargs):

--- a/docs/lint-triage.md
+++ b/docs/lint-triage.md
@@ -73,7 +73,7 @@ empty result or a no-op. Narrow the exception and log the rest.
 
 | Site | Risk | Suggested |
 | --- | --- | --- |
-| [`api/views.py:1780`](../django/api/views.py) | Any exception in search filtering becomes "0 results" — a bug silently looks like an empty search. | Catch the expected query/value errors, `logger.warning(...)` anything else (or let it 500). |
+| ✅ [`api/views.py:1780`](../django/api/views.py) | Any exception in search filtering becomes "0 results" — a bug silently looks like an empty search. | **Done** — narrowed to `(AttributeError, TypeError, ValueError)` + `logger.warning`, rest propagates. `AuthorSearchView` aligned too. |
 | [`gregory/admin.py:76,144`](../django/gregory/admin.py) | Errors in admin org-scoping / choice-filtering are swallowed; could hide an org-visibility bug. | Narrow to the expected lookup error, log the rest. |
 | [`indexers/sage.py:23`](../django/indexers/sage.py) | bare `except:` on `Articles.objects.create()` treats *every* error as a uniqueness collision; `print()` instead of logging. **Also verify this module is still used** — it reads a top-level `input` and looks like a standalone script. | If kept: `except IntegrityError:` + `logger.warning(...)`. If dead: delete. |
 


### PR DESCRIPTION
Part of the empty-catch lint-gate worklist (Group C). **Stacked on `chore/ruff-lint-gate`** — review that one first.

`ArticleSearchView` and `AuthorSearchView` caught **every** exception in `get_queryset()` and returned an empty queryset, so a genuine bug surfaced as an empty search result instead of an error.

## Changes
- Narrow both to `(AttributeError, TypeError, ValueError)` — the realistic malformed-param errors from a JSON POST body — and log them.
- Let any unexpected exception propagate instead of hiding it.
- Add module-level `import logging` (was a local import).

## Validation
- Full suite: **1179 passed**.
- Lint gate green.

Retires the `api/views.py:1780` item from `docs/lint-triage.md` Group C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
