### PR TITLE
ci: gate build and deploy on Tests workflow passing

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,7 +1,11 @@
 name: Build & Push Docker Image
 
 on:
-  push:
+  # Trigger only after the Tests workflow completes on main, so the image is
+  # never built or deployed when pytest or lint has failed.
+  workflow_run:
+    workflows: ["Tests"]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -10,6 +14,9 @@ env:
 
 jobs:
   build-push:
+    # Skip if tests failed (workflow_run conclusion is not 'success').
+    # workflow_dispatch always proceeds so manual releases still work.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -35,7 +42,7 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE }}:latest
-            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:${{ github.event.workflow_run.head_sha || github.sha }}
           # Registry cache avoids the 10 GB cap of type=gha, which was being
           # exceeded by the torch/tensorflow wheels and causing full rebuilds.
           cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache


### PR DESCRIPTION
## Summary

- Previously `build-push.yaml` and `tests.yaml` both triggered independently on `push` to `main` — the deploy could complete (or start) before pytest had even finished
- `build-push.yaml` now triggers via `workflow_run` on the "Tests" workflow completing on `main`, ensuring the Docker build and deploy never run unless both `pytest` and `lint` have passed
- A job-level `if` guard on `build-push` skips the entire workflow when the Tests run concluded with anything other than `success`
- `workflow_dispatch` is preserved so manual releases still work without waiting for a test run
- Fixed the SHA image tag to use `github.event.workflow_run.head_sha` (the commit that was actually tested) rather than `github.sha` which can point to a newer HEAD

## Test plan

- [ ] Merge a passing PR to main — confirm "Build & Push Docker Image" workflow starts only after "Tests" workflow completes
- [ ] Verify the image SHA tag matches the commit that triggered the Tests run
- [ ] Confirm `workflow_dispatch` still triggers a build immediately without a preceding test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)