### PR TITLE
feat: add 'Add Article by DOI' to the Django admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local debug scripts
+debug_*.py
+
 # Python-specific
 __pycache__/
 *.py[cod]

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -620,6 +620,7 @@ class ArticleAdmin(OrganizationFilterMixin, SimpleHistoryAdmin):
 		from .admin_views import (
 			article_review_status_view,
 			update_article_relevance_ajax,
+			add_article_by_doi_view,
 		)
 
 		urls = super().get_urls()
@@ -634,13 +635,19 @@ class ArticleAdmin(OrganizationFilterMixin, SimpleHistoryAdmin):
 				self.admin_site.admin_view(update_article_relevance_ajax),
 				name="update_article_relevance",
 			),
+			path(
+				"add-by-doi/",
+				self.admin_site.admin_view(add_article_by_doi_view),
+				name="article_add_by_doi",
+			),
 		]
 		return custom_urls + urls
 
 	def changelist_view(self, request, extra_context=None):
-		"""Override changelist view to add a button to access review status page"""
+		"""Override changelist view to add buttons above the article list"""
 		extra_context = extra_context or {}
 		extra_context["review_status_url"] = reverse("admin:article_review_status")
+		extra_context["add_by_doi_url"] = reverse("admin:article_add_by_doi")
 		return super().changelist_view(request, extra_context=extra_context)
 
 	class Media:

--- a/django/gregory/admin_views.py
+++ b/django/gregory/admin_views.py
@@ -8,6 +8,8 @@ from django.db.models.functions import TruncDate, TruncWeek, TruncMonth
 from django.contrib import messages
 from django.utils.dateparse import parse_date
 from django.utils import timezone
+from django import forms
+from django.urls import reverse
 from .models import (
 	Articles,
 	Subject,
@@ -967,4 +969,91 @@ def subject_analytics_data(request):
 				"trials": sum(trials_data),
 			},
 		}
+	)
+
+
+class AddByDoiForm(forms.Form):
+	doi = forms.CharField(
+		label="DOI",
+		max_length=500,
+		help_text=(
+			"Paste the DOI of the article to import, e.g. "
+			"<code>10.1234/example</code> or the full URL "
+			"<code>https://doi.org/10.1234/example</code>."
+		),
+	)
+	source = forms.ModelChoiceField(
+		queryset=Sources.objects.none(),
+		label="Source",
+		help_text="Select the source to associate the article with.",
+	)
+
+	def __init__(self, *args, user=None, **kwargs):
+		super().__init__(*args, **kwargs)
+		qs = Sources.objects.filter(source_for="science paper").select_related(
+			"team", "subject"
+		)
+		if user and not user.is_superuser:
+			user_org_ids = user.organizations_organizationuser.values_list(
+				"organization__id", flat=True
+			)
+			qs = qs.filter(team__organization__id__in=user_org_ids)
+		self.fields["source"].queryset = qs.order_by("name")
+		self.fields["source"].label_from_instance = self._source_label
+
+	@staticmethod
+	def _source_label(source):
+		parts = [source.name or str(source.source_id)]
+		if source.team:
+			parts.append(f"Team: {source.team.name}")
+		if source.subject:
+			parts.append(f"Subject: {source.subject.subject_name}")
+		return " — ".join(parts)
+
+
+@staff_member_required
+def add_article_by_doi_view(request):
+	"""Admin view: import a single article by DOI."""
+	if not request.user.has_perm("gregory.add_articles"):
+		messages.error(request, "You do not have permission to add articles.")
+		return redirect("admin:gregory_articles_changelist")
+
+	form = AddByDoiForm(user=request.user)
+
+	if request.method == "POST":
+		form = AddByDoiForm(request.POST, user=request.user)
+		if form.is_valid():
+			from gregory.services.doi_import import ImportStatus, create_article_from_doi
+
+			doi = form.cleaned_data["doi"]
+			source = form.cleaned_data["source"]
+
+			result = create_article_from_doi(doi, source)
+
+			if result.status == ImportStatus.CREATED:
+				messages.success(request, result.message)
+				if result.authors_added:
+					messages.info(request, f"{result.authors_added} author(s) attached.")
+				return redirect(
+					reverse(
+						"admin:gregory_articles_change",
+						args=[result.article.pk],
+					)
+				)
+			elif result.status in (ImportStatus.EXISTS_BY_DOI, ImportStatus.EXISTS_BY_TITLE):
+				messages.warning(request, result.message)
+				if result.article:
+					return redirect(
+						reverse(
+							"admin:gregory_articles_change",
+							args=[result.article.pk],
+						)
+					)
+			else:
+				messages.error(request, result.message)
+
+	return render(
+		request,
+		"admin/gregory/articles/add_by_doi.html",
+		{"form": form, "title": "Add Article by DOI"},
 	)

--- a/django/gregory/management/commands/add_article_by_doi.py
+++ b/django/gregory/management/commands/add_article_by_doi.py
@@ -1,23 +1,23 @@
 """
 Django management command to import a single article by DOI.
 
-This command fetches article metadata from CrossRef, creates the article in the database,
-and runs through the enrichment pipeline steps (authors, categories, predictions).
+Metadata is fetched from CrossRef; enrichment (categories, takeaways,
+predictions) is optionally run afterwards.
 """
 
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management import call_command
-from django.db import transaction
-from django.utils import timezone
 
-from gregory.models import Articles, Sources, Authors
-from gregory.classes import SciencePaper
-from gregory.functions import normalize_orcid
-from gregory.utils.registry_utils import merge_links
+from gregory.models import Sources
+from gregory.services.doi_import import (
+	ImportStatus,
+	create_article_from_doi,
+	normalize_doi,
+)
 
 
 class Command(BaseCommand):
-	help = "Import a single article by DOI and run it through the pipeline."
+	help = "Import a single article by DOI and optionally run it through the pipeline."
 
 	def add_arguments(self, parser):
 		parser.add_argument(
@@ -52,157 +52,71 @@ class Command(BaseCommand):
 		)
 
 	def handle(self, *args, **options):
-		doi = options["doi"]
+		from gregory.classes import SciencePaper
+
+		doi = normalize_doi(options["doi"])
 		source_id = options["source_id"]
 		dry_run = options.get("dry_run", False)
 
-		# Normalize DOI (remove URL prefix if present)
-		doi = self.normalize_doi(doi)
-
-		self.stdout.write(f"Importing article with DOI: {doi}")
-
-		# Check if article already exists
-		existing = Articles.objects.filter(doi=doi).first()
-		if existing:
-			self.stdout.write(
-				self.style.WARNING(
-					f"Article already exists (ID: {existing.article_id}): {existing.title}"
-				)
-			)
-			# Optionally add source association if different
-			try:
-				source = Sources.objects.get(pk=source_id)
-				if source not in existing.sources.all():
-					if not dry_run:
-						existing.sources.add(source)
-						if source.team:
-							existing.teams.add(source.team)
-						if source.subject:
-							existing.subjects.add(source.subject)
-					self.stdout.write(
-						self.style.SUCCESS(
-							f"Added source '{source.name}' to existing article"
-						)
-					)
-			except Sources.DoesNotExist:
-				raise CommandError(f"Source with ID {source_id} not found")
-			return
-
-		# Validate source exists
 		try:
 			source = Sources.objects.get(pk=source_id)
 		except Sources.DoesNotExist:
 			raise CommandError(f"Source with ID {source_id} not found")
 
+		self.stdout.write(f"Importing DOI: {doi}")
 		self.stdout.write(f"Using source: {source.name}")
 
-		# Fetch article metadata from CrossRef
-		self.stdout.write("Fetching metadata from CrossRef...")
-		paper = SciencePaper(doi=doi)
-		result = paper.refresh()
-
-		if result and "error" in str(result).lower():
-			raise CommandError(f"Failed to fetch article data: {result}")
-
-		if not paper.title:
-			raise CommandError(
-				f"Could not retrieve article title from CrossRef for DOI: {doi}"
-			)
-
-		# Check if article with same title exists (case-insensitive)
-		existing_by_title = Articles.objects.filter(title__iexact=paper.title).first()
-		if existing_by_title:
-			self.stdout.write(
-				self.style.WARNING(
-					f"Article with same title already exists (ID: {existing_by_title.article_id})"
-				)
-			)
-			if existing_by_title.doi != doi:
-				self.stdout.write(
-					self.style.WARNING(
-						f"Existing article has different DOI: {existing_by_title.doi}"
-					)
-				)
-			return
-
 		if dry_run:
-			self.stdout.write(self.style.WARNING("DRY RUN - Would create article:"))
-			self.stdout.write(f"  Title: {paper.title}")
-			self.stdout.write(f"  DOI: {paper.doi}")
-			self.stdout.write(f"  Link: {paper.link}")
-			self.stdout.write(f"  Journal: {paper.journal}")
+			self.stdout.write(self.style.WARNING("DRY RUN — fetching metadata only, no changes saved"))
+			paper = SciencePaper(doi=doi)
+			paper.refresh()
+			if not paper.title:
+				raise CommandError(f"Could not retrieve metadata from CrossRef for DOI: {doi}")
+			self.stdout.write(f"  Title:     {paper.title}")
+			self.stdout.write(f"  DOI:       {paper.doi}")
+			self.stdout.write(f"  Link:      {paper.link}")
+			self.stdout.write(f"  Journal:   {paper.journal}")
 			self.stdout.write(f"  Publisher: {paper.publisher}")
 			self.stdout.write(f"  Published: {paper.published_date}")
-			self.stdout.write(f"  Access: {paper.access}")
-			self.stdout.write(f"  PDF link: {paper.pdf_link or 'N/A'}")
+			self.stdout.write(f"  Access:    {paper.access}")
+			self.stdout.write(f"  PDF link:  {paper.pdf_link or 'N/A'}")
 			self.stdout.write(
-				f"  Abstract: {paper.abstract[:200] if paper.abstract else 'N/A'}..."
+				f"  Abstract:  {paper.abstract[:200] if paper.abstract else 'N/A'}..."
 			)
 			return
 
-		# Create the article
-		self.stdout.write("Creating article...")
-		_link = paper.link or f"https://doi.org/{paper.doi}"
-		with transaction.atomic():
-			article = Articles.objects.create(
-				title=paper.title,
-				doi=paper.doi,
-				link=_link,
-				links=merge_links(None, _link),
-				summary=paper.clean_abstract() if paper.abstract else None,
-				published_date=paper.published_date,
-				access=paper.access,
-				publisher=paper.publisher,
-				container_title=paper.journal,
-				kind="science paper",
-				crossref_check=timezone.now(),
-				pdf_link=paper.pdf_link,
-			)
+		result = create_article_from_doi(
+			doi, source, skip_authors=options.get("skip_authors", False)
+		)
 
-			# Add source association
-			article.sources.add(source)
+		if result.status == ImportStatus.CROSSREF_FAILURE:
+			raise CommandError(f"Failed to fetch article data: {result.message}")
 
-			# Add team and subject from source
-			if source.team:
-				article.teams.add(source.team)
-			if source.subject:
-				article.subjects.add(source.subject)
+		if result.status in (ImportStatus.EXISTS_BY_DOI, ImportStatus.EXISTS_BY_TITLE):
+			self.stdout.write(self.style.WARNING(result.message))
+			return
 
-			self.stdout.write(
-				self.style.SUCCESS(
-					f"Created article (ID: {article.article_id}): {article.title}"
-				)
-			)
+		self.stdout.write(self.style.SUCCESS(result.message))
+		if result.authors_added:
+			self.stdout.write(self.style.SUCCESS(f"  Added {result.authors_added} authors"))
 
-		# Step 2: Get authors from CrossRef data
-		if not options.get("skip_authors") and paper.authors:
-			self.stdout.write("Processing authors...")
-			self.process_authors(article, paper.authors)
-
-		# Step 3: Assign categories
+		# Optional enrichment steps (heavy — skip in admin flow)
 		if not options.get("skip_categories"):
 			self.stdout.write("Assigning categories...")
 			try:
-				# Run rebuild_categories just for this article
 				call_command("rebuild_categories", articles_only=True, verbosity=0)
 				self.stdout.write(self.style.SUCCESS("Categories assigned"))
 			except Exception as e:
-				self.stdout.write(
-					self.style.WARNING(f"Category assignment failed: {e}")
-				)
+				self.stdout.write(self.style.WARNING(f"Category assignment failed: {e}"))
 
-		# Step 4: Generate takeaways
 		if not options.get("skip_takeaways"):
 			self.stdout.write("Generating takeaways...")
 			try:
 				call_command("get_takeaways")
 				self.stdout.write(self.style.SUCCESS("Takeaways generated"))
 			except Exception as e:
-				self.stdout.write(
-					self.style.WARNING(f"Takeaway generation failed: {e}")
-				)
+				self.stdout.write(self.style.WARNING(f"Takeaway generation failed: {e}"))
 
-		# Step 5: Run ML predictions
 		if not options.get("skip_predictions"):
 			self.stdout.write("Running ML predictions...")
 			try:
@@ -213,85 +127,6 @@ class Command(BaseCommand):
 
 		self.stdout.write(
 			self.style.SUCCESS(
-				f"\nArticle import complete! Article ID: {article.article_id}"
+				f"\nArticle import complete! Article ID: {result.article.article_id}"
 			)
 		)
-
-	def normalize_doi(self, doi):
-		"""
-		Normalize DOI by removing common URL prefixes.
-		"""
-		prefixes = [
-			"https://doi.org/",
-			"http://doi.org/",
-			"https://dx.doi.org/",
-			"http://dx.doi.org/",
-			"doi:",
-		]
-		doi = doi.strip()
-		for prefix in prefixes:
-			if doi.lower().startswith(prefix.lower()):
-				doi = doi[len(prefix) :]
-				break
-		return doi.strip()
-
-	def process_authors(self, article, authors_data):
-		"""
-		Process authors from CrossRef data and associate them with the article.
-		"""
-		added_count = 0
-		for author_data in authors_data:
-			given_name = author_data.get("given")
-			family_name = author_data.get("family")
-			raw_orcid = author_data.get("ORCID")
-			orcid = normalize_orcid(raw_orcid) if raw_orcid else None
-
-			if not given_name or not family_name:
-				self.stdout.write(
-					self.style.WARNING(
-						f"  Skipping author with missing name: {author_data}"
-					)
-				)
-				continue
-
-			# Try to find or create author
-			author_obj = None
-
-			if orcid:
-				# First try to match by ORCID
-				author_obj, created = Authors.objects.get_or_create(
-					ORCID=orcid,
-					defaults={"given_name": given_name, "family_name": family_name},
-				)
-				if not created:
-					# Update name if different
-					if (
-						author_obj.given_name != given_name
-						or author_obj.family_name != family_name
-					):
-						author_obj.given_name = given_name
-						author_obj.family_name = family_name
-						author_obj.save()
-			else:
-				# Try to find by name
-				try:
-					author_obj = Authors.objects.get(
-						given_name=given_name, family_name=family_name
-					)
-				except Authors.DoesNotExist:
-					author_obj = Authors.objects.create(
-						given_name=given_name, family_name=family_name, ORCID=orcid
-					)
-				except Authors.MultipleObjectsReturned:
-					self.stdout.write(
-						self.style.WARNING(
-							f"  Multiple authors found for {given_name} {family_name}, skipping"
-						)
-					)
-					continue
-
-			if author_obj:
-				article.authors.add(author_obj)
-				added_count += 1
-
-		self.stdout.write(self.style.SUCCESS(f"  Added {added_count} authors"))

--- a/django/gregory/services/doi_import.py
+++ b/django/gregory/services/doi_import.py
@@ -115,7 +115,7 @@ def create_article_from_doi(
 	existing = Articles.objects.filter(doi=doi).first()
 	if existing:
 		# Ensure source association is present
-		if source not in existing.sources.all():
+		if not existing.sources.filter(pk=source.pk).exists():
 			existing.sources.add(source)
 			if source.team:
 				existing.teams.add(source.team)

--- a/django/gregory/services/doi_import.py
+++ b/django/gregory/services/doi_import.py
@@ -1,0 +1,185 @@
+"""
+Service layer for importing a single article by DOI.
+
+Used by both the management command and the admin UI so logic stays in one place.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+
+from django.db import transaction
+from django.utils import timezone
+
+from gregory.classes import SciencePaper
+from gregory.functions import normalize_orcid
+from gregory.models import Articles, Authors, Sources
+from gregory.utils.registry_utils import merge_links
+
+logger = logging.getLogger(__name__)
+
+
+class ImportStatus(str, Enum):
+	CREATED = "created"
+	EXISTS_BY_DOI = "exists_by_doi"
+	EXISTS_BY_TITLE = "exists_by_title"
+	CROSSREF_FAILURE = "crossref_failure"
+
+
+@dataclass
+class ImportResult:
+	status: ImportStatus
+	message: str
+	article: Articles | None = None
+	authors_added: int = 0
+
+
+def normalize_doi(doi: str) -> str:
+	"""Strip common URL prefixes from a DOI string."""
+	prefixes = [
+		"https://doi.org/",
+		"http://doi.org/",
+		"https://dx.doi.org/",
+		"http://dx.doi.org/",
+		"doi:",
+	]
+	doi = doi.strip()
+	for prefix in prefixes:
+		if doi.lower().startswith(prefix.lower()):
+			doi = doi[len(prefix):]
+			break
+	return doi.strip()
+
+
+def _process_authors(article: Articles, authors_data: list) -> int:
+	"""Attach authors from CrossRef data to an article. Returns count added."""
+	added = 0
+	for author_data in authors_data:
+		given_name = author_data.get("given")
+		family_name = author_data.get("family")
+		raw_orcid = author_data.get("ORCID")
+		orcid = normalize_orcid(raw_orcid) if raw_orcid else None
+
+		if not given_name or not family_name:
+			logger.warning("Skipping author with missing name: %s", author_data)
+			continue
+
+		author_obj = None
+		if orcid:
+			author_obj, created = Authors.objects.get_or_create(
+				ORCID=orcid,
+				defaults={"given_name": given_name, "family_name": family_name},
+			)
+			if not created and (
+				author_obj.given_name != given_name
+				or author_obj.family_name != family_name
+			):
+				author_obj.given_name = given_name
+				author_obj.family_name = family_name
+				author_obj.save()
+		else:
+			try:
+				author_obj = Authors.objects.get(
+					given_name=given_name, family_name=family_name
+				)
+			except Authors.DoesNotExist:
+				author_obj = Authors.objects.create(
+					given_name=given_name, family_name=family_name, ORCID=orcid
+				)
+			except Authors.MultipleObjectsReturned:
+				logger.warning(
+					"Multiple authors for %s %s — skipping", given_name, family_name
+				)
+				continue
+
+		if author_obj:
+			article.authors.add(author_obj)
+			added += 1
+
+	return added
+
+
+def create_article_from_doi(
+	doi: str, source: Sources, *, skip_authors: bool = False
+) -> ImportResult:
+	"""
+	Fetch CrossRef metadata for *doi* and create an Articles record associated
+	with *source*.  Does NOT run enrichment (categories / takeaways / ML) — that
+	is left to the scheduled pipeline.
+
+	Returns an ImportResult describing what happened.
+	"""
+	doi = normalize_doi(doi)
+
+	# Dedup by DOI
+	existing = Articles.objects.filter(doi=doi).first()
+	if existing:
+		# Ensure source association is present
+		if source not in existing.sources.all():
+			existing.sources.add(source)
+			if source.team:
+				existing.teams.add(source.team)
+			if source.subject:
+				existing.subjects.add(source.subject)
+		return ImportResult(
+			status=ImportStatus.EXISTS_BY_DOI,
+			message=f"Article already exists (ID {existing.article_id}): {existing.title}",
+			article=existing,
+		)
+
+	# Fetch from CrossRef (+ Unpaywall via SciencePaper.refresh)
+	paper = SciencePaper(doi=doi)
+	result = paper.refresh()
+
+	if not paper.title:
+		error_detail = str(result) if result else "no response"
+		return ImportResult(
+			status=ImportStatus.CROSSREF_FAILURE,
+			message=f"Could not retrieve metadata from CrossRef ({error_detail})",
+		)
+
+	# Dedup by title
+	existing_by_title = Articles.objects.filter(title__iexact=paper.title).first()
+	if existing_by_title:
+		return ImportResult(
+			status=ImportStatus.EXISTS_BY_TITLE,
+			message=(
+				f"Article with the same title already exists "
+				f"(ID {existing_by_title.article_id}, DOI: {existing_by_title.doi})"
+			),
+			article=existing_by_title,
+		)
+
+	_link = paper.link or f"https://doi.org/{paper.doi}"
+
+	with transaction.atomic():
+		article = Articles.objects.create(
+			title=paper.title,
+			doi=paper.doi,
+			link=_link,
+			links=merge_links(None, _link),
+			summary=paper.clean_abstract() if paper.abstract else None,
+			published_date=paper.published_date,
+			access=paper.access,
+			publisher=paper.publisher,
+			container_title=paper.journal,
+			kind="science paper",
+			crossref_check=timezone.now(),
+			pdf_link=paper.pdf_link,
+		)
+		article.sources.add(source)
+		if source.team:
+			article.teams.add(source.team)
+		if source.subject:
+			article.subjects.add(source.subject)
+
+	authors_added = 0
+	if not skip_authors and paper.authors:
+		authors_added = _process_authors(article, paper.authors)
+
+	return ImportResult(
+		status=ImportStatus.CREATED,
+		message=f"Article created (ID {article.article_id}): {article.title}",
+		article=article,
+		authors_added=authors_added,
+	)

--- a/django/gregory/templates/admin/gregory/articles/add_by_doi.html
+++ b/django/gregory/templates/admin/gregory/articles/add_by_doi.html
@@ -1,0 +1,54 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}Add Article by DOI{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+  &rsaquo; <a href="{% url 'admin:gregory_articles_changelist' %}">Articles</a>
+  &rsaquo; Add Article by DOI
+</div>
+{% endblock %}
+
+{% block content %}
+<h1>Add Article by DOI</h1>
+<p>Enter a DOI to fetch metadata from CrossRef and create an article record.
+  Categories, takeaways, and ML predictions will be applied by the next scheduled pipeline run.</p>
+
+{% if messages %}
+<ul class="messagelist">
+  {% for message in messages %}
+  <li class="{{ message.tags }}">{{ message }}</li>
+  {% endfor %}
+</ul>
+{% endif %}
+
+<div class="module aligned">
+  <form method="post">
+    {% csrf_token %}
+    <fieldset class="module aligned">
+      {% for field in form %}
+      <div class="form-row">
+        {{ field.label_tag }}
+        {{ field }}
+        {% if field.help_text %}
+        <p class="help">{{ field.help_text|safe }}</p>
+        {% endif %}
+        {% if field.errors %}
+        <ul class="errorlist">
+          {% for error in field.errors %}
+          <li>{{ error }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+      {% endfor %}
+    </fieldset>
+    <div class="submit-row">
+      <input type="submit" value="Import Article" class="default" />
+      <a href="{% url 'admin:gregory_articles_changelist' %}" class="button cancel-link">Cancel</a>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/django/gregory/templates/admin/gregory/articles/change_list.html
+++ b/django/gregory/templates/admin/gregory/articles/change_list.html
@@ -3,6 +3,11 @@
 
 {% block object-tools-items %}
   <li>
+    <a href="{{ add_by_doi_url }}" class="addlink" style="background-color: #2e7d32;">
+      Add Article by DOI
+    </a>
+  </li>
+  <li>
     <a href="{{ review_status_url }}" class="addlink" style="background-color: #417690;">
       Review Status by Subject
     </a>

--- a/django/gregory/tests/test_doi_import_service.py
+++ b/django/gregory/tests/test_doi_import_service.py
@@ -217,10 +217,6 @@ class AddByDoiAdminViewTests(TestCase):
 			email="staff@example.com",
 			is_staff=True,
 		)
-		self.staff_user.user_permissions.add(
-			*User.objects.none().model._meta.app_label
-			and []  # placeholder; permissions added below
-		)
 		# Grant add_articles permission
 		from django.contrib.contenttypes.models import ContentType
 		from django.contrib.auth.models import Permission

--- a/django/gregory/tests/test_doi_import_service.py
+++ b/django/gregory/tests/test_doi_import_service.py
@@ -1,0 +1,327 @@
+"""
+Tests for gregory.services.doi_import and the admin view that uses it.
+
+Run with:
+    docker exec gregory python manage.py test gregory.tests.test_doi_import_service
+"""
+
+from unittest.mock import patch, MagicMock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, RequestFactory
+from django.urls import reverse
+from organizations.models import Organization, OrganizationUser
+
+from gregory.models import Articles, Sources, Subject, Team
+from gregory.services.doi_import import (
+	ImportStatus,
+	create_article_from_doi,
+	normalize_doi,
+)
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# normalize_doi
+# ---------------------------------------------------------------------------
+
+class NormalizeDoiTests(TestCase):
+	def test_strips_https_prefix(self):
+		self.assertEqual(normalize_doi("https://doi.org/10.1000/xyz"), "10.1000/xyz")
+
+	def test_strips_http_prefix(self):
+		self.assertEqual(normalize_doi("http://doi.org/10.1000/xyz"), "10.1000/xyz")
+
+	def test_strips_dx_prefix(self):
+		self.assertEqual(normalize_doi("https://dx.doi.org/10.1000/xyz"), "10.1000/xyz")
+
+	def test_strips_doi_colon_prefix(self):
+		self.assertEqual(normalize_doi("doi:10.1000/xyz"), "10.1000/xyz")
+
+	def test_bare_doi_unchanged(self):
+		self.assertEqual(normalize_doi("10.1000/xyz"), "10.1000/xyz")
+
+	def test_strips_whitespace(self):
+		self.assertEqual(normalize_doi("  10.1000/xyz  "), "10.1000/xyz")
+
+
+# ---------------------------------------------------------------------------
+# create_article_from_doi
+# ---------------------------------------------------------------------------
+
+def _make_org_stack():
+	"""Return (org, team, subject, source) for use in tests."""
+	org = Organization.objects.create(name="Test Org", slug="test-org-doi")
+	team = Team.objects.create(name="Test Team", slug="test-team-doi", organization=org)
+	subject = Subject.objects.create(subject_name="Test Subject", team=team)
+	source = Sources.objects.create(
+		name="Test Source",
+		source_for="science paper",
+		method="manual",
+		team=team,
+		subject=subject,
+	)
+	return org, team, subject, source
+
+
+def _mock_paper(title="Test Article Title", doi="10.9999/test", **kwargs):
+	"""Build a SciencePaper mock with sensible defaults."""
+	paper = MagicMock()
+	paper.title = title
+	paper.doi = doi
+	paper.link = f"https://doi.org/{doi}"
+	paper.abstract = "Test abstract."
+	paper.published_date = None
+	paper.access = "open"
+	paper.publisher = "Test Publisher"
+	paper.journal = "Test Journal"
+	paper.pdf_link = None
+	paper.authors = []
+	paper.retracted = None
+	paper.clean_abstract.return_value = "Test abstract."
+	paper.refresh.return_value = None
+	for k, v in kwargs.items():
+		setattr(paper, k, v)
+	return paper
+
+
+class CreateArticleFromDoiTests(TestCase):
+	def setUp(self):
+		self.org, self.team, self.subject, self.source = _make_org_stack()
+
+	@patch("gregory.services.doi_import.SciencePaper")
+	def test_creates_article(self, MockSciencePaper):
+		MockSciencePaper.return_value = _mock_paper()
+
+		result = create_article_from_doi("10.9999/test", self.source)
+
+		self.assertEqual(result.status, ImportStatus.CREATED)
+		self.assertIsNotNone(result.article)
+		article = result.article
+		self.assertEqual(article.title, "Test Article Title")
+		self.assertEqual(article.doi, "10.9999/test")
+		self.assertIn(self.source, article.sources.all())
+		self.assertIn(self.team, article.teams.all())
+		self.assertIn(self.subject, article.subjects.all())
+
+	@patch("gregory.services.doi_import.SciencePaper")
+	def test_normalizes_doi_url(self, MockSciencePaper):
+		mock_paper = _mock_paper(doi="10.9999/test")
+		MockSciencePaper.return_value = mock_paper
+
+		result = create_article_from_doi("https://doi.org/10.9999/test", self.source)
+
+		self.assertEqual(result.status, ImportStatus.CREATED)
+		# SciencePaper was instantiated with the normalised DOI
+		MockSciencePaper.assert_called_once_with(doi="10.9999/test")
+
+	@patch("gregory.services.doi_import.SciencePaper")
+	def test_dedup_by_doi(self, MockSciencePaper):
+		Articles.objects.create(
+			title="Existing Article",
+			doi="10.9999/existing",
+			link="https://doi.org/10.9999/existing",
+		)
+
+		result = create_article_from_doi("10.9999/existing", self.source)
+
+		self.assertEqual(result.status, ImportStatus.EXISTS_BY_DOI)
+		self.assertIsNotNone(result.article)
+		MockSciencePaper.assert_not_called()
+
+	@patch("gregory.services.doi_import.SciencePaper")
+	def test_dedup_by_title(self, MockSciencePaper):
+		Articles.objects.create(
+			title="Duplicate Title Article",
+			link="https://example.com/dup",
+		)
+		MockSciencePaper.return_value = _mock_paper(
+			title="Duplicate Title Article", doi="10.9999/new"
+		)
+
+		result = create_article_from_doi("10.9999/new", self.source)
+
+		self.assertEqual(result.status, ImportStatus.EXISTS_BY_TITLE)
+
+	@patch("gregory.services.doi_import.SciencePaper")
+	def test_crossref_failure_no_title(self, MockSciencePaper):
+		mock_paper = _mock_paper(title=None)
+		mock_paper.refresh.return_value = "DOI not found"
+		MockSciencePaper.return_value = mock_paper
+
+		result = create_article_from_doi("10.9999/missing", self.source)
+
+		self.assertEqual(result.status, ImportStatus.CROSSREF_FAILURE)
+		self.assertIsNone(result.article)
+
+	@patch("gregory.services.doi_import.SciencePaper")
+	def test_existing_doi_gets_source_added(self, MockSciencePaper):
+		"""If the article already exists, the source should be associated."""
+		existing = Articles.objects.create(
+			title="Already There",
+			doi="10.9999/already",
+			link="https://doi.org/10.9999/already",
+		)
+		result = create_article_from_doi("10.9999/already", self.source)
+
+		self.assertEqual(result.status, ImportStatus.EXISTS_BY_DOI)
+		existing.refresh_from_db()
+		self.assertIn(self.source, existing.sources.all())
+
+	@patch("gregory.services.doi_import.SciencePaper")
+	def test_authors_attached(self, MockSciencePaper):
+		mock_paper = _mock_paper(
+			authors=[
+				{"given": "Jane", "family": "Doe", "ORCID": None},
+				{"given": "John", "family": "Smith", "ORCID": "0000-0001-2345-6789"},
+			]
+		)
+		MockSciencePaper.return_value = mock_paper
+
+		result = create_article_from_doi("10.9999/authors", self.source)
+
+		self.assertEqual(result.status, ImportStatus.CREATED)
+		self.assertEqual(result.authors_added, 2)
+		self.assertEqual(result.article.authors.count(), 2)
+
+	@patch("gregory.services.doi_import.SciencePaper")
+	def test_skip_authors(self, MockSciencePaper):
+		mock_paper = _mock_paper(
+			authors=[{"given": "Jane", "family": "Doe", "ORCID": None}]
+		)
+		MockSciencePaper.return_value = mock_paper
+
+		result = create_article_from_doi("10.9999/noauth", self.source, skip_authors=True)
+
+		self.assertEqual(result.status, ImportStatus.CREATED)
+		self.assertEqual(result.authors_added, 0)
+		self.assertEqual(result.article.authors.count(), 0)
+
+
+# ---------------------------------------------------------------------------
+# Admin view
+# ---------------------------------------------------------------------------
+
+class AddByDoiAdminViewTests(TestCase):
+	def setUp(self):
+		self.factory = RequestFactory()
+		self.org, self.team, self.subject, self.source = _make_org_stack()
+
+		self.superuser = User.objects.create_superuser(
+			username="admin_doi", password="pass", email="admin@example.com"
+		)
+		self.staff_user = User.objects.create_user(
+			username="staff_doi",
+			password="pass",
+			email="staff@example.com",
+			is_staff=True,
+		)
+		self.staff_user.user_permissions.add(
+			*User.objects.none().model._meta.app_label
+			and []  # placeholder; permissions added below
+		)
+		# Grant add_articles permission
+		from django.contrib.contenttypes.models import ContentType
+		from django.contrib.auth.models import Permission
+
+		ct = ContentType.objects.get_for_model(Articles)
+		perm = Permission.objects.get(codename="add_articles", content_type=ct)
+		self.staff_user.user_permissions.add(perm)
+
+		OrganizationUser.objects.create(
+			organization=self.org, user=self.staff_user, is_admin=False
+		)
+
+	def _get_url(self):
+		return reverse("admin:article_add_by_doi")
+
+	def test_requires_login(self):
+		from django.test import Client
+		client = Client()
+		resp = client.get(self._get_url())
+		self.assertRedirects(resp, f"/admin/login/?next={self._get_url()}", fetch_redirect_response=False)
+
+	def test_permission_denied_without_add_articles(self):
+		from django.test import Client
+
+		no_perm_user = User.objects.create_user(
+			username="noperm_doi", password="pass", email="noperm@example.com", is_staff=True
+		)
+		client = Client()
+		client.force_login(no_perm_user)
+		resp = client.get(self._get_url())
+		# Should redirect to changelist with error
+		self.assertRedirects(resp, reverse("admin:gregory_articles_changelist"), fetch_redirect_response=False)
+
+	def test_get_renders_form(self):
+		from django.test import Client
+		client = Client()
+		client.force_login(self.superuser)
+		resp = client.get(self._get_url())
+		self.assertEqual(resp.status_code, 200)
+		self.assertContains(resp, "Add Article by DOI")
+		self.assertContains(resp, "DOI")
+
+	@patch("gregory.services.doi_import.SciencePaper")
+	def test_post_creates_article_and_redirects(self, MockSciencePaper):
+		MockSciencePaper.return_value = _mock_paper(doi="10.9999/viewtest")
+
+		from django.test import Client
+		client = Client()
+		client.force_login(self.superuser)
+		resp = client.post(self._get_url(), {
+			"doi": "10.9999/viewtest",
+			"source": self.source.pk,
+		})
+
+		article = Articles.objects.filter(doi="10.9999/viewtest").first()
+		self.assertIsNotNone(article)
+		self.assertRedirects(
+			resp,
+			reverse("admin:gregory_articles_change", args=[article.pk]),
+			fetch_redirect_response=False,
+		)
+
+	@patch("gregory.services.doi_import.SciencePaper")
+	def test_pipeline_commands_not_called(self, MockSciencePaper):
+		"""Enrichment commands must NOT run during the admin view."""
+		MockSciencePaper.return_value = _mock_paper(doi="10.9999/nopipeline")
+
+		from django.test import Client
+		from unittest.mock import patch as _patch
+
+		client = Client()
+		client.force_login(self.superuser)
+		# Patch at the django.core.management level — if any enrichment command
+		# is inadvertently called from the service, this will catch it.
+		with _patch("django.core.management.call_command") as mock_cmd:
+			client.post(self._get_url(), {
+				"doi": "10.9999/nopipeline",
+				"source": self.source.pk,
+			})
+			mock_cmd.assert_not_called()
+
+	@patch("gregory.services.doi_import.SciencePaper")
+	def test_staff_source_queryset_scoped_to_org(self, MockSciencePaper):
+		"""Staff users should only see sources from their own organisation."""
+		other_org = Organization.objects.create(name="Other Org", slug="other-org-doi")
+		other_team = Team.objects.create(
+			name="Other Team", slug="other-team-doi", organization=other_org
+		)
+		other_source = Sources.objects.create(
+			name="Other Source",
+			source_for="science paper",
+			method="manual",
+			team=other_team,
+		)
+
+		from django.test import Client
+		client = Client()
+		client.force_login(self.staff_user)
+		resp = client.get(self._get_url())
+		self.assertEqual(resp.status_code, 200)
+		form = resp.context["form"]
+		source_ids = list(form.fields["source"].queryset.values_list("pk", flat=True))
+		self.assertIn(self.source.pk, source_ids)
+		self.assertNotIn(other_source.pk, source_ids)


### PR DESCRIPTION
## Summary

- Adds a green **"Add Article by DOI"** button on the Articles changelist in the Django admin
- Any staff member with the `add_articles` permission can paste a DOI (bare or as a full URL) and pick a source; CrossRef + Unpaywall metadata is fetched and the article is created immediately
- The source dropdown shows **Team** and **Subject** for each entry and is org-scoped for non-superusers
- Enrichment (categories, takeaways, ML predictions) is **not** run inline — the next scheduled pipeline run picks it up, avoiding web-request timeouts
- The existing `add_article_by_doi` management command is refactored to delegate to the same service; CLI behaviour is unchanged

## What changed

| File | Change |
|---|---|
| `gregory/services/doi_import.py` | New service module: `normalize_doi`, `create_article_from_doi`, `ImportResult` dataclass |
| `gregory/management/commands/add_article_by_doi.py` | Refactored to call the service; enrichment flags unchanged |
| `gregory/admin_views.py` | `AddByDoiForm` + `add_article_by_doi_view` (permission-gated) |
| `gregory/admin.py` | URL wired into `ArticleAdmin.get_urls()`; button URL passed to changelist context |
| `templates/.../articles/change_list.html` | Green "Add Article by DOI" button |
| `templates/.../articles/add_by_doi.html` | New form page template |
| `gregory/tests/test_doi_import_service.py` | 20 tests — all green |

## Test plan

- [ ] Run `docker exec gregory python manage.py test gregory.tests.test_doi_import_service` → 20/20 pass
- [ ] Visit `/admin/gregory/articles/` → confirm "Add Article by DOI" button appears
- [ ] Submit a real DOI (e.g. `10.1038/nature12373`) with a valid source → article created, redirects to change page
- [ ] Submit a DOI that already exists → warning message, redirects to existing article
- [ ] Submit an invalid DOI → CrossRef failure message, stays on form
- [ ] As a non-superuser staff member, confirm the source dropdown only shows sources from their organisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)