### PR TITLE
fix: stop DRF SearchFilter from breaking boolean ?search= queries

### DIFF
--- a/django/api/tests/test_boolean_search.py
+++ b/django/api/tests/test_boolean_search.py
@@ -6,10 +6,19 @@ integration with ArticleFilter and TrialFilter via the ?search= parameter.
 from django.db.models import Q
 from django.test import TestCase, RequestFactory
 from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
 
 from api.filters import ArticleFilter, TrialFilter
 from api.utils.search import build_search_q, _tokenize
-from gregory.models import Articles, Trials
+from gregory.models import (
+	Articles,
+	Trials,
+	Team,
+	Subject,
+	Organization,
+	OrganizationApiSettings,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -279,3 +288,116 @@ class TrialFilterSearchTests(TestCase):
 	def test_malformed_does_not_raise(self):
 		self._filter("(((")
 		self._filter("OR NOT")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests: GET ?search= through the real viewsets.
+#
+# These exercise the full filter-backend stack (DjangoFilterBackend running the
+# boolean filterset). They are the regression guard for the double-filter bug:
+# the viewsets used to also list DRF's filters.SearchFilter, which reads the
+# same ?search= query param and AND-ed a naive token match on top — turning
+# `a OR b` into "must literally contain a, OR, and b" and wiping every result.
+# The filterset-only tests above could not catch it because they bypass the
+# view's backend list.
+# ---------------------------------------------------------------------------
+
+class ArticleViewSetBooleanSearchE2ETests(TestCase):
+	def setUp(self):
+		self.client = APIClient()
+		self.org = Organization.objects.create(name="Bool Org", slug="bool-search-org")
+		OrganizationApiSettings.objects.filter(organization=self.org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="Bool Team", slug="bool-search-team", organization=self.org
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Bool Subject", subject_slug="bool-subject", team=self.team
+		)
+
+		# No single article contains every term — mirrors the production category
+		# query (artemisinin OR dihydroartemisinin OR …) that returned nothing.
+		self.a_myelin = Articles.objects.create(
+			title="Myelin repair mechanisms", link="https://example.com/e1"
+		)
+		self.a_parkinson = Articles.objects.create(
+			title="Parkinson disease progression", link="https://example.com/e2"
+		)
+		self.a_cancer = Articles.objects.create(
+			title="Cancer treatment advances", link="https://example.com/e3"
+		)
+		for art in (self.a_myelin, self.a_parkinson, self.a_cancer):
+			art.teams.add(self.team)
+			art.subjects.add(self.subject)
+
+	def _ids(self, response):
+		return {r["article_id"] for r in response.data["results"]}
+
+	def test_or_query_returns_union_not_empty(self):
+		"""The exact failure mode: OR across non-co-occurring terms must union."""
+		response = self.client.get(
+			f"/articles/?team_id={self.team.id}&search=myelin OR parkinson"
+		)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = self._ids(response)
+		self.assertIn(self.a_myelin.article_id, ids)
+		self.assertIn(self.a_parkinson.article_id, ids)
+		self.assertNotIn(self.a_cancer.article_id, ids)
+
+	def test_multi_term_or_returns_union(self):
+		response = self.client.get(
+			f"/articles/?team_id={self.team.id}"
+			"&search=myelin OR parkinson OR cancer"
+		)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		self.assertEqual(len(response.data["results"]), 3)
+
+	def test_bare_terms_still_and(self):
+		"""AND semantics for space-separated terms are preserved after the fix."""
+		response = self.client.get(
+			f"/articles/?team_id={self.team.id}&search=myelin parkinson"
+		)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		self.assertEqual(self._ids(response), set())
+
+
+class TrialViewSetBooleanSearchE2ETests(TestCase):
+	def setUp(self):
+		self.client = APIClient()
+		self.org = Organization.objects.create(
+			name="Bool Trial Org", slug="bool-trial-org"
+		)
+		OrganizationApiSettings.objects.filter(organization=self.org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="Bool Trial Team", slug="bool-trial-team", organization=self.org
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Bool Trial Subject",
+			subject_slug="bool-trial-subject",
+			team=self.team,
+		)
+		self.t_myelin = Trials.objects.create(
+			title="Myelin restoration trial",
+			link="https://example.com/te1",
+			published_date=timezone.now(),
+		)
+		self.t_parkinson = Trials.objects.create(
+			title="Parkinson motor study",
+			link="https://example.com/te2",
+			published_date=timezone.now(),
+		)
+		for tr in (self.t_myelin, self.t_parkinson):
+			tr.teams.add(self.team)
+			tr.subjects.add(self.subject)
+
+	def test_or_query_returns_union_not_empty(self):
+		response = self.client.get(
+			f"/trials/?team_id={self.team.id}&search=myelin OR parkinson"
+		)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = {r["trial_id"] for r in response.data["results"]}
+		self.assertIn(self.t_myelin.trial_id, ids)
+		self.assertIn(self.t_parkinson.trial_id, ids)

--- a/django/api/tests/test_boolean_search.py
+++ b/django/api/tests/test_boolean_search.py
@@ -337,7 +337,8 @@ class ArticleViewSetBooleanSearchE2ETests(TestCase):
 	def test_or_query_returns_union_not_empty(self):
 		"""The exact failure mode: OR across non-co-occurring terms must union."""
 		response = self.client.get(
-			f"/articles/?team_id={self.team.id}&search=myelin OR parkinson"
+			"/articles/",
+			{"team_id": self.team.id, "search": "myelin OR parkinson"},
 		)
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
 		ids = self._ids(response)
@@ -347,8 +348,8 @@ class ArticleViewSetBooleanSearchE2ETests(TestCase):
 
 	def test_multi_term_or_returns_union(self):
 		response = self.client.get(
-			f"/articles/?team_id={self.team.id}"
-			"&search=myelin OR parkinson OR cancer"
+			"/articles/",
+			{"team_id": self.team.id, "search": "myelin OR parkinson OR cancer"},
 		)
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
 		self.assertEqual(len(response.data["results"]), 3)
@@ -356,7 +357,8 @@ class ArticleViewSetBooleanSearchE2ETests(TestCase):
 	def test_bare_terms_still_and(self):
 		"""AND semantics for space-separated terms are preserved after the fix."""
 		response = self.client.get(
-			f"/articles/?team_id={self.team.id}&search=myelin parkinson"
+			"/articles/",
+			{"team_id": self.team.id, "search": "myelin parkinson"},
 		)
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
 		self.assertEqual(self._ids(response), set())
@@ -395,7 +397,8 @@ class TrialViewSetBooleanSearchE2ETests(TestCase):
 
 	def test_or_query_returns_union_not_empty(self):
 		response = self.client.get(
-			f"/trials/?team_id={self.team.id}&search=myelin OR parkinson"
+			"/trials/",
+			{"team_id": self.team.id, "search": "myelin OR parkinson"},
 		)
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
 		ids = {r["trial_id"] for r in response.data["results"]}

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -958,13 +958,16 @@ class ArticleViewSet(
 	serializer_class = ArticleSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 	pagination_class = FlexiblePagination
+	# NOTE: `search` is handled solely by ArticleFilter.filter_search (boolean
+	# parser). DRF's SearchFilter is intentionally absent — it also binds to
+	# ?search= and would AND its naive token match on top of the parsed Q,
+	# turning a query like `a OR b` into a literal "must contain OR" and
+	# wiping the results. See api/utils/search.build_search_q.
 	filter_backends = [
 		django_filters.DjangoFilterBackend,
-		filters.SearchFilter,
 		NullsLastOrderingFilter,
 	]
 	filterset_class = ArticleFilter
-	search_fields = ["title", "summary"]
 	ordering_fields = ["discovery_date", "published_date", "title", "article_id", "ml_score"]
 	ordering = ["-discovery_date"]
 
@@ -1378,9 +1381,10 @@ class TrialViewSet(
 	serializer_class = TrialSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 	pagination_class = FlexiblePagination
+	# `search` is handled solely by TrialFilter.filter_search (boolean parser);
+	# DRF's SearchFilter is omitted to avoid double-filtering ?search=. See ArticleViewSet.
 	filter_backends = [
 		django_filters.DjangoFilterBackend,
-		filters.SearchFilter,
 		filters.OrderingFilter,
 	]
 	filterset_class = TrialFilter
@@ -1413,7 +1417,6 @@ class TrialViewSet(
 			)
 		return qs
 
-	search_fields = ["title", "summary"]
 	ordering_fields = [
 		"discovery_date",
 		"published_date",
@@ -1916,13 +1919,13 @@ class ArticlesByTeam(viewsets.ModelViewSet):
 
 	serializer_class = ArticleSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+	# `search` is handled solely by ArticleFilter.filter_search; DRF's
+	# SearchFilter is omitted to avoid double-filtering ?search=. See ArticleViewSet.
 	filter_backends = [
 		django_filters.DjangoFilterBackend,
-		filters.SearchFilter,
 		filters.OrderingFilter,
 	]
 	filterset_class = ArticleFilter
-	search_fields = ["title", "summary"]
 	ordering_fields = ["discovery_date", "published_date", "title", "article_id"]
 	ordering = ["-discovery_date"]
 
@@ -1970,13 +1973,13 @@ class ArticlesBySubject(viewsets.ModelViewSet):
 
 	serializer_class = ArticleSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+	# `search` is handled solely by ArticleFilter.filter_search; DRF's
+	# SearchFilter is omitted to avoid double-filtering ?search=. See ArticleViewSet.
 	filter_backends = [
 		django_filters.DjangoFilterBackend,
-		filters.SearchFilter,
 		filters.OrderingFilter,
 	]
 	filterset_class = ArticleFilter
-	search_fields = ["title", "summary"]
 	ordering_fields = ["discovery_date", "published_date", "title", "article_id"]
 	ordering = ["-discovery_date"]
 
@@ -2160,13 +2163,14 @@ class ArticleSearchView(generics.ListAPIView):
 	permission_classes = [
 		permissions.AllowAny
 	]  # Allow access to anyone since we require team_id and subject_id
+	# `search` is parsed by build_search_q in get_queryset (and by ArticleFilter
+	# for GET query params). DRF's SearchFilter is omitted so it can't AND a
+	# naive token match on top and break boolean queries. See ArticleViewSet.
 	filter_backends = [
-		filters.SearchFilter,
 		django_filters.DjangoFilterBackend,
 		filters.OrderingFilter,
 	]
 	filterset_class = ArticleFilter
-	search_fields = ["title", "summary"]
 	ordering_fields = ["discovery_date", "published_date", "title", "article_id"]
 	ordering = ["-discovery_date"]  # Default ordering by newest first
 	pagination_class = FlexiblePagination
@@ -2354,13 +2358,14 @@ class TrialSearchView(generics.ListAPIView):
 	permission_classes = [
 		permissions.AllowAny
 	]  # Allow access to anyone since we require team_id and subject_id
+	# `search` is parsed by build_search_q in get_queryset (and by TrialFilter
+	# for GET query params). DRF's SearchFilter is omitted so it can't AND a
+	# naive token match on top and break boolean queries. See ArticleViewSet.
 	filter_backends = [
-		filters.SearchFilter,
 		django_filters.DjangoFilterBackend,
 		filters.OrderingFilter,
 	]
 	filterset_class = TrialFilter
-	search_fields = ["title", "summary"]
 	ordering_fields = [
 		"discovery_date",
 		"published_date",


### PR DESCRIPTION
## Problem

On the brain-regeneration advanced search, a boolean query like `artemisinin OR dihydroartemisinin OR artesunate OR artemether OR SM934 OR artemisia OR TPN10518` returned **zero** results — even though those terms back a category with ~30 articles.

## Root cause

The `/articles/` and `/trials/` list endpoints (the ones the advanced search actually calls, via `GET ?search=…`) declared **two** filter backends that both bind to `?search=`:

- `DjangoFilterBackend` → `ArticleFilter`/`TrialFilter.filter_search` → `build_search_q` (the boolean parser) — correctly returns the union
- DRF's `filters.SearchFilter` — splits on whitespace, treats `OR` as a **literal mandatory token**, and AND-requires every term in a single record

The two are AND-ed, so `a OR b OR c` became "must contain `a`, `OR`, `b`, `OR`, `c`" → 0 results. Proven against the dev DB:

| Filter | Matches |
|---|---|
| `build_search_q` (boolean) alone | 31 |
| `DjangoFilterBackend` / `ArticleFilter` alone | 31 |
| DRF `SearchFilter` alone | 0 |
| **Both combined (as the viewset ran them)** | **0** |

The recent boolean-search work added `build_search_q` to the filtersets but left DRF's `SearchFilter` active on the same parameter. Existing boolean tests didn't catch it because they instantiate the filtersets directly or POST the query in the **body** — where DRF's `SearchFilter` (which only reads `query_params`) stays dormant. The frontend uses **GET**, where it fires.

## Fix

Removed the redundant `filters.SearchFilter` (and its now-dead `search_fields`) from the six views whose filterset already owns `search`:

- `ArticleViewSet`, `TrialViewSet`
- `ArticlesByTeam`, `ArticlesBySubject` (deprecated team views)
- `ArticleSearchView`, `TrialSearchView` (the boolean logic still runs in their `get_queryset` for the POST-body path)

The boolean parser replicates the old substring + space-separated-AND behavior, so single-word and multi-word AND searches are unchanged. Views whose filtersets don't define a `search` field (`Category`/`Source`/`Author`/`Subject`) keep their `SearchFilter` — there's no double-filter there.

## Tests

Added end-to-end tests in `test_boolean_search.py` that exercise the real viewsets over **GET** (the path the unit tests didn't cover). Verified they **fail without the fix** (`0 != 3`, `set()`) and pass with it. Full `api` suite: **540 tests pass**.

## Reviewer notes

- Behavior change is intentional and narrow: `?search=` boolean queries (`OR`, `-`/`NOT`, `"phrases"`, `()`) now work over GET; everything else is identical.
- This is a code fix only — it takes effect once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)