### PR TITLE
Fix training-data text preparation and per-subject labels

### DIFF
--- a/django/gregory/management/commands/train_models.py
+++ b/django/gregory/management/commands/train_models.py
@@ -531,9 +531,13 @@ class Command(BaseCommand):
 				"Collecting unlabeled articles...", VerbosityLevel.PROGRESS
 			)
 
-			# Get articles from the same team but without relevance labels for this subject
+			# Get articles from the same team but without relevance labels for this subject.
+			# NULL is_relevant means "Not Reviewed", which is still unlabeled and should
+			# remain eligible for pseudo-labeling. Only exclude articles that already have
+			# a reviewed (non-NULL) relevance entry for this subject.
 			unlabeled_articles = Articles.objects.filter(teams__slug=team_slug).exclude(
-				article_subject_relevances__subject=subject
+				article_subject_relevances__subject=subject,
+				article_subject_relevances__is_relevant__isnull=False,
 			)[:100]  # Limit to 100 for efficiency in this example
 
 			# Convert to DataFrame with the same structure and text cleaning as build_dataset

--- a/django/gregory/management/commands/train_models.py
+++ b/django/gregory/management/commands/train_models.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 
 from gregory.models import Team, Subject, Articles, PredictionRunLog
 from gregory.utils.dataset import collect_articles, build_dataset, train_val_test_split
-from gregory.utils.summariser import summarise_bulk
+from gregory.utils.text_utils import cleanHTML, cleanText, MIN_WORD_COUNT
 from gregory.utils.versioning import make_version_path
 from gregory.utils.verboser import Verboser, VerbosityLevel
 
@@ -361,10 +361,6 @@ class Command(BaseCommand):
 
 		Raises:
 		    ValueError: If dataset preparation or training fails
-
-		Note:
-		    Generated summaries are stored as 'generated_summary' in the training DataFrame
-		    and are never saved back to the database. They are only used for training purposes.
 		"""
 		results = {
 			"team": team_slug,
@@ -414,6 +410,7 @@ class Command(BaseCommand):
 
 		# Collect articles query
 		articles_qs = collect_articles(team_slug, subject_slug, window_days)
+		subject = Subject.objects.get(subject_slug=subject_slug, team__slug=team_slug)
 
 		# Add detailed logging about article counts
 		total_articles = Articles.objects.filter(
@@ -438,7 +435,7 @@ class Command(BaseCommand):
 			f"Building dataset with {labeled_articles} labeled articles",
 			VerbosityLevel.PROGRESS,
 		)
-		dataset_df = build_dataset(articles_qs)
+		dataset_df = build_dataset(articles_qs, subject)
 
 		if len(dataset_df) == 0:
 			raise ValueError(
@@ -479,36 +476,6 @@ class Command(BaseCommand):
 			f"Built dataset with {len(dataset_df)} labeled articles",
 			VerbosityLevel.PROGRESS,
 		)
-
-		# Step 2: Generate summaries for all texts
-		self.log_message("Generating text summaries...", VerbosityLevel.PROGRESS)
-
-		# We already have the text combined from build_dataset, but we need to
-		# extract titles if we need to separately summarize
-		if "title" not in dataset_df.columns:
-			# If we only have the combined text, we'll work with that directly
-			titles = dataset_df["text"].tolist()
-		else:
-			titles = dataset_df["title"].tolist()
-
-		# Generate summaries for all texts
-		summaries = summarise_bulk(titles, batch_size=4, usage_type="training")
-
-		# Update the dataset with generated summaries - use 'generated_summary' instead of 'summary'
-		# to avoid overwriting original article abstracts
-		dataset_df["generated_summary"] = summaries
-
-		# Create final text column combining title and generated summary
-		dataset_df["text"] = dataset_df.apply(
-			lambda row: (
-				f"{row['title']} {row['generated_summary']}".strip()
-				if "title" in dataset_df.columns
-				else f"{row['text']} {row['generated_summary']}".strip()
-			),
-			axis=1,
-		)
-
-		self.log_message("Text summarization complete", VerbosityLevel.PROGRESS)
 
 		# Double-check the class distribution before splitting
 		class_counts = dataset_df["relevant"].value_counts()
@@ -566,18 +533,24 @@ class Command(BaseCommand):
 
 			# Get articles from the same team but without relevance labels for this subject
 			unlabeled_articles = Articles.objects.filter(teams__slug=team_slug).exclude(
-				article_subject_relevances__subject__slug=subject_slug
+				article_subject_relevances__subject=subject
 			)[:100]  # Limit to 100 for efficiency in this example
 
-			# Convert to DataFrame with the same structure
+			# Convert to DataFrame with the same structure and text cleaning as build_dataset
 			unlabeled_data = []
 			for article in unlabeled_articles:
+				text = cleanText(
+					cleanHTML(f"{article.title} {article.summary or ''}"),
+					min_words=MIN_WORD_COUNT,
+				)
+				if not text:
+					continue
 				unlabeled_data.append(
 					{
 						"article_id": article.article_id,
 						"title": article.title,
 						"summary": article.summary or "",
-						"text": f"{article.title} {article.summary or ''}".strip(),
+						"text": text,
 					}
 				)
 
@@ -588,20 +561,6 @@ class Command(BaseCommand):
 				)
 			else:
 				unlabelled_df = pd.DataFrame(unlabeled_data)
-
-				# Generate summaries for unlabeled data if needed
-				if len(unlabeled_data) > 0:
-					unlabeled_titles = unlabelled_df["title"].tolist()
-					unlabeled_summaries = summarise_bulk(
-						unlabeled_titles, batch_size=4, usage_type="training"
-					)
-					unlabelled_df["generated_summary"] = unlabeled_summaries
-					unlabelled_df["text"] = unlabelled_df.apply(
-						lambda row: (
-							f"{row['title']} {row['generated_summary']}".strip()
-						),
-						axis=1,
-					)
 
 				# Generate pseudo-labels
 				self.log_message(
@@ -617,20 +576,20 @@ class Command(BaseCommand):
 					algorithm=algorithm,
 				)
 
-			# Save pseudo-labels to CSV
-			pseudo_dir = (
-				Path(BASE_MODEL_DIR) / team_slug / subject_slug / "pseudo_labels"
-			)
-			pseudo_file = save_pseudo_csv(
-				enhanced_train_df, pseudo_dir, prefix=algorithm
-			)
+				# Save pseudo-labels to CSV
+				pseudo_dir = (
+					Path(BASE_MODEL_DIR) / team_slug / subject_slug / "pseudo_labels"
+				)
+				pseudo_file = save_pseudo_csv(
+					enhanced_train_df, pseudo_dir, prefix=algorithm
+				)
 
-			self.log_message(
-				f"Saved pseudo-labels to {pseudo_file}", VerbosityLevel.PROGRESS
-			)
+				self.log_message(
+					f"Saved pseudo-labels to {pseudo_file}", VerbosityLevel.PROGRESS
+				)
 
-			# Use the enhanced training set
-			train_df = enhanced_train_df
+				# Use the enhanced training set
+				train_df = enhanced_train_df
 
 		# Step 5: Train the model
 		self.log_message(f"Initializing {algorithm} trainer", VerbosityLevel.PROGRESS)

--- a/django/gregory/tests/test_dataset.py
+++ b/django/gregory/tests/test_dataset.py
@@ -34,11 +34,19 @@ class DatasetTestCase(TestCase):
 			subject_name="Test Subject", subject_slug="test-subject", team=self.team
 		)
 
+		# Summary long enough to survive cleanText's MIN_WORD_COUNT filter
+		self.summary = (
+			"This study evaluates treatment outcomes in multiple sclerosis patients "
+			"using magnetic resonance imaging biomarkers alongside clinical disability "
+			"scores collected during a twenty four month follow up period."
+		)
+
 		# Create sample articles
 		self.articles = []
 		for i in range(5):
 			article = Articles.objects.create(
 				title=f"Test Article {i}",
+				summary=self.summary,
 				link=f"https://example.com/{i}",
 				discovery_date=datetime.now() - timedelta(days=i),
 			)
@@ -90,7 +98,7 @@ class DatasetTestCase(TestCase):
 	def test_build_dataset_creates_dataframe(self):
 		"""Test that build_dataset returns a DataFrame with the right structure."""
 		articles = collect_articles("test-team", "test-subject")
-		df = build_dataset(articles)
+		df = build_dataset(articles, self.subject)
 
 		# Check DataFrame structure
 		self.assertIsInstance(df, pd.DataFrame)
@@ -106,6 +114,96 @@ class DatasetTestCase(TestCase):
 		self.assertEqual(
 			relevant_count, 3
 		)  # 3 articles should be relevant (indices 0, 2, 4)
+
+	def test_build_dataset_cleans_text(self):
+		"""Text is cleaned like prediction time: HTML stripped, lowercased."""
+		article = Articles.objects.create(
+			title="An <b>HTML</b> Title About Sclerosis",
+			summary=f"<p>{self.summary}</p>",
+			link="https://example.com/html",
+		)
+		article.teams.add(self.team)
+		article.subjects.add(self.subject)
+		ArticleSubjectRelevance.objects.create(
+			article=article, subject=self.subject, is_relevant=True
+		)
+
+		df = build_dataset(
+			Articles.objects.filter(article_id=article.article_id), self.subject
+		)
+
+		self.assertEqual(len(df), 1)
+		text = df["text"].iloc[0]
+		self.assertNotIn("<", text)
+		self.assertNotIn(">", text)
+		self.assertEqual(text, text.lower())
+		self.assertIn("sclerosis", text)
+
+	def test_build_dataset_drops_short_texts(self):
+		"""Articles under MIN_WORD_COUNT words after cleaning are dropped."""
+		article = Articles.objects.create(
+			title="Too short", summary="", link="https://example.com/short"
+		)
+		article.teams.add(self.team)
+		article.subjects.add(self.subject)
+		ArticleSubjectRelevance.objects.create(
+			article=article, subject=self.subject, is_relevant=True
+		)
+
+		df = build_dataset(
+			Articles.objects.filter(article_id=article.article_id), self.subject
+		)
+
+		self.assertEqual(len(df), 0)
+
+	def test_build_dataset_uses_label_for_given_subject(self):
+		"""A multi-subject article must use the trained subject's label."""
+		other_subject = Subject.objects.create(
+			subject_name="Other Subject", subject_slug="other-subject", team=self.team
+		)
+		article = Articles.objects.create(
+			title="Multi subject article",
+			summary=self.summary,
+			link="https://example.com/multi",
+		)
+		article.teams.add(self.team)
+		article.subjects.add(self.subject, other_subject)
+		ArticleSubjectRelevance.objects.create(
+			article=article, subject=self.subject, is_relevant=True
+		)
+		ArticleSubjectRelevance.objects.create(
+			article=article, subject=other_subject, is_relevant=False
+		)
+
+		qs = Articles.objects.filter(article_id=article.article_id)
+
+		df_subject = build_dataset(qs, self.subject)
+		self.assertEqual(df_subject["relevant"].iloc[0], 1)
+
+		df_other = build_dataset(qs, other_subject)
+		self.assertEqual(df_other["relevant"].iloc[0], 0)
+
+	def test_build_dataset_excludes_articles_labeled_for_other_subject_only(self):
+		"""An article whose only label belongs to another subject is excluded."""
+		other_subject = Subject.objects.create(
+			subject_name="Other Subject", subject_slug="other-subject", team=self.team
+		)
+		article = Articles.objects.create(
+			title="Labeled elsewhere",
+			summary=self.summary,
+			link="https://example.com/elsewhere",
+		)
+		article.teams.add(self.team)
+		article.subjects.add(self.subject, other_subject)
+		ArticleSubjectRelevance.objects.create(
+			article=article, subject=other_subject, is_relevant=True
+		)
+
+		df = build_dataset(
+			Articles.objects.filter(article_id=article.article_id), self.subject
+		)
+
+		self.assertEqual(len(df), 0)
 
 	def test_train_val_test_split_correct_sizes(self):
 		"""Test that train_val_test_split returns the expected proportions."""
@@ -253,7 +351,7 @@ class DatasetTestCase(TestCase):
 		all_articles = Articles.objects.filter(teams=self.team, subjects=self.subject)
 
 		# Build dataset - should handle None gracefully
-		df = build_dataset(all_articles)
+		df = build_dataset(all_articles, self.subject)
 
 		# The unreviewed article should be excluded from the dataset
 		self.assertEqual(len(df), 5)  # Only the 5 reviewed articles

--- a/django/gregory/tests/test_train_models.py
+++ b/django/gregory/tests/test_train_models.py
@@ -179,65 +179,57 @@ class TrainModelsCommandTest(TestCase):
 				)
 
 				# Create mocks for the main dependencies
-				with patch(
-					"gregory.utils.summariser.summarise_bulk"
-				) as mock_summarise_bulk:
-					with patch("gregory.ml.get_trainer") as mock_get_trainer:
-						# Set up mocks
-						mock_summarise_bulk.return_value = [
-							"Summarized text" for _ in range(10)
-						]
+				with patch("gregory.ml.get_trainer") as mock_get_trainer:
+					# Create mock trainers for each algorithm
+					mock_trainers = {}
+					for algo in ["pubmed_bert", "lgbm_tfidf", "lstm"]:
+						mock_trainers[algo] = self.mock_trainer_factory(algo)
 
-						# Create mock trainers for each algorithm
-						mock_trainers = {}
-						for algo in ["pubmed_bert", "lgbm_tfidf", "lstm"]:
-							mock_trainers[algo] = self.mock_trainer_factory(algo)
+					# Set up get_trainer to return appropriate mock based on algo
+					mock_get_trainer.side_effect = lambda algo, **kwargs: (
+						mock_trainers[algo]
+					)
 
-						# Set up get_trainer to return appropriate mock based on algo
-						mock_get_trainer.side_effect = lambda algo, **kwargs: (
-							mock_trainers[algo]
+					# Create version directory paths
+					for algo in ["pubmed_bert", "lgbm_tfidf", "lstm"]:
+						version_path = os.path.join(
+							self.test_models_dir,
+							"test-team",
+							"test-subject",
+							algo,
+							"20250518",
 						)
+						os.makedirs(version_path, exist_ok=True)
 
-						# Create version directory paths
-						for algo in ["pubmed_bert", "lgbm_tfidf", "lstm"]:
-							version_path = os.path.join(
-								self.test_models_dir,
-								"test-team",
-								"test-subject",
-								algo,
-								"20250518",
-							)
-							os.makedirs(version_path, exist_ok=True)
+					# Execute the test - simulate running the command
+					self._run_command_test(mock_command)
 
-						# Execute the test - simulate running the command
-						self._run_command_test(mock_command)
+					# Verify artifacts were created
+					for algo in ["pubmed_bert", "lgbm_tfidf", "lstm"]:
+						version = "20250518"
+						model_path = os.path.join(
+							self.test_models_dir,
+							"test-team",
+							"test-subject",
+							algo,
+							version,
+						)
+						# Check that model directory exists
+						self.assertTrue(os.path.exists(model_path))
+						# Check for the model file
+						model_file = os.path.join(model_path, f"{algo}_model.bin")
+						self.assertTrue(os.path.exists(model_file))
+						# Check for metrics.json with both val_ and test_ keys
+						metrics_path = os.path.join(model_path, "metrics.json")
+						self.assertTrue(os.path.exists(metrics_path))
 
-						# Verify artifacts were created
-						for algo in ["pubmed_bert", "lgbm_tfidf", "lstm"]:
-							version = "20250518"
-							model_path = os.path.join(
-								self.test_models_dir,
-								"test-team",
-								"test-subject",
-								algo,
-								version,
-							)
-							# Check that model directory exists
-							self.assertTrue(os.path.exists(model_path))
-							# Check for the model file
-							model_file = os.path.join(model_path, f"{algo}_model.bin")
-							self.assertTrue(os.path.exists(model_file))
-							# Check for metrics.json with both val_ and test_ keys
-							metrics_path = os.path.join(model_path, "metrics.json")
-							self.assertTrue(os.path.exists(metrics_path))
+						with open(metrics_path, "r") as f:
+							metrics = json.load(f)
 
-							with open(metrics_path, "r") as f:
-								metrics = json.load(f)
-
-							self.assertIn("val_accuracy", metrics)
-							self.assertIn("test_accuracy", metrics)
-							self.assertIn("val_f1", metrics)
-							self.assertIn("test_f1", metrics)
+						self.assertIn("val_accuracy", metrics)
+						self.assertIn("test_accuracy", metrics)
+						self.assertIn("val_f1", metrics)
+						self.assertIn("test_f1", metrics)
 		except Exception as e:
 			debug_print(f"Exception occurred: {e}")
 			debug_print(traceback.format_exc())

--- a/django/gregory/utils/dataset.py
+++ b/django/gregory/utils/dataset.py
@@ -14,6 +14,7 @@ from django.db.models import QuerySet
 from sklearn.model_selection import train_test_split
 
 from gregory.models import Articles, Team, Subject
+from gregory.utils.text_utils import cleanHTML, cleanText, MIN_WORD_COUNT
 
 
 def collect_articles(
@@ -58,44 +59,53 @@ def collect_articles(
 	return queryset.select_related().prefetch_related("article_subject_relevances")
 
 
-def build_dataset(queryset: QuerySet) -> pd.DataFrame:
+def build_dataset(queryset: QuerySet, subject: Subject) -> pd.DataFrame:
 	"""
 	Build a dataset from a queryset of articles, merging title and summary and
-	including relevance labels.
+	including relevance labels for the given subject.
 
 	Args:
 	    queryset (QuerySet): The queryset of Articles objects
+	    subject (Subject): The subject whose relevance labels should be used
 
 	Returns:
 	    pd.DataFrame: DataFrame with columns:
 	        - article_id: The article's primary key
-	        - text: Combined title and summary
-	        - relevant: Boolean indicating relevance
+	        - text: cleanText(cleanHTML(title + summary)), matching prediction-time
+	          preparation; articles under MIN_WORD_COUNT words are dropped
+	        - relevant: 0/1 relevance label for the given subject
 
 	Note:
-	    Articles without relevance labels will be dropped.
+	    Articles without a manually reviewed relevance label for the subject
+	    will be dropped.
 	"""
 	data = []
 
 	for article in queryset:
-		# Get the relevance information for this article
-		relevance_entries = article.article_subject_relevances.all()
-
-		if not relevance_entries.exists():
-			continue  # Skip articles without relevance information
-
-		# Use the first relevance entry (there should be one per subject)
-		relevance = relevance_entries.first()
+		# Use the relevance entry for the subject being trained; an article tagged
+		# with several subjects may carry a different label for each of them
+		relevance = next(
+			(
+				r
+				for r in article.article_subject_relevances.all()
+				if r.subject_id == subject.id
+			),
+			None,
+		)
 
 		# Skip articles where relevance has not been manually reviewed (is_relevant is None)
-		if relevance.is_relevant is None:
+		if relevance is None or relevance.is_relevant is None:
 			continue
 
-		# Combine title and summary
-		text = article.title
+		# Combine title and summary, cleaned the same way predict_articles prepares text
+		raw_text = article.title
 		if article.summary:
 			# Using the original article summary (abstract) here, not a generated one
-			text += " " + article.summary
+			raw_text += " " + article.summary
+
+		text = cleanText(cleanHTML(raw_text), min_words=MIN_WORD_COUNT)
+		if not text:
+			continue
 
 		data.append(
 			{


### PR DESCRIPTION
## Summary

Audit of the ML pipeline against the reference repo (`files_repo_PBL_nsbe`) found that models were **trained on different text than they predict on**, plus a label bug for multi-subject articles. This PR fixes the training-data side; a follow-up PR fixes the prediction side of `predict_articles`.

- **Train/serve skew:** training used raw `title + summary` with a machine-generated summary appended (`summarise_bulk`), while `predict_articles` feeds `cleanText(cleanHTML(title + summary))`. `build_dataset` now uses the same cleaned text as prediction time (and the reference pipeline), dropping articles under `MIN_WORD_COUNT` (10) words. The summarisation step is removed from training entirely — also lighter on the 4GB prod VPS.
- **Per-subject labels:** `build_dataset` used `article_subject_relevances.all().first()` regardless of subject, so an article tagged with several subjects could train on another subject's label. It now takes the trained `Subject` and selects that subject's relevance entry.
- **Pseudo-label branch fixes:** the `exclude()` used `subject__slug`, which doesn't exist on `Subject` (would raise `FieldError`); the `save_pseudo_csv` block ran even when no unlabeled articles existed (`NameError` on `enhanced_train_df`). Both fixed, and unlabeled text now gets the same cleaning.

## ⚠️ Operational note

All existing model versions were trained on the old text. After merging, **retrain all teams/subjects** (`python manage.py train_models ...`) so new version dirs exist — predictions from old model versions on the new cleaned text are not trustworthy.

## Tests

- New: per-subject label selection for multi-subject articles; exclusion of articles labeled only for another subject; HTML stripping/lowercasing; <10-word articles dropped.
- Updated: `build_dataset` signature call sites; removed the stale `summarise_bulk` mock.
- Full suite: 1444 tests pass in the `gregory` container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)