### PR TITLE
Add per-article summary toggle to article review status page

### DIFF
--- a/django/gregory/templates/admin/article_review_status.html
+++ b/django/gregory/templates/admin/article_review_status.html
@@ -441,6 +441,31 @@
       padding: 6px 12px;
     }
 
+    /* ── Per-article summary toggle ── */
+    .summary-toggle {
+      display: inline-block;
+      margin-top: 5px;
+      font-size: 12px;
+      color: #3b82f6;
+      cursor: pointer;
+      user-select: none;
+      text-decoration: none;
+    }
+
+    .summary-toggle:hover { text-decoration: underline; }
+
+    .article-summary {
+      display: none;
+      margin-top: 8px;
+      padding-top: 8px;
+      border-top: 1px solid #f1f5f9;
+      font-size: 13px;
+      color: #6b7280;
+      line-height: 1.55;
+    }
+
+    .article-summary.visible { display: block; }
+
     /* ── Empty state ── */
     .empty-state {
       background: #fff;
@@ -647,6 +672,10 @@
                 <a class="article-title" href="{{ item.article.link }}" target="_blank" rel="noopener noreferrer">
                   {{ item.article.title }}<span class="ext-icon">&#8599;</span>
                 </a>
+                {% if item.article.summary %}
+                <a class="summary-toggle" onclick="toggleSummary(this)">&#9654; Show summary</a>
+                <div class="article-summary">{{ item.article.summary }}</div>
+                {% endif %}
               </td>
               <td>
                 <span class="date-text">{{ item.article.discovery_date|date:"M d, Y" }}</span>
@@ -758,6 +787,12 @@
     const el = document.getElementById('date-inputs');
     if (!el) return;
     el.classList.toggle('hidden', value !== 'custom');
+  }
+
+  function toggleSummary(link) {
+    const summary = link.nextElementSibling;
+    const open = summary.classList.toggle('visible');
+    link.innerHTML = open ? '&#9660; Hide summary' : '&#9654; Show summary';
   }
 
   function sortBy(field) {

--- a/django/gregory/templates/admin/article_review_status.html
+++ b/django/gregory/templates/admin/article_review_status.html
@@ -443,9 +443,16 @@
 
     /* ── Per-article summary toggle ── */
     .summary-toggle {
-      display: inline-block;
+      /* reset button defaults */
+      appearance: none;
+      background: none;
+      border: none;
+      padding: 0;
       margin-top: 5px;
+      /* link-like look */
+      display: inline-block;
       font-size: 12px;
+      font-family: inherit;
       color: #3b82f6;
       cursor: pointer;
       user-select: none;
@@ -673,8 +680,11 @@
                   {{ item.article.title }}<span class="ext-icon">&#8599;</span>
                 </a>
                 {% if item.article.summary %}
-                <a class="summary-toggle" onclick="toggleSummary(this)">&#9654; Show summary</a>
-                <div class="article-summary">{{ item.article.summary }}</div>
+                <button type="button" class="summary-toggle"
+                        aria-expanded="false"
+                        aria-controls="summary-{{ item.article.article_id }}"
+                        onclick="toggleSummary(this)">&#9654; Show summary</button>
+                <div id="summary-{{ item.article.article_id }}" class="article-summary">{{ item.article.summary }}</div>
                 {% endif %}
               </td>
               <td>
@@ -789,10 +799,11 @@
     el.classList.toggle('hidden', value !== 'custom');
   }
 
-  function toggleSummary(link) {
-    const summary = link.nextElementSibling;
+  function toggleSummary(btn) {
+    const summary = document.getElementById(btn.getAttribute('aria-controls'));
     const open = summary.classList.toggle('visible');
-    link.innerHTML = open ? '&#9660; Hide summary' : '&#9654; Show summary';
+    btn.setAttribute('aria-expanded', open);
+    btn.textContent = open ? '▼ Hide summary' : '► Show summary';
   }
 
   function sortBy(field) {


### PR DESCRIPTION
## Summary

- Adds a **▶ Show summary** link beneath each article title in the review status page (`/admin/gregory/articles/review-status/`)
- Clicking the link expands the article's `summary` field inline below the title and changes to **▼ Hide summary**
- Clicking again collapses it back
- Articles with no summary value show no toggle (guarded by `{% if item.article.summary %}`)

## What changed

`django/gregory/templates/admin/article_review_status.html`:
- Added `.summary-toggle` and `.article-summary` CSS classes for styling and default-hidden state
- Added the toggle link + summary `<div>` inside the title cell, conditionally rendered
- Added `toggleSummary(link)` JS function that toggles `.visible` on the adjacent summary div and swaps the link label

## Test plan

- [ ] Visit `/admin/gregory/articles/review-status/` with a subject that has articles
- [ ] Confirm articles with a summary show a "▶ Show summary" link beneath the title
- [ ] Click it — summary expands and link changes to "▼ Hide summary"
- [ ] Click again — collapses back
- [ ] Confirm articles without a summary show no toggle link
- [ ] Confirm existing filters, batch actions, and relevance buttons are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)