### PR TITLE
feat: add entrypoint to automate migrate and collectstatic on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,12 @@ RUN --mount=type=bind,from=builder,source=/wheels,target=/wheels \
 # Copy application code
 COPY django/ /code/
 
+# Copy and register entrypoint
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 # Expose port
 EXPOSE 8000
 
-# Default command
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["gunicorn", "--workers", "4", "--threads", "2", "--log-level", "debug", "-b", "0.0.0.0:8000", "admin.wsgi"]

--- a/docker-compose.override.yaml.example
+++ b/docker-compose.override.yaml.example
@@ -1,0 +1,4 @@
+services:
+  gregory:
+    volumes:
+      - ./django:/code   # dev only: live code from the working tree

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,6 @@ services:
     restart: always
     image: amaralbruno/gregory-ai:latest
     build: .
-    command: sh -c 'if echo "$$DJANGO_DEBUG" | grep -qiE "^(true|1|yes)$$"; then python manage.py runserver 0.0.0.0:8000; else gunicorn --workers 4 --threads 2 --log-level debug -b 0.0.0.0:8000 admin.wsgi; fi'
     volumes:
       - ./django/media:/code/media                  # user uploads (persist)
       - ./django/models:/code/models                # trained ML models (persist)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,20 @@
 #!/bin/sh
 set -e
-python manage.py migrate --noinput
-python manage.py collectstatic --noinput
+
+wait_for_db() {
+    echo "Waiting for database..."
+    until python manage.py check --database default >/dev/null 2>&1; do
+        sleep 2
+    done
+}
+
+# Only run init tasks when starting the web server, not for one-off commands
+# (e.g. docker compose run gregory sh, or manage.py shell)
+if [ "$1" = "gunicorn" ] || echo "$DJANGO_DEBUG" | grep -qiE "^(true|1|yes)$"; then
+    wait_for_db
+    python manage.py migrate --noinput
+    python manage.py collectstatic --noinput
+fi
 
 if echo "$DJANGO_DEBUG" | grep -qiE "^(true|1|yes)$"; then
     exec python manage.py runserver 0.0.0.0:8000

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+python manage.py migrate --noinput
+python manage.py collectstatic --noinput
+
+if echo "$DJANGO_DEBUG" | grep -qiE "^(true|1|yes)$"; then
+    exec python manage.py runserver 0.0.0.0:8000
+else
+    exec "$@"
+fi


### PR DESCRIPTION
## Summary

- Adds `entrypoint.sh` that runs `migrate` and `collectstatic --noinput` before starting the server
- Entrypoint handles dev/prod switching: `runserver` when `DJANGO_DEBUG` is set, gunicorn otherwise
- Removes the `command:` override from `docker-compose.yaml` — startup logic now lives entirely in the image

## Result

Production deploy is now a single step:
```bash
docker compose pull && docker compose up -d
```

No `git pull`, no manual `manage.py` commands, no post-deploy runbook.

## Test plan

- [ ] Build image locally and confirm `migrate` runs on startup
- [ ] Confirm `runserver` starts when `DJANGO_DEBUG=True`
- [ ] Confirm gunicorn starts when `DJANGO_DEBUG` is unset or false

🤖 Generated with [Claude Code](https://claude.com/claude-code)