### PR TITLE
Make category matching configurable per-category instead of global

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -142,9 +142,9 @@ Backend auto-fetches missing metadata via `SciencePaper` class (queries CrossRef
 ## Critical Patterns
 
 **Category Assignment** (`rebuild_categories`):
-- Scans `TeamCategory.category_terms` (array of keywords)
-- Searches in `Articles.utitle` (uppercase generated field with GIN index for fast ILIKE)
-- M2M link via `article.team_categories.add(category)`
+- Scans `TeamCategory.category_terms` (array of keywords); only `category_type=automatic` categories are matched
+- Per category, `match_scope` selects the fields searched/scored: `title` (title only) or `title_summary` (title + summary, plus the extra trial fields). `match_weights` sets the per-field points and `match_min_score` the threshold — a fixed +2 bonus per unique matched term is always added
+- Whole-word term matches are scored against `Articles.utitle`/`usummary` (uppercase generated fields with GIN indexes); items reaching `match_min_score` are linked via the automatic-source `ArticleCategoryAssignment`/`TrialCategoryAssignment` through model (manual assignments are preserved)
 
 **Newsletter Filtering** (`send_weekly_summary`):
 - Excludes articles where `relevant=False` for ALL subjects in the list
@@ -162,7 +162,7 @@ Backend auto-fetches missing metadata via `SciencePaper` class (queries CrossRef
 1. **Import errors in ML code**: ML dependencies optional - wrap imports in try/except, check `ML_AVAILABLE` flag
 2. **API 401s**: Ensure `Authorization` header has raw key (no prefix). Check `APIAccessScheme` has valid `begin_date`/`end_date`
 3. **Missing authors**: Run `get_authors` after `update_articles_info` - author extraction depends on CrossRef data
-4. **Category not assigning**: Check `utitle` field populated, verify `category_terms` contains exact match (case-insensitive ILIKE)
+4. **Category not assigning**: Check `utitle`/`usummary` populated and `category_terms` has a whole-word match; confirm the score reaches `match_min_score` and that `match_scope` includes the field where the term appears (a `title`-only category ignores summary/intervention/outcome matches)
 5. **Newsletter not sending**: Verify `Lists.send_weekly_digest=True`, check `ml_prediction_threshold`, ensure articles not in `SentArticleNotification`
 
 ## Key Files Reference

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -143,8 +143,8 @@ Backend auto-fetches missing metadata via `SciencePaper` class (queries CrossRef
 
 **Category Assignment** (`rebuild_categories`):
 - Scans `TeamCategory.category_terms` (array of keywords); only `category_type=automatic` categories are matched
-- Per category, `match_scope` selects the fields searched/scored: `title` (title only) or `title_summary` (title + summary, plus the extra trial fields). `match_weights` sets the per-field points and `match_min_score` the threshold — a fixed +2 bonus per unique matched term is always added
-- Whole-word term matches are scored against `Articles.utitle`/`usummary` (uppercase generated fields with GIN indexes); items reaching `match_min_score` are linked via the automatic-source `ArticleCategoryAssignment`/`TrialCategoryAssignment` through model (manual assignments are preserved)
+- Per category, `match_scope` selects the fields searched/scored: `title` (title only) or `title_summary` (title + summary, plus the extra trial fields). `match_weights` sets the per-field points and `match_min_score_articles`/`match_min_score_trials` the per-content-type thresholds — a fixed +2 bonus per unique matched term is always added
+- Candidates are pre-filtered in the DB using the uppercase `Articles.utitle`/`usummary` columns (GIN-indexed) for title/summary; whole-word scoring then runs in Python against the model fields. Items reaching the relevant threshold (`match_min_score_articles` for articles, `match_min_score_trials` for trials) are linked via the automatic-source `ArticleCategoryAssignment`/`TrialCategoryAssignment` through model (manual assignments are preserved)
 
 **Newsletter Filtering** (`send_weekly_summary`):
 - Excludes articles where `relevant=False` for ALL subjects in the list
@@ -162,7 +162,7 @@ Backend auto-fetches missing metadata via `SciencePaper` class (queries CrossRef
 1. **Import errors in ML code**: ML dependencies optional - wrap imports in try/except, check `ML_AVAILABLE` flag
 2. **API 401s**: Ensure `Authorization` header has raw key (no prefix). Check `APIAccessScheme` has valid `begin_date`/`end_date`
 3. **Missing authors**: Run `get_authors` after `update_articles_info` - author extraction depends on CrossRef data
-4. **Category not assigning**: Check `utitle`/`usummary` populated and `category_terms` has a whole-word match; confirm the score reaches `match_min_score` and that `match_scope` includes the field where the term appears (a `title`-only category ignores summary/intervention/outcome matches)
+4. **Category not assigning**: Check `category_terms` has a whole-word match in an in-scope field and that `match_scope` includes that field (a `title`-only category ignores summary/intervention/outcome matches); confirm the score reaches the threshold for that content type (`match_min_score_articles` or `match_min_score_trials`). Candidate pre-filtering also needs `utitle`/`usummary` populated for title/summary matches
 5. **Newsletter not sending**: Verify `Lists.send_weekly_digest=True`, check `ml_prediction_threshold`, ensure articles not in `SentArticleNotification`
 
 ## Key Files Reference

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -41,6 +41,7 @@ from .models import (
 	ArticleCategoryAssignment,
 	TrialCategoryAssignment,
 	CategoryType,
+	default_match_weights,
 )
 from .widgets import MLPredictionsWidget
 from .fields import MLPredictionsField
@@ -1666,26 +1667,165 @@ class AuthorsAdmin(admin.ModelAdmin):
 		return super().get_inline_instances(request, obj)
 
 
+# Maps each stored weight (content type → field) to the admin form field that
+# edits it. Keeps the JSON ``match_weights`` column out of the form in favour of
+# friendly per-field integer inputs.
+TEAMCATEGORY_WEIGHT_FIELDS = {
+	"article": {
+		"title": "weight_article_title",
+		"summary": "weight_article_summary",
+	},
+	"trial": {
+		"title": "weight_trial_title",
+		"summary": "weight_trial_summary",
+		"scientific_title": "weight_trial_scientific_title",
+		"intervention": "weight_trial_intervention",
+		"primary_outcome": "weight_trial_primary_outcome",
+		"secondary_outcome": "weight_trial_secondary_outcome",
+		"therapeutic_areas": "weight_trial_therapeutic_areas",
+	},
+}
+
+
+class TeamCategoryAdminForm(forms.ModelForm):
+	"""Edits TeamCategory matching settings, exposing the per-field weights stored
+	in the ``match_weights`` JSON column as friendly integer inputs."""
+
+	weight_article_title = forms.IntegerField(min_value=0, label="Title")
+	weight_article_summary = forms.IntegerField(min_value=0, label="Summary")
+	weight_trial_title = forms.IntegerField(min_value=0, label="Title")
+	weight_trial_summary = forms.IntegerField(min_value=0, label="Summary")
+	weight_trial_scientific_title = forms.IntegerField(
+		min_value=0, label="Scientific title"
+	)
+	weight_trial_intervention = forms.IntegerField(min_value=0, label="Intervention")
+	weight_trial_primary_outcome = forms.IntegerField(
+		min_value=0, label="Primary outcome"
+	)
+	weight_trial_secondary_outcome = forms.IntegerField(
+		min_value=0, label="Secondary outcome"
+	)
+	weight_trial_therapeutic_areas = forms.IntegerField(
+		min_value=0, label="Therapeutic areas"
+	)
+
+	class Meta:
+		model = TeamCategory
+		exclude = ["match_weights"]
+
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		if self.instance and self.instance.pk:
+			weights = {
+				content_type: self.instance.get_match_weights(content_type)
+				for content_type in TEAMCATEGORY_WEIGHT_FIELDS
+			}
+		else:
+			weights = default_match_weights()
+		for content_type, fmap in TEAMCATEGORY_WEIGHT_FIELDS.items():
+			ct_weights = weights.get(content_type, {})
+			for field_key, form_field in fmap.items():
+				self.fields[form_field].initial = ct_weights.get(field_key, 0)
+
+	def save(self, commit=True):
+		instance = super().save(commit=False)
+		instance.match_weights = {
+			content_type: {
+				field_key: self.cleaned_data[form_field]
+				for field_key, form_field in fmap.items()
+			}
+			for content_type, fmap in TEAMCATEGORY_WEIGHT_FIELDS.items()
+		}
+		if commit:
+			instance.save()
+			self.save_m2m()
+		return instance
+
+
 @admin.register(TeamCategory)
 class TeamCategoryAdmin(OrganizationFilterMixin, ReassignToTeamMixin, admin.ModelAdmin):
+	form = TeamCategoryAdminForm
 	list_display = (
 		"category_name",
 		"team",
 		"category_type",
+		"display_match_scope",
 		"article_count",
 		"display_subjects",
 	)
 	search_fields = ("category_name", "team__name", "subjects__subject_name")
 	list_filter = [
 		"category_type",
+		"match_scope",
 		("team", OrganizationRestrictedFieldListFilter),
 		("subjects", OrganizationRestrictedFieldListFilter),
 	]
 	filter_horizontal = ("subjects",)
 	actions = ["reassign_to_team_action"]
+	fieldsets = (
+		(
+			None,
+			{
+				"fields": (
+					"team",
+					"category_name",
+					"category_slug",
+					"category_description",
+					"subjects",
+					"category_type",
+				)
+			},
+		),
+		(
+			"Matching",
+			{
+				"fields": ("category_terms", "match_scope", "match_min_score"),
+				"description": (
+					"Automatic categories match content whose in-scope fields contain these "
+					"terms and whose score reaches the minimum. A fixed bonus of 2 points per "
+					"unique matched term is added on top of the field weights below. In "
+					"'Title only' scope every field except the title is ignored."
+				),
+			},
+		),
+		(
+			"Article score weights",
+			{"fields": ("weight_article_title", "weight_article_summary")},
+		),
+		(
+			"Trial score weights",
+			{
+				"classes": ("collapse",),
+				"fields": (
+					"weight_trial_title",
+					"weight_trial_summary",
+					"weight_trial_scientific_title",
+					"weight_trial_intervention",
+					"weight_trial_primary_outcome",
+					"weight_trial_secondary_outcome",
+					"weight_trial_therapeutic_areas",
+				),
+			},
+		),
+	)
 
 	# Form fields that affect which articles/trials match the category
-	MATCHING_CONFIG_FIELDS = {"category_terms", "subjects", "category_type"}
+	MATCHING_CONFIG_FIELDS = {
+		"category_terms",
+		"subjects",
+		"category_type",
+		"match_scope",
+		"match_min_score",
+		"weight_article_title",
+		"weight_article_summary",
+		"weight_trial_title",
+		"weight_trial_summary",
+		"weight_trial_scientific_title",
+		"weight_trial_intervention",
+		"weight_trial_primary_outcome",
+		"weight_trial_secondary_outcome",
+		"weight_trial_therapeutic_areas",
+	}
 
 	def save_related(self, request, form, formsets, change):
 		"""Re-match an automatic category as soon as its configuration is saved.
@@ -1727,6 +1867,11 @@ class TeamCategoryAdmin(OrganizationFilterMixin, ReassignToTeamMixin, admin.Mode
 		return obj.articles.count()
 
 	article_count.short_description = "Articles"
+
+	@admin.display(description="Match scope", ordering="match_scope")
+	def display_match_scope(self, obj):
+		"""Human-readable label for the category's match scope."""
+		return obj.get_match_scope_display()
 
 	def display_subjects(self, obj):
 		"""Display subjects as a comma-separated list"""

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -1779,12 +1779,19 @@ class TeamCategoryAdmin(OrganizationFilterMixin, ReassignToTeamMixin, admin.Mode
 		(
 			"Matching",
 			{
-				"fields": ("category_terms", "match_scope", "match_min_score"),
+				"fields": (
+					"category_terms",
+					"match_scope",
+					"match_min_score_articles",
+					"match_min_score_trials",
+				),
 				"description": (
 					"Automatic categories match content whose in-scope fields contain these "
 					"terms and whose score reaches the minimum. A fixed bonus of 2 points per "
 					"unique matched term is added on top of the field weights below. In "
-					"'Title only' scope every field except the title is ignored."
+					"'Title only' scope every field except the title is ignored. "
+					"Articles are scored on up to 2 fields; trials on up to 7, so separate "
+					"thresholds let you tune both independently."
 				),
 			},
 		),
@@ -1815,7 +1822,8 @@ class TeamCategoryAdmin(OrganizationFilterMixin, ReassignToTeamMixin, admin.Mode
 		"subjects",
 		"category_type",
 		"match_scope",
-		"match_min_score",
+		"match_min_score_articles",
+		"match_min_score_trials",
 		"weight_article_title",
 		"weight_article_summary",
 		"weight_trial_title",

--- a/django/gregory/management/commands/rebuild_categories.py
+++ b/django/gregory/management/commands/rebuild_categories.py
@@ -180,7 +180,8 @@ class Command(BaseCommand):
 				# Iterate the (prefetched) relation instead of values_list, which
 				# would bypass prefetch_related and re-query per category
 				"subjects": sorted(subject.id for subject in cat.subjects.all()),
-				"min_score": cat.match_min_score,
+				"min_score_articles": cat.match_min_score_articles,
+				"min_score_trials": cat.match_min_score_trials,
 				"scope": cat.match_scope,
 				"weights": {
 					"article": self.active_weights(cat, "article"),
@@ -298,7 +299,7 @@ class Command(BaseCommand):
 			cat_cutoff = self.category_cutoff(cat, cutoff_date, config_hash)
 
 			weights = self.active_weights(cat, "article")
-			min_score = cat.match_min_score
+			min_score = cat.match_min_score_articles
 
 			# Prepare term patterns for more accurate matching
 			term_patterns = [
@@ -460,7 +461,7 @@ class Command(BaseCommand):
 			cat_cutoff = self.category_cutoff(cat, cutoff_date, config_hash)
 
 			weights = self.active_weights(cat, "trial")
-			min_score = cat.match_min_score
+			min_score = cat.match_min_score_trials
 
 			# Prepare term patterns for more accurate matching
 			term_patterns = [

--- a/django/gregory/management/commands/rebuild_categories.py
+++ b/django/gregory/management/commands/rebuild_categories.py
@@ -19,13 +19,47 @@ from datetime import timedelta
 # Configure logging
 logger = logging.getLogger(__name__)
 
+# Bonus added per unique matched term, on top of the per-field weights. Fixed for
+# now; the per-category weights cover the rest of the scoring configuration.
+MULTI_TERM_BONUS = 2
+
+# Map each scored field to the ORM lookup used to pre-filter candidates and to the
+# attribute read off the model instance when scoring. ``upper`` marks the lookups
+# that run against the persisted uppercase helper columns (utitle/usummary).
+ARTICLE_FIELD_QUERY = {
+	"title": ("utitle__contains", True),
+	"summary": ("usummary__contains", True),
+}
+ARTICLE_FIELD_ATTR = {
+	"title": "title",
+	"summary": "summary",
+}
+TRIAL_FIELD_QUERY = {
+	"title": ("utitle__contains", True),
+	"summary": ("usummary__contains", True),
+	"scientific_title": ("scientific_title__icontains", False),
+	"intervention": ("intervention__icontains", False),
+	"primary_outcome": ("primary_outcome__icontains", False),
+	"secondary_outcome": ("secondary_outcome__icontains", False),
+	"therapeutic_areas": ("therapeutic_areas__icontains", False),
+}
+TRIAL_FIELD_ATTR = {
+	"title": "title",
+	"summary": "summary",
+	"scientific_title": "scientific_title",
+	"intervention": "intervention",
+	"primary_outcome": "primary_outcome",
+	"secondary_outcome": "secondary_outcome",
+	"therapeutic_areas": "therapeutic_areas",
+}
+
 
 class Command(BaseCommand):
 	help = (
 		"Rebuilds category associations for articles and trials by diffing the desired state against the "
 		"current state: matching items are added and stale items removed, without ever clearing the tables. "
-		"For trials, searches across multiple fields including title, summary, intervention, outcomes, "
-		"scientific title, and therapeutic areas."
+		"Each category decides which fields are searched (title only, or title and summary/extra fields), "
+		"the per-field score weights, and the minimum score required to qualify."
 	)
 
 	def add_arguments(self, parser):
@@ -39,12 +73,6 @@ class Command(BaseCommand):
 		)
 		parser.add_argument(
 			"--batch-size", type=int, default=1000, help="Batch size for processing"
-		)
-		parser.add_argument(
-			"--min-score",
-			type=int,
-			default=3,
-			help="Minimum score to categorize content",
 		)
 		parser.add_argument(
 			"--articles-only",
@@ -72,7 +100,6 @@ class Command(BaseCommand):
 		self.category_id = options.get("category")
 		days = options.get("days")
 		batch_size = options.get("batch_size")
-		min_score = options.get("min_score")
 
 		if self.category_id is not None:
 			try:
@@ -95,17 +122,17 @@ class Command(BaseCommand):
 			)
 
 		if not options.get("trials_only"):
-			self.rebuild_cats_articles(days, batch_size, min_score)
+			self.rebuild_cats_articles(days, batch_size)
 
 		if not options.get("articles_only"):
-			self.rebuild_cats_trials(days, batch_size, min_score)
+			self.rebuild_cats_trials(days, batch_size)
 
 		if (
 			not self.dry_run
 			and not options.get("articles_only")
 			and not options.get("trials_only")
 		):
-			self.finalize_sync_state(min_score)
+			self.finalize_sync_state()
 
 		self.stdout.write(
 			self.style.SUCCESS("Successfully rebuilt category associations.")
@@ -136,7 +163,16 @@ class Command(BaseCommand):
 			qs = qs.filter(pk=self.category_id)
 		return qs.prefetch_related("subjects")
 
-	def category_config_hash(self, cat, min_score):
+	def active_weights(self, cat, content_type):
+		"""Per-field weights actually used for scoring: scope-aware and with zero
+		weights dropped, so a field weighted 0 is neither searched nor scored."""
+		return {
+			field: weight
+			for field, weight in cat.get_scored_fields(content_type).items()
+			if weight > 0
+		}
+
+	def category_config_hash(self, cat):
 		"""Fingerprint of everything that affects which items match this category."""
 		payload = json.dumps(
 			{
@@ -144,7 +180,12 @@ class Command(BaseCommand):
 				# Iterate the (prefetched) relation instead of values_list, which
 				# would bypass prefetch_related and re-query per category
 				"subjects": sorted(subject.id for subject in cat.subjects.all()),
-				"min_score": min_score,
+				"min_score": cat.match_min_score,
+				"scope": cat.match_scope,
+				"weights": {
+					"article": self.active_weights(cat, "article"),
+					"trial": self.active_weights(cat, "trial"),
+				},
 			},
 			sort_keys=True,
 		)
@@ -165,7 +206,7 @@ class Command(BaseCommand):
 			return None
 		return cutoff_date
 
-	def finalize_sync_state(self, min_score):
+	def finalize_sync_state(self):
 		"""Record the matching configuration each automatic category was synced with.
 
 		Only called after a complete run (articles and trials): storing the hash
@@ -174,7 +215,7 @@ class Command(BaseCommand):
 		"""
 		now = timezone.now()
 		for cat in self.target_categories():
-			cat.match_config_hash = self.category_config_hash(cat, min_score)
+			cat.match_config_hash = self.category_config_hash(cat)
 			cat.last_synced_at = now
 			cat.save(update_fields=["match_config_hash", "last_synced_at"])
 
@@ -196,7 +237,36 @@ class Command(BaseCommand):
 				manager.remove(*to_remove)
 		return len(to_add), len(to_remove)
 
-	def rebuild_cats_articles(self, days=None, batch_size=1000, min_score=3):
+	def candidate_query(self, terms, weights, field_query):
+		"""Broad DB filter: any term appearing in any in-scope field."""
+		query = Q()
+		for term in terms:
+			upper_term = term.upper()
+			term_q = Q()
+			for field in weights:
+				lookup, use_upper = field_query[field]
+				term_q |= Q(**{lookup: upper_term if use_upper else term})
+			if term_q:
+				query |= term_q
+		return query
+
+	def score_item(self, item, terms, term_patterns, weights, field_attr):
+		"""Return (score, matched_terms) for one item against the in-scope fields."""
+		score = 0
+		matched_terms = set()
+		for field, weight in weights.items():
+			text = getattr(item, field_attr[field], None) or ""
+			if not text:
+				continue
+			text = text.lower()
+			for i, pattern in enumerate(term_patterns):
+				if pattern.search(text):
+					score += weight
+					matched_terms.add(terms[i])
+		score += len(matched_terms) * MULTI_TERM_BONUS
+		return score, matched_terms
+
+	def rebuild_cats_articles(self, days=None, batch_size=1000):
 		self.stdout.write("Processing articles categorization...")
 
 		# Define date cutoff for incremental updates
@@ -224,23 +294,33 @@ class Command(BaseCommand):
 				f"[{index}/{total_categories}] Processing category: {cat.category_name}"
 			)
 
-			config_hash = self.category_config_hash(cat, min_score)
+			config_hash = self.category_config_hash(cat)
 			cat_cutoff = self.category_cutoff(cat, cutoff_date, config_hash)
+
+			weights = self.active_weights(cat, "article")
+			min_score = cat.match_min_score
 
 			# Prepare term patterns for more accurate matching
 			term_patterns = [
 				re.compile(r"\b" + re.escape(term.lower()) + r"\b") for term in terms
 			]
 
-			# Desired set of article ids for this category; empty terms mean no articles qualify
+			# Desired set of article ids for this category; with no terms or no
+			# scored fields nothing qualifies and stale automatic links are removed
 			desired_ids = set()
+			should_match = bool(terms) and bool(weights)
 
 			if not terms:
 				self.log_message(
 					f"  Category '{cat.category_name}' has no terms; stale automatic associations will be removed"
 				)
+			elif not weights:
+				self.log_message(
+					f"  Category '{cat.category_name}' has no scored fields for articles; "
+					"stale automatic associations will be removed"
+				)
 
-			for subject in cat.subjects.all() if terms else []:
+			for subject in cat.subjects.all() if should_match else []:
 				self.log_message(f"  - Processing subject: {subject.subject_name}")
 
 				matched_for_subject = 0
@@ -255,15 +335,10 @@ class Command(BaseCommand):
 						| Q(last_updated__gte=cat_cutoff)
 					)
 
-				# Initial database filtering (broad match)
-				query = Q()
-				for term in terms:
-					upper_term = term.upper()
-					query |= Q(utitle__contains=upper_term) | Q(
-						usummary__contains=upper_term
-					)
-
-				candidates = base_query.filter(query)
+				# Initial database filtering (broad match), scoped to the searched fields
+				candidates = base_query.filter(
+					self.candidate_query(terms, weights, ARTICLE_FIELD_QUERY)
+				)
 				total_candidates = candidates.count()
 				self.log_message(f"    Found {total_candidates} candidate articles")
 
@@ -276,25 +351,9 @@ class Command(BaseCommand):
 					articles_with_scores = []
 
 					for article in batch:
-						score = 0
-						matched_terms = set()
-						title = article.title.lower()
-						summary = (article.summary or "").lower()
-
-						# Check for whole-word matches in title (higher weight)
-						for i, pattern in enumerate(term_patterns):
-							if pattern.search(title):
-								score += 3
-								matched_terms.add(terms[i])
-
-						# Check for whole-word matches in summary
-						for i, pattern in enumerate(term_patterns):
-							if pattern.search(summary):
-								score += 1
-								matched_terms.add(terms[i])
-
-						# Bonus for multiple term matches
-						score += len(matched_terms) * 2
+						score, matched_terms = self.score_item(
+							article, terms, term_patterns, weights, ARTICLE_FIELD_ATTR
+						)
 
 						# Add if score meets threshold
 						if score >= min_score:
@@ -369,7 +428,7 @@ class Command(BaseCommand):
 				)
 			)
 
-	def rebuild_cats_trials(self, days=None, batch_size=1000, min_score=3):
+	def rebuild_cats_trials(self, days=None, batch_size=1000):
 		self.stdout.write("Processing trials categorization...")
 
 		# Define date cutoff for incremental updates
@@ -397,23 +456,33 @@ class Command(BaseCommand):
 				f"[{index}/{total_categories}] Processing category: {cat.category_name}"
 			)
 
-			config_hash = self.category_config_hash(cat, min_score)
+			config_hash = self.category_config_hash(cat)
 			cat_cutoff = self.category_cutoff(cat, cutoff_date, config_hash)
+
+			weights = self.active_weights(cat, "trial")
+			min_score = cat.match_min_score
 
 			# Prepare term patterns for more accurate matching
 			term_patterns = [
 				re.compile(r"\b" + re.escape(term.lower()) + r"\b") for term in terms
 			]
 
-			# Desired set of trial ids for this category; empty terms mean no trials qualify
+			# Desired set of trial ids for this category; with no terms or no
+			# scored fields nothing qualifies and stale automatic links are removed
 			desired_ids = set()
+			should_match = bool(terms) and bool(weights)
 
 			if not terms:
 				self.log_message(
 					f"  Category '{cat.category_name}' has no terms; stale automatic associations will be removed"
 				)
+			elif not weights:
+				self.log_message(
+					f"  Category '{cat.category_name}' has no scored fields for trials; "
+					"stale automatic associations will be removed"
+				)
 
-			for subject in cat.subjects.all() if terms else []:
+			for subject in cat.subjects.all() if should_match else []:
 				self.log_message(f"  - Processing subject: {subject.subject_name}")
 
 				matched_for_subject = 0
@@ -428,21 +497,10 @@ class Command(BaseCommand):
 						| Q(last_updated__gte=cat_cutoff)
 					)
 
-				# Initial database filtering (broad match) - trials have more searchable fields
-				query = Q()
-				for term in terms:
-					upper_term = term.upper()
-					query |= (
-						Q(utitle__contains=upper_term)
-						| Q(usummary__contains=upper_term)
-						| Q(intervention__icontains=term)
-						| Q(primary_outcome__icontains=term)
-						| Q(scientific_title__icontains=term)
-						| Q(secondary_outcome__icontains=term)
-						| Q(therapeutic_areas__icontains=term)
-					)
-
-				candidates = base_query.filter(query)
+				# Initial database filtering (broad match), scoped to the searched fields
+				candidates = base_query.filter(
+					self.candidate_query(terms, weights, TRIAL_FIELD_QUERY)
+				)
 				total_candidates = candidates.count()
 				self.log_message(f"    Found {total_candidates} candidate trials")
 
@@ -455,69 +513,9 @@ class Command(BaseCommand):
 					trials_with_scores = []
 
 					for trial in batch:
-						score = 0
-						matched_terms = set()
-						title = trial.title.lower()
-						summary = (trial.summary or "").lower()
-						intervention = (trial.intervention or "").lower()
-						primary_outcome = (trial.primary_outcome or "").lower()
-						scientific_title = (trial.scientific_title or "").lower()
-						secondary_outcome = (trial.secondary_outcome or "").lower()
-						therapeutic_areas = (trial.therapeutic_areas or "").lower()
-
-						# Scoring system for trial categorization:
-						# Title matches: 3 points (highest priority - most descriptive)
-						# Summary matches: 2 points (good context)
-						# Scientific title matches: 2 points (formal description)
-						# Intervention matches: 2 points (what's being tested)
-						# Primary/Secondary outcome matches: 1 point each (results focus)
-						# Therapeutic areas matches: 1 point (general categorization)
-						# Multiple term bonus: +2 points per unique matched term
-
-						# Check for whole-word matches in title (highest weight)
-						for i, pattern in enumerate(term_patterns):
-							if pattern.search(title):
-								score += 3
-								matched_terms.add(terms[i])
-
-						# Check for whole-word matches in summary
-						for i, pattern in enumerate(term_patterns):
-							if pattern.search(summary):
-								score += 2
-								matched_terms.add(terms[i])
-
-						# Check for whole-word matches in scientific title
-						for i, pattern in enumerate(term_patterns):
-							if pattern.search(scientific_title):
-								score += 2
-								matched_terms.add(terms[i])
-
-						# Check for whole-word matches in intervention
-						for i, pattern in enumerate(term_patterns):
-							if pattern.search(intervention):
-								score += 2
-								matched_terms.add(terms[i])
-
-						# Check for whole-word matches in primary outcome
-						for i, pattern in enumerate(term_patterns):
-							if pattern.search(primary_outcome):
-								score += 1
-								matched_terms.add(terms[i])
-
-						# Check for whole-word matches in secondary outcome
-						for i, pattern in enumerate(term_patterns):
-							if pattern.search(secondary_outcome):
-								score += 1
-								matched_terms.add(terms[i])
-
-						# Check for whole-word matches in therapeutic areas
-						for i, pattern in enumerate(term_patterns):
-							if pattern.search(therapeutic_areas):
-								score += 1
-								matched_terms.add(terms[i])
-
-						# Bonus for multiple term matches
-						score += len(matched_terms) * 2
+						score, matched_terms = self.score_item(
+							trial, terms, term_patterns, weights, TRIAL_FIELD_ATTR
+						)
 
 						# Add if score meets threshold
 						if score >= min_score:
@@ -539,29 +537,22 @@ class Command(BaseCommand):
 								f"      Trial {trial_id}: Score {score}, Terms: {', '.join(matched)}"
 							)
 							self.log_message(f"        Title: {title[:100]}...")
-							# Show which fields contributed to the match
+							# Show which in-scope fields contributed to the match
 							trial = next(
 								(t for t in batch if t.trial_id == trial_id), None
 							)
 							if trial:
-								search_fields = {
-									"title": trial.title,
-									"summary": trial.summary or "",
-									"intervention": trial.intervention or "",
-									"primary_outcome": trial.primary_outcome or "",
-									"scientific_title": trial.scientific_title or "",
-									"secondary_outcome": trial.secondary_outcome or "",
-									"therapeutic_areas": trial.therapeutic_areas or "",
-								}
 								matching_fields = []
-								for field_name, field_value in search_fields.items():
-									for term in matched:
-										if term.lower() in field_value.lower():
-											matching_fields.append(field_name)
-											break
+								for field in weights:
+									value = (
+										getattr(trial, TRIAL_FIELD_ATTR[field], None)
+										or ""
+									).lower()
+									if any(term.lower() in value for term in matched):
+										matching_fields.append(field)
 								if matching_fields:
 									self.log_message(
-										f"        Matched in fields: {', '.join(set(matching_fields))}"
+										f"        Matched in fields: {', '.join(matching_fields)}"
 									)
 
 					self.log_message(

--- a/django/gregory/migrations/0067_teamcategory_match_settings.py
+++ b/django/gregory/migrations/0067_teamcategory_match_settings.py
@@ -1,0 +1,65 @@
+"""Add per-category matching settings to TeamCategory.
+
+- ``match_scope``: search/score the title only, or the title and summary
+  (and, for trials, the full set of searchable fields).
+- ``match_min_score``: per-category score threshold, replacing the previous
+  global ``--min-score`` argument on rebuild_categories.
+- ``match_weights``: per-field score weights keyed by content type.
+
+Defaults reproduce the historical hard-coded scoring so existing categories
+keep behaving exactly as before until someone edits them.
+"""
+from django.db import migrations, models
+import gregory.models
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		("gregory", "0066_remove_historicalarticles_crossref_retraction_check"),
+	]
+
+	operations = [
+		migrations.AddField(
+			model_name="teamcategory",
+			name="match_scope",
+			field=models.CharField(
+				choices=[
+					("title", "Title only"),
+					("title_summary", "Title and summary"),
+				],
+				default="title_summary",
+				help_text=(
+					"Which fields are searched and scored when matching content to this "
+					"category. 'Title only' scores just the title; 'Title and summary' also "
+					"scores the summary (and, for trials, the scientific title, intervention, "
+					"outcomes and therapeutic areas)."
+				),
+				max_length=20,
+			),
+		),
+		migrations.AddField(
+			model_name="teamcategory",
+			name="match_min_score",
+			field=models.PositiveSmallIntegerField(
+				default=3,
+				help_text=(
+					"Minimum score an article or trial must reach to be assigned to this "
+					"category."
+				),
+			),
+		),
+		migrations.AddField(
+			model_name="teamcategory",
+			name="match_weights",
+			field=models.JSONField(
+				blank=True,
+				default=gregory.models.default_match_weights,
+				help_text=(
+					"Per-field score weights keyed by content type ('article', 'trial'). "
+					"Higher weights make a matched field count for more. A fixed bonus of 2 "
+					"points per unique matched term is always added."
+				),
+			),
+		),
+	]

--- a/django/gregory/migrations/0068_teamcategory_split_min_score.py
+++ b/django/gregory/migrations/0068_teamcategory_split_min_score.py
@@ -1,0 +1,57 @@
+"""Split TeamCategory.match_min_score into two per-content-type thresholds.
+
+Articles are scored on up to 2 fields (title, summary); trials on up to 7
+(title, summary, scientific title, intervention, primary/secondary outcome,
+therapeutic areas).  A single shared threshold can't serve both well, so we
+replace it with match_min_score_articles and match_min_score_trials.
+
+The data migration copies the existing value into both new fields so every
+existing category retains exactly its current behaviour after the upgrade.
+"""
+from django.db import migrations, models
+
+
+def copy_min_score(apps, schema_editor):
+	TeamCategory = apps.get_model("gregory", "TeamCategory")
+	TeamCategory.objects.update(
+		match_min_score_articles=models.F("match_min_score"),
+		match_min_score_trials=models.F("match_min_score"),
+	)
+
+
+class Migration(migrations.Migration):
+
+	dependencies = [
+		("gregory", "0067_teamcategory_match_settings"),
+	]
+
+	operations = [
+		migrations.AddField(
+			model_name="teamcategory",
+			name="match_min_score_articles",
+			field=models.PositiveSmallIntegerField(
+				default=3,
+				help_text=(
+					"Minimum score an article must reach to be assigned to this category. "
+					"Articles are scored on up to 2 fields (title, summary)."
+				),
+			),
+		),
+		migrations.AddField(
+			model_name="teamcategory",
+			name="match_min_score_trials",
+			field=models.PositiveSmallIntegerField(
+				default=3,
+				help_text=(
+					"Minimum score a trial must reach to be assigned to this category. "
+					"Trials are scored on up to 7 fields (title, summary, scientific title, "
+					"intervention, primary outcome, secondary outcome, therapeutic areas)."
+				),
+			),
+		),
+		migrations.RunPython(copy_min_score, reverse_code=migrations.RunPython.noop),
+		migrations.RemoveField(
+			model_name="teamcategory",
+			name="match_min_score",
+		),
+	]

--- a/django/gregory/models.py
+++ b/django/gregory/models.py
@@ -136,10 +136,19 @@ class TeamCategory(models.Model):
 			"(and, for trials, the scientific title, intervention, outcomes and therapeutic areas)."
 		),
 	)
-	match_min_score = models.PositiveSmallIntegerField(
+	match_min_score_articles = models.PositiveSmallIntegerField(
 		default=3,
 		help_text=(
-			"Minimum score an article or trial must reach to be assigned to this category."
+			"Minimum score an article must reach to be assigned to this category. "
+			"Articles are scored on up to 2 fields (title, summary)."
+		),
+	)
+	match_min_score_trials = models.PositiveSmallIntegerField(
+		default=3,
+		help_text=(
+			"Minimum score a trial must reach to be assigned to this category. "
+			"Trials are scored on up to 7 fields (title, summary, scientific title, "
+			"intervention, primary outcome, secondary outcome, therapeutic areas)."
 		),
 	)
 	match_weights = models.JSONField(

--- a/django/gregory/models.py
+++ b/django/gregory/models.py
@@ -60,6 +60,42 @@ class CategoryType(models.TextChoices):
 	AUTOMATIC = "automatic", "Automatic"
 
 
+class CategoryMatchScope(models.TextChoices):
+	TITLE = "title", "Title only"
+	TITLE_SUMMARY = "title_summary", "Title and summary"
+
+
+# Default per-field score weights used when matching content to a category.
+# These reproduce the historical hard-coded scoring so existing categories keep
+# behaving exactly as before until someone edits them. A fixed bonus of 2 points
+# per unique matched term is added on top of these (see rebuild_categories).
+DEFAULT_ARTICLE_MATCH_WEIGHTS = {
+	"title": 3,
+	"summary": 1,
+}
+DEFAULT_TRIAL_MATCH_WEIGHTS = {
+	"title": 3,
+	"summary": 2,
+	"scientific_title": 2,
+	"intervention": 2,
+	"primary_outcome": 1,
+	"secondary_outcome": 1,
+	"therapeutic_areas": 1,
+}
+MATCH_WEIGHT_DEFAULTS = {
+	"article": DEFAULT_ARTICLE_MATCH_WEIGHTS,
+	"trial": DEFAULT_TRIAL_MATCH_WEIGHTS,
+}
+
+
+def default_match_weights():
+	"""Default for TeamCategory.match_weights (a fresh copy each time)."""
+	return {
+		content_type: dict(weights)
+		for content_type, weights in MATCH_WEIGHT_DEFAULTS.items()
+	}
+
+
 class TeamCategory(models.Model):
 	team = models.ForeignKey(
 		"Team",
@@ -90,6 +126,31 @@ class TeamCategory(models.Model):
 			"by hand and are never touched by the command."
 		),
 	)
+	match_scope = models.CharField(
+		max_length=20,
+		choices=CategoryMatchScope.choices,
+		default=CategoryMatchScope.TITLE_SUMMARY,
+		help_text=(
+			"Which fields are searched and scored when matching content to this category. "
+			"'Title only' scores just the title; 'Title and summary' also scores the summary "
+			"(and, for trials, the scientific title, intervention, outcomes and therapeutic areas)."
+		),
+	)
+	match_min_score = models.PositiveSmallIntegerField(
+		default=3,
+		help_text=(
+			"Minimum score an article or trial must reach to be assigned to this category."
+		),
+	)
+	match_weights = models.JSONField(
+		default=default_match_weights,
+		blank=True,
+		help_text=(
+			"Per-field score weights keyed by content type ('article', 'trial'). Higher "
+			"weights make a matched field count for more. A fixed bonus of 2 points per "
+			"unique matched term is always added."
+		),
+	)
 	match_config_hash = models.CharField(
 		max_length=64,
 		blank=True,
@@ -112,6 +173,37 @@ class TeamCategory(models.Model):
 		if not self.category_slug:
 			self.category_slug = slugify(self.category_name)
 		super().save(*args, **kwargs)
+
+	def get_match_weights(self, content_type):
+		"""Return the per-field weights for 'article' or 'trial'.
+
+		Falls back to the historical defaults for any field missing from the
+		stored configuration and ignores unknown fields, so a partial or legacy
+		``match_weights`` value can never break matching.
+		"""
+		defaults = MATCH_WEIGHT_DEFAULTS.get(content_type, {})
+		stored = {}
+		if isinstance(self.match_weights, dict):
+			candidate = self.match_weights.get(content_type)
+			if isinstance(candidate, dict):
+				stored = candidate
+		weights = {}
+		for field, default in defaults.items():
+			try:
+				weights[field] = int(stored.get(field, default))
+			except (TypeError, ValueError):
+				weights[field] = default
+		return weights
+
+	def get_scored_fields(self, content_type):
+		"""Return {field: weight} actually used for scoring, honouring match_scope.
+
+		In 'title only' scope every field except the title is dropped.
+		"""
+		weights = self.get_match_weights(content_type)
+		if self.match_scope == CategoryMatchScope.TITLE:
+			return {"title": weights.get("title", 0)}
+		return weights
 
 	def __str__(self):
 		return f"{self.team.name} - {self.category_name}"

--- a/django/gregory/tests/management/test_rebuild_categories_command.py
+++ b/django/gregory/tests/management/test_rebuild_categories_command.py
@@ -20,6 +20,7 @@ from gregory.models import (
 	Articles,
 	ArticleCategoryAssignment,
 	CategoryAssignmentSource,
+	CategoryMatchScope,
 	CategoryType,
 	Subject,
 	Team,
@@ -342,6 +343,162 @@ class RebuildCategoriesDiffSyncTest(TestCase):
 		self.assertEqual(self.article_assignment(matching).pk, row_id)
 
 
+class MatchScopeAndScoringTest(TestCase):
+	"""Per-category match scope, score threshold, and field weights."""
+
+	def setUp(self):
+		self.org = Organization.objects.create(name="Test Org")
+		self.team = Team.objects.create(
+			organization=self.org, name="Research", slug="research"
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Neurology", subject_slug="neurology", team=self.team
+		)
+		self.category = TeamCategory.objects.create(
+			team=self.team,
+			category_name="Neuroplasticity",
+			category_terms=["neuroplasticity"],
+		)
+		self.category.subjects.add(self.subject)
+
+	def make_article(self, title, summary=""):
+		article = Articles.objects.create(
+			title=title,
+			summary=summary,
+			link=f"https://example.com/{abs(hash(title))}",
+		)
+		article.subjects.add(self.subject)
+		return article
+
+	def make_trial(self, title, summary="", **fields):
+		trial = Trials.objects.create(
+			title=title,
+			summary=summary,
+			link=f"https://example.com/trial/{abs(hash(title))}",
+			discovery_date=timezone.now(),
+			**fields,
+		)
+		trial.subjects.add(self.subject)
+		return trial
+
+	def backdate(self, model, obj, days=30):
+		old = timezone.now() - timedelta(days=days)
+		model.objects.filter(pk=obj.pk).update(discovery_date=old, last_updated=old)
+
+	# --- match scope ---------------------------------------------------------
+
+	def test_default_scope_scores_summary(self):
+		# title+summary is the default: a summary-only mention still qualifies
+		summary_only = self.make_article("Unrelated topic", "A study of neuroplasticity")
+
+		call_command("rebuild_categories", articles_only=True)
+
+		self.assertIn(summary_only, self.category.articles.all())
+
+	def test_title_only_scope_ignores_summary(self):
+		self.category.match_scope = CategoryMatchScope.TITLE
+		self.category.save()
+		title_match = self.make_article("Neuroplasticity in adults")
+		summary_only = self.make_article("Unrelated topic", "About neuroplasticity")
+
+		call_command("rebuild_categories", articles_only=True)
+
+		self.assertIn(title_match, self.category.articles.all())
+		self.assertNotIn(summary_only, self.category.articles.all())
+
+	# --- per-category threshold ---------------------------------------------
+
+	def test_higher_min_score_excludes_single_title_match(self):
+		# title (3) + bonus (2) = 5; raise the bar above that
+		self.category.match_min_score = 6
+		self.category.save()
+		single = self.make_article("Neuroplasticity in adults")
+		# title (3) + summary (1) + bonus (2) = 6 clears the bar
+		both = self.make_article("Neuroplasticity in adults", "more neuroplasticity")
+
+		call_command("rebuild_categories", articles_only=True)
+
+		self.assertNotIn(single, self.category.articles.all())
+		self.assertIn(both, self.category.articles.all())
+
+	# --- per-field weights ---------------------------------------------------
+
+	def test_zero_weight_disables_field(self):
+		self.category.match_weights = {
+			"article": {"title": 3, "summary": 0},
+			"trial": {},
+		}
+		self.category.save()
+		title_match = self.make_article("Neuroplasticity in adults")
+		summary_only = self.make_article("Unrelated topic", "About neuroplasticity")
+
+		call_command("rebuild_categories", articles_only=True)
+
+		self.assertIn(title_match, self.category.articles.all())
+		self.assertNotIn(summary_only, self.category.articles.all())
+
+	# --- trials --------------------------------------------------------------
+
+	def test_trial_default_scope_uses_extra_fields(self):
+		self.category.category_terms = ["dopamine"]
+		self.category.save()
+		# intervention (2) + bonus (2) = 4 >= 3 under the default title+summary scope
+		via_intervention = self.make_trial(
+			"Unrelated trial", intervention="dopamine agonist"
+		)
+
+		call_command("rebuild_categories", trials_only=True)
+
+		self.assertIn(via_intervention, self.category.trials.all())
+
+	def test_trial_title_only_ignores_extra_fields(self):
+		self.category.category_terms = ["dopamine"]
+		self.category.match_scope = CategoryMatchScope.TITLE
+		self.category.save()
+		title_match = self.make_trial("Dopamine rehabilitation trial")
+		via_intervention = self.make_trial(
+			"Unrelated trial", intervention="dopamine agonist"
+		)
+
+		call_command("rebuild_categories", trials_only=True)
+
+		self.assertIn(title_match, self.category.trials.all())
+		self.assertNotIn(via_intervention, self.category.trials.all())
+
+	# --- config-change re-match ---------------------------------------------
+
+	def test_changing_scope_triggers_full_rematch(self):
+		summary_only = self.make_article("Unrelated topic", "About neuroplasticity")
+		call_command("rebuild_categories")
+		self.assertIn(summary_only, self.category.articles.all())
+
+		# Push it outside the incremental window, then narrow the scope
+		self.backdate(Articles, summary_only)
+		self.category.match_scope = CategoryMatchScope.TITLE
+		self.category.save()
+
+		call_command("rebuild_categories", days=7)
+
+		# The scope change forces a full re-match despite --days
+		self.assertNotIn(summary_only, self.category.articles.all())
+
+	def test_changing_weight_triggers_full_rematch(self):
+		summary_only = self.make_article("Unrelated topic", "About neuroplasticity")
+		call_command("rebuild_categories")
+		self.assertIn(summary_only, self.category.articles.all())
+
+		self.backdate(Articles, summary_only)
+		self.category.match_weights = {
+			"article": {"title": 3, "summary": 0},
+			"trial": {},
+		}
+		self.category.save()
+
+		call_command("rebuild_categories", days=7)
+
+		self.assertNotIn(summary_only, self.category.articles.all())
+
+
 class TeamCategoryAdminBackfillTest(TestCase):
 	"""Creating an automatic category in the admin backfills it immediately."""
 
@@ -369,19 +526,35 @@ class TeamCategoryAdminBackfillTest(TestCase):
 		)
 		self.trial.subjects.add(self.subject)
 
-	def create_category_via_admin(self, category_type):
-		return self.client.post(
-			reverse("admin:gregory_teamcategory_add"),
-			{
-				"team": self.team.pk,
-				"subjects": [self.subject.pk],
-				"category_name": "Neuroplasticity",
-				"category_slug": "neuroplasticity",
-				"category_description": "",
-				"category_terms": "neuroplasticity",
-				"category_type": category_type,
-			},
-		)
+	# Default values for the matching-settings form fields, mirroring the model
+	# defaults so a posted form reproduces today's behaviour unless overridden.
+	DEFAULT_MATCH_FIELDS = {
+		"match_scope": "title_summary",
+		"match_min_score": 3,
+		"weight_article_title": 3,
+		"weight_article_summary": 1,
+		"weight_trial_title": 3,
+		"weight_trial_summary": 2,
+		"weight_trial_scientific_title": 2,
+		"weight_trial_intervention": 2,
+		"weight_trial_primary_outcome": 1,
+		"weight_trial_secondary_outcome": 1,
+		"weight_trial_therapeutic_areas": 1,
+	}
+
+	def create_category_via_admin(self, category_type, **overrides):
+		data = {
+			"team": self.team.pk,
+			"subjects": [self.subject.pk],
+			"category_name": "Neuroplasticity",
+			"category_slug": "neuroplasticity",
+			"category_description": "",
+			"category_terms": "neuroplasticity",
+			"category_type": category_type,
+			**self.DEFAULT_MATCH_FIELDS,
+		}
+		data.update(overrides)
+		return self.client.post(reverse("admin:gregory_teamcategory_add"), data)
 
 	def test_new_automatic_category_is_backfilled(self):
 		response = self.create_category_via_admin(CategoryType.AUTOMATIC)
@@ -407,6 +580,8 @@ class TeamCategoryAdminBackfillTest(TestCase):
 		self.assertEqual(category.trials.count(), 0)
 
 	def edit_category_via_admin(self, category, **overrides):
+		article_weights = category.get_match_weights("article")
+		trial_weights = category.get_match_weights("trial")
 		data = {
 			"team": self.team.pk,
 			"subjects": [self.subject.pk],
@@ -418,11 +593,57 @@ class TeamCategoryAdminBackfillTest(TestCase):
 			# hidden initial input and compares against it to detect changes
 			"initial-category_terms": ",".join(category.category_terms or []),
 			"category_type": category.category_type,
+			"match_scope": category.match_scope,
+			"match_min_score": category.match_min_score,
+			"weight_article_title": article_weights["title"],
+			"weight_article_summary": article_weights["summary"],
+			"weight_trial_title": trial_weights["title"],
+			"weight_trial_summary": trial_weights["summary"],
+			"weight_trial_scientific_title": trial_weights["scientific_title"],
+			"weight_trial_intervention": trial_weights["intervention"],
+			"weight_trial_primary_outcome": trial_weights["primary_outcome"],
+			"weight_trial_secondary_outcome": trial_weights["secondary_outcome"],
+			"weight_trial_therapeutic_areas": trial_weights["therapeutic_areas"],
 		}
 		data.update(overrides)
 		return self.client.post(
 			reverse("admin:gregory_teamcategory_change", args=[category.pk]), data
 		)
+
+	def test_admin_saves_custom_match_settings(self):
+		response = self.create_category_via_admin(
+			CategoryType.AUTOMATIC,
+			match_scope="title",
+			match_min_score=5,
+			weight_article_summary=4,
+		)
+		self.assertEqual(response.status_code, 302)
+
+		category = TeamCategory.objects.get(category_slug="neuroplasticity")
+		self.assertEqual(category.match_scope, "title")
+		self.assertEqual(category.match_min_score, 5)
+		self.assertEqual(category.match_weights["article"]["summary"], 4)
+		self.assertEqual(category.match_weights["article"]["title"], 3)
+
+	def test_changing_scope_via_admin_rematches(self):
+		summary_only = Articles.objects.create(
+			title="Unrelated topic",
+			summary="A study of neuroplasticity",
+			link="https://example.com/admin-summary-only",
+		)
+		summary_only.subjects.add(self.subject)
+
+		self.create_category_via_admin(CategoryType.AUTOMATIC)
+		category = TeamCategory.objects.get(category_slug="neuroplasticity")
+		# default title+summary scope matched the summary-only article on backfill
+		self.assertIn(summary_only, category.articles.all())
+
+		response = self.edit_category_via_admin(category, match_scope="title")
+		self.assertEqual(response.status_code, 302)
+
+		category.refresh_from_db()
+		self.assertEqual(category.match_scope, "title")
+		self.assertNotIn(summary_only, category.articles.all())
 
 	def test_editing_terms_triggers_immediate_rematch(self):
 		self.create_category_via_admin(CategoryType.AUTOMATIC)

--- a/django/gregory/tests/management/test_rebuild_categories_command.py
+++ b/django/gregory/tests/management/test_rebuild_categories_command.py
@@ -414,7 +414,7 @@ class MatchScopeAndScoringTest(TestCase):
 		self.category.save()
 		single = self.make_article("Neuroplasticity in adults")
 		# title (3) + summary (1) + bonus (2) = 6 clears the bar
-		both = self.make_article("Neuroplasticity in adults", "more neuroplasticity")
+		both = self.make_article("Neuroplasticity research in adults", "more neuroplasticity")
 
 		call_command("rebuild_categories", articles_only=True)
 

--- a/django/gregory/tests/management/test_rebuild_categories_command.py
+++ b/django/gregory/tests/management/test_rebuild_categories_command.py
@@ -410,7 +410,7 @@ class MatchScopeAndScoringTest(TestCase):
 
 	def test_higher_min_score_excludes_single_title_match(self):
 		# title (3) + bonus (2) = 5; raise the bar above that
-		self.category.match_min_score = 6
+		self.category.match_min_score_articles = 6
 		self.category.save()
 		single = self.make_article("Neuroplasticity in adults")
 		# title (3) + summary (1) + bonus (2) = 6 clears the bar
@@ -530,7 +530,8 @@ class TeamCategoryAdminBackfillTest(TestCase):
 	# defaults so a posted form reproduces today's behaviour unless overridden.
 	DEFAULT_MATCH_FIELDS = {
 		"match_scope": "title_summary",
-		"match_min_score": 3,
+		"match_min_score_articles": 3,
+		"match_min_score_trials": 3,
 		"weight_article_title": 3,
 		"weight_article_summary": 1,
 		"weight_trial_title": 3,
@@ -594,7 +595,8 @@ class TeamCategoryAdminBackfillTest(TestCase):
 			"initial-category_terms": ",".join(category.category_terms or []),
 			"category_type": category.category_type,
 			"match_scope": category.match_scope,
-			"match_min_score": category.match_min_score,
+			"match_min_score_articles": category.match_min_score_articles,
+			"match_min_score_trials": category.match_min_score_trials,
 			"weight_article_title": article_weights["title"],
 			"weight_article_summary": article_weights["summary"],
 			"weight_trial_title": trial_weights["title"],
@@ -614,14 +616,16 @@ class TeamCategoryAdminBackfillTest(TestCase):
 		response = self.create_category_via_admin(
 			CategoryType.AUTOMATIC,
 			match_scope="title",
-			match_min_score=5,
+			match_min_score_articles=5,
+			match_min_score_trials=7,
 			weight_article_summary=4,
 		)
 		self.assertEqual(response.status_code, 302)
 
 		category = TeamCategory.objects.get(category_slug="neuroplasticity")
 		self.assertEqual(category.match_scope, "title")
-		self.assertEqual(category.match_min_score, 5)
+		self.assertEqual(category.match_min_score_articles, 5)
+		self.assertEqual(category.match_min_score_trials, 7)
 		self.assertEqual(category.match_weights["article"]["summary"], 4)
 		self.assertEqual(category.match_weights["article"]["title"], 3)
 


### PR DESCRIPTION
## Summary

Refactors the `rebuild_categories` command to move matching configuration from global command-line arguments to per-category settings stored in the database. This allows each category to have its own match scope, score thresholds, and per-field weights, providing much finer control over how content is matched to categories.

## Key Changes

- **Removed global `--min-score` argument** from `rebuild_categories` command; score thresholds are now per-category via `match_min_score_articles` and `match_min_score_trials` fields
- **Added `CategoryMatchScope` enum** with two options:
  - `TITLE`: Search/score only the title field
  - `TITLE_SUMMARY`: Search/score title and summary (and for trials, additional fields like scientific title, intervention, outcomes, therapeutic areas)
- **Added per-field score weights** via `match_weights` JSONField, keyed by content type ('article', 'trial'), allowing fine-grained control over how much each field contributes to the score
- **Extracted scoring logic** into reusable `score_item()` and `candidate_query()` methods that respect the category's configured scope and weights
- **Updated config hash calculation** to include all matching settings (scope, thresholds, weights) so configuration changes trigger full re-matching even with `--days` incremental mode
- **Added admin form** (`TeamCategoryAdminForm`) that exposes per-field weights as friendly integer inputs instead of raw JSON
- **Updated admin interface** with fieldsets for matching settings and a new `display_match_scope` column
- **Created two migrations** to add the new fields and split the single `match_min_score` into separate article/trial thresholds
- **Added comprehensive tests** covering match scope behavior, per-category thresholds, per-field weights, and config-change re-matching

## Implementation Details

- Default weights reproduce the historical hard-coded scoring (title: 3, summary: 1 for articles; title: 3, summary: 2, scientific_title: 2, intervention: 2, outcomes: 1 each for trials) so existing categories behave identically until edited
- A fixed bonus of 2 points per unique matched term is still applied on top of field weights
- Zero-weighted fields are neither searched nor scored, allowing categories to disable specific fields
- The `get_scored_fields()` method applies scope filtering so 'title only' scope drops all non-title fields
- Admin form fields are mapped to/from the JSON structure via `TEAMCATEGORY_WEIGHT_FIELDS` mapping

https://claude.ai/code/session_017guhFTZUjC7jhKLQFyFrG9