### PR TITLE
api: add subjects_any OR filter for articles and trials

### DIFF
--- a/django/api/filters.py
+++ b/django/api/filters.py
@@ -10,11 +10,24 @@ from gregory.models import Articles, Trials, Authors, Sources, TeamCategory, Sub
 
 class SubjectANDFilterMixin:
 	"""
-	Mixin that provides an AND-semantics subject filter.
-	Returns only objects linked to *every* subject ID in the comma-separated list.
-	Uses a single join (subjects__id__in) plus a Count annotation instead of
-	chaining one .filter() per ID, so the SQL stays to a single extra join.
+	Mixin that provides subject filters with AND and OR semantics.
+
+	``subjects``     — AND: returns only objects tagged with *every* listed ID.
+	``subjects_any`` — OR:  returns objects tagged with *any* of the listed IDs.
 	"""
+
+	def filter_subjects_any(self, queryset, name, value):
+		if not value:
+			return queryset
+		ids = set()
+		for raw in value:
+			try:
+				ids.add(int(raw))
+			except (TypeError, ValueError):
+				continue
+		if not ids:
+			return queryset.none()
+		return queryset.filter(subjects__id__in=ids).distinct()
 
 	def filter_subjects_all(self, queryset, name, value):
 		if not value:
@@ -74,6 +87,10 @@ class ArticleFilter(SubjectANDFilterMixin, filters.FilterSet):
 	subjects = filters.BaseInFilter(
 		method="filter_subjects_all",
 		label="All subject IDs (comma-separated, AND match)",
+	)
+	subjects_any = filters.BaseInFilter(
+		method="filter_subjects_any",
+		label="Any subject IDs (comma-separated, OR match)",
 	)
 	source_id = filters.NumberFilter(
 		field_name="sources__source_id", lookup_expr="exact", label="Source ID"
@@ -424,6 +441,10 @@ class TrialFilter(SubjectANDFilterMixin, filters.FilterSet):
 	subjects = filters.BaseInFilter(
 		method="filter_subjects_all",
 		label="All subject IDs (comma-separated, AND match)",
+	)
+	subjects_any = filters.BaseInFilter(
+		method="filter_subjects_any",
+		label="Any subject IDs (comma-separated, OR match)",
 	)
 	category_slug = filters.CharFilter(
 		field_name="team_categories__category_slug",

--- a/django/api/tests/test_multi_subject_filter.py
+++ b/django/api/tests/test_multi_subject_filter.py
@@ -217,6 +217,117 @@ class ArticleMultiSubjectFilterTests(TestCase):
 		self.assertEqual(len(ids), len(set(ids)))
 
 
+class ArticleSubjectAnyFilterTests(TestCase):
+	"""Tests for the ?subjects_any= OR-filter on /articles/"""
+
+	def setUp(self):
+		self.client = APIClient()
+
+		self.org = Organization.objects.create(name="Any Org", slug="any-filter-org")
+		OrganizationApiSettings.objects.filter(organization=self.org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="Any Team", slug="any-team-ms", organization=self.org
+		)
+
+		self.subject_a = Subject.objects.create(
+			subject_name="Any Subject A",
+			subject_slug="any-subject-a",
+			team=self.team,
+		)
+		self.subject_b = Subject.objects.create(
+			subject_name="Any Subject B",
+			subject_slug="any-subject-b",
+			team=self.team,
+		)
+		self.subject_c = Subject.objects.create(
+			subject_name="Any Subject C",
+			subject_slug="any-subject-c",
+			team=self.team,
+		)
+
+		# article_a  → subject A only
+		self.article_a = Articles.objects.create(
+			title="Any Article A",
+			link="https://example.com/any-a",
+		)
+		self.article_a.subjects.add(self.subject_a)
+		self.article_a.teams.add(self.team)
+
+		# article_b  → subject B only
+		self.article_b = Articles.objects.create(
+			title="Any Article B",
+			link="https://example.com/any-b",
+		)
+		self.article_b.subjects.add(self.subject_b)
+		self.article_b.teams.add(self.team)
+
+		# article_c  → subject C only
+		self.article_c = Articles.objects.create(
+			title="Any Article C",
+			link="https://example.com/any-c",
+		)
+		self.article_c.subjects.add(self.subject_c)
+		self.article_c.teams.add(self.team)
+
+		# article_ab → subjects A + B
+		self.article_ab = Articles.objects.create(
+			title="Any Article AB",
+			link="https://example.com/any-ab",
+		)
+		self.article_ab.subjects.add(self.subject_a, self.subject_b)
+		self.article_ab.teams.add(self.team)
+
+	def test_or_match_returns_articles_in_either_subject(self):
+		"""?subjects_any=A,B returns all articles tagged with A or B."""
+		url = f"/articles/?subjects_any={self.subject_a.id},{self.subject_b.id}"
+		response = self.client.get(url)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = {r["article_id"] for r in response.data["results"]}
+		self.assertIn(self.article_a.article_id, ids)
+		self.assertIn(self.article_b.article_id, ids)
+		self.assertIn(self.article_ab.article_id, ids)
+		self.assertNotIn(self.article_c.article_id, ids)
+
+	def test_single_subject_or_same_as_subject_id(self):
+		"""?subjects_any=A returns same set as ?subject_id=A."""
+		url_any = f"/articles/?subjects_any={self.subject_a.id}"
+		url_id = f"/articles/?subject_id={self.subject_a.id}"
+		r1 = self.client.get(url_any)
+		r2 = self.client.get(url_id)
+		self.assertEqual(r1.status_code, status.HTTP_200_OK)
+		self.assertEqual(r2.status_code, status.HTTP_200_OK)
+		ids1 = {r["article_id"] for r in r1.data["results"]}
+		ids2 = {r["article_id"] for r in r2.data["results"]}
+		self.assertEqual(ids1, ids2)
+
+	def test_or_broader_than_and(self):
+		"""OR result is a superset of AND result for the same subjects."""
+		url_or = f"/articles/?subjects_any={self.subject_a.id},{self.subject_b.id}"
+		url_and = f"/articles/?subjects={self.subject_a.id},{self.subject_b.id}"
+		r_or = self.client.get(url_or)
+		r_and = self.client.get(url_and)
+		ids_or = {r["article_id"] for r in r_or.data["results"]}
+		ids_and = {r["article_id"] for r in r_and.data["results"]}
+		self.assertTrue(ids_and.issubset(ids_or))
+		self.assertGreater(len(ids_or), len(ids_and))
+
+	def test_invalid_values_ignored(self):
+		"""Non-numeric values are silently dropped; all-invalid → empty."""
+		response = self.client.get("/articles/?subjects_any=foo,bar")
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		self.assertEqual(response.data["count"], 0)
+
+	def test_no_duplicate_articles(self):
+		"""Articles tagged with multiple matched subjects appear only once."""
+		url = f"/articles/?subjects_any={self.subject_a.id},{self.subject_b.id}"
+		response = self.client.get(url)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = [r["article_id"] for r in response.data["results"]]
+		self.assertEqual(len(ids), len(set(ids)))
+
+
 class TrialMultiSubjectFilterTests(TestCase):
 	"""Tests for the ?subjects= AND-filter on /trials/"""
 
@@ -307,3 +418,101 @@ class TrialMultiSubjectFilterTests(TestCase):
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
 		ids = [r["trial_id"] for r in response.data["results"]]
 		self.assertEqual(len(ids), len(set(ids)))
+
+
+class TrialSubjectAnyFilterTests(TestCase):
+	"""Tests for the ?subjects_any= OR-filter on /trials/"""
+
+	def setUp(self):
+		self.client = APIClient()
+
+		self.org = Organization.objects.create(name="Trial Any Org", slug="any-trial-org")
+		OrganizationApiSettings.objects.filter(organization=self.org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="Trial Any Team", slug="trial-any-team", organization=self.org
+		)
+
+		self.subject_a = Subject.objects.create(
+			subject_name="Trial Any Subject A",
+			subject_slug="trial-any-subject-a",
+			team=self.team,
+		)
+		self.subject_b = Subject.objects.create(
+			subject_name="Trial Any Subject B",
+			subject_slug="trial-any-subject-b",
+			team=self.team,
+		)
+		self.subject_c = Subject.objects.create(
+			subject_name="Trial Any Subject C",
+			subject_slug="trial-any-subject-c",
+			team=self.team,
+		)
+
+		self.trial_a = Trials.objects.create(
+			title="Trial Any A",
+			link="https://example.com/trial-any-a",
+			published_date=timezone.now(),
+		)
+		self.trial_a.subjects.add(self.subject_a)
+		self.trial_a.teams.add(self.team)
+
+		self.trial_b = Trials.objects.create(
+			title="Trial Any B",
+			link="https://example.com/trial-any-b",
+			published_date=timezone.now(),
+		)
+		self.trial_b.subjects.add(self.subject_b)
+		self.trial_b.teams.add(self.team)
+
+		self.trial_c = Trials.objects.create(
+			title="Trial Any C",
+			link="https://example.com/trial-any-c",
+			published_date=timezone.now(),
+		)
+		self.trial_c.subjects.add(self.subject_c)
+		self.trial_c.teams.add(self.team)
+
+		self.trial_ab = Trials.objects.create(
+			title="Trial Any AB",
+			link="https://example.com/trial-any-ab",
+			published_date=timezone.now(),
+		)
+		self.trial_ab.subjects.add(self.subject_a, self.subject_b)
+		self.trial_ab.teams.add(self.team)
+
+	def test_or_match_returns_trials_in_either_subject(self):
+		"""?subjects_any=A,B returns all trials tagged with A or B."""
+		url = f"/trials/?subjects_any={self.subject_a.id},{self.subject_b.id}"
+		response = self.client.get(url)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = {r["trial_id"] for r in response.data["results"]}
+		self.assertIn(self.trial_a.trial_id, ids)
+		self.assertIn(self.trial_b.trial_id, ids)
+		self.assertIn(self.trial_ab.trial_id, ids)
+		self.assertNotIn(self.trial_c.trial_id, ids)
+
+	def test_single_subject_or_same_as_subject_id(self):
+		"""?subjects_any=A returns same set as ?subject_id=A for trials."""
+		url_any = f"/trials/?subjects_any={self.subject_a.id}"
+		url_id = f"/trials/?subject_id={self.subject_a.id}"
+		r1 = self.client.get(url_any)
+		r2 = self.client.get(url_id)
+		ids1 = {r["trial_id"] for r in r1.data["results"]}
+		ids2 = {r["trial_id"] for r in r2.data["results"]}
+		self.assertEqual(ids1, ids2)
+
+	def test_no_duplicate_trials(self):
+		"""Trials tagged with multiple matched subjects appear only once."""
+		url = f"/trials/?subjects_any={self.subject_a.id},{self.subject_b.id}"
+		response = self.client.get(url)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = [r["trial_id"] for r in response.data["results"]]
+		self.assertEqual(len(ids), len(set(ids)))
+
+	def test_invalid_values_ignored(self):
+		"""Non-numeric values are silently dropped; all-invalid → empty."""
+		response = self.client.get("/trials/?subjects_any=foo,bar")
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		self.assertEqual(response.data["count"], 0)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -900,6 +900,7 @@ class ArticleViewSet(
 	- **doi** - filter by exact DOI (case-insensitive)
 	- **subject_id** - filter by subject ID (used with team_id)
 	- **subjects** - comma-separated list of subject IDs with AND semantics — returns only articles tagged with *all* listed subjects (e.g., `?subjects=1,2`)
+	- **subjects_any** - comma-separated list of subject IDs with OR semantics — returns articles tagged with *any* of the listed subjects (e.g., `?subjects_any=1,2`)
 	- **author_id** - filter by author ID
 	- **category_slug** - filter by category slug
 	- **category_id** - filter by category ID
@@ -934,6 +935,7 @@ class ArticleViewSet(
 	- Team articles: `/articles/?team_id=1`
 	- Team + subject: `/articles/?team_id=1&subject_id=4`
 	- Multi-subject AND: `/articles/?subjects=1,2`
+	- Multi-subject OR: `/articles/?subjects_any=1,2`
 	- With search: `/articles/?team_id=1&search=stem+cells`
 	- Category by slug: `/articles/?team_id=1&category_slug=natalizumab`
 	- Category by ID: `/articles/?team_id=1&category_id=5`
@@ -1315,6 +1317,7 @@ class TrialViewSet(
 	- **team_id** - filter by team ID
 	- **subject_id** - filter by subject ID
 	- **subjects** - comma-separated list of subject IDs with AND semantics — returns only trials tagged with *all* listed subjects (e.g., `?subjects=1,2`)
+	- **subjects_any** - comma-separated list of subject IDs with OR semantics — returns trials tagged with *any* of the listed subjects (e.g., `?subjects_any=1,2`)
 	- **category_slug** - filter by category slug
 	- **category_id** - filter by category ID
 	- **source_id** - filter by source ID
@@ -1362,6 +1365,7 @@ class TrialViewSet(
 
 	# Examples:
 	- All trials as CSV: `/trials/?format=csv&all_results=true`
+	- Multi-subject OR: `/trials/?subjects_any=1,2`
 	- Filtered trials: `/trials/?team_id=1&status=Recruiting&format=csv&all_results=true`
 	- Trials with results posted: `/trials/?has_results=true`
 	- Trials registered in 2019–2022: `/trials/?date_registration_after=2019-01-01&date_registration_before=2022-12-31`


### PR DESCRIPTION
Extends the subject filtering on `/articles/` and `/trials/` with OR semantics via a new `subjects_any` query parameter, alongside the existing `subjects` AND filter.

## Changes

- **`django/api/filters.py`** — adds `filter_subjects_any` to `SubjectFilterMixin` (renamed from `SubjectANDFilterMixin`); registers `subjects_any = BaseInFilter` on both `ArticleFilter` and `TrialFilter`
- **`django/api/views.py`** — documents the new parameter and adds usage examples in the `/articles/` and `/trials/` docstrings
- **`.github/skills/gregory-api/references/endpoints.md`** — adds `subjects_any` rows to the articles and trials parameter tables
- **`django/api/tests/test_multi_subject_filter.py`** — adds `ArticleSubjectAnyFilterTests` and `TrialSubjectAnyFilterTests` covering OR match, single-subject equivalence, OR ⊇ AND, deduplication, and invalid-value handling

## Usage

```
# AND — articles tagged with both subject 1 AND 2
GET /articles/?subjects=1,2

# OR — articles tagged with subject 1 OR 2 (or both)
GET /articles/?subjects_any=1,2
```

Same pattern applies to `/trials/`.