### PR TITLE
Add resumable log to backfill_unpaywall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ specs/
 
 .claude/worktrees/
 django/*.xlsx
+django/debug_*.py
+django/backfill_unpaywall.log
+django/unpaywall_cache

--- a/django/gregory/management/commands/backfill_unpaywall.py
+++ b/django/gregory/management/commands/backfill_unpaywall.py
@@ -107,11 +107,11 @@ class Command(BaseCommand):
 
 		seen_ids = self._load_log(log_path)
 		if seen_ids:
-			self.stdout.write(f"Skipping {len(seen_ids)} already-processed article_ids from {log_path}.")
+			self.stdout.write(
+				f"Log loaded: {len(seen_ids)} already-processed article_ids will be skipped."
+			)
 
 		qs = self._build_queryset(run_access, run_pdf, days)
-		if seen_ids:
-			qs = qs.exclude(article_id__in=seen_ids)
 		if limit:
 			qs = qs[:limit]
 
@@ -125,6 +125,8 @@ class Command(BaseCommand):
 
 		with self._open_csv(csv_path) as csv_writer:
 			for i, article in enumerate(qs, 1):
+				if article.article_id in seen_ids:
+					continue
 				access_before = article.access
 				pdf_link_before = article.pdf_link
 

--- a/django/gregory/management/commands/backfill_unpaywall.py
+++ b/django/gregory/management/commands/backfill_unpaywall.py
@@ -74,6 +74,13 @@ class Command(BaseCommand):
 			dest="csv_path",
 			help="Stream a per-article result report to this CSV file.",
 		)
+		parser.add_argument(
+			"--log-file",
+			default="backfill_unpaywall.log",
+			metavar="PATH",
+			help="File that records processed article_ids so resumed runs skip them "
+			     "(default: backfill_unpaywall.log). Pass an empty string to disable.",
+		)
 
 	def handle(self, *args, **options):
 		dry_run = options["dry_run"]
@@ -82,6 +89,7 @@ class Command(BaseCommand):
 		limit = options.get("limit")
 		verbosity = options.get("verbosity", 1)
 		csv_path = options.get("csv_path")
+		log_path = options.get("log_file") or ""
 
 		run_access = options["access"] or options["all"]
 		run_pdf = options["pdf_links"] or options["all"]
@@ -97,7 +105,13 @@ class Command(BaseCommand):
 			self.stderr.write(self.style.ERROR("No admin email in site settings — required by Unpaywall."))
 			return
 
+		seen_ids = self._load_log(log_path)
+		if seen_ids:
+			self.stdout.write(f"Skipping {len(seen_ids)} already-processed article_ids from {log_path}.")
+
 		qs = self._build_queryset(run_access, run_pdf, days)
+		if seen_ids:
+			qs = qs.exclude(article_id__in=seen_ids)
 		if limit:
 			qs = qs[:limit]
 
@@ -129,6 +143,8 @@ class Command(BaseCommand):
 						csv_writer.writerow(self._csv_row(
 							article, "no_data", [], access_before, pdf_link_before,
 						))
+					if not dry_run:
+						self._append_log(log_path, article.article_id)
 					if sleep:
 						time.sleep(sleep)
 					continue
@@ -173,6 +189,9 @@ class Command(BaseCommand):
 					csv_writer.writerow(self._csv_row(
 						article, status, will_change, access_before, pdf_link_before,
 					))
+
+				if not dry_run:
+					self._append_log(log_path, article.article_id)
 
 				if verbosity >= 1 and i % 100 == 0:
 					self.stdout.write(f"  Progress: {i}/{total}")
@@ -256,3 +275,22 @@ class Command(BaseCommand):
 			"pdf_link_before": pdf_link_before or "",
 			"pdf_link_after": article.pdf_link or "",
 		}
+
+	@staticmethod
+	def _load_log(path):
+		if not path or not os.path.exists(path):
+			return set()
+		ids = set()
+		with open(path) as fh:
+			for line in fh:
+				line = line.strip()
+				if line.isdigit():
+					ids.add(int(line))
+		return ids
+
+	@staticmethod
+	def _append_log(path, article_id):
+		if not path:
+			return
+		with open(path, "a") as fh:
+			fh.write(f"{article_id}\n")

--- a/django/gregory/tests/management/test_backfill_unpaywall.py
+++ b/django/gregory/tests/management/test_backfill_unpaywall.py
@@ -307,3 +307,62 @@ class BackfillUnpaywallCommandTest(TestCase):
 			self.assertIsNone(self.needs_access.access)
 		finally:
 			os.unlink(csv_path)
+
+	# ------------------------------------------------------------------
+	# --log-file
+	# ------------------------------------------------------------------
+
+	@patch.dict(os.environ, {"DOMAIN_NAME": "test.example.com"})
+	@patch(PATCH_GET_DATA)
+	def test_log_file_records_processed_ids(self, mock_get):
+		mock_get.return_value = UNPAYWALL_OPEN
+		with tempfile.NamedTemporaryFile(suffix=".log", delete=False, mode="w") as tf:
+			log_path = tf.name
+		try:
+			call_command(
+				"backfill_unpaywall", access=True, sleep=0, verbosity=0,
+				log_file=log_path,
+			)
+			with open(log_path) as f:
+				logged_ids = {int(line.strip()) for line in f if line.strip().isdigit()}
+			self.assertIn(self.needs_access.article_id, logged_ids)
+		finally:
+			os.unlink(log_path)
+
+	@patch.dict(os.environ, {"DOMAIN_NAME": "test.example.com"})
+	@patch(PATCH_GET_DATA)
+	def test_log_file_skips_already_processed(self, mock_get):
+		mock_get.return_value = UNPAYWALL_OPEN
+		with tempfile.NamedTemporaryFile(suffix=".log", delete=False, mode="w") as tf:
+			log_path = tf.name
+			tf.write(f"{self.needs_access.article_id}\n")
+		try:
+			call_command(
+				"backfill_unpaywall", access=True, sleep=0, verbosity=0,
+				log_file=log_path,
+			)
+			# Article was pre-logged, so Unpaywall should never be called for its DOI.
+			called_dois = [call.args[0] for call in mock_get.call_args_list]
+			self.assertNotIn(self.needs_access.doi, called_dois)
+			# DB must remain untouched.
+			self.needs_access.refresh_from_db()
+			self.assertIsNone(self.needs_access.access)
+		finally:
+			os.unlink(log_path)
+
+	@patch.dict(os.environ, {"DOMAIN_NAME": "test.example.com"})
+	@patch(PATCH_GET_DATA)
+	def test_dry_run_does_not_write_log(self, mock_get):
+		mock_get.return_value = UNPAYWALL_OPEN
+		with tempfile.NamedTemporaryFile(suffix=".log", delete=False, mode="w") as tf:
+			log_path = tf.name
+		try:
+			call_command(
+				"backfill_unpaywall", access=True, dry_run=True, sleep=0, verbosity=0,
+				log_file=log_path,
+			)
+			with open(log_path) as f:
+				content = f.read().strip()
+			self.assertEqual(content, "", "dry-run must not write any IDs to the log file")
+		finally:
+			os.unlink(log_path)


### PR DESCRIPTION
## Summary

- Adds `--log-file PATH` argument to `backfill_unpaywall` (default: `backfill_unpaywall.log`)
- After each article is processed, its `article_id` is appended to the log file
- On the next run, article_ids already in the log are excluded from the queryset, so interrupted backfills can resume without re-querying Unpaywall
- `--dry-run` never writes to the log file
- Also gitignores `debug_*.py`, `backfill_unpaywall.log`, and `unpaywall_cache` to prevent accidental commits

## Test plan

- [x] `test_log_file_records_processed_ids` — verifies processed ids are written to log
- [x] `test_log_file_skips_already_processed` — verifies pre-logged ids are excluded from queryset and DB is untouched
- [x] `test_dry_run_does_not_write_log` — verifies dry-run leaves the log empty
- [x] All 20 existing + new tests pass (`pytest gregory/tests/management/test_backfill_unpaywall.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)