### PR TITLE
Default BERT max_len to 128 and restore saved architecture on load

### DIFF
--- a/django/gregory/ml/bert_wrapper.py
+++ b/django/gregory/ml/bert_wrapper.py
@@ -78,7 +78,7 @@ class BertTrainer:
 
 	def __init__(
 		self,
-		max_len: int = 400,
+		max_len: int = 128,
 		bert_model_name: str = "microsoft/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext",
 		learning_rate: float = 2e-5,
 		dense_units: int = 48,
@@ -89,7 +89,9 @@ class BertTrainer:
 		Initialize a new BertTrainer.
 
 		Args:
-		    max_len (int, optional): Maximum sequence length. Defaults to 400.
+		    max_len (int, optional): Maximum sequence length. Defaults to 128,
+		        matching the reference implementation; longer values multiply
+		        activation memory during training.
 		    bert_model_name (str, optional): HuggingFace model identifier.
 		        Defaults to 'microsoft/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext'.
 		    learning_rate (float, optional): Learning rate. Defaults to 2e-5.
@@ -417,15 +419,39 @@ class BertTrainer:
 		"""
 		Load model artifacts saved by save() from a directory.
 
+		If the directory contains a metrics.json written by save(), the
+		architecture parameters recorded there (max_len, dense_units) take
+		precedence over this instance's values, so artifacts trained with a
+		different configuration (e.g. older max_len=400 models) keep
+		predicting with the settings they were trained on.
+
 		Args:
 		    model_dir (Union[str, Path]): Directory containing bert_weights.h5
 
 		Raises:
 		    FileNotFoundError: If the weights file doesn't exist
 		"""
-		weights_path = Path(model_dir) / "bert_weights.h5"
+		model_dir = Path(model_dir)
+		weights_path = model_dir / "bert_weights.h5"
 		if not weights_path.exists():
 			raise FileNotFoundError(f"BERT weights not found at {weights_path}")
+
+		metrics_path = model_dir / "metrics.json"
+		if metrics_path.exists():
+			with open(metrics_path) as f:
+				saved = json.load(f)
+			rebuild = False
+			saved_max_len = saved.get("max_len")
+			if saved_max_len and saved_max_len != self.max_len:
+				self.max_len = saved_max_len
+				rebuild = True
+			saved_dense_units = saved.get("dense_units")
+			if saved_dense_units and saved_dense_units != self.dense_units:
+				self.dense_units = saved_dense_units
+				rebuild = True
+			if rebuild:
+				self.model = self._create_model()
+
 		self.load_weights(weights_path)
 
 	def perform_pseudo_labeling(

--- a/django/gregory/ml/bert_wrapper.py
+++ b/django/gregory/ml/bert_wrapper.py
@@ -438,15 +438,63 @@ class BertTrainer:
 
 		metrics_path = model_dir / "metrics.json"
 		if metrics_path.exists():
-			with open(metrics_path) as f:
-				saved = json.load(f)
+			try:
+				with open(metrics_path) as f:
+					saved = json.load(f)
+				if not isinstance(saved, dict):
+					logging.warning(
+						"Ignoring invalid metrics file %s: expected JSON object, got %s",
+						metrics_path,
+						type(saved).__name__,
+					)
+					saved = {}
+			except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+				logging.warning(
+					"Failed to parse metrics file %s; loading weights with current architecture. Error: %s",
+					metrics_path,
+					exc,
+				)
+				saved = {}
+
+			def _coerce_positive_int(value: Any, field_name: str) -> Optional[int]:
+				if value is None:
+					return None
+				if isinstance(value, bool):
+					logging.warning(
+						"Ignoring invalid %s in %s: boolean values are not supported",
+						field_name,
+						metrics_path,
+					)
+					return None
+				try:
+					int_value = int(value)
+				except (TypeError, ValueError):
+					logging.warning(
+						"Ignoring invalid %s in %s: %r",
+						field_name,
+						metrics_path,
+						value,
+					)
+					return None
+				if int_value <= 0:
+					logging.warning(
+						"Ignoring invalid %s in %s: expected positive integer, got %r",
+						field_name,
+						metrics_path,
+						value,
+					)
+					return None
+				return int_value
+
 			rebuild = False
-			saved_max_len = saved.get("max_len")
-			if saved_max_len and saved_max_len != self.max_len:
+			saved_max_len = _coerce_positive_int(saved.get("max_len"), "max_len")
+			if saved_max_len is not None and saved_max_len != self.max_len:
 				self.max_len = saved_max_len
 				rebuild = True
-			saved_dense_units = saved.get("dense_units")
-			if saved_dense_units and saved_dense_units != self.dense_units:
+			saved_dense_units = _coerce_positive_int(
+				saved.get("dense_units"), "dense_units"
+			)
+			if saved_dense_units is not None and saved_dense_units != self.dense_units:
 				self.dense_units = saved_dense_units
 				rebuild = True
 			if rebuild:

--- a/django/gregory/ml/pseudo.py
+++ b/django/gregory/ml/pseudo.py
@@ -105,7 +105,7 @@ def generate_pseudo_labels(
 	# Set default parameters based on algorithm
 	model_params = model_params or {}
 	if algorithm == "pubmed_bert":
-		model_params.setdefault("max_len", 400)
+		model_params.setdefault("max_len", 128)
 		model_params.setdefault("learning_rate", 2e-5)
 		model_params.setdefault("dense_units", 48)
 		model_params.setdefault(

--- a/django/gregory/tests/test_bert_wrapper.py
+++ b/django/gregory/tests/test_bert_wrapper.py
@@ -5,6 +5,7 @@ This module contains tests for the BertTrainer class functionality, including
 model creation, text encoding, training, evaluation, and saving/loading.
 """
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -269,6 +270,47 @@ class TestBertTrainer(unittest.TestCase):
 			with patch.object(self.trainer, "load_weights") as mock_load:
 				self.trainer.load(temp_dir)
 				mock_load.assert_called_once_with(weights_path)
+
+	def test_load_restores_architecture_from_metrics(self):
+		"""load() rebuilds the model with the max_len/dense_units the artifact was trained with."""
+		with tempfile.TemporaryDirectory() as temp_dir:
+			(Path(temp_dir) / "bert_weights.h5").touch()
+			with open(Path(temp_dir) / "metrics.json", "w") as f:
+				json.dump({"max_len": 400, "dense_units": 48}, f)
+
+			with (
+				patch.object(self.trainer, "load_weights") as mock_load,
+				patch.object(self.trainer, "_create_model") as mock_create,
+			):
+				rebuilt_model = MagicMock()
+				mock_create.return_value = rebuilt_model
+				self.trainer.load(temp_dir)
+
+				self.assertEqual(self.trainer.max_len, 400)
+				self.assertEqual(self.trainer.dense_units, 48)
+				self.assertEqual(self.trainer.model, rebuilt_model)
+				mock_create.assert_called_once()
+				mock_load.assert_called_once()
+
+	def test_load_keeps_architecture_when_metrics_match(self):
+		"""load() does not rebuild the model when the saved config matches this instance."""
+		with tempfile.TemporaryDirectory() as temp_dir:
+			(Path(temp_dir) / "bert_weights.h5").touch()
+			# Matches the setUp trainer (max_len=10, dense_units=16)
+			with open(Path(temp_dir) / "metrics.json", "w") as f:
+				json.dump({"max_len": 10, "dense_units": 16}, f)
+
+			original_model = self.trainer.model
+			with (
+				patch.object(self.trainer, "load_weights") as mock_load,
+				patch.object(self.trainer, "_create_model") as mock_create,
+			):
+				self.trainer.load(temp_dir)
+
+				self.assertEqual(self.trainer.max_len, 10)
+				self.assertEqual(self.trainer.model, original_model)
+				mock_create.assert_not_called()
+				mock_load.assert_called_once()
 
 	def test_perform_pseudo_labeling(self):
 		"""Test pseudo-labeling functionality."""

--- a/django/gregory/tests/test_bert_wrapper.py
+++ b/django/gregory/tests/test_bert_wrapper.py
@@ -312,6 +312,52 @@ class TestBertTrainer(unittest.TestCase):
 				mock_create.assert_not_called()
 				mock_load.assert_called_once()
 
+	def test_load_ignores_corrupted_metrics_json(self):
+		"""load() should still load weights when metrics.json is unreadable."""
+		with tempfile.TemporaryDirectory() as temp_dir:
+			(Path(temp_dir) / "bert_weights.h5").touch()
+			with open(Path(temp_dir) / "metrics.json", "w") as f:
+				f.write("{invalid_json")
+
+			original_max_len = self.trainer.max_len
+			original_dense_units = self.trainer.dense_units
+			original_model = self.trainer.model
+
+			with (
+				patch.object(self.trainer, "load_weights") as mock_load,
+				patch.object(self.trainer, "_create_model") as mock_create,
+			):
+				self.trainer.load(temp_dir)
+
+				self.assertEqual(self.trainer.max_len, original_max_len)
+				self.assertEqual(self.trainer.dense_units, original_dense_units)
+				self.assertEqual(self.trainer.model, original_model)
+				mock_create.assert_not_called()
+				mock_load.assert_called_once()
+
+	def test_load_ignores_invalid_metrics_values(self):
+		"""load() ignores non-positive/non-numeric metrics values and keeps defaults."""
+		with tempfile.TemporaryDirectory() as temp_dir:
+			(Path(temp_dir) / "bert_weights.h5").touch()
+			with open(Path(temp_dir) / "metrics.json", "w") as f:
+				json.dump({"max_len": 0, "dense_units": "abc"}, f)
+
+			original_max_len = self.trainer.max_len
+			original_dense_units = self.trainer.dense_units
+			original_model = self.trainer.model
+
+			with (
+				patch.object(self.trainer, "load_weights") as mock_load,
+				patch.object(self.trainer, "_create_model") as mock_create,
+			):
+				self.trainer.load(temp_dir)
+
+				self.assertEqual(self.trainer.max_len, original_max_len)
+				self.assertEqual(self.trainer.dense_units, original_dense_units)
+				self.assertEqual(self.trainer.model, original_model)
+				mock_create.assert_not_called()
+				mock_load.assert_called_once()
+
 	def test_perform_pseudo_labeling(self):
 		"""Test pseudo-labeling functionality."""
 		# Mock methods

--- a/django/gregory/tests/test_pseudo.py
+++ b/django/gregory/tests/test_pseudo.py
@@ -212,7 +212,7 @@ class TestGeneratePseudoLabels:
 		mock_get_trainer.assert_called_with(
 			"pubmed_bert",
 			**{
-				"max_len": 400,
+				"max_len": 128,
 				"learning_rate": 2e-5,
 				"dense_units": 48,
 				"freeze_weights": True,


### PR DESCRIPTION
## Why

Phase 2 of the ML training work (see `HANDOVER-ML-TRAINING.md`): a measurement run on the production VPS (3.8 GiB RAM, 8 GiB swap, 2 vCPU) confirmed that fine-tuning BiomedBERT at `max_len=400` exhausts **all** memory — RAM plus the full 8 GiB of swap — and the training process is OOM-killed during epoch 1. The reference implementation (`files_repo_PBL_nsbe`) achieved its reported 96.5% recall at `max_len=128`, which needs roughly a third of the activation memory.

Measured peaks per algorithm (`train_models --all-articles`, 2,514 labeled articles, container `memory.current` sampled every 2s):

| Algorithm | Peak container memory | Wall time | Outcome |
|---|---|---|---|
| `lgbm_tfidf` | 1.31 GiB | 63 s | trained + saved |
| `lstm` | 1.43 GiB | 135 s | trained + saved |
| `pubmed_bert` (max_len=400) | 3.44 GiB + 8 GiB swap exhausted | killed at 313 s | OOM (exit 137) |

## What

- `BertTrainer` default `max_len`: 400 → 128 (and the pseudo-labeling default in `gregory/ml/pseudo.py`).
- `BertTrainer.load()` now reads `max_len` / `dense_units` from the `metrics.json` written by `save()` and rebuilds the model when they differ from the instance's values. Without this, existing `max_len=400` artifacts would silently tokenize at 128 during prediction after the default change.
- Tests: two new tests covering the load-time architecture restore; updated the pseudo-labeling default assertion.

Full suite: 1,480 passed, 65 subtests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)