### PR TITLE
Add pdf_link to ArticleAdmin fieldset

### DIFF
--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -562,6 +562,7 @@ class ArticleAdmin(OrganizationFilterMixin, SimpleHistoryAdmin):
 					"entities",
 					"kind",
 					"access",
+					"pdf_link",
 					"publisher",
 					"container_title",
 					"crossref_check",


### PR DESCRIPTION
## Summary

- Adds `pdf_link` to the `Article Information` fieldset in `ArticleAdmin`, making the new field editable and visible in the Django admin interface.

## Test plan

- [ ] Open any article in the Django admin — `pdf_link` should appear below the `access` field
- [ ] Verify it renders as a URL input that accepts or clears a value

🤖 Generated with [Claude Code](https://claude.com/claude-code)