### PR TITLE
feat: date-range filters for /articles/ and /trials/ endpoints

### DIFF
--- a/django/api/filters.py
+++ b/django/api/filters.py
@@ -96,14 +96,12 @@ class ArticleFilter(SubjectANDFilterMixin, filters.FilterSet):
 		method="filter_has_clinical_trials", label="Has Clinical Trials"
 	)
 	published_date_after = filters.DateFilter(
-		field_name="published_date",
-		lookup_expr="date__gte",
+		method="filter_published_date_after",
 		input_formats=["%Y-%m-%d"],
 		label="Published date on or after (YYYY-MM-DD)",
 	)
 	published_date_before = filters.DateFilter(
-		field_name="published_date",
-		lookup_expr="date__lte",
+		method="filter_published_date_before",
 		input_formats=["%Y-%m-%d"],
 		label="Published date on or before (YYYY-MM-DD)",
 	)
@@ -387,6 +385,18 @@ class ArticleFilter(SubjectANDFilterMixin, filters.FilterSet):
 		if value:
 			return queryset.filter(trial_references__isnull=False).distinct()
 		return queryset.filter(trial_references__isnull=True)
+
+	def filter_published_date_after(self, queryset, name, value):
+		# Use datetime boundary so the btree index on published_date is usable.
+		start = timezone.make_aware(datetime(value.year, value.month, value.day))
+		return queryset.filter(published_date__gte=start)
+
+	def filter_published_date_before(self, queryset, name, value):
+		# Strict less-than start of next day keeps whole-day inclusive semantics
+		# while allowing the btree index on published_date to be used.
+		next_day = value + timedelta(days=1)
+		end = timezone.make_aware(datetime(next_day.year, next_day.month, next_day.day))
+		return queryset.filter(published_date__lt=end)
 
 
 class TrialFilter(SubjectANDFilterMixin, filters.FilterSet):

--- a/django/api/filters.py
+++ b/django/api/filters.py
@@ -95,6 +95,18 @@ class ArticleFilter(SubjectANDFilterMixin, filters.FilterSet):
 	has_clinical_trials = filters.BooleanFilter(
 		method="filter_has_clinical_trials", label="Has Clinical Trials"
 	)
+	published_date_after = filters.DateFilter(
+		field_name="published_date",
+		lookup_expr="date__gte",
+		input_formats=["%Y-%m-%d"],
+		label="Published date on or after (YYYY-MM-DD)",
+	)
+	published_date_before = filters.DateFilter(
+		field_name="published_date",
+		lookup_expr="date__lte",
+		input_formats=["%Y-%m-%d"],
+		label="Published date on or before (YYYY-MM-DD)",
+	)
 
 	class Meta:
 		model = Articles
@@ -117,6 +129,8 @@ class ArticleFilter(SubjectANDFilterMixin, filters.FilterSet):
 			"week",
 			"year",
 			"has_clinical_trials",
+			"published_date_after",
+			"published_date_before",
 		]
 
 	def filter_title(self, queryset, name, value):
@@ -485,6 +499,20 @@ class TrialFilter(SubjectANDFilterMixin, filters.FilterSet):
 		label="Has results posted (results_posted flag, results completion date, results link, or results available = Yes)",
 	)
 
+	# Date-range filters
+	date_registration_after = filters.DateFilter(
+		field_name="date_registration",
+		lookup_expr="gte",
+		input_formats=["%Y-%m-%d"],
+		label="Date registered on or after (YYYY-MM-DD)",
+	)
+	date_registration_before = filters.DateFilter(
+		field_name="date_registration",
+		lookup_expr="lte",
+		input_formats=["%Y-%m-%d"],
+		label="Date registered on or before (YYYY-MM-DD)",
+	)
+
 	class Meta:
 		model = Trials
 		fields = [
@@ -518,6 +546,8 @@ class TrialFilter(SubjectANDFilterMixin, filters.FilterSet):
 			"inclusion_agemax",
 			"inclusion_gender",
 			"has_results",
+			"date_registration_after",
+			"date_registration_before",
 		]
 
 	def filter_title(self, queryset, name, value):

--- a/django/api/tests/test_date_range_filter_articles.py
+++ b/django/api/tests/test_date_range_filter_articles.py
@@ -1,0 +1,198 @@
+from datetime import datetime
+
+from django.test import TestCase, RequestFactory
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from api.filters import ArticleFilter
+from gregory.models import Articles, Organization, OrganizationApiSettings, Subject, Team
+
+
+class ArticleDateRangeFilterTests(TestCase):
+	"""Tests for published_date_after / published_date_before on ArticleFilter."""
+
+	def setUp(self):
+		self.factory = RequestFactory()
+
+		self.org = Organization.objects.create(name="Date Test Org", slug="date-test-org")
+		OrganizationApiSettings.objects.filter(organization=self.org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="Date Test Team", slug="date-test-team", organization=self.org
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Date Subject",
+			subject_slug="date-subject",
+			team=self.team,
+		)
+
+		def make_article(title, link, pub_date):
+			a = Articles.objects.create(title=title, link=link)
+			a.published_date = pub_date
+			a.save(update_fields=["published_date"])
+			a.teams.add(self.team)
+			a.subjects.add(self.subject)
+			return a
+
+		# Spread articles across 2022-2024 including boundary edge cases
+		self.a_2022 = make_article(
+			"Article 2022-06-01",
+			"https://example.com/1",
+			timezone.make_aware(datetime(2022, 6, 1, 9, 0)),
+		)
+		self.a_2023_start = make_article(
+			"Article 2023-01-01",
+			"https://example.com/2",
+			timezone.make_aware(datetime(2023, 1, 1, 0, 0)),
+		)
+		# Late on the end-boundary day — the key test for DateTimeField inclusive-end
+		self.a_2023_end = make_article(
+			"Article 2023-12-31 late",
+			"https://example.com/3",
+			timezone.make_aware(datetime(2023, 12, 31, 23, 30)),
+		)
+		self.a_2024 = make_article(
+			"Article 2024-02-01",
+			"https://example.com/4",
+			timezone.make_aware(datetime(2024, 2, 1, 12, 0)),
+		)
+		# Article with no published_date (NULL)
+		self.a_null = Articles.objects.create(
+			title="No pub date",
+			link="https://example.com/null",
+		)
+		self.a_null.teams.add(self.team)
+
+	def _filter(self, params):
+		request = self.factory.get("/articles/", params)
+		qs = Articles.objects.all()
+		return ArticleFilter(request.GET, queryset=qs, request=request).qs
+
+	# --- after only ---
+
+	def test_after_only(self):
+		qs = self._filter({"published_date_after": "2023-01-01"})
+		pks = set(qs.values_list("article_id", flat=True))
+		self.assertIn(self.a_2023_start.article_id, pks)
+		self.assertIn(self.a_2023_end.article_id, pks)
+		self.assertIn(self.a_2024.article_id, pks)
+		self.assertNotIn(self.a_2022.article_id, pks)
+
+	def test_after_boundary_inclusive(self):
+		qs = self._filter({"published_date_after": "2022-06-01"})
+		pks = set(qs.values_list("article_id", flat=True))
+		self.assertIn(self.a_2022.article_id, pks)
+
+	# --- before only ---
+
+	def test_before_only(self):
+		qs = self._filter({"published_date_before": "2023-12-31"})
+		pks = set(qs.values_list("article_id", flat=True))
+		self.assertIn(self.a_2022.article_id, pks)
+		self.assertIn(self.a_2023_start.article_id, pks)
+		# Late on 2023-12-31 must be included (whole-day inclusive end via __date__lte)
+		self.assertIn(self.a_2023_end.article_id, pks)
+		self.assertNotIn(self.a_2024.article_id, pks)
+
+	def test_before_boundary_inclusive(self):
+		qs = self._filter({"published_date_before": "2024-02-01"})
+		pks = set(qs.values_list("article_id", flat=True))
+		self.assertIn(self.a_2024.article_id, pks)
+
+	# --- closed range ---
+
+	def test_closed_range(self):
+		qs = self._filter({
+			"published_date_after": "2023-01-01",
+			"published_date_before": "2023-12-31",
+		})
+		pks = set(qs.values_list("article_id", flat=True))
+		self.assertIn(self.a_2023_start.article_id, pks)
+		self.assertIn(self.a_2023_end.article_id, pks)
+		self.assertNotIn(self.a_2022.article_id, pks)
+		self.assertNotIn(self.a_2024.article_id, pks)
+
+	def test_closed_range_count(self):
+		qs = self._filter({
+			"published_date_after": "2023-01-01",
+			"published_date_before": "2023-12-31",
+		})
+		self.assertEqual(qs.count(), 2)
+
+	# --- no params is a no-op ---
+
+	def test_no_date_params_returns_all(self):
+		qs = self._filter({})
+		self.assertEqual(qs.count(), Articles.objects.count())
+
+	# --- NULL published_date rows are excluded by both filters ---
+
+	def test_null_published_date_excluded(self):
+		qs = self._filter({"published_date_after": "2020-01-01"})
+		pks = set(qs.values_list("article_id", flat=True))
+		self.assertNotIn(self.a_null.article_id, pks)
+
+	# --- compose with subjects ---
+
+	def test_compose_with_subjects(self):
+		qs = self._filter({
+			"published_date_after": "2023-01-01",
+			"published_date_before": "2023-12-31",
+			"subjects": str(self.subject.id),
+		})
+		self.assertEqual(qs.count(), 2)
+
+	# --- compose with search ---
+
+	def test_compose_with_search(self):
+		qs = self._filter({
+			"published_date_after": "2023-01-01",
+			"published_date_before": "2023-12-31",
+			"search": "2023-01-01",
+		})
+		self.assertEqual(qs.count(), 1)
+		self.assertEqual(qs.first().article_id, self.a_2023_start.article_id)
+
+
+class ArticleDateRangeAPITests(TestCase):
+	"""HTTP-level tests: valid params return 200, invalid dates return 400."""
+
+	def setUp(self):
+		self.client = APIClient()
+
+		self.org = Organization.objects.create(
+			name="API Date Org", slug="api-date-org"
+		)
+		OrganizationApiSettings.objects.filter(organization=self.org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="API Date Team", slug="api-date-team", organization=self.org
+		)
+
+	def test_valid_date_range_returns_200(self):
+		response = self.client.get(
+			"/articles/",
+			{"published_date_after": "2023-01-01", "published_date_before": "2023-12-31"},
+		)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+	def test_invalid_month_returns_400(self):
+		response = self.client.get(
+			"/articles/", {"published_date_after": "2023-13-40"}
+		)
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+	def test_non_date_string_returns_400(self):
+		response = self.client.get(
+			"/articles/", {"published_date_after": "not-a-date"}
+		)
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+	def test_non_iso_format_returns_400(self):
+		response = self.client.get(
+			"/articles/", {"published_date_before": "31/12/2023"}
+		)
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/django/api/tests/test_date_range_filter_trials.py
+++ b/django/api/tests/test_date_range_filter_trials.py
@@ -29,9 +29,13 @@ class TrialDateRangeFilterTests(TestCase):
 			team=self.team,
 		)
 
+		self._link_n = 0
+
 		def make_trial(title, reg_date):
+			self._link_n += 1
 			t = Trials.objects.create(
 				title=title,
+				link=f"https://example.com/trial-{self._link_n}",
 				date_registration=reg_date,
 			)
 			t.teams.add(self.team)
@@ -44,7 +48,9 @@ class TrialDateRangeFilterTests(TestCase):
 		self.t_2022_end = make_trial("Trial 2022-12-31", date(2022, 12, 31))
 		self.t_2023 = make_trial("Trial 2023-03-10", date(2023, 3, 10))
 		# Trial with NULL date_registration
-		self.t_null = Trials.objects.create(title="Trial no date")
+		self.t_null = Trials.objects.create(
+			title="Trial no date", link="https://example.com/trial-null"
+		)
 		self.t_null.teams.add(self.team)
 
 	def _filter(self, params):

--- a/django/api/tests/test_date_range_filter_trials.py
+++ b/django/api/tests/test_date_range_filter_trials.py
@@ -1,0 +1,189 @@
+from datetime import date
+
+from django.test import TestCase, RequestFactory
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from api.filters import TrialFilter
+from gregory.models import Organization, OrganizationApiSettings, Subject, Team, Trials
+
+
+class TrialDateRangeFilterTests(TestCase):
+	"""Tests for date_registration_after / date_registration_before on TrialFilter."""
+
+	def setUp(self):
+		self.factory = RequestFactory()
+
+		self.org = Organization.objects.create(
+			name="Trial Date Org", slug="trial-date-org"
+		)
+		OrganizationApiSettings.objects.filter(organization=self.org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="Trial Date Team", slug="trial-date-team", organization=self.org
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Trial Date Subject",
+			subject_slug="trial-date-subject",
+			team=self.team,
+		)
+
+		def make_trial(title, reg_date):
+			t = Trials.objects.create(
+				title=title,
+				date_registration=reg_date,
+			)
+			t.teams.add(self.team)
+			t.subjects.add(self.subject)
+			return t
+
+		self.t_2018 = make_trial("Trial 2018-06-15", date(2018, 6, 15))
+		self.t_2019 = make_trial("Trial 2019-01-01", date(2019, 1, 1))
+		self.t_2021 = make_trial("Trial 2021-07-20", date(2021, 7, 20))
+		self.t_2022_end = make_trial("Trial 2022-12-31", date(2022, 12, 31))
+		self.t_2023 = make_trial("Trial 2023-03-10", date(2023, 3, 10))
+		# Trial with NULL date_registration
+		self.t_null = Trials.objects.create(title="Trial no date")
+		self.t_null.teams.add(self.team)
+
+	def _filter(self, params):
+		request = self.factory.get("/trials/", params)
+		qs = Trials.objects.all()
+		return TrialFilter(request.GET, queryset=qs, request=request).qs
+
+	# --- after only ---
+
+	def test_after_only(self):
+		qs = self._filter({"date_registration_after": "2019-01-01"})
+		pks = set(qs.values_list("trial_id", flat=True))
+		self.assertIn(self.t_2019.trial_id, pks)
+		self.assertIn(self.t_2021.trial_id, pks)
+		self.assertIn(self.t_2022_end.trial_id, pks)
+		self.assertIn(self.t_2023.trial_id, pks)
+		self.assertNotIn(self.t_2018.trial_id, pks)
+
+	def test_after_boundary_inclusive(self):
+		qs = self._filter({"date_registration_after": "2018-06-15"})
+		pks = set(qs.values_list("trial_id", flat=True))
+		self.assertIn(self.t_2018.trial_id, pks)
+
+	# --- before only ---
+
+	def test_before_only(self):
+		qs = self._filter({"date_registration_before": "2022-12-31"})
+		pks = set(qs.values_list("trial_id", flat=True))
+		self.assertIn(self.t_2018.trial_id, pks)
+		self.assertIn(self.t_2019.trial_id, pks)
+		self.assertIn(self.t_2021.trial_id, pks)
+		self.assertIn(self.t_2022_end.trial_id, pks)
+		self.assertNotIn(self.t_2023.trial_id, pks)
+
+	def test_before_boundary_inclusive(self):
+		qs = self._filter({"date_registration_before": "2022-12-31"})
+		pks = set(qs.values_list("trial_id", flat=True))
+		self.assertIn(self.t_2022_end.trial_id, pks)
+
+	# --- closed range ---
+
+	def test_closed_range(self):
+		qs = self._filter({
+			"date_registration_after": "2019-01-01",
+			"date_registration_before": "2022-12-31",
+		})
+		pks = set(qs.values_list("trial_id", flat=True))
+		self.assertIn(self.t_2019.trial_id, pks)
+		self.assertIn(self.t_2021.trial_id, pks)
+		self.assertIn(self.t_2022_end.trial_id, pks)
+		self.assertNotIn(self.t_2018.trial_id, pks)
+		self.assertNotIn(self.t_2023.trial_id, pks)
+
+	def test_closed_range_count(self):
+		qs = self._filter({
+			"date_registration_after": "2019-01-01",
+			"date_registration_before": "2022-12-31",
+		})
+		self.assertEqual(qs.count(), 3)
+
+	# --- no params is a no-op ---
+
+	def test_no_date_params_returns_all(self):
+		qs = self._filter({})
+		self.assertEqual(qs.count(), Trials.objects.count())
+
+	# --- NULL date_registration rows are excluded by date filters ---
+
+	def test_null_date_excluded(self):
+		qs = self._filter({"date_registration_after": "2010-01-01"})
+		pks = set(qs.values_list("trial_id", flat=True))
+		self.assertNotIn(self.t_null.trial_id, pks)
+
+	# --- compose with subjects ---
+
+	def test_compose_with_subjects(self):
+		qs = self._filter({
+			"date_registration_after": "2019-01-01",
+			"date_registration_before": "2022-12-31",
+			"subjects": str(self.subject.id),
+		})
+		self.assertEqual(qs.count(), 3)
+
+	# --- compose with phase ---
+
+	def test_compose_with_phase(self):
+		self.t_2021.phase = "PHASE3"
+		self.t_2021.save(update_fields=["phase"])
+		qs = self._filter({
+			"date_registration_after": "2019-01-01",
+			"date_registration_before": "2022-12-31",
+			"phase": "PHASE3",
+		})
+		self.assertEqual(qs.count(), 1)
+		self.assertEqual(qs.first().trial_id, self.t_2021.trial_id)
+
+
+class TrialDateRangeAPITests(TestCase):
+	"""HTTP-level tests: valid params return 200, invalid dates return 400."""
+
+	def setUp(self):
+		self.client = APIClient()
+
+		self.org = Organization.objects.create(
+			name="API Trial Date Org", slug="api-trial-date-org"
+		)
+		OrganizationApiSettings.objects.filter(organization=self.org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="API Trial Date Team",
+			slug="api-trial-date-team",
+			organization=self.org,
+		)
+
+	def test_valid_date_range_returns_200(self):
+		response = self.client.get(
+			"/trials/",
+			{
+				"date_registration_after": "2019-01-01",
+				"date_registration_before": "2022-12-31",
+			},
+		)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+	def test_invalid_month_returns_400(self):
+		response = self.client.get(
+			"/trials/", {"date_registration_after": "2023-13-40"}
+		)
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+	def test_non_date_string_returns_400(self):
+		response = self.client.get(
+			"/trials/", {"date_registration_after": "not-a-date"}
+		)
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+	def test_non_iso_format_returns_400(self):
+		response = self.client.get(
+			"/trials/", {"date_registration_before": "31/12/2023"}
+		)
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary

- Adds `published_date_after` / `published_date_before` query params to `ArticleFilter` (filters `Articles.published_date`, a `DateTimeField`)
- Adds `date_registration_after` / `date_registration_before` query params to `TrialFilter` (filters `Trials.date_registration`, a `DateField`)
- No model or migration changes — both target fields already exist

## Why

The Advanced Search UI at `/search/` renders date-range inputs as disabled with the note "Date filtering pending API support." These params are the backend half; the frontend can now simply drop the `disabled` attribute.

## Implementation notes

- **`DateTimeField` inclusive-end semantics**: `lookup_expr="date__gte"` / `"date__lte"` applies the `__date` transform so that e.g. `published_date_before=2023-12-31` includes articles published at `2023-12-31 23:30`, not just at midnight.
- **`DateField`**: plain `gte` / `lte` suffices for `date_registration`.
- **400 on invalid input**: enforced automatically by `DjangoFilterBackend` (`raise_exception=True`) + `DateFilter`'s internal `DateField` validation. `input_formats=["%Y-%m-%d"]` rejects non-ISO formats.
- Filters are additive declarations — they AND with all existing params and don't touch pagination or CSV export.

## Tests (28 new)

`api/tests/test_date_range_filter_articles.py` and `api/tests/test_date_range_filter_trials.py`:
- after-only, before-only, closed range, neither (no-op)
- boundary inclusivity at both ends (including late-in-day edge case for `DateTimeField`)
- NULL `published_date` / `date_registration` rows are excluded when a filter is active
- Compose with `subjects`, `search`, `phase`
- `APIClient` tests: valid range → 200; invalid month (`2023-13-40`), non-date string, non-ISO format → 400

## Reviewer checklist

- [ ] `__date__gte` / `__date__lte` transform on `DateTimeField` is correct for the project's timezone setting
- [ ] No unintended interactions with `last_days` / `week` / `year` filters (they filter `discovery_date`, not `published_date`)