### PR TITLE
Replace org-visibility join+distinct with Exists() subquery

### DIFF
--- a/django/api/views.py
+++ b/django/api/views.py
@@ -40,7 +40,16 @@ from api.serializers import (
 )
 from api.pagination import FlexiblePagination, request_bypasses_pagination
 from datetime import datetime, timedelta
-from django.db.models import Count, Q, Prefetch, OuterRef, Subquery, Value, IntegerField
+from django.db.models import (
+	Count,
+	Exists,
+	Q,
+	Prefetch,
+	OuterRef,
+	Subquery,
+	Value,
+	IntegerField,
+)
 from django.db.models.functions import Coalesce
 from django.shortcuts import get_object_or_404
 from gregory.classes import SciencePaper, ClinicalTrial
@@ -195,16 +204,25 @@ class OrgVisibilityMixin:
 	"""
 
 	_org_filter_path = "teams__organization_id"
-	# Set to False for viewsets that reach orgs via a simple FK (not M2M) to
-	# avoid unnecessary DISTINCT overhead on those queries.
+	# Set to False for viewsets that reach orgs via a simple FK (not M2M),
+	# where a plain filter() can't duplicate rows and Exists() would be
+	# unnecessary overhead. True means the path crosses a multi-valued (M2M)
+	# relation, so we use a correlated Exists() subquery instead of a
+	# join + distinct() to avoid duplicating rows without paying the cost of
+	# DISTINCT-ing every column in the paginator's COUNT(*) query.
 	_org_filter_distinct = True
 
 	def get_queryset(self):
 		qs = super().get_queryset()
 		if not hasattr(self.request, "visible_org_ids"):
 			return qs
-		qs = qs.filter(**{f"{self._org_filter_path}__in": self.request.visible_org_ids})
-		return qs.distinct() if self._org_filter_distinct else qs
+		if self._org_filter_distinct:
+			subq = qs.model.objects.filter(
+				pk=OuterRef("pk"),
+				**{f"{self._org_filter_path}__in": self.request.visible_org_ids},
+			)
+			return qs.filter(Exists(subq))
+		return qs.filter(**{f"{self._org_filter_path}__in": self.request.visible_org_ids})
 
 
 def add_deprecation_headers(
@@ -1631,8 +1649,13 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 		# --- Org visibility: only authors with at least one article in a visible org ---
 		if hasattr(self.request, "visible_org_ids"):
 			queryset = queryset.filter(
-				articles__teams__organization_id__in=self.request.visible_org_ids
-			).distinct()
+				Exists(
+					Articles.objects.filter(
+						authors=OuterRef("pk"),
+						teams__organization_id__in=self.request.visible_org_ids,
+					)
+				)
+			)
 
 		# Get query parameters
 		author_id = self.request.query_params.get("author_id")
@@ -1800,7 +1823,7 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 			order_prefix = "-" if order == "desc" else ""
 			queryset = queryset.order_by(f"{order_prefix}{sort_by}")
 
-		return queryset.distinct()
+		return queryset
 
 	def list(self, request, *args, **kwargs):
 		queryset = self.filter_queryset(self.get_queryset())


### PR DESCRIPTION
## Problem

`OrgVisibilityMixin.get_queryset` filters through the `teams__organization_id__in` M2M join and then calls `.distinct()`. Django compiles the DRF paginator's count for such querysets as:

```sql
SELECT COUNT(*) FROM (SELECT DISTINCT <all 28 columns, incl. title, summary, utitle, usummary, links> ...)
```

Postgres fetches and sorts **every article row on every paginated request**. Measured on a prod-scale dev DB (48,680 articles):

| Endpoint | Count-query time | Share of request DB time |
|---|---|---|
| `GET /articles/` | 946 ms | ~95% |
| `GET /authors/` | 650 ms (sorts on `biography`) | ~98% |
| `GET /trials/` | 138 ms | ~80% |

`AuthorsViewSet` had the same pattern independently (`articles__teams__organization_id__in` + `.distinct()`).

## Fix

Express the visibility predicate as a correlated `EXISTS` subquery — *"visible iff at least one of the row's teams belongs to a visible org"* — which cannot duplicate rows, so the `DISTINCT` becomes unnecessary:

- `OrgVisibilityMixin`: the multi-valued (M2M) case (`ArticleViewSet`, `TrialViewSet`) now uses `Exists()`; simple-FK viewsets (`Sources`, `Teams`, `Subjects`) keep their plain filter, SQL unchanged.
- `AuthorsViewSet`: org filter rewritten as `Exists(...)`; the trailing `.distinct()` removed (no remaining row-duplicating joins — name/orcid/country filters add no joins and the `article_count` paths aggregate via `annotate(Count(...))`).

As a side benefit, tenancy no longer depends on every future queryset remembering to pair the join with `.distinct()` — `Exists()` can't produce duplicates in the first place.

## Verification

- **Row-set equivalence** proven against the real dev DB: old vs new querysets return identical counts — 48,675 articles, 247,387 authors (276 articles belong to >1 team, so this exercises the dedup path).
- **Timings** (same DB, cold throwaway container, two runs each):
  - Articles count: 0.37–0.46 s → **0.018–0.030 s**
  - Authors count: 0.44–0.65 s → **0.073–0.129 s**
  - Hand-tuned EXPLAIN ANALYZE of the equivalent SQL: 784 ms → 15 ms (52×).
- **Tests**: full `api` + `gregory` suites — **1,322/1,322 passed**, including the nine per-endpoint visibility suites (`test_visibility_articles/trials/authors/sources/subjects/teams/categories/rss/stats`) and `test_org_scoped_serializer_mixin`. Multi-tenant scoping semantics are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)