### PR TITLE
Fix runaway CPU on /authors/ pagination COUNT(*)

### DIFF
--- a/django/api/tests/test_author_coauthors.py
+++ b/django/api/tests/test_author_coauthors.py
@@ -229,10 +229,14 @@ class AuthorCoauthorsQueryCountTest(TestCase):
 	def test_author_list_query_budget_is_pinned(self):
 		"""Pins the query count for /authors/ under org-visibility scope so a
 		real regression is caught. article_count and relevant_articles_count
-		are both computed via get_queryset annotations, and get_site() uses
-		Django's cached Site.objects.get_current(), so the query count must
-		stay flat regardless of how many authors are returned."""
-		with self.assertNumQueries(4):
+		are computed for the paginated page only (one extra bounded query),
+		not annotated onto the full queryset used for pagination's COUNT(*) —
+		annotating them there would force Postgres to evaluate a correlated
+		subquery per author just to paginate, which is what caused runaway
+		CPU on production. get_site() uses Django's cached
+		Site.objects.get_current(), so the query count must stay flat
+		regardless of how many authors are returned."""
+		with self.assertNumQueries(5):
 			response = self.client.get("/authors/")
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
 		self.assertGreater(len(response.data["results"]), 0)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1754,14 +1754,12 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 			queryset = queryset.annotate(
 				article_count=Count("articles", filter=combined_q, distinct=True)
 			).filter(article_count__gt=0)
-		else:
-			# No sort/filter needs an article_count annotation, but the serializer
-			# still needs one to avoid a per-row COUNT query for every author.
-			queryset = queryset.annotate(
-				article_count=author_articles_count_subquery(
-					getattr(self.request, "visible_org_ids", None), relevant_only=False
-				)
-			)
+		# NOTE: article_count/relevant_articles_count for the default (no
+		# sort_by=article_count, no count_filters) case are deliberately NOT
+		# annotated here. Annotating them on the full queryset forces
+		# Postgres to evaluate a correlated subquery per author just to
+		# compute pagination's COUNT(*) over the whole table. They're
+		# attached to the paginated page only, in list() below.
 
 		# Apply sorting
 		if sort_by == "article_count":
@@ -1772,13 +1770,40 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 			order_prefix = "-" if order == "desc" else ""
 			queryset = queryset.order_by(f"{order_prefix}{sort_by}")
 
-		queryset = queryset.annotate(
-			relevant_articles_count=author_articles_count_subquery(
-				getattr(self.request, "visible_org_ids", None), relevant_only=True,
-			)
-		)
-
 		return queryset.distinct()
+
+	def list(self, request, *args, **kwargs):
+		queryset = self.filter_queryset(self.get_queryset())
+		page = self.paginate_queryset(queryset)
+		target = page if page is not None else list(queryset)
+
+		if target:
+			visible_org_ids = getattr(request, "visible_org_ids", None)
+			author_ids = [obj.author_id for obj in target]
+			counts_by_id = {
+				row["author_id"]: row
+				for row in Authors.objects.filter(author_id__in=author_ids)
+				.annotate(
+					_article_count=author_articles_count_subquery(
+						visible_org_ids, relevant_only=False
+					),
+					_relevant_articles_count=author_articles_count_subquery(
+						visible_org_ids, relevant_only=True
+					),
+				)
+				.values("author_id", "_article_count", "_relevant_articles_count")
+			}
+			for obj in target:
+				row = counts_by_id.get(obj.author_id, {})
+				if not hasattr(obj, "article_count"):
+					obj.article_count = row.get("_article_count", 0)
+				obj.relevant_articles_count = row.get("_relevant_articles_count", 0)
+
+		if page is not None:
+			serializer = self.get_serializer(page, many=True)
+			return self.get_paginated_response(serializer.data)
+		serializer = self.get_serializer(target, many=True)
+		return Response(serializer.data)
 
 	@action(detail=False, methods=["get"])
 	def by_team_subject(self, request):

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1780,22 +1780,33 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 		if target:
 			visible_org_ids = getattr(request, "visible_org_ids", None)
 			author_ids = [obj.author_id for obj in target]
+
+			# article_count is already annotated on the page (via a cheap
+			# Count()) whenever sort_by=article_count or count_filters were
+			# applied in get_queryset(). Only fetch it here when it's
+			# actually missing, so we don't pay for a correlated subquery
+			# the serializer would just discard.
+			needs_article_count = not hasattr(target[0], "article_count")
+
+			annotations = {
+				"_relevant_articles_count": author_articles_count_subquery(
+					visible_org_ids, relevant_only=True
+				),
+			}
+			if needs_article_count:
+				annotations["_article_count"] = author_articles_count_subquery(
+					visible_org_ids, relevant_only=False
+				)
+
 			counts_by_id = {
 				row["author_id"]: row
 				for row in Authors.objects.filter(author_id__in=author_ids)
-				.annotate(
-					_article_count=author_articles_count_subquery(
-						visible_org_ids, relevant_only=False
-					),
-					_relevant_articles_count=author_articles_count_subquery(
-						visible_org_ids, relevant_only=True
-					),
-				)
-				.values("author_id", "_article_count", "_relevant_articles_count")
+				.annotate(**annotations)
+				.values("author_id", *annotations.keys())
 			}
 			for obj in target:
 				row = counts_by_id.get(obj.author_id, {})
-				if not hasattr(obj, "article_count"):
+				if needs_article_count:
 					obj.article_count = row.get("_article_count", 0)
 				obj.relevant_articles_count = row.get("_relevant_articles_count", 0)
 


### PR DESCRIPTION
## Summary

`AuthorsViewSet.get_queryset()` (django/api/views.py) annotated `article_count`/`relevant_articles_count` via a correlated subquery onto the *full* queryset before pagination. DRF's paginator calls `queryset.count()` to build pagination metadata, which forced Postgres to evaluate those two correlated subqueries across every row of the `authors` table just to report a row count — observed taking 13.8s+ per call in production, with repeated requests to the endpoint piling up concurrent long-running `SELECT`s and pegging CPU (multiple `postgres: gregory gregorybackoffice ... SELECT` backends at ~30% CPU each, some running 400+ seconds).

This was introduced by #737 (merged 2026-07-05), which added the correlated-subquery helper to fix an N+1 problem in the serializer — a real fix, but it moved the expensive computation to the wrong place (onto the full queryset instead of the paginated page).

## Fix

`AuthorsViewSet.list()` now paginates first, then attaches `article_count`/`relevant_articles_count` only to the small set of rows actually being serialized (the current page), via a single bounded query keyed by `author_id__in=[...]`. The full/unpaginated queryset used for `COUNT(*)` no longer carries these annotations, so pagination stays cheap regardless of table size.

Verified live in the running `gregory` container by copying the fix into its filesystem (not committed at the time) and hitting `/authors/`:
- Pagination `COUNT(*)`: **13.8s → 865ms**
- Response payload (`articles_count`, `relevant_articles_count` fields) unchanged
- All 98 author-related tests pass, with one `assertNumQueries` budget bumped from 4 → 5 (one extra bounded query for the page-scoped counts, replacing the multi-second full-table `COUNT(*)`)

## Test plan

- [x] `python manage.py test api.tests.test_author_api api.tests.test_author_filter api.tests.test_author_search api.tests.test_author_url_format api.tests.test_author_coauthors api.tests.test_author_serializers api.tests.test_article_author_filter api.tests.test_visibility_authors api.tests.test_categories_authors gregory.tests.test_authors_api_sorting` — 98 passed
- [x] Verified live against the running container: `/authors/` pagination count query dropped from 13.8s to 865ms, response fields unchanged
- [x] Kill any still-running stuck queries on production and confirm CPU returns to normal after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)