### PR TITLE
Fix ML relevance to use only the latest prediction per (article, subject, algorithm)

### DIFF
--- a/django/api/filters.py
+++ b/django/api/filters.py
@@ -217,12 +217,17 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 		Build a database-level query to find ML-relevant articles based on consensus logic.
 		This avoids the N+1 query problem by using efficient Django ORM queries.
 
+		Only the latest prediction per (article, subject, algorithm) counts toward
+		consensus — a retired model_version's stale score must not keep an article
+		"relevant" forever after a retrain. The whole thing stays an unevaluated Q
+		of subqueries (no Python id materialization) so the caller's queryset compiles
+		to a single SQL statement.
+
 		If filtered_subject_id is provided, only check relevance for that specific subject.
 		"""
-		from django.db.models import Count, Q
+		from django.db.models import Count, Max, OuterRef, Q, Subquery
 
-		# Get all article IDs that meet ML consensus for at least one subject
-		ml_relevant_ids = set()
+		from gregory.models import MLPredictions
 
 		# Get subjects with auto_predict enabled, optionally filtered by subject_id
 		auto_predict_subjects = Subject.objects.filter(auto_predict=True)
@@ -230,6 +235,7 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 			auto_predict_subjects = auto_predict_subjects.filter(id=filtered_subject_id)
 		auto_predict_subjects = auto_predict_subjects.values("id", "ml_consensus_type")
 
+		combined_q = None
 		for subject_data in auto_predict_subjects:
 			subject_id = subject_data["id"]
 			consensus_type = subject_data["ml_consensus_type"]
@@ -239,26 +245,45 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 				consensus_type, 1
 			)  # Default to 'any' if unknown
 
-			# Find articles that meet consensus for this subject
+			# For each (article, algorithm) pair within this subject, find the most
+			# recent prediction's created_date. Filtering on created_date equal to
+			# that maximum isolates the latest prediction per pair (ties simply
+			# match more than one row, which is harmless for the exists/count below).
+			latest_date_per_pair = (
+				MLPredictions.objects.filter(
+					article=OuterRef("article"),
+					subject_id=subject_id,
+					algorithm=OuterRef("algorithm"),
+				)
+				.values("article", "algorithm")
+				.annotate(latest=Max("created_date"))
+				.values("latest")[:1]
+			)
+
+			# Find articles that meet consensus for this subject, using only the
+			# latest prediction per (article, algorithm) pair.
 			articles_for_subject = (
-				Articles.objects.filter(
-					subjects__id=subject_id,
-					ml_predictions_detail__subject_id=subject_id,
-					ml_predictions_detail__predicted_relevant=True,
-					ml_predictions_detail__probability_score__gte=threshold,
+				MLPredictions.objects.filter(
+					subject_id=subject_id,
+					article__subjects__id=subject_id,
+					algorithm__isnull=False,
+					predicted_relevant=True,
+					probability_score__gte=threshold,
+					created_date=Subquery(latest_date_per_pair),
 				)
-				.annotate(
-					algorithm_count=Count(
-						"ml_predictions_detail__algorithm", distinct=True
-					)
-				)
+				.values("article_id")
+				.annotate(algorithm_count=Count("algorithm", distinct=True))
 				.filter(algorithm_count__gte=min_algorithms)
 				.values_list("article_id", flat=True)
 			)
 
-			ml_relevant_ids.update(articles_for_subject)
+			subject_q = Q(article_id__in=articles_for_subject)
+			combined_q = subject_q if combined_q is None else combined_q | subject_q
 
-		return Q(article_id__in=list(ml_relevant_ids))
+		if combined_q is None:
+			# No auto_predict subjects (or none matching filtered_subject_id): match nothing.
+			return Q(article_id__in=[])
+		return combined_q
 
 	def filter_relevant(self, queryset, name, value):
 		"""

--- a/django/api/tests/test_relevant_filter_latest_prediction.py
+++ b/django/api/tests/test_relevant_filter_latest_prediction.py
@@ -1,0 +1,195 @@
+"""Regression tests for the ?relevant= and ?ml_threshold= article filters.
+
+Every model retrain writes a new MLPredictions row (unique per
+article/subject/model_version/algorithm). Before this fix, ArticleFilter's
+ML-relevance check counted ANY historical prediction meeting the threshold,
+so an article stayed "relevant" forever once a since-retired model_version
+had scored it high -- even if every current model scores it low. Only the
+*latest* prediction per (article, subject, algorithm) should count.
+"""
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+from organizations.models import Organization
+from rest_framework.test import APIClient
+
+from gregory.models import (
+	Articles,
+	ArticleSubjectRelevance,
+	MLPredictions,
+	OrganizationApiSettings,
+	Subject,
+	Team,
+)
+
+
+class RelevantFilterLatestPredictionTestCase(TestCase):
+	def setUp(self):
+		self.client = APIClient()
+
+		org = Organization.objects.create(name="Latest Pred Org", slug="latest-pred-org")
+		OrganizationApiSettings.objects.filter(organization=org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			organization=org, name="Latest Pred Team", slug="latest-pred-team"
+		)
+		self.subject_any = Subject.objects.create(
+			team=self.team,
+			subject_name="Any Subj",
+			subject_slug="latest-pred-any-subj",
+			auto_predict=True,
+			ml_consensus_type="any",
+		)
+		self.subject_majority = Subject.objects.create(
+			team=self.team,
+			subject_name="Majority Subj",
+			subject_slug="latest-pred-majority-subj",
+			auto_predict=True,
+			ml_consensus_type="majority",
+		)
+
+	def _article(self, title, subject):
+		article = Articles.objects.create(
+			title=title,
+			link=f"https://example.com/{title.lower().replace(' ', '-')}",
+		)
+		article.subjects.add(subject)
+		article.teams.add(self.team)
+		return article
+
+	def _predict(self, article, subject, algorithm, score, model_version, days_ago=0):
+		pred = MLPredictions.objects.create(
+			article=article,
+			subject=subject,
+			algorithm=algorithm,
+			model_version=model_version,
+			probability_score=score,
+			predicted_relevant=score >= 0.5,
+		)
+		if days_ago:
+			MLPredictions.objects.filter(pk=pred.pk).update(
+				created_date=timezone.now() - timedelta(days=days_ago)
+			)
+		return pred
+
+	def _relevant_ids(self, value="true", **extra):
+		params = {"relevant": value}
+		params.update(extra)
+		resp = self.client.get("/articles/", params)
+		self.assertEqual(resp.status_code, 200)
+		return {r["article_id"] for r in resp.data["results"]}
+
+	# ------------------------------------------------------------------
+	# Superseded prediction: old high score, new low score -> not relevant.
+	# ------------------------------------------------------------------
+
+	def test_superseded_high_score_excluded_from_relevant_true(self):
+		article = self._article("Superseded high score", self.subject_any)
+		self._predict(
+			article, self.subject_any, "pubmed_bert", 0.9, "v1", days_ago=10
+		)
+		self._predict(article, self.subject_any, "pubmed_bert", 0.3, "v2", days_ago=0)
+
+		self.assertNotIn(article.article_id, self._relevant_ids("true"))
+		self.assertIn(article.article_id, self._relevant_ids("false"))
+
+	def test_superseded_high_score_excluded_from_ml_threshold(self):
+		article = self._article("Superseded high score threshold", self.subject_any)
+		self._predict(
+			article, self.subject_any, "pubmed_bert", 0.9, "v1", days_ago=10
+		)
+		self._predict(article, self.subject_any, "pubmed_bert", 0.3, "v2", days_ago=0)
+
+		resp = self.client.get("/articles/", {"ml_threshold": "0.8"})
+		self.assertEqual(resp.status_code, 200)
+		ids = {r["article_id"] for r in resp.data["results"]}
+		self.assertNotIn(article.article_id, ids)
+
+	# ------------------------------------------------------------------
+	# Reverse: old low score, new high score -> relevant.
+	# ------------------------------------------------------------------
+
+	def test_superseded_low_score_becomes_relevant(self):
+		article = self._article("Superseded low score", self.subject_any)
+		self._predict(
+			article, self.subject_any, "pubmed_bert", 0.3, "v1", days_ago=10
+		)
+		self._predict(article, self.subject_any, "pubmed_bert", 0.9, "v2", days_ago=0)
+
+		self.assertIn(article.article_id, self._relevant_ids("true"))
+		self.assertNotIn(article.article_id, self._relevant_ids("false"))
+
+	# ------------------------------------------------------------------
+	# Manual relevance always qualifies, regardless of ML predictions.
+	# ------------------------------------------------------------------
+
+	def test_manual_relevance_qualifies_regardless_of_stale_predictions(self):
+		article = self._article("Manually relevant despite stale ML", self.subject_any)
+		# Only a stale (superseded, now-low) prediction exists.
+		self._predict(
+			article, self.subject_any, "pubmed_bert", 0.9, "v1", days_ago=10
+		)
+		self._predict(article, self.subject_any, "pubmed_bert", 0.1, "v2", days_ago=0)
+		ArticleSubjectRelevance.objects.create(
+			article=article, subject=self.subject_any, is_relevant=True
+		)
+
+		self.assertIn(article.article_id, self._relevant_ids("true"))
+		self.assertNotIn(article.article_id, self._relevant_ids("false"))
+
+	def test_manual_relevance_qualifies_with_no_predictions_at_all(self):
+		article = self._article("Manually relevant no predictions", self.subject_any)
+		ArticleSubjectRelevance.objects.create(
+			article=article, subject=self.subject_any, is_relevant=True
+		)
+
+		self.assertIn(article.article_id, self._relevant_ids("true"))
+
+	# ------------------------------------------------------------------
+	# Consensus (majority) honored on latest-only predictions.
+	# ------------------------------------------------------------------
+
+	def test_majority_consensus_on_latest_predictions_only(self):
+		article = self._article("Majority latest only", self.subject_majority)
+
+		# pubmed_bert: latest prediction passes.
+		self._predict(
+			article, self.subject_majority, "pubmed_bert", 0.9, "v1", days_ago=10
+		)
+		self._predict(
+			article, self.subject_majority, "pubmed_bert", 0.85, "v2", days_ago=0
+		)
+		# lgbm_tfidf: latest prediction passes too -> majority (2) reached.
+		self._predict(
+			article, self.subject_majority, "lgbm_tfidf", 0.9, "v1", days_ago=10
+		)
+		self._predict(
+			article, self.subject_majority, "lgbm_tfidf", 0.82, "v2", days_ago=0
+		)
+
+		self.assertIn(article.article_id, self._relevant_ids("true"))
+
+	def test_majority_consensus_fails_when_one_algorithm_drops_below_threshold(self):
+		article = self._article("Majority one dropped", self.subject_majority)
+
+		# pubmed_bert: latest prediction still passes.
+		self._predict(
+			article, self.subject_majority, "pubmed_bert", 0.9, "v1", days_ago=10
+		)
+		self._predict(
+			article, self.subject_majority, "pubmed_bert", 0.85, "v2", days_ago=0
+		)
+		# lgbm_tfidf: old prediction passed, but the retrained latest dropped
+		# below threshold -- only 1 algorithm now qualifies, majority fails.
+		self._predict(
+			article, self.subject_majority, "lgbm_tfidf", 0.9, "v1", days_ago=10
+		)
+		self._predict(
+			article, self.subject_majority, "lgbm_tfidf", 0.2, "v2", days_ago=0
+		)
+
+		self.assertNotIn(article.article_id, self._relevant_ids("true"))
+		self.assertIn(article.article_id, self._relevant_ids("false"))

--- a/django/gregory/models.py
+++ b/django/gregory/models.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import GinIndex
 from django.db import models
-from django.db.models import GeneratedField, Q
+from django.db.models import GeneratedField, Max, OuterRef, Q, Subquery
 from django.db.models.fields.json import KeyTextTransform
 from django.db.models.functions import Upper
 from django.utils.text import slugify
@@ -634,7 +634,9 @@ class Articles(models.Model):
 
 		Only the latest prediction per algorithm for this (article, subject) pair counts —
 		a retired model_version's stale score must not keep an article "relevant" forever
-		after a retrain.
+		after a retrain. Ties on created_date are all considered: the algorithm qualifies
+		if any tied latest row does, matching api.filters._get_ml_relevant_articles_query
+		and gregory.relevance.recompute_article_relevance.
 
 		Args:
 			subject: Subject instance to check relevance for
@@ -643,22 +645,30 @@ class Articles(models.Model):
 		Returns:
 			bool: True if article meets the ML consensus criteria for the subject
 		"""
-		# Latest prediction per algorithm for this article+subject pair (Postgres DISTINCT ON).
-		latest_predictions = (
-			self.ml_predictions_detail.filter(subject=subject)
-			.order_by("algorithm", "-created_date")
-			.distinct("algorithm")
+		# Latest created_date per algorithm for this article+subject pair. Filtering
+		# on created_date equal to that maximum keeps every tied latest row, unlike
+		# DISTINCT ON, which would pick one tied row arbitrarily.
+		latest_date_per_algorithm = (
+			MLPredictions.objects.filter(
+				article=self,
+				subject=subject,
+				algorithm=OuterRef("algorithm"),
+			)
+			.values("algorithm")
+			.annotate(latest=Max("created_date"))
+			.values("latest")[:1]
 		)
 
 		# Count unique algorithms whose *latest* prediction predicted relevant with
 		# sufficient confidence.
-		relevant_algorithms = {
-			pred.algorithm
-			for pred in latest_predictions
-			if pred.predicted_relevant
-			and pred.probability_score is not None
-			and pred.probability_score >= threshold
-		}
+		relevant_algorithms = set(
+			self.ml_predictions_detail.filter(
+				subject=subject,
+				predicted_relevant=True,
+				probability_score__gte=threshold,
+				created_date=Subquery(latest_date_per_algorithm),
+			).values_list("algorithm", flat=True)
+		)
 		total_predictions = len(relevant_algorithms)
 
 		if total_predictions == 0:

--- a/django/gregory/models.py
+++ b/django/gregory/models.py
@@ -632,6 +632,10 @@ class Articles(models.Model):
 		Check if this article is ML-relevant for a specific subject based on the subject's consensus type
 		and probability threshold.
 
+		Only the latest prediction per algorithm for this (article, subject) pair counts —
+		a retired model_version's stale score must not keep an article "relevant" forever
+		after a retrain.
+
 		Args:
 			subject: Subject instance to check relevance for
 			threshold: Minimum probability score required (default: 0.8)
@@ -639,17 +643,26 @@ class Articles(models.Model):
 		Returns:
 			bool: True if article meets the ML consensus criteria for the subject
 		"""
-		# Get all ML predictions for this article and subject that meet the threshold
-		predictions = self.ml_predictions_detail.filter(
-			subject=subject, predicted_relevant=True, probability_score__gte=threshold
-		).values_list("algorithm", flat=True)
+		# Latest prediction per algorithm for this article+subject pair (Postgres DISTINCT ON).
+		latest_predictions = (
+			self.ml_predictions_detail.filter(subject=subject)
+			.order_by("algorithm", "-created_date")
+			.distinct("algorithm")
+		)
 
-		if not predictions.exists():
-			return False
-
-		# Count unique algorithms that predicted relevant with sufficient confidence
-		relevant_algorithms = set(predictions)
+		# Count unique algorithms whose *latest* prediction predicted relevant with
+		# sufficient confidence.
+		relevant_algorithms = {
+			pred.algorithm
+			for pred in latest_predictions
+			if pred.predicted_relevant
+			and pred.probability_score is not None
+			and pred.probability_score >= threshold
+		}
 		total_predictions = len(relevant_algorithms)
+
+		if total_predictions == 0:
+			return False
 
 		# Apply consensus logic based on subject's ml_consensus_type
 		if subject.ml_consensus_type == "any":

--- a/django/gregory/relevance.py
+++ b/django/gregory/relevance.py
@@ -3,6 +3,16 @@ from django.db import connection
 
 def recompute_article_relevance(article_ids=None, threshold=0.8):
 	"""Sync articles.relevant with manual + ML-consensus relevance.
+
+	ML consensus only counts the *latest* prediction per (article, subject,
+	algorithm) pair — a retired model_version's stale score must not keep an
+	article "relevant" forever after a retrain. The correlated MAX ranges over
+	ALL predictions for the pair (not only qualifying ones), so a latest
+	prediction that dropped below threshold correctly disqualifies the pair.
+	Ties on created_date match multiple rows, which is harmless for the
+	DISTINCT-algorithm count. The lookup is backed by mlpred_art_subj_date_idx
+	on (article, subject, -created_date).
+
 	Full pass when article_ids is None. Returns number of rows changed."""
 	scope, params = "", [threshold]
 	if article_ids is not None:
@@ -29,6 +39,13 @@ def recompute_article_relevance(article_ids=None, threshold=0.8):
 						AND mp.subject_id = xs.subject_id
 						AND mp.predicted_relevant IS TRUE
 						AND mp.probability_score >= %s
+						AND mp.created_date = (
+							SELECT MAX(mp2.created_date)
+							FROM gregory_mlpredictions mp2
+							WHERE mp2.article_id = mp.article_id
+							  AND mp2.subject_id = mp.subject_id
+							  AND mp2.algorithm = mp.algorithm
+						)
 					WHERE xs.articles_id = a2.article_id
 					GROUP BY xs.subject_id, s.ml_consensus_type
 					HAVING COUNT(DISTINCT mp.algorithm) >=

--- a/django/gregory/tests/test_article_relevance.py
+++ b/django/gregory/tests/test_article_relevance.py
@@ -1,6 +1,9 @@
 """Tests for the denormalized Articles.relevant flag: recompute logic and signals."""
 
+from datetime import timedelta
+
 from django.test import TestCase
+from django.utils import timezone
 from organizations.models import Organization
 
 from gregory.models import (
@@ -298,3 +301,146 @@ class ArticleRelevanceSignalTestCase(TestCase):
 		prediction.delete()
 		self._refresh()
 		self.assertFalse(self.article.relevant)
+
+
+class RecomputeArticleRelevanceLatestPredictionTestCase(TestCase):
+	"""Regression tests: only the latest prediction per (article, subject, algorithm)
+	counts toward ML consensus.
+
+	Every model retrain writes a new MLPredictions row (unique per
+	article/subject/model_version/algorithm). Before this fix,
+	recompute_article_relevance counted ANY historical prediction meeting the
+	threshold, so an article stayed relevant forever once a since-retired
+	model_version had scored it high."""
+
+	def setUp(self):
+		org = Organization.objects.create(name="Latest Prediction Relevance Org")
+		self.team = Team.objects.create(
+			organization=org, name="Latest Prediction Team", slug="latest-prediction-team"
+		)
+		self.subject_any = Subject.objects.create(
+			subject_name="Latest Any Subject",
+			subject_slug="latest-any-subject",
+			team=self.team,
+			auto_predict=True,
+			ml_consensus_type="any",
+		)
+		self.subject_majority = Subject.objects.create(
+			subject_name="Latest Majority Subject",
+			subject_slug="latest-majority-subject",
+			team=self.team,
+			auto_predict=True,
+			ml_consensus_type="majority",
+		)
+		self.subject_all = Subject.objects.create(
+			subject_name="Latest All Subject",
+			subject_slug="latest-all-subject",
+			team=self.team,
+			auto_predict=True,
+			ml_consensus_type="all",
+		)
+
+	def _make_article(self, title, link):
+		return Articles.objects.create(title=title, link=link)
+
+	def _predict(self, article, subject, algorithm, score, model_version, days_ago=0):
+		"""Create a prediction, optionally backdated (created_date is auto_now_add,
+		so backdating must bypass save() via a queryset .update())."""
+		pred = MLPredictions.objects.create(
+			article=article,
+			subject=subject,
+			algorithm=algorithm,
+			model_version=model_version,
+			probability_score=score,
+			predicted_relevant=score >= 0.5,
+		)
+		if days_ago:
+			MLPredictions.objects.filter(pk=pred.pk).update(
+				created_date=timezone.now() - timedelta(days=days_ago)
+			)
+		return pred
+
+	def test_superseded_high_score_clears_flag(self):
+		"""Old model_version scored 0.9; the retrained latest scored 0.3.
+		Only the latest counts, so the flag must be False after recompute."""
+		article = self._make_article("Superseded high", "https://example.com/lp1")
+		article.subjects.add(self.subject_any)
+		self._predict(article, self.subject_any, "pubmed_bert", 0.9, "v1", days_ago=10)
+		self._predict(article, self.subject_any, "pubmed_bert", 0.3, "v2")
+
+		recompute_article_relevance()
+		article.refresh_from_db()
+		self.assertFalse(
+			article.relevant,
+			"A stale superseded prediction must not keep the article relevant",
+		)
+
+	def test_superseded_low_score_sets_flag(self):
+		"""Reverse: old model_version scored low, the retrained latest scored high."""
+		article = self._make_article("Superseded low", "https://example.com/lp2")
+		article.subjects.add(self.subject_any)
+		self._predict(article, self.subject_any, "pubmed_bert", 0.3, "v1", days_ago=10)
+		self._predict(article, self.subject_any, "pubmed_bert", 0.9, "v2")
+
+		recompute_article_relevance()
+		article.refresh_from_db()
+		self.assertTrue(article.relevant)
+
+	def test_majority_consensus_on_latest_predictions_only(self):
+		"""Majority (>=2 algorithms): two algorithms' old predictions passed, but
+		one algorithm's latest dropped below threshold -> only 1 qualifies -> False.
+		Raising a third algorithm's latest above threshold restores majority -> True."""
+		article = self._make_article("Majority latest", "https://example.com/lp3")
+		article.subjects.add(self.subject_majority)
+
+		# pubmed_bert: latest still passes.
+		self._predict(article, self.subject_majority, "pubmed_bert", 0.9, "v1", days_ago=10)
+		self._predict(article, self.subject_majority, "pubmed_bert", 0.85, "v2")
+		# lgbm_tfidf: old passed, retrained latest dropped below threshold.
+		self._predict(article, self.subject_majority, "lgbm_tfidf", 0.9, "v1", days_ago=10)
+		self._predict(article, self.subject_majority, "lgbm_tfidf", 0.2, "v2")
+
+		recompute_article_relevance()
+		article.refresh_from_db()
+		self.assertFalse(
+			article.relevant,
+			"One qualifying latest prediction must not satisfy majority consensus",
+		)
+
+		self._predict(article, self.subject_majority, "lstm", 0.9, "v1")
+		recompute_article_relevance()
+		article.refresh_from_db()
+		self.assertTrue(article.relevant)
+
+	def test_all_consensus_on_latest_predictions_only(self):
+		"""Unanimous (>=3 algorithms): all three passed historically, but one
+		algorithm's latest dropped below threshold -> False."""
+		article = self._make_article("All latest", "https://example.com/lp4")
+		article.subjects.add(self.subject_all)
+
+		self._predict(article, self.subject_all, "pubmed_bert", 0.9, "v1", days_ago=10)
+		self._predict(article, self.subject_all, "lgbm_tfidf", 0.9, "v1", days_ago=10)
+		self._predict(article, self.subject_all, "lstm", 0.9, "v1", days_ago=10)
+		# lstm retrained and dropped below threshold.
+		self._predict(article, self.subject_all, "lstm", 0.4, "v2")
+
+		recompute_article_relevance()
+		article.refresh_from_db()
+		self.assertFalse(
+			article.relevant,
+			"A stale unanimous consensus must not survive one algorithm's latest drop",
+		)
+
+	def test_manual_relevance_wins_despite_stale_predictions(self):
+		"""Manual ArticleSubjectRelevance keeps the flag True regardless of ML state."""
+		article = self._make_article("Manual wins", "https://example.com/lp5")
+		article.subjects.add(self.subject_any)
+		self._predict(article, self.subject_any, "pubmed_bert", 0.9, "v1", days_ago=10)
+		self._predict(article, self.subject_any, "pubmed_bert", 0.1, "v2")
+		ArticleSubjectRelevance.objects.create(
+			article=article, subject=self.subject_any, is_relevant=True
+		)
+
+		recompute_article_relevance()
+		article.refresh_from_db()
+		self.assertTrue(article.relevant)

--- a/django/gregory/tests/test_is_ml_relevant_for_subject.py
+++ b/django/gregory/tests/test_is_ml_relevant_for_subject.py
@@ -1,0 +1,118 @@
+"""Regression tests for Articles.is_ml_relevant_for_subject staleness handling.
+
+Every model retrain writes a new MLPredictions row (unique per
+article/subject/model_version/algorithm). Only the *latest* prediction per
+(article, subject, algorithm) should count toward ML consensus -- an old
+model_version's score must not keep an article "relevant" forever after a
+retrain.
+"""
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+from organizations.models import Organization
+
+from gregory.models import Articles, MLPredictions, Subject, Team
+
+
+class IsMlRelevantForSubjectStalePredictionsTestCase(TestCase):
+	def setUp(self):
+		org = Organization.objects.create(name="Stale Prediction Org")
+		self.team = Team.objects.create(
+			organization=org, name="Stale Prediction Team", slug="stale-prediction-team"
+		)
+		self.subject_any = Subject.objects.create(
+			subject_name="Any Subject",
+			subject_slug="stale-any-subject",
+			team=self.team,
+			auto_predict=True,
+			ml_consensus_type="any",
+		)
+		self.subject_majority = Subject.objects.create(
+			subject_name="Majority Subject",
+			subject_slug="stale-majority-subject",
+			team=self.team,
+			auto_predict=True,
+			ml_consensus_type="majority",
+		)
+
+	def _article(self, title, link):
+		return Articles.objects.create(title=title, link=link)
+
+	def _predict(self, article, subject, algorithm, score, model_version, days_ago=0, predicted_relevant=None):
+		if predicted_relevant is None:
+			predicted_relevant = score >= 0.5
+		pred = MLPredictions.objects.create(
+			article=article,
+			subject=subject,
+			algorithm=algorithm,
+			model_version=model_version,
+			probability_score=score,
+			predicted_relevant=predicted_relevant,
+		)
+		if days_ago:
+			MLPredictions.objects.filter(pk=pred.pk).update(
+				created_date=timezone.now() - timedelta(days=days_ago)
+			)
+		return pred
+
+	def test_superseded_high_score_is_not_relevant(self):
+		"""Old model_version scored 0.9 (qualifying); newer model_version (same
+		algorithm+subject) scored 0.3. Only the latest counts, so this must NOT
+		be relevant."""
+		article = self._article("Superseded high score", "https://example.com/stale-1")
+		article.subjects.add(self.subject_any)
+		self._predict(
+			article, self.subject_any, "pubmed_bert", 0.9, "v1", days_ago=10
+		)
+		self._predict(article, self.subject_any, "pubmed_bert", 0.3, "v2", days_ago=0)
+
+		self.assertFalse(article.is_ml_relevant_for_subject(self.subject_any, threshold=0.8))
+
+	def test_superseded_low_score_becomes_relevant(self):
+		"""Reverse case: old model_version scored low, newer model_version scored
+		high. Latest prediction qualifies, so this must be relevant."""
+		article = self._article("Superseded low score", "https://example.com/stale-2")
+		article.subjects.add(self.subject_any)
+		self._predict(
+			article, self.subject_any, "pubmed_bert", 0.3, "v1", days_ago=10
+		)
+		self._predict(article, self.subject_any, "pubmed_bert", 0.9, "v2", days_ago=0)
+
+		self.assertTrue(article.is_ml_relevant_for_subject(self.subject_any, threshold=0.8))
+
+	def test_majority_consensus_uses_latest_predictions_only(self):
+		"""Majority consensus (>=2 algorithms) must be evaluated on each
+		algorithm's *latest* prediction. Two algorithms' old predictions passed,
+		but only one algorithm's latest prediction still passes -- not relevant."""
+		article = self._article("Majority stale", "https://example.com/stale-3")
+		article.subjects.add(self.subject_majority)
+
+		# pubmed_bert: latest prediction still passes.
+		self._predict(
+			article, self.subject_majority, "pubmed_bert", 0.9, "v1", days_ago=10
+		)
+		self._predict(
+			article, self.subject_majority, "pubmed_bert", 0.85, "v2", days_ago=0
+		)
+
+		# lgbm_tfidf: old prediction passed, but the latest (retrained) dropped
+		# below threshold.
+		self._predict(
+			article, self.subject_majority, "lgbm_tfidf", 0.9, "v1", days_ago=10
+		)
+		self._predict(
+			article, self.subject_majority, "lgbm_tfidf", 0.2, "v2", days_ago=0
+		)
+
+		# Only 1 algorithm's latest prediction qualifies -- majority (>=2) fails.
+		self.assertFalse(
+			article.is_ml_relevant_for_subject(self.subject_majority, threshold=0.8)
+		)
+
+		# Now bring lstm's latest prediction up to threshold too: majority holds.
+		self._predict(article, self.subject_majority, "lstm", 0.9, "v1", days_ago=0)
+		self.assertTrue(
+			article.is_ml_relevant_for_subject(self.subject_majority, threshold=0.8)
+		)

--- a/django/gregory/tests/test_is_ml_relevant_for_subject.py
+++ b/django/gregory/tests/test_is_ml_relevant_for_subject.py
@@ -116,3 +116,24 @@ class IsMlRelevantForSubjectStalePredictionsTestCase(TestCase):
 		self.assertTrue(
 			article.is_ml_relevant_for_subject(self.subject_majority, threshold=0.8)
 		)
+
+	def test_tied_created_date_counts_any_qualifying_row(self):
+		"""Two predictions for the same algorithm share the same created_date (tie).
+		All tied latest rows must be considered — the algorithm qualifies if any
+		tied row does — matching the api.filters and gregory.relevance
+		implementations, which filter on created_date == MAX(created_date)."""
+		article = self._article("Tied created_date", "https://example.com/stale-tie")
+		article.subjects.add(self.subject_any)
+
+		low = self._predict(article, self.subject_any, "pubmed_bert", 0.3, "v1")
+		high = self._predict(article, self.subject_any, "pubmed_bert", 0.9, "v2")
+
+		# Force an exact created_date tie between the two rows.
+		tied_at = timezone.now() - timedelta(days=1)
+		MLPredictions.objects.filter(pk__in=[low.pk, high.pk]).update(
+			created_date=tied_at
+		)
+
+		self.assertTrue(
+			article.is_ml_relevant_for_subject(self.subject_any, threshold=0.8)
+		)


### PR DESCRIPTION
## Problem

Three implementations of "is this article ML-relevant?" treated an article as relevant if **any historical** `MLPredictions` row met the probability threshold — not the **latest** one per (article, subject, algorithm) pair:

1. `ArticleFilter._get_ml_relevant_articles_query` — behind the API's `?relevant=true/false` and `?ml_threshold=` filters
2. `Articles.is_ml_relevant_for_subject` — used by the weekly newsletter command
3. `recompute_article_relevance` (raw SQL in `gregory/relevance.py`) — maintains the denormalized `Articles.relevant` flag via signals, `refresh_article_relevance`, and the pipeline

Every retrain writes new prediction rows (unique per article/subject/model_version/algorithm; 13 model versions exist across the 3 algorithms), so an article scored relevant by a since-retired model version stayed "relevant" forever, even after the current models scored it below threshold. Measured on a prod-scale dev DB: **10,570 of 48,680 articles** carry a stale ≥0.8 prediction whose latest counterpart is <0.8.

This contradicts the documented semantics (`Articles.ml_score` help text: *"latest prediction per (algorithm, subject) pair"*) and the already-correct implementation in `CategorySerializer.get_monthly_counts`.

## Fix

All three implementations now restrict qualifying predictions to `created_date = MAX(created_date)` over **all** predictions for the same (article, subject, algorithm) — ranging over all rows, not just qualifying ones, so a latest prediction that dropped below threshold correctly disqualifies the pair. Ties on `created_date` match multiple rows, harmless for the DISTINCT-algorithm consensus count. Backed by the existing `mlpred_art_subj_date_idx` index.

Consensus rules (`any`/`majority`/`all`), subject scoping, the `relevant=false` exclude path, and manual `ArticleSubjectRelevance` precedence are all preserved.

Side improvement: the filter helper no longer materializes matching IDs into a Python set / giant `IN (id, id, …)` literal — it now compiles to `article_id IN (SELECT …)` subqueries, one branch per auto_predict subject.

## Impact on data (measured, dev DB at threshold 0.8)

- ML-relevant articles: **3,173 → 477** (identical counts from the ORM helper and the raw SQL, confirming the implementations now agree)
- Overall `relevant` (manual OR ML): 3,353 → 816
- **2,538 articles' denormalized `relevant` flag will flip** on the next recompute: 2,537 TRUE→FALSE (stale-only articles), 1 FALSE→TRUE

## ⚠️ Post-deploy step

Run once after deploying:

```bash
docker exec gregory python manage.py refresh_article_relevance
```

so the denormalized flag reflects the corrected semantics (same pattern as previous denormalized-field backfills).

## Verification

- 15 new regression tests: superseded high→low is not relevant, superseded low→high is relevant, majority/unanimous consensus evaluated on latest-per-algorithm only, manual relevance wins despite stale predictions — covering the filter, the ORM method, and the raw SQL (`test_relevant_filter_latest_prediction.py`, `test_is_ml_relevant_for_subject.py`, extensions to `test_article_relevance.py`)
- Full suites pass: `api` 573 tests, `gregory` 764 tests; no existing assertions changed
- Read-only validation against the real dev DB (no UPDATE executed) produced the numbers above

🤖 Generated with [Claude Code](https://claude.com/claude-code)