### PR TITLE
fix(admin): stop org-scoping filters swallowing all errors

### DIFF
--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -3,12 +3,14 @@ from io import StringIO
 from django.contrib import admin, messages
 from django.apps import apps
 from django.core.management import call_command
+from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.urls import path, reverse
 import csv
+import logging
 from simple_history.admin import SimpleHistoryAdmin  # Import SimpleHistoryAdmin
 from .admin_filters import DateRangeFilter, SourceHealthFilter
 from django.db import models  # Add this import for models.Count
@@ -72,9 +74,13 @@ class OrganizationRestrictedFieldListFilter(admin.RelatedFieldListFilter):
 				else:
 					# If no organization field, include it
 					filtered_choices.append((choice_value, choice_label))
-			except:  # noqa: E722, S110
-				pass
-		
+			except (ObjectDoesNotExist, AttributeError, ValueError, TypeError) as e:
+				# Fail closed: if a choice's org can't be resolved, omit it rather
+				# than risk leaking it; logged so a systematic failure stays visible.
+				logging.getLogger(__name__).warning(
+					"OrganizationRestrictedFieldListFilter: skipping choice %r (%s)", choice_value, e
+				)
+
 		return filtered_choices
 
 
@@ -139,11 +145,10 @@ class OrganizationFilterMixin:
 		try:
 			# Check if 'teams' is a M2M field
 			qs.model._meta.get_field('teams')
-			return qs.filter(teams__organization__id__in=user_orgs).distinct()
-		except:  # noqa: E722, S110
-			pass
-		
-		return qs
+		except FieldDoesNotExist:
+			# Model has no 'teams' field; fall through to the unscoped queryset.
+			return qs
+		return qs.filter(teams__organization__id__in=user_orgs).distinct()
 
 
 # @admin.register(PredictionRunLog)

--- a/django/gregory/tests/test_admin_org_filter.py
+++ b/django/gregory/tests/test_admin_org_filter.py
@@ -1,0 +1,75 @@
+"""
+Tests for gregory.admin.OrganizationFilterMixin.get_queryset — the Django admin
+queryset scoping that limits non-superusers to their own organisation's objects.
+
+Guards the fix where a bare `except: pass` could silently return the UNFILTERED
+queryset (an org-visibility leak) when the team-scoping branch raised.
+
+Run with:
+    docker exec gregory python manage.py test gregory.tests.test_admin_org_filter
+"""
+from django.contrib import admin
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.test import TestCase, RequestFactory
+from organizations.models import Organization, OrganizationUser
+
+from gregory.admin import OrganizationFilterMixin
+from gregory.models import Articles, Authors, Team
+
+User = get_user_model()
+
+
+class _ArticleOrgAdmin(OrganizationFilterMixin, admin.ModelAdmin):
+	"""Minimal admin exercising the mixin on a model with a `teams` M2M."""
+
+
+class _AuthorOrgAdmin(OrganizationFilterMixin, admin.ModelAdmin):
+	"""Minimal admin on a model with no team/org relationship."""
+
+
+class OrganizationFilterMixinTests(TestCase):
+	def setUp(self):
+		self.factory = RequestFactory()
+		self.site = AdminSite()
+
+		self.org_a = Organization.objects.create(name='Org A', slug='org-a-admin')
+		self.org_b = Organization.objects.create(name='Org B', slug='org-b-admin')
+		self.team_a = Team.objects.create(organization=self.org_a, name='Team A', slug='team-a-admin')
+		self.team_b = Team.objects.create(organization=self.org_b, name='Team B', slug='team-b-admin')
+
+		self.article_a = Articles.objects.create(title='Article A', link='https://example.com/a')
+		self.article_a.teams.add(self.team_a)
+		self.article_b = Articles.objects.create(title='Article B', link='https://example.com/b')
+		self.article_b.teams.add(self.team_b)
+
+		# Non-superuser belonging only to org A.
+		self.user = User.objects.create_user(username='org-a-user', password='pw')
+		OrganizationUser.objects.create(organization=self.org_a, user=self.user)
+
+		self.superuser = User.objects.create_superuser(username='root', email='r@e.com', password='pw')
+
+	def _queryset_for(self, admin_cls, model, user):
+		model_admin = admin_cls(model, self.site)
+		request = self.factory.get('/admin/')
+		request.user = user
+		return model_admin.get_queryset(request)
+
+	def test_superuser_sees_all_articles(self):
+		qs = self._queryset_for(_ArticleOrgAdmin, Articles, self.superuser)
+		self.assertIn(self.article_a, qs)
+		self.assertIn(self.article_b, qs)
+
+	def test_non_superuser_sees_only_their_org(self):
+		# Regression guard: an org-A user must NOT see org-B's article. If the
+		# mixin ever falls back to the unfiltered queryset, this fails.
+		qs = self._queryset_for(_ArticleOrgAdmin, Articles, self.user)
+		self.assertIn(self.article_a, qs)
+		self.assertNotIn(self.article_b, qs)
+
+	def test_model_without_teams_falls_through_unscoped(self):
+		# Authors has no organisation/team/teams: the FieldDoesNotExist branch
+		# returns the queryset unchanged (these models aren't org-scoped).
+		author = Authors.objects.create(given_name='Jane', family_name='Doe')
+		qs = self._queryset_for(_AuthorOrgAdmin, Authors, self.user)
+		self.assertIn(author, qs)

--- a/docs/lint-triage.md
+++ b/docs/lint-triage.md
@@ -74,7 +74,7 @@ empty result or a no-op. Narrow the exception and log the rest.
 | Site | Risk | Suggested |
 | --- | --- | --- |
 | ✅ [`api/views.py:1780`](../django/api/views.py) | Any exception in search filtering becomes "0 results" — a bug silently looks like an empty search. | **Done** — narrowed to `(AttributeError, TypeError, ValueError)` + `logger.warning`, rest propagates. `AuthorSearchView` aligned too. |
-| [`gregory/admin.py:76,144`](../django/gregory/admin.py) | Errors in admin org-scoping / choice-filtering are swallowed; could hide an org-visibility bug. | Narrow to the expected lookup error, log the rest. |
+| ✅ [`gregory/admin.py:75,143`](../django/gregory/admin.py) | Errors in admin org-scoping / choice-filtering were swallowed; could hide an org-visibility bug. | **Done** — `field_choices` narrowed to `(ObjectDoesNotExist, AttributeError, ValueError, TypeError)` + log (fail-closed); `get_queryset` narrowed to `FieldDoesNotExist`, so a filter error now propagates instead of silently returning the **unfiltered** queryset. |
 | [`indexers/sage.py:23`](../django/indexers/sage.py) | bare `except:` on `Articles.objects.create()` treats *every* error as a uniqueness collision; `print()` instead of logging. **Also verify this module is still used** — it reads a top-level `input` and looks like a standalone script. | If kept: `except IntegrityError:` + `logger.warning(...)`. If dead: delete. |
 
 ---


### PR DESCRIPTION
Part of the empty-catch lint-gate worklist (Group C). **Stacked on `fix/search-view-error-handling`** — review that one first.

`OrganizationRestrictedFieldListFilter.field_choices` and `OrganizationFilterMixin.get_queryset` used bare `except: pass`, hiding failures in Django-admin org-visibility scoping.

## Changes
- `field_choices`: narrow to `(ObjectDoesNotExist, AttributeError, ValueError, TypeError)` + log; keep fail-closed (skip the choice).
- `get_queryset`: narrow to `FieldDoesNotExist` (the "no teams field" control-flow signal). **Security:** a filter error now propagates instead of silently returning the *unfiltered* queryset — a potential cross-org leak.
- Add `gregory/tests/test_admin_org_filter.py`: superuser bypass, non-superuser org scoping (the leak guard), and the no-teams fallthrough. **Mutation-checked** — the guard fails if scoping is removed.

## Validation
- Full suite: **1182 passed** (incl. 3 new tests).
- Lint gate green.

Retires the `gregory/admin.py` item from `docs/lint-triage.md` Group C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
