### PR TITLE
Expand ml_predictions subject to include name and description

### DIFF
--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -75,7 +75,15 @@ class ArticleSubjectRelevanceSerializer(serializers.ModelSerializer):
 		fields = ["subject", "subject_id", "is_relevant"]
 
 
+class MLPredictionSubjectSerializer(serializers.ModelSerializer):
+	class Meta:
+		model = Subject
+		fields = ["id", "subject_name", "description"]
+
+
 class MLPredictionsSerializer(serializers.ModelSerializer):
+	subject = MLPredictionSubjectSerializer(read_only=True)
+
 	class Meta:
 		model = MLPredictions
 		fields = [

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -209,8 +209,11 @@ class OrgScopedSerializerMixin:
 		# an extra per-object query when the relation is not prefetched.
 		if "ml_predictions" in ret:
 			vs = _request_visible_subject_ids(request, visible)
+			def _subject_id(p):
+				s = p.get("subject")
+				return s.get("id") if isinstance(s, dict) else s
 			ret["ml_predictions"] = [
-				p for p in ret["ml_predictions"] if p.get("subject") in vs
+				p for p in ret["ml_predictions"] if _subject_id(p) in vs
 			]
 
 		return ret

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -203,15 +203,20 @@ class OrgScopedSerializerMixin:
 			]
 
 		# --- ml_predictions: filter directly on already-serialised data ---
-		# Each item in ret['ml_predictions'] already has a 'subject' key (the FK
-		# integer) from MLPredictionsSerializer.  Filtering here avoids hitting
-		# instance.ml_predictions_detail.all() a second time, which would cause
-		# an extra per-object query when the relation is not prefetched.
+		# Each item in ret['ml_predictions'] has a 'subject' key that is either a
+		# nested dict {id, subject_name, description} (from MLPredictionsSerializer)
+		# or a bare integer FK (from legacy/test serializers).  Filtering here avoids
+		# hitting instance.ml_predictions_detail.all() a second time, which would
+		# cause an extra per-object query when the relation is not prefetched.
 		if "ml_predictions" in ret:
 			vs = _request_visible_subject_ids(request, visible)
+
 			def _subject_id(p):
 				s = p.get("subject")
-				return s.get("id") if isinstance(s, dict) else s
+				if isinstance(s, dict):
+					return s.get("id")
+				return s if isinstance(s, int) else None
+
 			ret["ml_predictions"] = [
 				p for p in ret["ml_predictions"] if _subject_id(p) in vs
 			]

--- a/django/api/tests/test_org_scoped_serializer_mixin.py
+++ b/django/api/tests/test_org_scoped_serializer_mixin.py
@@ -92,6 +92,40 @@ class _MLPredictionsSerializer(serializers.ModelSerializer):
 		fields = ["id", "subject", "algorithm", "probability_score"]
 
 
+class _NestedSubjectSerializer(serializers.ModelSerializer):
+	class Meta:
+		model = Subject
+		fields = ["id", "subject_name", "description"]
+
+
+class _MLPredictionsNestedSerializer(serializers.ModelSerializer):
+	subject = _NestedSubjectSerializer(read_only=True)
+
+	class Meta:
+		model = MLPredictions
+		fields = ["id", "subject", "algorithm", "probability_score"]
+
+
+class _TestArticleNestedSubjectSerializer(OrgScopedSerializerMixin, serializers.ModelSerializer):
+	teams = _TeamSerializer(many=True, read_only=True)
+	subjects = _SubjectSerializer(many=True, read_only=True)
+	team_categories = _TeamCategorySerializer(many=True, read_only=True)
+	ml_predictions = _MLPredictionsNestedSerializer(
+		many=True, read_only=True, source="ml_predictions_detail"
+	)
+
+	class Meta:
+		model = Articles
+		fields = [
+			"article_id",
+			"title",
+			"teams",
+			"subjects",
+			"team_categories",
+			"ml_predictions",
+		]
+
+
 class _TestArticleSerializer(OrgScopedSerializerMixin, serializers.ModelSerializer):
 	teams = _TeamSerializer(many=True, read_only=True)
 	subjects = _SubjectSerializer(many=True, read_only=True)
@@ -215,3 +249,51 @@ class OrgScopedSerializerMixinMLPredictionsTest(TestCase):
 		pred_ids = [p["id"] for p in data["ml_predictions"]]
 		self.assertIn(self.pred_a.id, pred_ids)
 		self.assertNotIn(self.pred_b.id, pred_ids)
+
+
+class OrgScopedSerializerMixinMLPredictionsNestedSubjectTest(TestCase):
+	"""Verify visibility filtering works when subject is a nested dict (new shape)."""
+
+	def setUp(self):
+		self.org_a = _make_org("Org A", "org-a-nested", public=False)
+		self.org_b = _make_org("Org B", "org-b-nested", public=False)
+		self.team_a = _make_team(self.org_a, "Team A Nested")
+		self.team_b = _make_team(self.org_b, "Team B Nested")
+		self.subject_a = _make_subject(self.team_a, "Subj Nested A")
+		self.subject_b = _make_subject(self.team_b, "Subj Nested B")
+
+		self.article = _make_article(title="Nested Article", link="https://example.com/nested")
+
+		self.pred_a = MLPredictions.objects.create(
+			article=self.article,
+			subject=self.subject_a,
+			algorithm="lgbm_tfidf",
+			probability_score=0.9,
+			predicted_relevant=True,
+			model_version="v1",
+		)
+		self.pred_b = MLPredictions.objects.create(
+			article=self.article,
+			subject=self.subject_b,
+			algorithm="lgbm_tfidf",
+			probability_score=0.8,
+			predicted_relevant=True,
+			model_version="v1",
+		)
+
+	def test_hidden_ml_predictions_stripped_nested_subject(self):
+		req = _request_with_visible({self.org_a.id})
+		data = _TestArticleNestedSubjectSerializer(self.article, context={"request": req}).data
+		pred_ids = [p["id"] for p in data["ml_predictions"]]
+		self.assertIn(self.pred_a.id, pred_ids)
+		self.assertNotIn(self.pred_b.id, pred_ids)
+
+	def test_nested_subject_shape(self):
+		req = _request_with_visible({self.org_a.id})
+		data = _TestArticleNestedSubjectSerializer(self.article, context={"request": req}).data
+		self.assertEqual(len(data["ml_predictions"]), 1)
+		subject = data["ml_predictions"][0]["subject"]
+		self.assertIsInstance(subject, dict)
+		self.assertEqual(subject["id"], self.subject_a.id)
+		self.assertIn("subject_name", subject)
+		self.assertIn("description", subject)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -52,6 +52,7 @@ from gregory.models import (
 	Team,
 	Subject,
 	TeamCategory,
+	MLPredictions,
 )
 from organizations.models import Organization
 from rest_framework import permissions, viewsets, generics, filters, status
@@ -959,7 +960,12 @@ class ArticleViewSet(
 	- Complex filter: `/articles/?team_id=1&subject_id=4&author_id=123&search=regeneration&relevant=true&ml_threshold=0.8&ordering=-ml_score`
 	"""
 
-	queryset = Articles.objects.all().order_by("-discovery_date")
+	queryset = Articles.objects.all().prefetch_related(
+		Prefetch(
+			"ml_predictions_detail",
+			queryset=MLPredictions.objects.select_related("subject"),
+		)
+	).order_by("-discovery_date")
 	serializer_class = ArticleSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 	pagination_class = FlexiblePagination
@@ -2121,7 +2127,10 @@ class ArticlesByCategoryAndTeam(viewsets.ModelViewSet):
 				"authors",
 				"teams",
 				"subjects",
-				"ml_predictions",
+				Prefetch(
+					"ml_predictions_detail",
+					queryset=MLPredictions.objects.select_related("subject"),
+				),
 			)
 			.order_by("-discovery_date")
 		)


### PR DESCRIPTION
## Summary

- The `subject` field inside each `ml_predictions` entry was previously serialised as a bare integer FK, forcing API consumers to make a separate request to look up the subject name.
- Now it is a nested object with `id`, `subject_name`, and `description` — making each prediction self-contained.
- The org-scoped mixin visibility filter was updated to handle both the new dict shape and any legacy integer shape from other serializers (backwards-compatible).
- Added `Prefetch("ml_predictions_detail", queryset=MLPredictions.objects.select_related("subject"))` on `ArticleViewSet` and `ArticlesByCategoryAndTeam` to prevent N+1 queries.

## Before / After

**Before:**
```json
"subject": 1
```

**After:**
```json
"subject": {
    "id": 1,
    "subject_name": "Multiple Sclerosis",
    "description": "..."
}
```

## Test plan

- [x] All 547 existing API tests pass (`python manage.py test api.tests`)
- [ ] Manually verify `/articles/` response shows nested subject in `ml_predictions`
- [ ] Verify org-scoped visibility filtering still hides predictions from other orgs

🤖 Generated with [Claude Code](https://claude.com/claude-code)