### PR TITLE
Fix model loading, version resolution, and batching in predict_articles

### DIFF
--- a/django/gregory/management/commands/predict_articles.py
+++ b/django/gregory/management/commands/predict_articles.py
@@ -6,8 +6,8 @@ stores the results in MLPredictions, and logs each (subject × algorithm) run in
 """
 
 import os
+import re
 import sys
-import json
 import traceback
 from datetime import timedelta
 from pathlib import Path
@@ -18,7 +18,7 @@ from django.db.models import Q, Exists, OuterRef
 from django.utils import timezone
 
 from gregory.models import Team, Articles, MLPredictions, PredictionRunLog
-from gregory.utils.text_utils import cleanHTML, cleanText
+from gregory.utils.text_utils import cleanHTML, cleanText, MIN_WORD_COUNT
 
 # Base path for models
 BASE_MODEL_DIR = os.path.join(settings.BASE_DIR, "models")
@@ -28,6 +28,26 @@ DEFAULT_LOOKBACK_DAYS = 90
 DEFAULT_THRESHOLD = 0.8
 DEFAULT_ALGORITHMS = ["pubmed_bert", "lgbm_tfidf", "lstm"]
 DEFAULT_VERBOSITY = 1
+
+# Articles per model.predict() call; bounds memory usage on small hosts
+PREDICT_BATCH_SIZE = 32
+
+# Model versions are named YYYYMMDD by make_version_path, with _2, _3, ... on collision
+VERSION_NAME_RE = re.compile(r"^(\d{8})(?:_(\d+))?$")
+
+
+def _version_sort_key(name):
+	"""
+	Sort key for model version directory names.
+
+	Date-style versions (YYYYMMDD, optionally suffixed _n) sort by date then
+	numeric suffix, so 20250518_10 ranks above 20250518_2. Any other name
+	sorts below date-style versions, lexicographically among themselves.
+	"""
+	match = VERSION_NAME_RE.match(name)
+	if match:
+		return (1, int(match.group(1)), int(match.group(2) or 1), name)
+	return (0, 0, 0, name)
 
 
 class ModelLoadError(Exception):
@@ -117,8 +137,8 @@ def resolve_model_version(base_path, explicit_version=None):
 				f"Requested model version '{explicit_version}' not found in '{base_path}'"
 			)
 
-	# Otherwise, return the lexicographically largest (most recent) version
-	return sorted(versions)[-1]
+	# Otherwise, return the most recent version (date-aware natural sort)
+	return max(versions, key=_version_sort_key)
 
 
 def load_model(team, subject, algorithm, model_version):
@@ -140,14 +160,11 @@ def load_model(team, subject, algorithm, model_version):
 	# Import the necessary modules
 	try:
 		if algorithm == "pubmed_bert":
-			from gregory.ml.bert_wrapper import BertTrainer
+			from gregory.ml.bert_wrapper import BertTrainer as trainer_class
 		elif algorithm == "lgbm_tfidf":
-			from gregory.ml.lgbm_wrapper import LGBMTfidfTrainer
-			import joblib
+			from gregory.ml.lgbm_wrapper import LGBMTfidfTrainer as trainer_class
 		elif algorithm == "lstm":
-			from gregory.ml.lstm_wrapper import LSTMTrainer
-			import tensorflow as tf  # noqa: F401
-			from tensorflow.keras.layers import TextVectorization
+			from gregory.ml.lstm_wrapper import LSTMTrainer as trainer_class
 		else:
 			raise ModelLoadError(f"Unsupported algorithm: {algorithm}")
 	except ImportError as e:
@@ -163,84 +180,12 @@ def load_model(team, subject, algorithm, model_version):
 	if not os.path.exists(model_dir):
 		raise ModelLoadError(f"Model directory not found: {model_dir}")
 
+	# Each trainer's load() reads the artifacts its save() wrote, so loading
+	# stays in sync with training (file names, saved vectorizer config, etc.)
 	try:
-		# Load the appropriate model based on algorithm
-		if algorithm == "pubmed_bert":
-			# For BERT, load weights and tokenizer
-			model_path = os.path.join(model_dir, "bert_weights.h5")
-			if not os.path.exists(model_path):
-				raise ModelLoadError(f"BERT weights not found at {model_path}")
-
-			# Initialize and load the model
-			model = BertTrainer()
-			model.load_weights(model_path)
-			return model
-
-		elif algorithm == "lgbm_tfidf":
-			# For LGBM, load vectorizer and classifier
-			vectorizer_path = os.path.join(model_dir, "tfidf_vectorizer.joblib")
-			# Try both possible classifier filenames
-			model_path = os.path.join(
-				model_dir, "lgbm_classifier.joblib"
-			)  # Updated filename
-			if not os.path.exists(model_path):
-				# Fall back to alternate filename if first one doesn't exist
-				model_path = os.path.join(model_dir, "classifier.joblib")
-				if not os.path.exists(model_path):
-					raise ModelLoadError(
-						f"LGBM classifier not found at either:\n- {os.path.join(model_dir, 'lgbm_classifier.joblib')}\n- {os.path.join(model_dir, 'classifier.joblib')}"
-					)
-
-			if not os.path.exists(vectorizer_path):
-				raise ModelLoadError(
-					f"TF-IDF vectorizer not found at {vectorizer_path}"
-				)
-
-			# Load the model
-			model = LGBMTfidfTrainer()
-			model.vectorizer = joblib.load(vectorizer_path)
-			model.model = joblib.load(model_path)
-			return model
-
-		elif algorithm == "lstm":
-			# For LSTM, load model and tokenizer (Keras 3.x requires .weights.h5 suffix)
-			model_path = os.path.join(model_dir, "lstm.weights.h5")
-			tokenizer_path = os.path.join(model_dir, "tokenizer.json")
-
-			if not os.path.exists(model_path):
-				raise ModelLoadError(f"LSTM weights not found at {model_path}")
-			if not os.path.exists(tokenizer_path):
-				raise ModelLoadError(f"LSTM tokenizer not found at {tokenizer_path}")
-
-			# Load the model
-			model = LSTMTrainer()
-
-			# Load the vectorizer config from JSON file first
-			with open(tokenizer_path, "r") as f:
-				config = json.load(f)
-
-			# Create new vectorizer with our standard settings
-			model.vectorizer = TextVectorization(
-				max_tokens=model.max_tokens,
-				output_sequence_length=model.sequence_length,
-				standardize=model._custom_standardization,
-			)
-
-			# Set the vocabulary
-			model.vectorizer.set_vocabulary(config["vocabulary"])
-
-			# AFTER setting the vocabulary, create the model
-			# This ensures the embedding layer has the right input_dim
-			model.model = model._create_model()
-
-			# Build the model with the correct input shape before loading weights
-			# Keras 3.x requires the model to be built before load_weights()
-			model.model.build(input_shape=(None, model.sequence_length))
-
-			# Then load the weights
-			model.model.load_weights(model_path)
-
-			return model
+		model = trainer_class()
+		model.load(model_dir)
+		return model
 	except Exception as e:
 		raise ModelLoadError(f"Failed to load {algorithm} model: {str(e)}")
 
@@ -253,7 +198,8 @@ def prepare_text(article):
 	    article (Articles): The article to prepare text for
 
 	Returns:
-	    str: The prepared text
+	    str: The prepared text, or None if empty or under MIN_WORD_COUNT words
+	         after cleaning (matching training-time preparation)
 	"""
 	if article.summary:
 		text = f"{article.title} {article.summary}"
@@ -261,7 +207,7 @@ def prepare_text(article):
 		text = article.title
 
 	# Clean the text
-	return cleanText(cleanHTML(text))
+	return cleanText(cleanHTML(text), min_words=MIN_WORD_COUNT)
 
 
 class Command(BaseCommand):
@@ -355,6 +301,10 @@ class Command(BaseCommand):
 
 		Returns:
 		    dict: Statistics about the run
+
+		Note:
+		    Articles are predicted in batches of PREDICT_BATCH_SIZE; if a batch
+		    raises, every article in that batch is counted as a failure.
 		"""
 		stats = {"processed": 0, "skipped": 0, "failures": 0, "new_predictions": 0}
 
@@ -454,67 +404,51 @@ class Command(BaseCommand):
 
 				return stats
 
-			# Process each article
+			# Prepare texts, skipping articles that clean to nothing
+			pairs = []
 			for article in articles:
+				text = prepare_text(article)
+				if not text:
+					stats["skipped"] += 1
+					if verbose >= 3:
+						self.stdout.write(
+							f"    Skipped article {article.article_id}: No text after cleaning"
+						)
+					continue
+				pairs.append((article, text))
+
+			# Predict in batches; if a batch fails, all its articles count as failures
+			for start in range(0, len(pairs), PREDICT_BATCH_SIZE):
+				batch = pairs[start : start + PREDICT_BATCH_SIZE]
+
 				try:
-					# Prepare text
-					text = prepare_text(article)
-
-					if not text:
-						stats["skipped"] += 1
-						if verbose >= 3:
-							self.stdout.write(
-								f"    Skipped article {article.article_id}: No text after cleaning"
-							)
-						continue
-
-					# Use the appropriate prediction method based on algorithm
-					if algorithm == "pubmed_bert" or algorithm == "lstm":
-						binary_prediction, probability = model.predict(
-							[text], threshold=prob_threshold
-						)
-						# Handle both list return and single value return (for tests)
-						if (
-							isinstance(binary_prediction, list)
-							and len(binary_prediction) > 0
-						):
-							binary_prediction = binary_prediction[
-								0
-							]  # Extract single value from list
-						if isinstance(probability, list) and len(probability) > 0:
-							probability = probability[
-								0
-							]  # Extract single value from list
-					elif algorithm == "lgbm_tfidf":
-						binary_prediction, probability = model.predict(
-							[text], threshold=prob_threshold
-						)
-						# Handle both list return and single value return (for tests)
-						if (
-							isinstance(binary_prediction, list)
-							and len(binary_prediction) > 0
-						):
-							binary_prediction = binary_prediction[
-								0
-							]  # Extract single value from list
-						if isinstance(probability, list) and len(probability) > 0:
-							probability = probability[
-								0
-							]  # Extract single value from list
-					else:
-						raise ValueError(f"Unsupported algorithm: {algorithm}")
-
-					# Create MLPredictions instance
-					prediction = MLPredictions(
-						subject=subject,
-						article=article,
-						model_version=resolved_version,  # Always use the resolved model version
-						algorithm=algorithm,
-						probability_score=probability,
-						predicted_relevant=(binary_prediction == 1),
+					binary_predictions, probabilities = model.predict(
+						[text for _, text in batch], threshold=prob_threshold
 					)
+				except Exception as e:
+					stats["failures"] += len(batch)
+					failed_articles.extend(article.article_id for article, _ in batch)
+					if verbose >= 2:
+						self.stderr.write(
+							self.style.ERROR(
+								f"    Failed to predict batch of {len(batch)} articles: {str(e)}"
+							)
+						)
+					continue
 
-					prediction_instances.append(prediction)
+				for (article, _), binary_prediction, probability in zip(
+					batch, binary_predictions, probabilities
+				):
+					prediction_instances.append(
+						MLPredictions(
+							subject=subject,
+							article=article,
+							model_version=resolved_version,  # Always use the resolved model version
+							algorithm=algorithm,
+							probability_score=probability,
+							predicted_relevant=(binary_prediction == 1),
+						)
+					)
 					stats["processed"] += 1
 
 					if verbose >= 3:
@@ -525,24 +459,20 @@ class Command(BaseCommand):
 							f"    Article {article.article_id}: {relevance} ({probability:.4f})"
 						)
 
-				except Exception as e:
-					stats["failures"] += 1
-					failed_articles.append(article.article_id)
-					if verbose >= 2:
-						self.stderr.write(
-							self.style.ERROR(
-								f"    Failed to process article {article.article_id}: {str(e)}"
-							)
-						)
-
-			# Bulk create MLPredictions (ignore conflicts in case of duplicates)
+			# Bulk create MLPredictions, counting actual new rows: with
+			# ignore_conflicts=True, bulk_create's return value includes rows
+			# that were skipped as duplicates
 			if prediction_instances and not dry_run:
-				created = len(
-					MLPredictions.objects.bulk_create(
-						prediction_instances, ignore_conflicts=True
-					)
+				existing = MLPredictions.objects.filter(
+					subject=subject,
+					algorithm=algorithm,
+					model_version=resolved_version,
 				)
-				stats["new_predictions"] = created
+				before = existing.count()
+				MLPredictions.objects.bulk_create(
+					prediction_instances, ignore_conflicts=True
+				)
+				stats["new_predictions"] = existing.count() - before
 			elif prediction_instances:
 				# For dry run, we just count would-be creations
 				stats["new_predictions"] = len(prediction_instances)
@@ -786,5 +716,6 @@ class Command(BaseCommand):
 				self.style.WARNING("\nDRY RUN: No database changes were made")
 			)
 
-		# Always exit with code 0 as per spec
+		# Always exit with code 0 as per spec. Cron cannot detect failures from
+		# the exit code; check PredictionRunLog.success instead.
 		sys.exit(0)

--- a/django/gregory/management/commands/predict_articles.py
+++ b/django/gregory/management/commands/predict_articles.py
@@ -170,7 +170,7 @@ def load_model(team, subject, algorithm, model_version):
 	except ImportError as e:
 		raise ModelLoadError(
 			f"Failed to import required modules for {algorithm}: {str(e)}"
-		)
+		) from e
 
 	# Construct the path to the model directory
 	model_dir = os.path.join(
@@ -187,7 +187,7 @@ def load_model(team, subject, algorithm, model_version):
 		model.load(model_dir)
 		return model
 	except Exception as e:
-		raise ModelLoadError(f"Failed to load {algorithm} model: {str(e)}")
+		raise ModelLoadError(f"Failed to load {algorithm} model: {str(e)}") from e
 
 
 def prepare_text(article):
@@ -461,18 +461,19 @@ class Command(BaseCommand):
 
 			# Bulk create MLPredictions, counting actual new rows: with
 			# ignore_conflicts=True, bulk_create's return value includes rows
-			# that were skipped as duplicates
+			# that were skipped as duplicates. Only count conflicts among the
+			# articles in this batch, rather than scanning the whole table.
 			if prediction_instances and not dry_run:
-				existing = MLPredictions.objects.filter(
+				conflicts = MLPredictions.objects.filter(
 					subject=subject,
 					algorithm=algorithm,
 					model_version=resolved_version,
-				)
-				before = existing.count()
+					article_id__in=[p.article_id for p in prediction_instances],
+				).count()
 				MLPredictions.objects.bulk_create(
 					prediction_instances, ignore_conflicts=True
 				)
-				stats["new_predictions"] = existing.count() - before
+				stats["new_predictions"] = len(prediction_instances) - conflicts
 			elif prediction_instances:
 				# For dry run, we just count would-be creations
 				stats["new_predictions"] = len(prediction_instances)

--- a/django/gregory/ml/bert_wrapper.py
+++ b/django/gregory/ml/bert_wrapper.py
@@ -413,6 +413,21 @@ class BertTrainer:
 		self.model.load_weights(str(weights_path))
 		logging.info(f"Loaded model weights from {weights_path}")
 
+	def load(self, model_dir: Union[str, Path]) -> None:
+		"""
+		Load model artifacts saved by save() from a directory.
+
+		Args:
+		    model_dir (Union[str, Path]): Directory containing bert_weights.h5
+
+		Raises:
+		    FileNotFoundError: If the weights file doesn't exist
+		"""
+		weights_path = Path(model_dir) / "bert_weights.h5"
+		if not weights_path.exists():
+			raise FileNotFoundError(f"BERT weights not found at {weights_path}")
+		self.load_weights(weights_path)
+
 	def perform_pseudo_labeling(
 		self,
 		labeled_texts: List[str],

--- a/django/gregory/tests/management/test_predict_articles.py
+++ b/django/gregory/tests/management/test_predict_articles.py
@@ -25,6 +25,7 @@ from gregory.management.commands.predict_articles import (
 	resolve_model_version,
 	prepare_text,
 )
+from gregory.utils.text_utils import MIN_WORD_COUNT
 from gregory.models import Team, Subject, Articles, MLPredictions, PredictionRunLog
 
 
@@ -302,6 +303,34 @@ class TestResolveModelVersion(TestCase):
 	def test_resolve_model_version_latest(self):
 		self.assertEqual(resolve_model_version(self.base_path), "v2.0")
 
+	def test_resolve_model_version_date_suffix(self):
+		"""A suffixed same-day retrain outranks the unsuffixed version."""
+		with tempfile.TemporaryDirectory() as base:
+			for version in ["20250518", "20250518_2"]:
+				os.makedirs(os.path.join(base, version))
+			self.assertEqual(resolve_model_version(base), "20250518_2")
+
+	def test_resolve_model_version_numeric_suffix_order(self):
+		"""Suffixes compare numerically: _10 outranks _2."""
+		with tempfile.TemporaryDirectory() as base:
+			for version in ["20250518_2", "20250518_10"]:
+				os.makedirs(os.path.join(base, version))
+			self.assertEqual(resolve_model_version(base), "20250518_10")
+
+	def test_resolve_model_version_newer_date_wins(self):
+		"""A newer date outranks any suffix of an older date."""
+		with tempfile.TemporaryDirectory() as base:
+			for version in ["20250517_5", "20250518"]:
+				os.makedirs(os.path.join(base, version))
+			self.assertEqual(resolve_model_version(base), "20250518")
+
+	def test_resolve_model_version_date_beats_legacy_names(self):
+		"""Date-style versions outrank legacy free-form version names."""
+		with tempfile.TemporaryDirectory() as base:
+			for version in ["v1.0", "20250518"]:
+				os.makedirs(os.path.join(base, version))
+			self.assertEqual(resolve_model_version(base), "20250518")
+
 	def test_resolve_model_version_explicit(self):
 		self.assertEqual(resolve_model_version(self.base_path, "v1.0"), "v1.0")
 
@@ -397,7 +426,9 @@ class TestPrepareText(TestCase):
 		article.summary = "Test Summary"
 		result = prepare_text(article)
 		mock_clean_html.assert_called_once_with("Test Title Test Summary")
-		mock_clean_text.assert_called_once_with("cleaned HTML")
+		mock_clean_text.assert_called_once_with(
+			"cleaned HTML", min_words=MIN_WORD_COUNT
+		)
 		self.assertEqual(result, "cleaned text")
 
 	@patch("gregory.management.commands.predict_articles.cleanHTML")
@@ -410,8 +441,17 @@ class TestPrepareText(TestCase):
 		article.summary = ""
 		result = prepare_text(article)
 		mock_clean_html.assert_called_once_with("Test Title")
-		mock_clean_text.assert_called_once_with("cleaned HTML")
+		mock_clean_text.assert_called_once_with(
+			"cleaned HTML", min_words=MIN_WORD_COUNT
+		)
 		self.assertEqual(result, "cleaned text")
+
+	def test_prepare_text_returns_none_for_short_text(self):
+		"""Texts under MIN_WORD_COUNT words after cleaning are rejected."""
+		article = MagicMock()
+		article.title = "Short title"
+		article.summary = ""
+		self.assertIsNone(prepare_text(article))
 
 
 @patch("gregory.management.commands.predict_articles.get_articles")
@@ -457,18 +497,23 @@ class TestRunPredictionsFor(TestCase):
 		mock_get_articles.return_value = [self.article1, self.article2]
 		mock_resolve_version.return_value = "v1.0"
 		mock_model = MagicMock()
-		mock_model.predict.side_effect = [(1, 0.9), (0, 0.3)]
+		mock_model.predict.return_value = ([1, 0], [0.9, 0.3])
 		mock_load_model.return_value = mock_model
 		mock_prepare_text.side_effect = ["prepared text 1", "prepared text 2"]
 		initial = MLPredictions.objects.count()
 		stats = self.command.run_predictions_for(
 			self.subject, "pubmed_bert", "v1.0", 90, 0.8, dry_run=False, verbose=1
 		)
+		# Both articles are predicted in a single batched call
+		mock_model.predict.assert_called_once_with(
+			["prepared text 1", "prepared text 2"], threshold=0.8
+		)
 		self.assertEqual(PredictionRunLog.objects.count(), 1)
 		self.assertEqual(MLPredictions.objects.count(), initial + 2)
 		self.assertEqual(stats["processed"], 2)
 		self.assertEqual(stats["skipped"], 0)
 		self.assertEqual(stats["failures"], 0)
+		self.assertEqual(stats["new_predictions"], 2)
 
 	def test_run_predictions_dry_run(
 		self,
@@ -480,7 +525,7 @@ class TestRunPredictionsFor(TestCase):
 		mock_get_articles.return_value = [self.article1, self.article2]
 		mock_resolve_version.return_value = "v1.0"
 		mock_model = MagicMock()
-		mock_model.predict.side_effect = [(1, 0.9), (0, 0.3)]
+		mock_model.predict.return_value = ([1, 0], [0.9, 0.3])
 		mock_load_model.return_value = mock_model
 		mock_prepare_text.side_effect = ["prepared text 1", "prepared text 2"]
 		preds_before = MLPredictions.objects.count()
@@ -493,6 +538,81 @@ class TestRunPredictionsFor(TestCase):
 		self.assertEqual(stats["processed"], 2)
 		self.assertEqual(stats["skipped"], 0)
 		self.assertEqual(stats["failures"], 0)
+
+	def test_run_predictions_chunks_by_batch_size(
+		self,
+		mock_prepare_text,
+		mock_load_model,
+		mock_resolve_version,
+		mock_get_articles,
+	):
+		"""With PREDICT_BATCH_SIZE=2 and 5 articles, predict runs in 3 chunks."""
+		articles = [self.article1, self.article2]
+		for i in range(3, 6):
+			article = Articles.objects.create(
+				title=f"Article {i}",
+				link=f"http://example.com/{i}",
+				summary=f"Test summary {i}",
+			)
+			article.subjects.add(self.subject)
+			articles.append(article)
+
+		mock_get_articles.return_value = articles
+		mock_resolve_version.return_value = "v1.0"
+		mock_model = MagicMock()
+		mock_model.predict.side_effect = lambda texts, threshold: (
+			[1] * len(texts),
+			[0.9] * len(texts),
+		)
+		mock_load_model.return_value = mock_model
+		mock_prepare_text.side_effect = [f"prepared text {i}" for i in range(1, 6)]
+
+		with patch(
+			"gregory.management.commands.predict_articles.PREDICT_BATCH_SIZE", 2
+		):
+			stats = self.command.run_predictions_for(
+				self.subject, "pubmed_bert", "v1.0", 90, 0.8, dry_run=False, verbose=1
+			)
+
+		self.assertEqual(mock_model.predict.call_count, 3)
+		batch_sizes = [
+			len(call.args[0]) for call in mock_model.predict.call_args_list
+		]
+		self.assertEqual(batch_sizes, [2, 2, 1])
+		self.assertEqual(stats["processed"], 5)
+		self.assertEqual(stats["failures"], 0)
+
+	def test_new_predictions_excludes_conflicting_rows(
+		self,
+		mock_prepare_text,
+		mock_load_model,
+		mock_resolve_version,
+		mock_get_articles,
+	):
+		"""new_predictions counts only rows actually inserted, not conflicts."""
+		# Pre-existing prediction for article1 with the same unique key
+		MLPredictions.objects.create(
+			subject=self.subject,
+			article=self.article1,
+			algorithm="pubmed_bert",
+			model_version="v1.0",
+			probability_score=0.5,
+			predicted_relevant=False,
+		)
+
+		mock_get_articles.return_value = [self.article1, self.article2]
+		mock_resolve_version.return_value = "v1.0"
+		mock_model = MagicMock()
+		mock_model.predict.return_value = ([1, 0], [0.9, 0.3])
+		mock_load_model.return_value = mock_model
+		mock_prepare_text.side_effect = ["prepared text 1", "prepared text 2"]
+
+		stats = self.command.run_predictions_for(
+			self.subject, "pubmed_bert", "v1.0", 90, 0.8, dry_run=False, verbose=1
+		)
+
+		self.assertEqual(stats["processed"], 2)
+		self.assertEqual(stats["new_predictions"], 1)
 
 
 class TestSummaryTableFormatting(TestCase):

--- a/django/gregory/tests/management/test_predict_articles_extended.py
+++ b/django/gregory/tests/management/test_predict_articles_extended.py
@@ -15,9 +15,11 @@ Covers scenarios not in test_predict_articles.py:
 11. Prediction stores correct predicted_relevant and probability_score
 12. load_model with unsupported algorithm
 13. get_articles returns distinct results (no duplicates)
-14. run_predictions_for correctly unwraps list returns from model.predict
+14. run_predictions_for handles single-article batches from model.predict
 """
 
+import os
+import tempfile
 from datetime import datetime, timedelta
 from unittest.mock import patch, MagicMock
 
@@ -35,6 +37,7 @@ from gregory.management.commands.predict_articles import (
 	prepare_text,
 )
 from gregory.models import Team, Subject, Articles, MLPredictions, PredictionRunLog
+from gregory.utils.text_utils import MIN_WORD_COUNT
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +163,7 @@ class TestRunPredictionsEdgeCases(PredictArticlesTestMixin, TestCase):
 	def test_model_predict_exception_counted_as_failure(
 		self, mock_prepare, mock_load, mock_resolve, mock_get
 	):
-		"""If model.predict raises, the article is counted as a failure, not as skipped."""
+		"""If model.predict raises, every article in the batch is counted as a failure."""
 		mock_resolve.return_value = "v1"
 		mock_get.return_value = [self.article1]
 		mock_prepare.return_value = "some cleaned text"
@@ -219,7 +222,7 @@ class TestRunPredictionsEdgeCases(PredictArticlesTestMixin, TestCase):
 		mock_prepare.side_effect = ["text one", "text two"]
 		mock_model = MagicMock()
 		# First article relevant (prob 0.92), second not (prob 0.15)
-		mock_model.predict.side_effect = [([1], [0.92]), ([0], [0.15])]
+		mock_model.predict.return_value = ([1, 0], [0.92, 0.15])
 		mock_load.return_value = mock_model
 
 		self.command.run_predictions_for(
@@ -240,11 +243,11 @@ class TestRunPredictionsEdgeCases(PredictArticlesTestMixin, TestCase):
 		self.assertFalse(pred2.predicted_relevant)
 		self.assertAlmostEqual(pred2.probability_score, 0.15, places=2)
 
-	# ---- unwraps list returns from model.predict ----
+	# ---- single-article batch from model.predict ----
 	def test_unwraps_single_element_list_predictions(
 		self, mock_prepare, mock_load, mock_resolve, mock_get
 	):
-		"""model.predict may return ([1], [0.9]); the command must unwrap the inner lists."""
+		"""A single-article batch returning ([1], [0.95]) is stored correctly."""
 		mock_resolve.return_value = "v1"
 		mock_get.return_value = [self.article1]
 		mock_prepare.return_value = "text"
@@ -284,7 +287,7 @@ class TestPrepareTextNoneSummary(TestCase):
 		result = prepare_text(article)
 		# summary is None → falsy → only title used
 		mock_clean_html.assert_called_once_with("Test Title")
-		mock_clean_text.assert_called_once_with("cleaned html")
+		mock_clean_text.assert_called_once_with("cleaned html", min_words=MIN_WORD_COUNT)
 		self.assertEqual(result, "cleaned text")
 
 
@@ -350,6 +353,76 @@ class TestLoadModelUnsupported(TestCase):
 
 
 # ===========================================================================
+# 12b. load_model delegates to the wrappers' own load() methods
+# ===========================================================================
+class TestLoadModelDelegation(TestCase):
+	TRAINER_CLASSES = {
+		"pubmed_bert": "gregory.ml.bert_wrapper.BertTrainer",
+		"lgbm_tfidf": "gregory.ml.lgbm_wrapper.LGBMTfidfTrainer",
+		"lstm": "gregory.ml.lstm_wrapper.LSTMTrainer",
+	}
+
+	def setUp(self):
+		self.team = MagicMock()
+		self.team.slug = "test-team"
+		self.subject = MagicMock()
+		self.subject.subject_slug = "test-subject"
+
+	def _model_dir(self, base, algorithm, version="v1"):
+		model_dir = os.path.join(
+			base, self.team.slug, self.subject.subject_slug, algorithm, version
+		)
+		os.makedirs(model_dir)
+		return model_dir
+
+	def test_load_model_calls_wrapper_load(self):
+		"""Each algorithm's trainer is instantiated and load(model_dir) called."""
+		for algorithm, trainer_path in self.TRAINER_CLASSES.items():
+			with self.subTest(algorithm=algorithm):
+				with tempfile.TemporaryDirectory() as base:
+					model_dir = self._model_dir(base, algorithm)
+					with (
+						patch(
+							"gregory.management.commands.predict_articles.BASE_MODEL_DIR",
+							base,
+						),
+						patch(trainer_path) as mock_trainer_class,
+					):
+						instance = mock_trainer_class.return_value
+						model = load_model(self.team, self.subject, algorithm, "v1")
+						instance.load.assert_called_once_with(model_dir)
+						self.assertIs(model, instance)
+
+	def test_wrapper_file_not_found_becomes_model_load_error(self):
+		"""FileNotFoundError from the wrapper surfaces as ModelLoadError."""
+		with tempfile.TemporaryDirectory() as base:
+			self._model_dir(base, "lgbm_tfidf")
+			with (
+				patch(
+					"gregory.management.commands.predict_articles.BASE_MODEL_DIR",
+					base,
+				),
+				patch("gregory.ml.lgbm_wrapper.LGBMTfidfTrainer") as mock_trainer_class,
+			):
+				mock_trainer_class.return_value.load.side_effect = FileNotFoundError(
+					"lgbm_classifier.joblib not found"
+				)
+				with self.assertRaises(ModelLoadError) as ctx:
+					load_model(self.team, self.subject, "lgbm_tfidf", "v1")
+				self.assertIn("Failed to load lgbm_tfidf model", str(ctx.exception))
+
+	def test_missing_model_dir_raises_model_load_error(self):
+		"""A model directory that doesn't exist raises ModelLoadError."""
+		with tempfile.TemporaryDirectory() as base:
+			with patch(
+				"gregory.management.commands.predict_articles.BASE_MODEL_DIR", base
+			):
+				with self.assertRaises(ModelLoadError) as ctx:
+					load_model(self.team, self.subject, "lgbm_tfidf", "v1")
+				self.assertIn("Model directory not found", str(ctx.exception))
+
+
+# ===========================================================================
 # 13. get_articles returns distinct results
 # ===========================================================================
 class TestGetArticlesDistinct(PredictArticlesTestMixin, TestCase):
@@ -392,7 +465,7 @@ class TestPredictionRunLogModelVersion(PredictArticlesTestMixin, TestCase):
 		mock_get.return_value = [self.article1]
 		mock_prepare.return_value = "text"
 		mock_model = MagicMock()
-		mock_model.predict.return_value = (1, 0.9)
+		mock_model.predict.return_value = ([1], [0.9])
 		mock_load.return_value = mock_model
 
 		self.command.run_predictions_for(
@@ -415,7 +488,7 @@ class TestPredictionRunLogModelVersion(PredictArticlesTestMixin, TestCase):
 		mock_get.return_value = [self.article1]
 		mock_prepare.return_value = "text"
 		mock_model = MagicMock()
-		mock_model.predict.return_value = (0, 0.2)
+		mock_model.predict.return_value = ([0], [0.2])
 		mock_load.return_value = mock_model
 
 		self.command.run_predictions_for(

--- a/django/gregory/tests/test_bert_wrapper.py
+++ b/django/gregory/tests/test_bert_wrapper.py
@@ -256,6 +256,20 @@ class TestBertTrainer(unittest.TestCase):
 			# Verify results
 			mock_load.assert_called_once_with("fake_path.h5")
 
+	def test_load(self):
+		"""Test loading model artifacts from a directory."""
+		with tempfile.TemporaryDirectory() as temp_dir:
+			# Missing weights file raises FileNotFoundError
+			with self.assertRaises(FileNotFoundError):
+				self.trainer.load(temp_dir)
+
+			# With the weights file present, load_weights gets its path
+			weights_path = Path(temp_dir) / "bert_weights.h5"
+			weights_path.touch()
+			with patch.object(self.trainer, "load_weights") as mock_load:
+				self.trainer.load(temp_dir)
+				mock_load.assert_called_once_with(weights_path)
+
 	def test_perform_pseudo_labeling(self):
 		"""Test pseudo-labeling functionality."""
 		# Mock methods


### PR DESCRIPTION
## Summary

Prediction-side fixes from the ML pipeline audit (training-side fixes are in #732; the two PRs are independent).

- **Date-aware version resolution.** `resolve_model_version` sorted lexicographically, so `20250521_2` outranked `20250521_13` — this exact collision already exists in the dev `models/` tree. Versions now sort by `(date, numeric suffix)`; legacy free-form names still work and rank below date-style versions.
- **Model loading delegates to the wrappers.** `load_model` hand-reimplemented each trainer's loading. The LSTM path rebuilt its vectorizer with the trainer's *default* `max_tokens`/`sequence_length` instead of the saved `tokenizer.json` config — silent drift if training ever uses non-default settings. Now each algorithm calls its wrapper's own `load(model_dir)` (added a thin `BertTrainer.load` for symmetry), and the dead `classifier.joblib` fallback is gone.
- **Batched prediction.** The command called `model.predict([text])` once per article — pathologically slow for BERT. Articles are now predicted in chunks of `PREDICT_BATCH_SIZE` (32, bounding memory on the 4GB prod VPS). A batch failure marks all its articles as failed. This also removed the duplicated per-algorithm branches.
- **Accurate `new_predictions`.** `len(bulk_create(..., ignore_conflicts=True))` counted conflicted rows as created; the stat is now computed from the database.
- **`prepare_text` min-words filter.** Applies `MIN_WORD_COUNT` (10) to match the reference pipeline preprocessing (and #732's training text). Sub-10-word articles show up in `skipped` on every run — harmless, they have no usable text.
- Note added at `sys.exit(0)`: cron can't detect failures from the exit code; `PredictionRunLog.success` is the signal.

## Verification

- Full suite: 1451 tests pass in the `gregory` container.
- Dry run against the dev DB (`--team team-gregory --subject multiple-sclerosis --algo lgbm_tfidf --lookback-days 400 --dry-run`): resolved version `20251226` correctly, loaded via wrapper `.load()`, **processed 3,325 articles in batches with 0 failures**, 6 skipped by the min-words guard, no DB writes.

New tests: date-version sorting (suffix ordering, newer-date-wins, legacy names), wrapper-load delegation per algorithm, `FileNotFoundError` → `ModelLoadError`, batch chunking (batch size 2 → 3 calls for 5 articles), conflict-excluded `new_predictions` count, `BertTrainer.load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)