### PR TITLE
feat: accept comma-separated DOI list in ?doi= filter

### DIFF
--- a/django/api/filters.py
+++ b/django/api/filters.py
@@ -153,9 +153,11 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 		Filter by one or more DOIs (case-insensitive).
 		Accepts a single DOI or a comma-separated list, e.g. ?doi=10.1/a or ?doi=10.1/a,10.2/b
 		"""
-		dois = [d.strip().upper() for d in value.split(",") if d.strip()]
+		dois = list({d.strip().upper() for d in value.split(",") if d.strip()})
 		if not dois:
 			return queryset
+		if len(dois) == 1:
+			return queryset.filter(doi__iexact=dois[0])
 		return queryset.annotate(_doi_upper=Upper("doi")).filter(_doi_upper__in=dois)
 
 	def filter_title(self, queryset, name, value):

--- a/django/api/filters.py
+++ b/django/api/filters.py
@@ -68,7 +68,7 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 	author_id = filters.NumberFilter(
 		field_name="authors__author_id", lookup_expr="exact", label="Author ID"
 	)
-	doi = filters.CharFilter(field_name="doi", lookup_expr="iexact", label="DOI")
+	doi = filters.CharFilter(method="filter_doi", label="DOI")
 	category_slug = filters.CharFilter(
 		field_name="team_categories__category_slug",
 		lookup_expr="exact",
@@ -147,6 +147,16 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 			"published_date_after",
 			"published_date_before",
 		]
+
+	def filter_doi(self, queryset, name, value):
+		"""
+		Filter by one or more DOIs (case-insensitive).
+		Accepts a single DOI or a comma-separated list, e.g. ?doi=10.1/a or ?doi=10.1/a,10.2/b
+		"""
+		dois = [d.strip().upper() for d in value.split(",") if d.strip()]
+		if not dois:
+			return queryset
+		return queryset.annotate(_doi_upper=Upper("doi")).filter(_doi_upper__in=dois)
 
 	def filter_title(self, queryset, name, value):
 		"""

--- a/django/api/tests/test_doi_filter.py
+++ b/django/api/tests/test_doi_filter.py
@@ -1,0 +1,63 @@
+from django.test import TestCase
+
+from api.filters import ArticleFilter
+from gregory.models import Articles
+
+
+class DoiFilterTestCase(TestCase):
+	def setUp(self):
+		self.a1 = Articles.objects.create(
+			title="Article One", link="https://example.com/1", doi="10.1000/AAA"
+		)
+		self.a2 = Articles.objects.create(
+			title="Article Two", link="https://example.com/2", doi="10.2000/bbb"
+		)
+		self.a3 = Articles.objects.create(
+			title="Article Three", link="https://example.com/3", doi="10.3000/CCC"
+		)
+		self.no_doi = Articles.objects.create(
+			title="Article No DOI", link="https://example.com/4"
+		)
+
+	def _filter(self, doi_param):
+		f = ArticleFilter(
+			data={"doi": doi_param},
+			queryset=Articles.objects.all(),
+		)
+		return list(f.qs.values_list("article_id", flat=True))
+
+	def test_single_doi_exact_case(self):
+		ids = self._filter("10.1000/AAA")
+		self.assertIn(self.a1.article_id, ids)
+		self.assertEqual(len(ids), 1)
+
+	def test_single_doi_case_insensitive(self):
+		ids = self._filter("10.1000/aaa")
+		self.assertIn(self.a1.article_id, ids)
+		self.assertEqual(len(ids), 1)
+
+	def test_multi_doi(self):
+		ids = self._filter("10.1000/AAA,10.2000/bbb")
+		self.assertIn(self.a1.article_id, ids)
+		self.assertIn(self.a2.article_id, ids)
+		self.assertNotIn(self.a3.article_id, ids)
+		self.assertNotIn(self.no_doi.article_id, ids)
+
+	def test_multi_doi_mixed_case(self):
+		ids = self._filter("10.1000/aaa,10.3000/ccc")
+		self.assertIn(self.a1.article_id, ids)
+		self.assertIn(self.a3.article_id, ids)
+		self.assertEqual(len(ids), 2)
+
+	def test_multi_doi_with_spaces(self):
+		ids = self._filter("10.1000/AAA , 10.2000/BBB")
+		self.assertIn(self.a1.article_id, ids)
+		self.assertIn(self.a2.article_id, ids)
+
+	def test_nonexistent_doi_returns_empty(self):
+		ids = self._filter("10.9999/nope")
+		self.assertEqual(ids, [])
+
+	def test_empty_value_returns_all(self):
+		f = ArticleFilter(data={"doi": ""}, queryset=Articles.objects.all())
+		self.assertEqual(f.qs.count(), Articles.objects.all().count())

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -898,7 +898,7 @@ class ArticleViewSet(
 
 	# Query Parameters:
 	- **team_id** - filter by team ID
-	- **doi** - filter by exact DOI (case-insensitive)
+	- **doi** - filter by DOI, case-insensitive; accepts a single value or a comma-separated list (e.g. `?doi=10.1/a,10.2/b`)
 	- **subject_id** - filter by subject ID (used with team_id)
 	- **subjects** - comma-separated list of subject IDs with AND semantics — returns only articles tagged with *all* listed subjects (e.g., `?subjects=1,2`)
 	- **subjects_any** - comma-separated list of subject IDs with OR semantics — returns articles tagged with *any* of the listed subjects (e.g., `?subjects_any=1,2`)
@@ -932,7 +932,8 @@ class ArticleViewSet(
 	prediction per (algorithm, subject) pair. `null` when no predictions exist yet.
 
 	# Examples:
-	- By DOI: `/articles/?doi=10.1016/j.procs.2023.01.401`
+	- By DOI (single): `/articles/?doi=10.1016/j.procs.2023.01.401`
+	- By DOI (multiple): `/articles/?doi=10.1016/j.procs.2023.01.401,10.1016/j.other.2024.02.001`
 	- Team articles: `/articles/?team_id=1`
 	- Team + subject: `/articles/?team_id=1&subject_id=4`
 	- Multi-subject AND: `/articles/?subjects=1,2`


### PR DESCRIPTION
## Summary

- The `?doi=` query parameter on the Articles API previously only accepted a single DOI value.
- It now accepts a comma-separated list (e.g. `?doi=10.1016/j.procs.2023.01.401,10.1016/j.other.2024.02.001`), returning all articles whose DOI matches any of the supplied values.
- Lookup remains case-insensitive. Single-DOI calls are fully backward compatible.

## What changed

- **`django/api/filters.py`** — replaced the single `CharFilter(iexact)` on `doi` with a custom `filter_doi` method that splits on commas, normalises to uppercase, and filters via a `_doi_upper` annotation (the same pattern used for title/summary search).
- **`django/api/views.py`** — updated the `ArticleViewSet` docstring to document the comma-separated syntax.
- **`django/api/tests/test_doi_filter.py`** — new test file with 7 cases: single DOI exact, single DOI case-insensitive, multi-DOI, multi-DOI mixed case, multi-DOI with whitespace, non-existent DOI, and empty value.

## Test plan

- [ ] `docker exec gregory python manage.py test api.tests.test_doi_filter` — all 7 tests pass
- [ ] `GET /articles/?doi=<single>` still returns one article (backward compat)
- [ ] `GET /articles/?doi=<doi1>,<doi2>` returns both articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)