### PR TITLE
fix: TypeError in PredictionRunLog admin changelist (Django 6.0 format_html)

### DIFF
--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -2412,17 +2412,16 @@ class PredictionRunLogAdmin(OrganizationFilterMixin, admin.ModelAdmin):
 
 	def status_label(self, obj):
 		if obj.success is True:
-			return format_html(
-				'<span style="color: green; font-weight: bold;">Success</span>'
-			)
+			color, label = "green", "Success"
 		elif obj.success is False:
-			return format_html(
-				'<span style="color: red; font-weight: bold;">Failed</span>'
-			)
+			color, label = "red", "Failed"
 		else:
-			return format_html(
-				'<span style="color: orange; font-weight: bold;">Running</span>'
-			)
+			color, label = "orange", "Running"
+		return format_html(
+			'<span style="color: {}; font-weight: bold;">{}</span>',
+			color,
+			label,
+		)
 
 	status_label.short_description = "Status"
 


### PR DESCRIPTION
## Summary

- Django 6.0 added a strict guard in `format_html()` that raises `TypeError: args or kwargs must be provided.` when the function is called with only a format string and no interpolation arguments.
- `PredictionRunLogAdmin.status_label` was calling `format_html()` with static HTML strings (no `{}` placeholders and no arguments) in all three branches, triggering this error every time the `/admin/gregory/predictionrunlog/` changelist rendered.
- Fixed by extracting `color` and `label` as variables and passing them as proper format arguments to a single `format_html()` call — which is also the correct pattern for safely interpolating dynamic values into HTML.

## What changed

`django/gregory/admin.py` — `PredictionRunLogAdmin.status_label`: replaced three separate `format_html(static_string)` calls (no args) with one `format_html(template, color, label)` call.

## Test plan

- [ ] Visit `/admin/gregory/predictionrunlog/` — page should load without `TypeError`
- [ ] Confirm the Status column renders green/red/orange labels correctly for success/failed/running rows