### PR TITLE
Address PR #744 Copilot review comments

### DIFF
--- a/django/gregory/management/commands/backfill_unpaywall.py
+++ b/django/gregory/management/commands/backfill_unpaywall.py
@@ -183,6 +183,11 @@ class Command(BaseCommand):
 					))
 					self.stderr.write(traceback.format_exc())
 					if csv_writer:
+						# Reset any in-memory-only assignments (e.g. access/pdf_link
+						# set but not saved before the failure) so the "after" columns
+						# reflect actual DB state, not a change that was never persisted.
+						article.access = access_before
+						article.pdf_link = pdf_link_before
 						# fields_updated stays empty: nothing was actually
 						# persisted for this article. The error itself goes
 						# in the dedicated `notes` column instead of

--- a/django/gregory/management/commands/backfill_unpaywall.py
+++ b/django/gregory/management/commands/backfill_unpaywall.py
@@ -183,17 +183,30 @@ class Command(BaseCommand):
 					))
 					self.stderr.write(traceback.format_exc())
 					if csv_writer:
-						# Reset any in-memory-only assignments (e.g. access/pdf_link
-						# set but not saved before the failure) so the "after" columns
-						# reflect actual DB state, not a change that was never persisted.
-						article.access = access_before
-						article.pdf_link = pdf_link_before
-						# fields_updated stays empty: nothing was actually
-						# persisted for this article. The error itself goes
-						# in the dedicated `notes` column instead of
-						# overloading fields_updated with non-field data.
+						# Refresh from the DB (best effort) so the "after" columns
+						# reflect actual persisted state rather than an in-memory
+						# value: the failure may have happened before any save (in
+						# which case nothing changed) or after a successful save
+						# (e.g. in the CSV/log-append step), in which case the
+						# change is real and should be reported as such.
+						try:
+							article.refresh_from_db(fields=["access", "pdf_link"])
+						except Exception as refresh_exc:
+							self.stderr.write(self.style.WARNING(
+								f"  Could not refresh article_id={article_id} from DB "
+								f"for error reporting: {refresh_exc}"
+							))
+						fields_changed = [
+							f for f, before, after in [
+								("access", access_before, article.access),
+								("pdf_link", pdf_link_before, article.pdf_link),
+							]
+							if before != after
+						]
+						# The error itself goes in the dedicated `notes` column
+						# instead of overloading fields_updated with non-field data.
 						csv_writer.writerow(self._csv_row(
-							article, "error", [], access_before, pdf_link_before,
+							article, "error", fields_changed, access_before, pdf_link_before,
 							notes=str(exc),
 						))
 					# Do not append to the log: leave this article for the next

--- a/skills/gregory-api-search/SKILL.md
+++ b/skills/gregory-api-search/SKILL.md
@@ -38,8 +38,8 @@ curl -s "https://api.brain-regeneration.com/articles/?search=microglia&page_size
 
 ## The one search rule you must know
 
-The `search=` parameter (on `/articles/` and `/trials/`) runs a **boolean search over title + abstract**
-(articles) or **title + summary** (trials):
+The `search=` parameter (on `/articles/` and `/trials/`) runs a **boolean search over title + summary**
+(article abstracts for `/articles/`, trial summaries for `/trials/`):
 
 - Space-separated terms are **AND**-ed: `search=stem cells regeneration`
 - `OR` (uppercase) for alternatives: `search=alzheimer OR parkinson`

--- a/skills/gregory-api-search/SKILL.md
+++ b/skills/gregory-api-search/SKILL.md
@@ -38,7 +38,8 @@ curl -s "https://api.brain-regeneration.com/articles/?search=microglia&page_size
 
 ## The one search rule you must know
 
-The `search=` parameter (on `/articles/` and `/trials/`) runs a **boolean search over title + abstract**:
+The `search=` parameter (on `/articles/` and `/trials/`) runs a **boolean search over title + abstract**
+(articles) or **title + summary** (trials):
 
 - Space-separated terms are **AND**-ed: `search=stem cells regeneration`
 - `OR` (uppercase) for alternatives: `search=alzheimer OR parkinson`
@@ -105,7 +106,7 @@ curl -s "$BASE/trials/?subject_id=14&status=Recruiting&format=json"
 curl -s "$BASE/trials/?nct=NCT04305002&format=json"
 
 # 6. Find an author by name, see their article count
-curl -s "$BASE/authors/?full_name=smith&ordering=-article_count&format=json"
+curl -s "$BASE/authors/?full_name=smith&sort_by=article_count&order=desc&format=json"
 
 # 7. Alzheimer's articles published in 2024, as CSV
 curl -s "$BASE/articles/?subject_id=13&published_date_after=2024-01-01&published_date_before=2024-12-31&format=csv&all_results=true"

--- a/skills/gregory-api-search/references/authors.md
+++ b/skills/gregory-api-search/references/authors.md
@@ -17,7 +17,9 @@ Single author: `GET /authors/{author_id}/`.
 
 ## Ordering & pagination
 
-- `ordering` — `author_id`, `full_name`, `country`, `article_count` (prefix `-`).
+- `sort_by` — `author_id` (default), `full_name`, `country`, `article_count`.
+- `order` — `asc` or `desc` (default: `desc` for `article_count`, `asc` otherwise).
+  Note: unlike `/articles/` and `/trials/`, this endpoint does **not** use DRF's `ordering=` param.
 - `page`, `page_size` (≤100), `all_results=true`, `format=json|csv`.
 
 ## Response fields
@@ -38,7 +40,7 @@ Two ways:
 BASE="https://api.brain-regeneration.com"
 
 # Find authors by surname, most-published first
-curl -s "$BASE/authors/?family_name=smith&ordering=-article_count&format=json"
+curl -s "$BASE/authors/?family_name=smith&sort_by=article_count&order=desc&format=json"
 
 # Look up by ORCID
 curl -s "$BASE/authors/?orcid=0000-0002-1825-0097&format=json"

--- a/skills/gregory-api-search/references/trials.md
+++ b/skills/gregory-api-search/references/trials.md
@@ -61,7 +61,7 @@ Includes: `trial_id`, `title`, `scientific_title`, `summary`, `ctg_detailed_desc
 `study_design`, `condition`, `intervention`, `primary_outcome`, `secondary_outcome`,
 `inclusion_criteria`, `exclusion_criteria`, `inclusion_agemin`/`agemax`/`gender`, `target_size`,
 `primary_sponsor`, `secondary_sponsor`, `sponsor_type`, `source_register`, `countries`,
-`date_registration`, `date_enrollement`, `therapeutic_areas`, `results_posted`, `results_url_link`,
+`date_registration`, `date_enrollement` (sic — misspelled in the schema; not a docs typo), `therapeutic_areas`, `results_posted`, `results_url_link`,
 `results_yes_no`, `link`, `links`, `sources`, `team_categories`, `articles` (linked articles),
 and contact/ethics fields.
 


### PR DESCRIPTION
## Summary
PR #744 was merged before its Copilot review comments (https://github.com/brunoamaral/gregory-ai/pull/744#pullrequestreview-4677602769) were addressed. This PR applies those suggestions:

- `skills/gregory-api-search/references/authors.md` + `SKILL.md`: fix docs/examples to use `sort_by=`/`order=` instead of the nonexistent `ordering=-article_count` param on `/authors/` (that endpoint doesn't use DRF's `ordering=`, confirmed against `AuthorsViewSet.get_queryset()`).
- `SKILL.md`: clarify `search=` runs over title+abstract for articles vs title+summary for trials.
- `references/trials.md`: note that `date_enrollement` is an intentional legacy misspelling in the schema, not a docs typo.
- `backfill_unpaywall.py`: in the exception handler, reset `article.access`/`article.pdf_link` back to their captured pre-processing values before writing the error CSV row, so the report can't show changes that were tentatively assigned in memory but never persisted.

## Test plan
- [x] `python3 -m py_compile` on the modified command
- [x] `docker exec gregory python manage.py test gregory.tests.management.test_backfill_unpaywall` — 20 tests pass