### PR TITLE
fix: exclude already-reviewed articles from admin summary

### DIFF
--- a/django/subscriptions/management/commands/utils/subscription.py
+++ b/django/subscriptions/management/commands/utils/subscription.py
@@ -19,18 +19,20 @@ def get_articles_for_list(lst):
 	list_subjects = lst.subjects.all()
 
 	# Sub-subquery: has this (article, subject) pair been reviewed?
-	has_review = ArticleSubjectRelevance.objects.filter(
-		article_id=OuterRef(OuterRef('pk')),
-		subject_id=OuterRef('pk'),
-		is_relevant__isnull=False,
+	has_review = Exists(
+		ArticleSubjectRelevance.objects.filter(
+			article_id=OuterRef(OuterRef('pk')),
+			subject_id=OuterRef('pk'),
+			is_relevant__isnull=False,
+		)
 	)
 
-	# Subquery: does this article have at least one list-subject with no review?
+	# True when at least one list-subject the article belongs to has no review
 	has_unreviewed_subject = Exists(
 		Subject.objects.filter(
 			pk__in=list_subjects,
 			articles__pk=OuterRef('pk'),
-		).exclude(Exists(has_review))
+		).alias(reviewed=has_review).filter(reviewed=False)
 	)
 
 	return (
@@ -38,7 +40,8 @@ def get_articles_for_list(lst):
 			subjects__in=list_subjects,
 			discovery_date__gte=now() - timedelta(days=30),
 		)
-		.filter(has_unreviewed_subject)
+		.alias(has_unreviewed=has_unreviewed_subject)
+		.filter(has_unreviewed=True)
 		.distinct()
 	)
 

--- a/django/subscriptions/management/commands/utils/subscription.py
+++ b/django/subscriptions/management/commands/utils/subscription.py
@@ -1,8 +1,9 @@
 # utils/subscription.py
 
 from datetime import timedelta
+from django.db.models import Exists, OuterRef
 from django.utils.timezone import now
-from gregory.models import Articles, Trials
+from gregory.models import Articles, ArticleSubjectRelevance, Subject, Trials
 
 
 def get_trials_for_list(lst):
@@ -13,10 +14,33 @@ def get_trials_for_list(lst):
 
 
 def get_articles_for_list(lst):
-	"""Returns articles discovered in the last 30 days for the given list."""
-	return Articles.objects.filter(
-		subjects__in=lst.subjects.all(), discovery_date__gte=now() - timedelta(days=30)
-	).distinct()
+	"""Returns articles discovered in the last 30 days for the given list
+	that are missing at least one human review across the list's subjects."""
+	list_subjects = lst.subjects.all()
+
+	# Sub-subquery: has this (article, subject) pair been reviewed?
+	has_review = ArticleSubjectRelevance.objects.filter(
+		article_id=OuterRef(OuterRef('pk')),
+		subject_id=OuterRef('pk'),
+		is_relevant__isnull=False,
+	)
+
+	# Subquery: does this article have at least one list-subject with no review?
+	has_unreviewed_subject = Exists(
+		Subject.objects.filter(
+			pk__in=list_subjects,
+			articles__pk=OuterRef('pk'),
+		).exclude(Exists(has_review))
+	)
+
+	return (
+		Articles.objects.filter(
+			subjects__in=list_subjects,
+			discovery_date__gte=now() - timedelta(days=30),
+		)
+		.filter(has_unreviewed_subject)
+		.distinct()
+	)
 
 
 def get_latest_research_by_category(lst, days=30):

--- a/django/subscriptions/tests/test_get_articles_for_list.py
+++ b/django/subscriptions/tests/test_get_articles_for_list.py
@@ -1,0 +1,92 @@
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+
+import django
+
+django.setup()
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+from gregory.models import Articles, ArticleSubjectRelevance, Subject, Team
+from organizations.models import Organization
+from subscriptions.models import Lists
+from subscriptions.management.commands.utils.subscription import get_articles_for_list
+
+
+class GetArticlesForListTest(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(name="Test Org", slug="test-org")
+		self.team = Team.objects.create(
+			name="Test Team", organization=self.org, slug="test-team"
+		)
+		self.subject_a = Subject.objects.create(
+			subject_name="Subject A", team=self.team, subject_slug="subject-a"
+		)
+		self.subject_b = Subject.objects.create(
+			subject_name="Subject B", team=self.team, subject_slug="subject-b"
+		)
+		self.admin_list = Lists.objects.create(
+			list_name="Admin Summary List",
+			admin_summary=True,
+			team=self.team,
+		)
+		self.admin_list.subjects.add(self.subject_a, self.subject_b)
+
+		self.article = Articles.objects.create(
+			title="Test Article",
+			link="https://example.com/article/1",
+		)
+		self.article.subjects.add(self.subject_a, self.subject_b)
+
+	def test_no_reviews_included(self):
+		"""Articles with no ArticleSubjectRelevance records are included."""
+		qs = get_articles_for_list(self.admin_list)
+		self.assertIn(self.article, qs)
+
+	def test_one_subject_reviewed_one_not_included(self):
+		"""Article with one reviewed and one unreviewed list-subject is included."""
+		ArticleSubjectRelevance.objects.create(
+			article=self.article, subject=self.subject_a, is_relevant=True
+		)
+		qs = get_articles_for_list(self.admin_list)
+		self.assertIn(self.article, qs)
+
+	def test_all_subjects_reviewed_excluded(self):
+		"""Article with all list-subjects reviewed is excluded."""
+		ArticleSubjectRelevance.objects.create(
+			article=self.article, subject=self.subject_a, is_relevant=True
+		)
+		ArticleSubjectRelevance.objects.create(
+			article=self.article, subject=self.subject_b, is_relevant=False
+		)
+		qs = get_articles_for_list(self.admin_list)
+		self.assertNotIn(self.article, qs)
+
+	def test_review_for_subject_outside_list_does_not_exclude(self):
+		"""A review for a subject not in the list does not cause exclusion."""
+		subject_c = Subject.objects.create(
+			subject_name="Subject C", team=self.team, subject_slug="subject-c"
+		)
+		self.article.subjects.add(subject_c)
+		ArticleSubjectRelevance.objects.create(
+			article=self.article, subject=subject_c, is_relevant=False
+		)
+		qs = get_articles_for_list(self.admin_list)
+		self.assertIn(self.article, qs)
+
+	def test_old_articles_excluded(self):
+		"""Articles older than 30 days are not returned regardless of review status."""
+		old_article = Articles.objects.create(
+			title="Old Article",
+			link="https://example.com/article/old",
+		)
+		# discovery_date is auto_now_add; bypass it with update() to backdate
+		Articles.objects.filter(pk=old_article.pk).update(
+			discovery_date=timezone.now() - timedelta(days=31)
+		)
+		old_article.subjects.add(self.subject_a)
+		qs = get_articles_for_list(self.admin_list)
+		self.assertNotIn(old_article, qs)


### PR DESCRIPTION
## Summary

- `get_articles_for_list` in `subscription.py` previously returned all articles discovered in the last 30 days with no review-status filtering
- The admin summary was therefore including articles that had already been reviewed (`ArticleSubjectRelevance.is_relevant` set to `True` or `False`)
- Now uses a nested `Exists` subquery: an article is included only if at least one of the list's subjects that the article belongs to has no reviewed `ArticleSubjectRelevance` record (`is_relevant IS NULL` or no record at all)

## Test plan

- [ ] Confirm articles with all list-subjects reviewed no longer appear in the admin summary email
- [ ] Confirm articles with at least one unreviewed list-subject still appear
- [ ] Confirm articles with no `ArticleSubjectRelevance` records at all (never reviewed) are still included
- [ ] Run `docker exec gregory python manage.py send_admin_summary` and check output

🤖 Generated with [Claude Code](https://claude.com/claude-code)