### PR TITLE
Add off-box training: dataset export command and train_models --dataset-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ data/trials.json
 # Gregory
 postgres-data
 django/models/
+django/datasets/
 *.code-workspace
 ai_tests/
 .venv-tf/

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ TAG   ?= $(shell git rev-parse --short HEAD)
 PLATFORMS ?= linux/amd64,linux/arm64
 BUILDER ?= gregory-multiarch
 
-.PHONY: help build push db-pull db-restore db-upgrade db-upgrade-finish
+.PHONY: help build push db-pull db-restore db-upgrade db-upgrade-finish ml-export ml-train ml-ship
 
 help:
 	@echo "Available targets:"
@@ -30,6 +30,12 @@ help:
 	@echo "  db-restore         Restore the most recent backup in $(BACKUP_DIR)/"
 	@echo "  db-upgrade         Step 1 of major-version upgrade: dump current DB, stop db, move data dir aside"
 	@echo "  db-upgrade-finish  Step 2: recreate db container from new image, restore dump, migrate"
+	@echo "  ml-export          Export training data on production and copy the CSV here"
+	@echo "  ml-train           Train ML_ALGO locally from the newest exported dataset"
+	@echo "  ml-ship            Copy the newest trained model version to production and verify"
+	@echo ""
+	@echo "Off-box ML training (defaults: ML_TEAM=$(ML_TEAM) ML_SUBJECT=$(ML_SUBJECT) ML_ALGO=$(ML_ALGO)):"
+	@echo "  make ml-export && make ml-train && make ml-ship"
 
 ## Build the Gregory Docker image.
 ## Override image name or tag: make build IMAGE=myrepo/myimage TAG=v1.0
@@ -148,3 +154,60 @@ db-upgrade-finish: | $(BACKUP_DIR)
 
 $(BACKUP_DIR):
 	mkdir -p $(BACKUP_DIR)
+
+## Off-box ML training: export the dataset on production, train here, ship the
+## artifacts back. Prediction on production picks up the new version dir
+## automatically (resolve_model_version), no restart needed.
+##
+## Requirements:
+##   - ml-export: the production compose file mounts ./django/datasets:/code/datasets
+##   - ml-train: local containers running (docker compose up -d) and the team/subject
+##     present in the local DB (make db-pull if missing)
+##   - ml-ship: rsync on both ends
+##
+## Override scope per run, e.g.:
+##   make ml-export ml-train ml-ship ML_ALGO=lstm
+##   make ml-train ML_TEAM=other-team ML_SUBJECT=other-subject ML_ALGO=lgbm_tfidf
+ML_TEAM      ?= team-gregory
+ML_SUBJECT   ?= multiple-sclerosis
+ML_ALGO      ?= pubmed_bert
+ML_VERSION   ?=
+PROD_APP_DIR ?= gregory-ai
+DATASETS_DIR := django/datasets
+ML_MODEL_PATH = $(ML_TEAM)/$(ML_SUBJECT)/$(ML_ALGO)
+
+ml-export:
+	@echo "==> Exporting training data for $(ML_TEAM)/$(ML_SUBJECT) on $(PROD_HOST) ..."
+	ssh $(PROD_SSH_USER)@$(PROD_HOST) \
+		"docker exec gregory python manage.py export_training_data --team $(ML_TEAM) --subject $(ML_SUBJECT) --all-articles"
+	@mkdir -p $(DATASETS_DIR)
+	scp "$(PROD_SSH_USER)@$(PROD_HOST):$(PROD_APP_DIR)/django/datasets/$(ML_TEAM)_$(ML_SUBJECT)_*.csv" $(DATASETS_DIR)/
+	@echo "==> Dataset copied to $(DATASETS_DIR)/ — next: make ml-train"
+
+ml-train:
+	$(eval DATASET := $(shell ls -t $(DATASETS_DIR)/$(ML_TEAM)_$(ML_SUBJECT)_*.csv 2>/dev/null | head -1))
+	@if [ -z "$(DATASET)" ]; then \
+		echo "ERROR: no dataset for $(ML_TEAM)/$(ML_SUBJECT) in $(DATASETS_DIR)/. Run: make ml-export"; \
+		exit 1; \
+	fi
+	@echo "==> Training $(ML_ALGO) for $(ML_TEAM)/$(ML_SUBJECT) from $(DATASET) ..."
+	docker exec gregory python manage.py train_models \
+		--team $(ML_TEAM) --subject $(ML_SUBJECT) --algo $(ML_ALGO) \
+		--dataset-file /code/datasets/$(notdir $(DATASET)) --verbose 3
+	@echo "==> Artifacts in django/models/$(ML_MODEL_PATH)/ — next: make ml-ship"
+
+## Ships the newest version dir by default; pin one with ML_VERSION=YYYYMMDD[_n]
+ml-ship:
+	$(eval ML_VERSION := $(or $(ML_VERSION),$(shell ls -t django/models/$(ML_MODEL_PATH)/ 2>/dev/null | head -1)))
+	@if [ -z "$(ML_VERSION)" ]; then \
+		echo "ERROR: no trained versions in django/models/$(ML_MODEL_PATH)/. Run: make ml-train"; \
+		exit 1; \
+	fi
+	@echo "==> Shipping $(ML_MODEL_PATH)/$(ML_VERSION) to $(PROD_HOST) ..."
+	ssh $(PROD_SSH_USER)@$(PROD_HOST) "mkdir -p $(PROD_APP_DIR)/django/models/$(ML_MODEL_PATH)/$(ML_VERSION)"
+	rsync -av django/models/$(ML_MODEL_PATH)/$(ML_VERSION)/ \
+		$(PROD_SSH_USER)@$(PROD_HOST):$(PROD_APP_DIR)/django/models/$(ML_MODEL_PATH)/$(ML_VERSION)/
+	@echo "==> Verifying with a dry-run prediction on $(PROD_HOST) ..."
+	ssh $(PROD_SSH_USER)@$(PROD_HOST) \
+		"docker exec gregory python manage.py predict_articles --team $(ML_TEAM) --subject $(ML_SUBJECT) --algo $(ML_ALGO) --model-version $(ML_VERSION) --dry-run --verbose 1"
+	@echo "==> Done. $(ML_ALGO) $(ML_VERSION) is live for $(ML_TEAM)/$(ML_SUBJECT)."

--- a/django/gregory/management/commands/export_training_data.py
+++ b/django/gregory/management/commands/export_training_data.py
@@ -7,7 +7,6 @@ trained in place. Feed the resulting file back into training with
 `train_models --dataset-file`.
 """
 
-import os
 from datetime import datetime
 from pathlib import Path
 
@@ -82,8 +81,10 @@ class Command(BaseCommand):
 			None if options["all_articles"] else options.get("lookback_days") or 90
 		)
 
-		output_dir = Path(
-			options.get("output_dir") or os.path.join(settings.BASE_DIR, "datasets")
+		output_dir = (
+			Path(options["output_dir"])
+			if options.get("output_dir")
+			else Path(settings.BASE_DIR) / "datasets"
 		)
 		output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/django/gregory/management/commands/export_training_data.py
+++ b/django/gregory/management/commands/export_training_data.py
@@ -1,0 +1,121 @@
+"""
+Export labeled training datasets as CSV files for off-box model training.
+
+Produces the exact same rows `train_models` would train on (collect_articles +
+build_dataset), so a model trained elsewhere from the export matches one
+trained in place. Feed the resulting file back into training with
+`train_models --dataset-file`.
+"""
+
+import os
+from datetime import datetime
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from gregory.models import Team, Subject
+from gregory.utils.dataset import collect_articles, build_dataset
+
+
+class Command(BaseCommand):
+	help = (
+		"Export labeled training data (cleaned text + relevance labels) to CSV, "
+		"one file per subject, for training models off-box with "
+		"train_models --dataset-file"
+	)
+
+	def add_arguments(self, parser):
+		parser.add_argument(
+			"--team",
+			type=str,
+			required=True,
+			help="Team slug to export training data for",
+		)
+		parser.add_argument(
+			"--subject",
+			type=str,
+			help="Subject slug within the team (default: all subjects with auto_predict enabled)",
+		)
+
+		window_group = parser.add_mutually_exclusive_group()
+		window_group.add_argument(
+			"--all-articles",
+			action="store_true",
+			help="Use all labeled articles (ignores 90-day window)",
+		)
+		window_group.add_argument(
+			"--lookback-days",
+			type=int,
+			help="Override the default 90-day window for article discovery",
+		)
+
+		parser.add_argument(
+			"--output-dir",
+			type=str,
+			help="Directory to write CSV files to (default: <BASE_DIR>/datasets)",
+		)
+
+	def handle(self, *args, **options):
+		try:
+			team = Team.objects.get(slug=options["team"])
+		except Team.DoesNotExist:
+			raise CommandError(f"Team with slug '{options['team']}' does not exist")
+
+		if options["subject"]:
+			try:
+				subjects = [
+					Subject.objects.get(team=team, subject_slug=options["subject"])
+				]
+			except Subject.DoesNotExist:
+				raise CommandError(
+					f"Subject with slug '{options['subject']}' does not exist in team '{team.slug}'"
+				)
+		else:
+			subjects = list(team.subjects.filter(auto_predict=True))
+			if not subjects:
+				raise CommandError(
+					f"Team '{team.slug}' has no subjects with auto_predict enabled"
+				)
+
+		window_days = (
+			None if options["all_articles"] else options.get("lookback_days") or 90
+		)
+
+		output_dir = Path(
+			options.get("output_dir") or os.path.join(settings.BASE_DIR, "datasets")
+		)
+		output_dir.mkdir(parents=True, exist_ok=True)
+
+		date_tag = datetime.now().strftime("%Y%m%d")
+		exported = 0
+
+		for subject in subjects:
+			articles_qs = collect_articles(team.slug, subject.subject_slug, window_days)
+			dataset_df = build_dataset(articles_qs, subject)
+
+			if len(dataset_df) == 0:
+				self.stdout.write(
+					self.style.WARNING(
+						f"Skipping {team.slug}/{subject.subject_slug}: no labeled articles"
+					)
+				)
+				continue
+
+			output_path = (
+				output_dir / f"{team.slug}_{subject.subject_slug}_{date_tag}.csv"
+			)
+			dataset_df.to_csv(output_path, index=False)
+			exported += 1
+
+			class_counts = dataset_df["relevant"].value_counts()
+			self.stdout.write(
+				f"Exported {len(dataset_df)} articles "
+				f"(relevant={class_counts.get(1, 0)}, not relevant={class_counts.get(0, 0)}) "
+				f"for {team.slug}/{subject.subject_slug} to {output_path}"
+			)
+
+		if exported == 0:
+			raise CommandError("No datasets were exported")
+
+		self.stdout.write(self.style.SUCCESS(f"Exported {exported} dataset(s)"))

--- a/django/gregory/management/commands/train_models.py
+++ b/django/gregory/management/commands/train_models.py
@@ -258,6 +258,17 @@ class Command(BaseCommand):
 				raise CommandError(
 					f"Dataset file not found: {options['dataset_file']}"
 				)
+			try:
+				dataset_columns = set(pd.read_csv(options["dataset_file"], nrows=0).columns)
+			except Exception as e:
+				raise CommandError(
+					f"Dataset file could not be read: {e}"
+				)
+			missing_cols = {"text", "relevant"} - dataset_columns
+			if missing_cols:
+				raise CommandError(
+					f"Dataset file is missing required column(s): {', '.join(sorted(missing_cols))}"
+				)
 
 		# Validate algorithms
 		valid_algos = {"pubmed_bert", "lgbm_tfidf", "lstm"}

--- a/django/gregory/management/commands/train_models.py
+++ b/django/gregory/management/commands/train_models.py
@@ -166,6 +166,15 @@ class Command(BaseCommand):
 		)
 
 		parser.add_argument(
+			"--dataset-file",
+			type=str,
+			help=(
+				"Train from a CSV produced by export_training_data instead of the "
+				"database (requires --team and --subject)"
+			),
+		)
+
+		parser.add_argument(
 			"--prob-threshold",
 			type=float,
 			default=0.8,
@@ -229,6 +238,26 @@ class Command(BaseCommand):
 			raise CommandError(
 				"--all-articles and --lookback-days are mutually exclusive"
 			)
+
+		# Validate dataset file arguments
+		if options.get("dataset_file"):
+			if not (options["team"] and options["subject"]):
+				raise CommandError(
+					"--dataset-file requires both --team and --subject"
+				)
+			if options["all_articles"] or options["lookback_days"]:
+				raise CommandError(
+					"--dataset-file is mutually exclusive with --all-articles and --lookback-days"
+				)
+			if options["pseudo_label"]:
+				raise CommandError(
+					"--pseudo-label queries the database for unlabeled articles and "
+					"cannot be combined with --dataset-file"
+				)
+			if not os.path.isfile(options["dataset_file"]):
+				raise CommandError(
+					f"Dataset file not found: {options['dataset_file']}"
+				)
 
 		# Validate algorithms
 		valid_algos = {"pubmed_bert", "lgbm_tfidf", "lstm"}
@@ -399,43 +428,71 @@ class Command(BaseCommand):
 		)
 
 		# Step 1: Collect and prepare data
-		window_days = (
-			None if options["all_articles"] else options.get("lookback_days", 90)
-		)
-
-		self.log_message(
-			f"Collecting articles for {team_slug}/{subject_slug}",
-			VerbosityLevel.PROGRESS,
-		)
-
-		# Collect articles query
-		articles_qs = collect_articles(team_slug, subject_slug, window_days)
 		subject = Subject.objects.get(subject_slug=subject_slug, team__slug=team_slug)
 
-		# Add detailed logging about article counts
-		total_articles = Articles.objects.filter(
-			teams__slug=team_slug, subjects__subject_slug=subject_slug
-		).count()
-		labeled_articles = articles_qs.count()
-
-		if options["all_articles"]:
+		dataset_file = options.get("dataset_file")
+		if dataset_file:
+			# Off-box training path: load a CSV produced by export_training_data
+			# instead of querying the database
 			self.log_message(
-				f"Found {labeled_articles} labeled articles out of {total_articles} total articles (using all-articles flag)",
+				f"Loading dataset from {dataset_file}", VerbosityLevel.PROGRESS
+			)
+			dataset_df = pd.read_csv(dataset_file)
+
+			missing_cols = {"text", "relevant"} - set(dataset_df.columns)
+			if missing_cols:
+				raise ValueError(
+					f"Dataset file is missing required column(s): {', '.join(sorted(missing_cols))}"
+				)
+
+			dataset_df = dataset_df.dropna(subset=["text", "relevant"])
+			if not dataset_df["relevant"].isin([0, 1]).all():
+				raise ValueError(
+					"Dataset file column 'relevant' must contain only 0/1 labels"
+				)
+			dataset_df["relevant"] = dataset_df["relevant"].astype(int)
+
+			self.log_message(
+				f"Loaded {len(dataset_df)} labeled articles from {dataset_file}",
 				VerbosityLevel.PROGRESS,
 			)
 		else:
-			window_msg = f"last {window_days} days" if window_days else "all time"
+			window_days = (
+				None if options["all_articles"] else options.get("lookback_days", 90)
+			)
+
 			self.log_message(
-				f"Found {labeled_articles} labeled articles out of {total_articles} total articles ({window_msg})",
+				f"Collecting articles for {team_slug}/{subject_slug}",
 				VerbosityLevel.PROGRESS,
 			)
 
-		# Build dataset with collected articles
-		self.log_message(
-			f"Building dataset with {labeled_articles} labeled articles",
-			VerbosityLevel.PROGRESS,
-		)
-		dataset_df = build_dataset(articles_qs, subject)
+			# Collect articles query
+			articles_qs = collect_articles(team_slug, subject_slug, window_days)
+
+			# Add detailed logging about article counts
+			total_articles = Articles.objects.filter(
+				teams__slug=team_slug, subjects__subject_slug=subject_slug
+			).count()
+			labeled_articles = articles_qs.count()
+
+			if options["all_articles"]:
+				self.log_message(
+					f"Found {labeled_articles} labeled articles out of {total_articles} total articles (using all-articles flag)",
+					VerbosityLevel.PROGRESS,
+				)
+			else:
+				window_msg = f"last {window_days} days" if window_days else "all time"
+				self.log_message(
+					f"Found {labeled_articles} labeled articles out of {total_articles} total articles ({window_msg})",
+					VerbosityLevel.PROGRESS,
+				)
+
+			# Build dataset with collected articles
+			self.log_message(
+				f"Building dataset with {labeled_articles} labeled articles",
+				VerbosityLevel.PROGRESS,
+			)
+			dataset_df = build_dataset(articles_qs, subject)
 
 		if len(dataset_df) == 0:
 			raise ValueError(
@@ -819,7 +876,12 @@ class Command(BaseCommand):
 			)
 
 			window_days = options.get("lookback_days", 90)  # Default is 90 days
-			if options["all_articles"]:
+			if options.get("dataset_file"):
+				self.log_message(
+					f"Using dataset file: {options['dataset_file']}",
+					VerbosityLevel.PROGRESS,
+				)
+			elif options["all_articles"]:
 				self.log_message(
 					"Using all articles (no time window)", VerbosityLevel.PROGRESS
 				)

--- a/django/gregory/tests/management/test_export_training_data.py
+++ b/django/gregory/tests/management/test_export_training_data.py
@@ -1,0 +1,279 @@
+"""
+Tests for the export_training_data command and train_models --dataset-file,
+the two halves of the off-box training workflow.
+"""
+
+import os
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "admin.settings")
+django.setup()
+
+import tempfile
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from gregory.models import Team, Subject, Articles, ArticleSubjectRelevance
+from organizations.models import Organization
+
+
+SUMMARY = (
+	"This study evaluates treatment outcomes in multiple sclerosis patients "
+	"using magnetic resonance imaging biomarkers alongside clinical disability "
+	"scores collected during a twenty four month follow up period."
+)
+
+
+def create_labeled_articles(team, subject, count=10):
+	"""Create `count` labeled articles, alternating relevant/not relevant."""
+	articles = []
+	for i in range(count):
+		article = Articles.objects.create(
+			title=f"Test Article {subject.subject_slug} {i}",
+			summary=SUMMARY,
+			link=f"https://example.com/{subject.subject_slug}/{i}",
+		)
+		article.teams.add(team)
+		article.subjects.add(subject)
+		ArticleSubjectRelevance.objects.create(
+			article=article,
+			subject=subject,
+			is_relevant=(i % 2 == 0),
+		)
+		articles.append(article)
+	return articles
+
+
+class ExportTrainingDataTest(TestCase):
+	"""Test case for the export_training_data management command."""
+
+	def setUp(self):
+		self.organization = Organization.objects.create(name="Test Organization")
+		self.team = Team.objects.create(
+			slug="test-team", name="Test Team", organization=self.organization
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Test Subject",
+			subject_slug="test-subject",
+			team=self.team,
+			auto_predict=True,
+		)
+		create_labeled_articles(self.team, self.subject)
+		self.temp_dir = tempfile.TemporaryDirectory()
+		self.addCleanup(self.temp_dir.cleanup)
+
+	def export(self, *args):
+		out = StringIO()
+		call_command(
+			"export_training_data",
+			"--team",
+			self.team.slug,
+			"--output-dir",
+			self.temp_dir.name,
+			*args,
+			stdout=out,
+		)
+		return out.getvalue()
+
+	def exported_files(self):
+		return sorted(Path(self.temp_dir.name).glob("*.csv"))
+
+	def test_exports_csv_matching_build_dataset(self):
+		self.export("--subject", "test-subject", "--all-articles")
+
+		files = self.exported_files()
+		self.assertEqual(len(files), 1)
+		self.assertIn("test-team_test-subject_", files[0].name)
+
+		df = pd.read_csv(files[0])
+		self.assertEqual(list(df.columns), ["article_id", "text", "relevant"])
+		self.assertEqual(len(df), 10)
+		self.assertEqual(df["relevant"].sum(), 5)
+		# Text must be cleaned like prediction time (lowercased, no HTML)
+		self.assertTrue((df["text"] == df["text"].str.lower()).all())
+
+	def test_exports_all_auto_predict_subjects_by_default(self):
+		other = Subject.objects.create(
+			subject_name="Other Subject",
+			subject_slug="other-subject",
+			team=self.team,
+			auto_predict=True,
+		)
+		create_labeled_articles(self.team, other, count=4)
+		# Subjects without auto_predict are not exported
+		Subject.objects.create(
+			subject_name="Manual Subject",
+			subject_slug="manual-subject",
+			team=self.team,
+			auto_predict=False,
+		)
+
+		self.export("--all-articles")
+
+		names = [f.name for f in self.exported_files()]
+		self.assertEqual(len(names), 2)
+		self.assertTrue(any("test-subject" in n for n in names))
+		self.assertTrue(any("other-subject" in n for n in names))
+
+	def test_skips_subject_without_labeled_articles(self):
+		empty = Subject.objects.create(
+			subject_name="Empty Subject",
+			subject_slug="empty-subject",
+			team=self.team,
+			auto_predict=True,
+		)
+
+		output = self.export("--all-articles")
+
+		self.assertIn("Skipping test-team/empty-subject", output)
+		self.assertEqual(len(self.exported_files()), 1)
+
+	def test_unknown_team_raises(self):
+		with self.assertRaises(CommandError):
+			call_command(
+				"export_training_data",
+				"--team",
+				"nope",
+				"--output-dir",
+				self.temp_dir.name,
+			)
+
+	def test_unknown_subject_raises(self):
+		with self.assertRaises(CommandError):
+			self.export("--subject", "nope")
+
+	def test_no_exportable_datasets_raises(self):
+		ArticleSubjectRelevance.objects.all().update(is_relevant=None)
+		with self.assertRaises(CommandError):
+			self.export("--all-articles")
+
+
+class TrainModelsDatasetFileTest(TestCase):
+	"""Test case for train_models --dataset-file (the off-box training half)."""
+
+	def setUp(self):
+		self.organization = Organization.objects.create(name="Test Organization")
+		self.team = Team.objects.create(
+			slug="test-team", name="Test Team", organization=self.organization
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Test Subject",
+			subject_slug="test-subject",
+			team=self.team,
+			auto_predict=True,
+		)
+		self.temp_dir = tempfile.TemporaryDirectory()
+		self.addCleanup(self.temp_dir.cleanup)
+
+	def write_dataset(self, rows=20, columns=("article_id", "text", "relevant")):
+		"""Write a dataset CSV like export_training_data produces."""
+		data = [
+			{
+				"article_id": i,
+				"text": f"cleaned text for article number {i} about sclerosis research",
+				"relevant": i % 2,
+			}
+			for i in range(rows)
+		]
+		df = pd.DataFrame(data)[list(columns)]
+		path = Path(self.temp_dir.name) / "dataset.csv"
+		df.to_csv(path, index=False)
+		return str(path)
+
+	def call_train(self, dataset_path, **extra):
+		out = StringIO()
+		call_command(
+			"train_models",
+			"--team",
+			"test-team",
+			"--subject",
+			"test-subject",
+			"--algo",
+			"lgbm_tfidf",
+			"--dataset-file",
+			dataset_path,
+			stdout=out,
+			**extra,
+		)
+		return out.getvalue()
+
+	def test_trains_from_dataset_file_without_db_articles(self):
+		"""Training from a file must not depend on Articles rows in the DB."""
+		dataset_path = self.write_dataset()
+
+		mock_trainer = MagicMock()
+		mock_trainer.evaluate.return_value = {"accuracy": 0.9, "f1": 0.8}
+
+		with (
+			patch(
+				"gregory.management.commands.train_models.get_trainer",
+				return_value=mock_trainer,
+			),
+			patch(
+				"gregory.management.commands.train_models.collect_articles"
+			) as mock_collect,
+			patch("django.conf.settings.BASE_DIR", self.temp_dir.name),
+		):
+			self.call_train(dataset_path)
+
+		# The DB collection path must not run
+		mock_collect.assert_not_called()
+
+		# The trainer received the file's rows, split 70/15/15
+		mock_trainer.train.assert_called_once()
+		train_kwargs = mock_trainer.train.call_args.kwargs
+		self.assertEqual(len(train_kwargs["train_texts"]), 14)
+		self.assertEqual(len(train_kwargs["val_texts"]), 3)
+		mock_trainer.save.assert_called_once()
+
+	def test_missing_columns_fails_run(self):
+		dataset_path = self.write_dataset(columns=("article_id", "text"))
+
+		mock_trainer = MagicMock()
+		with (
+			patch(
+				"gregory.management.commands.train_models.get_trainer",
+				return_value=mock_trainer,
+			),
+			patch("django.conf.settings.BASE_DIR", self.temp_dir.name),
+		):
+			self.call_train(dataset_path)
+
+		mock_trainer.train.assert_not_called()
+
+	def test_dataset_file_requires_subject(self):
+		dataset_path = self.write_dataset()
+		with self.assertRaises(CommandError):
+			call_command(
+				"train_models",
+				"--team",
+				"test-team",
+				"--dataset-file",
+				dataset_path,
+			)
+
+	def test_dataset_file_conflicts_with_all_articles(self):
+		dataset_path = self.write_dataset()
+		with self.assertRaises(CommandError):
+			self.call_train(dataset_path, all_articles=True)
+
+	def test_dataset_file_conflicts_with_pseudo_label(self):
+		dataset_path = self.write_dataset()
+		with self.assertRaises(CommandError):
+			self.call_train(dataset_path, pseudo_label=True)
+
+	def test_missing_dataset_file_raises(self):
+		with self.assertRaises(CommandError):
+			self.call_train(str(Path(self.temp_dir.name) / "does-not-exist.csv"))
+
+
+if __name__ == "__main__":
+	import unittest
+
+	unittest.main()

--- a/django/gregory/tests/management/test_export_training_data.py
+++ b/django/gregory/tests/management/test_export_training_data.py
@@ -6,7 +6,7 @@ the two halves of the off-box training workflow.
 import os
 import django
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "admin.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
 django.setup()
 
 import tempfile
@@ -233,6 +233,8 @@ class TrainModelsDatasetFileTest(TestCase):
 		mock_trainer.save.assert_called_once()
 
 	def test_missing_columns_fails_run(self):
+		"""A dataset file missing required columns must fail fast during
+		argument validation, before any training run is attempted."""
 		dataset_path = self.write_dataset(columns=("article_id", "text"))
 
 		mock_trainer = MagicMock()
@@ -242,6 +244,7 @@ class TrainModelsDatasetFileTest(TestCase):
 				return_value=mock_trainer,
 			),
 			patch("django.conf.settings.BASE_DIR", self.temp_dir.name),
+			self.assertRaises(CommandError),
 		):
 			self.call_train(dataset_path)
 
@@ -271,6 +274,14 @@ class TrainModelsDatasetFileTest(TestCase):
 	def test_missing_dataset_file_raises(self):
 		with self.assertRaises(CommandError):
 			self.call_train(str(Path(self.temp_dir.name) / "does-not-exist.csv"))
+
+	def test_unreadable_dataset_file_raises(self):
+		"""An empty/corrupt CSV must fail argument validation, not silently
+		train on zero rows."""
+		bad_path = Path(self.temp_dir.name) / "empty.csv"
+		bad_path.write_text("")
+		with self.assertRaises(CommandError):
+			self.call_train(str(bad_path))
 
 
 if __name__ == "__main__":

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,8 @@ services:
     build: .
     volumes:
       - ./django/media:/code/media                  # user uploads (persist)
-      - ./django/models:/code/models                # trained ML models (persist)
+      - ./django/models:/code/models                # trained ML models (persist, ml-ship rsyncs into it)
+      - ./django/datasets:/code/datasets            # training data exports (ml-export reads them over SSH)
       - ./django/summary_cache:/code/summary_cache  # LLM summary cache (persist)
       - ./django/static:/code/static                # collectstatic output (host nginx reads it)
     ports:

--- a/docs/05-training-models.md
+++ b/docs/05-training-models.md
@@ -167,6 +167,69 @@ docker stats gregory
 
 3. **Model Persistence**: Models are saved to `./django/models/` which is mounted as a volume, so they persist after container restart.
 
+## Off-Box Training (Export → Train → Ship)
+
+When the production host is too small to train a model (BERT fine-tuning needs
+well over 4GB of RAM), train on another machine and ship the artifacts back.
+Prediction only reads the version directory under `models/`, so production never
+needs to run training at all.
+
+### 1. Export the dataset on production
+
+`export_training_data` writes the exact rows `train_models` would train on
+(same cleaned text, same per-subject labels) to CSV:
+
+```bash
+# On the production host
+docker exec gregory python manage.py export_training_data \
+  --team team-gregory --subject multiple-sclerosis --all-articles
+
+# Copy it out of the container and fetch it to the training machine
+docker cp gregory:/code/datasets/team-gregory_multiple-sclerosis_YYYYMMDD.csv .
+```
+
+Omitting `--subject` exports every subject in the team that has `auto_predict`
+enabled, one CSV per subject. Use `--output-dir` to write somewhere else.
+
+### 2. Train from the file on the training machine
+
+`--dataset-file` makes `train_models` skip the database article collection and
+train from the CSV instead. The team and subject must exist in the local
+database (they are used for the artifact path and the training run log), but no
+articles are needed locally:
+
+```bash
+cd django
+python manage.py train_models \
+  --team team-gregory --subject multiple-sclerosis \
+  --algo pubmed_bert \
+  --dataset-file /path/to/team-gregory_multiple-sclerosis_YYYYMMDD.csv
+```
+
+On Apple Silicon, add `--cpu` if GPU training causes bus errors.
+
+`--dataset-file` cannot be combined with `--all-articles`, `--lookback-days`,
+or `--pseudo-label` (pseudo-labeling queries the database for unlabeled
+articles).
+
+### 3. Ship the version directory to production
+
+Training writes `django/models/{team}/{subject}/{algorithm}/{version}/`. Copy
+that directory into the mounted models volume on the production host:
+
+```bash
+rsync -av django/models/team-gregory/multiple-sclerosis/pubmed_bert/20260704/ \
+  user@server:/path/to/gregory/django/models/team-gregory/multiple-sclerosis/pubmed_bert/20260704/
+```
+
+`predict_articles` resolves the newest version by date at every run, so the new
+model is picked up automatically — no restart needed. Verify with:
+
+```bash
+docker exec gregory python manage.py predict_articles \
+  --team team-gregory --subject multiple-sclerosis --algo pubmed_bert --dry-run
+```
+
 ## Model Output
 
 Trained models are saved to:

--- a/docs/05-training-models.md
+++ b/docs/05-training-models.md
@@ -174,6 +174,32 @@ well over 4GB of RAM), train on another machine and ship the artifacts back.
 Prediction only reads the version directory under `models/`, so production never
 needs to run training at all.
 
+### Quick path: Makefile
+
+The repo Makefile wraps the whole cycle. From the repo root on the training
+machine (local containers running, team/subject present in the local DB —
+`make db-pull` if missing):
+
+```bash
+make ml-export   # runs export_training_data on production, scp's the CSV here
+make ml-train    # trains from the newest exported CSV in the local container
+make ml-ship     # rsyncs the new version dir to production + dry-run verify
+```
+
+Defaults are `ML_TEAM=team-gregory ML_SUBJECT=multiple-sclerosis
+ML_ALGO=pubmed_bert`; override per run, e.g. `make ml-train ML_ALGO=lstm` or
+pin a version with `make ml-ship ML_VERSION=20260704`. Production access uses
+the same `PROD_HOST`/`PROD_SSH_USER` variables as `db-pull`, plus
+`PROD_APP_DIR` (default `gregory-ai`, relative to the SSH user's home).
+
+These targets rely on `docker-compose.yaml` mounting `./django/datasets` and
+`./django/models` into the container on **both** machines, so exports and
+model artifacts are plain host directories reachable by `scp`/`rsync`. After
+updating the compose file on production, recreate the container once
+(`docker compose up -d gregory`) to add the datasets mount.
+
+The manual steps below are what the targets do under the hood.
+
 ### 1. Export the dataset on production
 
 `export_training_data` writes the exact rows `train_models` would train on


### PR DESCRIPTION
## Why

The production VPS (4GB RAM) cannot fine-tune BERT: at `max_len=400` training is OOM-killed, and even at 128 (post-#734) it peaks at 3.31 GiB plus ~4.5 GiB of swap, projecting ~46 hours for 10 epochs. Prediction only needs the artifact directory under `models/`, so training can happen anywhere.

## What

- **New `export_training_data` command** — exports the labeled training rows to CSV (`article_id,text,relevant`), one file per subject. It uses the same `collect_articles` + `build_dataset` path as `train_models`, so the exported text and labels are exactly what on-box training would see. Defaults to all `auto_predict` subjects of the team; supports `--subject`, `--all-articles`/`--lookback-days`, and `--output-dir`.
- **New `train_models --dataset-file`** — trains from such a CSV instead of querying the database for articles. Requires `--team` and `--subject` (used for the artifact path and run log); rejects `--all-articles`, `--lookback-days`, and `--pseudo-label` (pseudo-labeling needs DB access). Everything downstream (split, training, evaluation, artifact layout, `metrics.json`) is unchanged, so `resolve_model_version` picks up a shipped version directory with no other changes.
- **Docs** — new "Off-Box Training (Export → Train → Ship)" section in `docs/05-training-models.md` with the full export → train → rsync → verify runbook.

## Tests

12 new tests covering the export command (CSV contents match `build_dataset`, per-subject files, auto_predict filtering, empty/error cases) and the `--dataset-file` path (trains from file without touching article collection, split sizes, column validation, flag conflicts). Full `gregory` suite: 666 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)