### PR TITLE
Add bulk add/remove source actions to Articles and Trials admin

### DIFF
--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -485,6 +485,107 @@ class TrialCategoryAssignmentInline(admin.TabularInline):
 		)
 
 
+class SourceActionForm(forms.Form):
+	"""Form for the 'Add source to selected' / 'Remove source from selected' actions."""
+
+	source = forms.ModelChoiceField(
+		queryset=Sources.objects.none(),
+		label="Source",
+	)
+
+
+class SourceBulkActionMixin:
+	"""
+	Admin mixin that adds 'Add source to selected…' and 'Remove source from
+	selected…' bulk actions for models with a `sources` ManyToManyField
+	(Articles, Trials).
+
+	Subclasses must set `source_for_values` to the list of Sources.source_for
+	values that are valid for their model (e.g. ["trials"]), and their model
+	must have a `sources` M2M field to Sources with the default reverse
+	accessor (`<model_name>_set`).
+	"""
+
+	source_for_values = []
+
+	def _get_source_queryset(self, request):
+		qs = Sources.objects.filter(source_for__in=self.source_for_values).order_by(
+			"name"
+		)
+		if request.user.is_superuser:
+			return qs
+		user_orgs = get_user_organizations(request.user)
+		return qs.filter(team__organization__id__in=user_orgs)
+
+	def _source_bulk_action(self, request, queryset, *, action_name, verb):
+		source_qs = self._get_source_queryset(request)
+
+		if "apply" not in request.POST:
+			form = SourceActionForm()
+			form.fields["source"].queryset = source_qs
+			return render(
+				request,
+				"admin/gregory/source_bulk_action_intermediate.html",
+				{
+					"title": f"{verb} source",
+					"objects": queryset,
+					"form": form,
+					"action_checkbox_name": admin.helpers.ACTION_CHECKBOX_NAME,
+					"model_name": queryset.model._meta.verbose_name_plural,
+					"action": action_name,
+					"verb": verb,
+				},
+			)
+
+		form = SourceActionForm(request.POST)
+		form.fields["source"].queryset = source_qs
+
+		if not form.is_valid():
+			self.message_user(
+				request, "Invalid form — please try again.", level=messages.ERROR
+			)
+			return
+
+		source = form.cleaned_data["source"]
+		model_plural = queryset.model._meta.verbose_name_plural
+
+		# Add/remove from the forward (obj.sources) side, one object at a time.
+		# django-simple-history tracks `sources` via m2m_fields on Articles/Trials'
+		# HistoricalRecords; the m2m_changed signal it relies on carries whichever
+		# instance initiated the change, so adding via the Sources reverse accessor
+		# (source.articles_set.add(...)) fires the signal with a Sources instance,
+		# which has no `.history` manager and breaks history recording.
+		if action_name == "add_source_action":
+			already_linked = queryset.filter(sources=source).count()
+			for obj in queryset:
+				obj.sources.add(source)
+			newly_linked = queryset.count() - already_linked
+			self.message_user(
+				request,
+				f"Added '{source}' to {newly_linked} {model_plural} "
+				f"({already_linked} already had it).",
+			)
+		else:
+			linked = queryset.filter(sources=source).count()
+			for obj in queryset:
+				obj.sources.remove(source)
+			self.message_user(
+				request, f"Removed '{source}' from {linked} {model_plural}."
+			)
+
+	@admin.action(description="Add source to selected…")
+	def add_source_action(self, request, queryset):
+		return self._source_bulk_action(
+			request, queryset, action_name="add_source_action", verb="Add"
+		)
+
+	@admin.action(description="Remove source from selected…")
+	def remove_source_action(self, request, queryset):
+		return self._source_bulk_action(
+			request, queryset, action_name="remove_source_action", verb="Remove"
+		)
+
+
 class ArticleAdminForm(forms.ModelForm):
 	ml_predictions_display = MLPredictionsField(required=False)
 
@@ -535,8 +636,10 @@ class ArticleAdminForm(forms.ModelForm):
 				)
 
 
-class ArticleAdmin(OrganizationFilterMixin, SimpleHistoryAdmin):
+class ArticleAdmin(OrganizationFilterMixin, SourceBulkActionMixin, SimpleHistoryAdmin):
 	form = ArticleAdminForm
+	source_for_values = ["science paper", "news article"]
+	actions = ["add_source_action", "remove_source_action"]
 	inlines = [
 		ArticleOrgContentInline,
 		ArticleSubjectRelevanceInline,
@@ -792,8 +895,10 @@ class TrialAdminForm(forms.ModelForm):
 		}
 
 
-class TrialAdmin(OrganizationFilterMixin, SimpleHistoryAdmin):
+class TrialAdmin(OrganizationFilterMixin, SourceBulkActionMixin, SimpleHistoryAdmin):
 	form = TrialAdminForm
+	source_for_values = ["trials"]
+	actions = ["add_source_action", "remove_source_action"]
 	list_display = [
 		"trial_id",
 		"title",

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -13,7 +13,7 @@ import csv
 import logging
 from simple_history.admin import SimpleHistoryAdmin  # Import SimpleHistoryAdmin
 from .admin_filters import DateRangeFilter, SourceHealthFilter
-from django.db import models  # Add this import for models.Count
+from django.db import models, transaction  # Add this import for models.Count
 from django.db.models import OuterRef, Subquery
 from django.utils import timezone
 from django import forms
@@ -549,29 +549,34 @@ class SourceBulkActionMixin:
 		source = form.cleaned_data["source"]
 		model_plural = queryset.model._meta.verbose_name_plural
 
-		# Add/remove from the forward (obj.sources) side, one object at a time.
-		# django-simple-history tracks `sources` via m2m_fields on Articles/Trials'
-		# HistoricalRecords; the m2m_changed signal it relies on carries whichever
-		# instance initiated the change, so adding via the Sources reverse accessor
-		# (source.articles_set.add(...)) fires the signal with a Sources instance,
-		# which has no `.history` manager and breaks history recording.
-		if action_name == "add_source_action":
-			already_linked = queryset.filter(sources=source).count()
-			for obj in queryset:
-				obj.sources.add(source)
-			newly_linked = queryset.count() - already_linked
-			self.message_user(
-				request,
-				f"Added '{source}' to {newly_linked} {model_plural} "
-				f"({already_linked} already had it).",
-			)
-		else:
-			linked = queryset.filter(sources=source).count()
-			for obj in queryset:
-				obj.sources.remove(source)
-			self.message_user(
-				request, f"Removed '{source}' from {linked} {model_plural}."
-			)
+		# Add/remove from the forward (obj.sources) side, one object at a time,
+		# inside a single transaction so a mid-loop failure (e.g. a signal or DB
+		# error) can't leave a partially applied change across the selection.
+		# `.only("pk").iterator()` avoids materializing every selected object in
+		# memory at once. django-simple-history tracks `sources` via m2m_fields
+		# on Articles/Trials' HistoricalRecords; the m2m_changed signal it relies
+		# on carries whichever instance initiated the change, so adding via the
+		# Sources reverse accessor (source.articles_set.add(...)) fires the
+		# signal with a Sources instance, which has no `.history` manager and
+		# breaks history recording.
+		with transaction.atomic():
+			if action_name == "add_source_action":
+				already_linked = queryset.filter(sources=source).count()
+				for obj in queryset.only("pk").iterator():
+					obj.sources.add(source)
+				newly_linked = queryset.count() - already_linked
+				self.message_user(
+					request,
+					f"Added '{source}' to {newly_linked} {model_plural} "
+					f"({already_linked} already had it).",
+				)
+			else:
+				linked = queryset.filter(sources=source).count()
+				for obj in queryset.only("pk").iterator():
+					obj.sources.remove(source)
+				self.message_user(
+					request, f"Removed '{source}' from {linked} {model_plural}."
+				)
 
 	@admin.action(description="Add source to selected…")
 	def add_source_action(self, request, queryset):

--- a/django/gregory/tests/test_admin_source_bulk_actions.py
+++ b/django/gregory/tests/test_admin_source_bulk_actions.py
@@ -1,0 +1,149 @@
+"""
+Tests for gregory.admin.SourceBulkActionMixin — the "Add source to selected…"
+and "Remove source from selected…" bulk admin actions on Articles/Trials.
+
+Run with:
+    docker exec gregory python manage.py test gregory.tests.test_admin_source_bulk_actions
+"""
+
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import TestCase, RequestFactory
+from organizations.models import Organization, OrganizationUser
+
+from gregory.admin import ArticleAdmin, TrialAdmin
+from gregory.models import Articles, Trials, Sources, Team
+
+User = get_user_model()
+
+
+class SourceBulkActionMixinTests(TestCase):
+	def setUp(self):
+		self.factory = RequestFactory()
+		self.site = AdminSite()
+
+		self.org_a = Organization.objects.create(name="Org A", slug="src-org-a")
+		self.org_b = Organization.objects.create(name="Org B", slug="src-org-b")
+		self.team_a = Team.objects.create(
+			organization=self.org_a, name="Team A", slug="src-team-a"
+		)
+		self.team_b = Team.objects.create(
+			organization=self.org_b, name="Team B", slug="src-team-b"
+		)
+
+		self.source_a = Sources.objects.create(
+			name="Source A", source_for="science paper", team=self.team_a
+		)
+		self.source_b = Sources.objects.create(
+			name="Source B", source_for="science paper", team=self.team_b
+		)
+		self.trial_source_a = Sources.objects.create(
+			name="Trial Source A", source_for="trials", team=self.team_a
+		)
+
+		self.article1 = Articles.objects.create(
+			title="Article 1", link="https://example.com/1"
+		)
+		self.article1.teams.add(self.team_a)
+		self.article2 = Articles.objects.create(
+			title="Article 2", link="https://example.com/2"
+		)
+		self.article2.teams.add(self.team_a)
+
+		self.trial1 = Trials.objects.create(title="Trial 1", link="https://example.com/t1")
+		self.trial1.teams.add(self.team_a)
+
+		self.staff_user = User.objects.create_user(
+			username="staff-a", password="pw", is_staff=True
+		)
+		OrganizationUser.objects.create(organization=self.org_a, user=self.staff_user)
+
+		self.superuser = User.objects.create_superuser(
+			username="root", email="r@e.com", password="pw"
+		)
+
+		self.article_admin = ArticleAdmin(Articles, self.site)
+		self.trial_admin = TrialAdmin(Trials, self.site)
+
+	def _request(self, user, post_data=None):
+		if post_data is not None:
+			request = self.factory.post("/admin/gregory/articles/", post_data)
+		else:
+			request = self.factory.get("/admin/gregory/articles/")
+		request.user = user
+		request.session = {}
+		request._messages = FallbackStorage(request)
+		return request
+
+	def test_source_queryset_scoped_by_source_for_and_org_for_staff(self):
+		request = self._request(self.staff_user)
+		qs = self.article_admin._get_source_queryset(request)
+		self.assertIn(self.source_a, qs)
+		self.assertNotIn(self.source_b, qs)  # belongs to a different org
+		self.assertNotIn(self.trial_source_a, qs)  # wrong source_for for Articles
+
+	def test_source_queryset_unrestricted_by_org_for_superuser(self):
+		request = self._request(self.superuser)
+		qs = self.article_admin._get_source_queryset(request)
+		self.assertIn(self.source_a, qs)
+		self.assertIn(self.source_b, qs)
+		self.assertNotIn(self.trial_source_a, qs)  # still filtered by source_for
+
+	def test_add_source_action_links_selected_articles(self):
+		request = self._request(
+			self.superuser, post_data={"apply": "1", "source": self.source_a.pk}
+		)
+		queryset = Articles.objects.filter(pk__in=[self.article1.pk, self.article2.pk])
+		self.article_admin.add_source_action(request, queryset)
+
+		self.assertIn(self.source_a, self.article1.sources.all())
+		self.assertIn(self.source_a, self.article2.sources.all())
+
+	def test_remove_source_action_unlinks_selected_articles(self):
+		self.article1.sources.add(self.source_a)
+		self.article2.sources.add(self.source_a)
+
+		request = self._request(
+			self.superuser, post_data={"apply": "1", "source": self.source_a.pk}
+		)
+		queryset = Articles.objects.filter(pk__in=[self.article1.pk, self.article2.pk])
+		self.article_admin.remove_source_action(request, queryset)
+
+		self.assertNotIn(self.source_a, self.article1.sources.all())
+		self.assertNotIn(self.source_a, self.article2.sources.all())
+
+	def test_add_source_action_records_history(self):
+		request = self._request(
+			self.superuser, post_data={"apply": "1", "source": self.source_a.pk}
+		)
+		queryset = Articles.objects.filter(pk=self.article1.pk)
+		self.article_admin.add_source_action(request, queryset)
+
+		self.assertTrue(self.article1.history.filter(history_type="~").exists())
+
+	def test_add_source_action_rejects_source_invalid_for_model(self):
+		# trial_source_a is source_for='trials', not valid for Articles, so it's
+		# excluded from the form's queryset and validation should fail silently
+		# (no crash, no link created).
+		request = self._request(
+			self.superuser, post_data={"apply": "1", "source": self.trial_source_a.pk}
+		)
+		queryset = Articles.objects.filter(pk=self.article1.pk)
+		self.article_admin.add_source_action(request, queryset)
+		self.article1.refresh_from_db()
+		self.assertNotIn(self.trial_source_a, self.article1.sources.all())
+
+	def test_trial_admin_scopes_to_trials_sources(self):
+		request = self._request(
+			self.superuser, post_data={"apply": "1", "source": self.trial_source_a.pk}
+		)
+		queryset = Trials.objects.filter(pk=self.trial1.pk)
+		self.trial_admin.add_source_action(request, queryset)
+		self.assertIn(self.trial_source_a, self.trial1.sources.all())
+
+	def test_confirmation_page_rendered_without_apply(self):
+		request = self._request(self.superuser)
+		queryset = Articles.objects.filter(pk=self.article1.pk)
+		response = self.article_admin.add_source_action(request, queryset)
+		self.assertEqual(response.status_code, 200)

--- a/django/gregory/tests/test_admin_source_bulk_actions.py
+++ b/django/gregory/tests/test_admin_source_bulk_actions.py
@@ -124,8 +124,8 @@ class SourceBulkActionMixinTests(TestCase):
 
 	def test_add_source_action_rejects_source_invalid_for_model(self):
 		# trial_source_a is source_for='trials', not valid for Articles, so it's
-		# excluded from the form's queryset and validation should fail silently
-		# (no crash, no link created).
+		# excluded from the form's queryset and validation should fail (no crash,
+		# no link created).
 		request = self._request(
 			self.superuser, post_data={"apply": "1", "source": self.trial_source_a.pk}
 		)

--- a/django/templates/admin/gregory/source_bulk_action_intermediate.html
+++ b/django/templates/admin/gregory/source_bulk_action_intermediate.html
@@ -1,0 +1,47 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{{ title }}</h1>
+
+<p>
+    {{ verb }} a source {% if verb == "Add" %}to{% else %}from{% endif %}
+    <strong>{{ objects.count }} {{ model_name }}</strong>:
+</p>
+
+<ul>
+{% for obj in objects %}
+    <li>{{ obj }}</li>
+{% endfor %}
+</ul>
+
+<form method="post">
+    {% csrf_token %}
+
+    {% for obj in objects %}
+        <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk }}">
+    {% endfor %}
+    <input type="hidden" name="action" value="{{ action }}">
+    <input type="hidden" name="apply" value="1">
+
+    <fieldset class="module aligned">
+        {% for field in form %}
+        <div class="form-row">
+            {{ field.label_tag }}
+            {{ field }}
+            {% if field.help_text %}
+                <p class="help">{{ field.help_text }}</p>
+            {% endif %}
+            {% for error in field.errors %}
+                <p class="errornote">{{ error }}</p>
+            {% endfor %}
+        </div>
+        {% endfor %}
+    </fieldset>
+
+    <div class="submit-row">
+        <input type="submit" value="Confirm" class="default">
+        <a href="../" class="button cancel-link">Cancel</a>
+    </div>
+</form>
+{% endblock %}

--- a/django/templates/admin/gregory/source_bulk_action_intermediate.html
+++ b/django/templates/admin/gregory/source_bulk_action_intermediate.html
@@ -9,18 +9,14 @@
     <strong>{{ objects.count }} {{ model_name }}</strong>:
 </p>
 
-<ul>
-{% for obj in objects %}
-    <li>{{ obj }}</li>
-{% endfor %}
-</ul>
-
 <form method="post">
     {% csrf_token %}
 
+    <ul>
     {% for obj in objects %}
-        <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk }}">
+        <li>{{ obj }}<input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk }}"></li>
     {% endfor %}
+    </ul>
     <input type="hidden" name="action" value="{{ action }}">
     <input type="hidden" name="apply" value="1">
 


### PR DESCRIPTION
## Summary
- Adds two new Django admin bulk actions, "Add source to selected…" and "Remove source from selected…", to both `ArticleAdmin` and `TrialAdmin`, so a Source can be attached/detached across many selected objects at once instead of editing each one individually.
- Source choices are scoped by `Sources.source_for` (only types compatible with Articles vs. Trials are offered) and by the acting user's organisation, mirroring the existing "Reassign to team" action's pattern. Superusers bypass the org restriction.
- Reuses the existing intermediate-confirmation-page UI convention (select objects → action → confirm page with a dropdown → apply).

## Implementation notes
- New `SourceBulkActionMixin` + `SourceActionForm` in `django/gregory/admin.py`, and a shared confirmation template `django/templates/admin/gregory/source_bulk_action_intermediate.html`.
- Adds/removes are applied via the forward `obj.sources.add()/.remove()` accessor, not the `Sources` reverse accessor. `django-simple-history` tracks `sources` as an `m2m_fields` entry on Articles/Trials' `HistoricalRecords`, and its `m2m_changed` signal handler expects the forward-side instance (which has `.history`); using the reverse accessor fired the signal with a `Sources` instance instead and crashed with `AttributeError: 'Sources' object has no attribute 'history'`. Caught this via manual testing before it could ship.

## Test plan
- [x] `docker exec gregory python manage.py check` — no issues
- [x] New test suite `gregory/tests/test_admin_source_bulk_actions.py` (8 tests): org/source_for scoping for staff vs. superuser, add/remove linking behaviour, history recording preserved, rejection of a source invalid for the model, Trials-specific scoping, and confirmation-page rendering
- [x] Ran alongside `test_admin_org_filter` — all 11 tests pass together
- [x] Manually exercised `.add()`/`.remove()` in a rolled-back shell transaction against real data to confirm history tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)