### PR TITLE
Make /articles/stats/ relevant count subject-strict and list-consistent

### DIFF
--- a/django/api/tests/test_articles_stats.py
+++ b/django/api/tests/test_articles_stats.py
@@ -8,6 +8,9 @@ Mirrors the /trials/stats/ suite for articles (both are built on
     runs the stats aggregation
   - /articles/stats/ totals: total, by_access (NULL access folded into
     "unknown"), relevant, retracted, missing_doi
+  - the relevant count uses the list's ?relevant=true semantics (live
+    manual+ML logic, subject-scoped when subject_id is present) — NOT the
+    denormalized any-subject Articles.relevant flag
   - filters (e.g. team_id) scope the stats like the equivalent list request
   - by_subject breakdown, including that hidden-org subjects on visible
     articles never leak into it
@@ -32,7 +35,14 @@ from organizations.models import Organization
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
-from gregory.models import Articles, OrganizationApiSettings, Subject, Team
+from gregory.models import (
+	Articles,
+	ArticleSubjectRelevance,
+	MLPredictions,
+	OrganizationApiSettings,
+	Subject,
+	Team,
+)
 
 
 def _make_org_team(name, slug, public=True):
@@ -105,7 +115,9 @@ class ArticleStatsBase(TestCase):
 		)
 		self.subject = _make_subject(self.team, "A-Stats Subject", "a-stats-subject")
 
-		# a1: open access, relevant, has DOI
+		# a1: open access, relevant (manually reviewed for the subject), has
+		# DOI. The stats `relevant` count uses the live per-subject logic —
+		# the denormalized flag alone is not enough to count as relevant.
 		self.a1 = _make_article(
 			"A1",
 			"https://article.example.com/1",
@@ -114,6 +126,9 @@ class ArticleStatsBase(TestCase):
 			access="open",
 			doi="10.1000/stats-a1",
 			relevant=True,
+		)
+		ArticleSubjectRelevance.objects.create(
+			article=self.a1, subject=self.subject, is_relevant=True
 		)
 		# a2: restricted, retracted, has DOI
 		self.a2 = _make_article(
@@ -299,13 +314,20 @@ class ArticleStatsCachingTest(ArticleStatsBase):
 		priv_org, priv_team = _make_org_team(
 			"A-Private Stats Org", "a-private-stats-org", public=False
 		)
-		_make_article(
+		priv_subject = _make_subject(
+			priv_team, "A-Private Subject", "a-private-subject"
+		)
+		priv_article = _make_article(
 			"Private A",
 			"https://article.example.com/priv",
 			[priv_team],
+			[priv_subject],
 			access="open",
 			doi="10.1000/stats-priv",
 			relevant=True,
+		)
+		ArticleSubjectRelevance.objects.create(
+			article=priv_article, subject=priv_subject, is_relevant=True
 		)
 		scheme = _make_api_scheme(priv_org, "a-stats-key")
 
@@ -328,6 +350,110 @@ class ArticleStatsCachingTest(ArticleStatsBase):
 		# not pick up the keyed caller's entry.
 		anon_again = anon.get("/articles/stats/")
 		self.assertEqual(anon_again.data["total"], 4)
+
+
+class ArticleStatsSubjectScopedRelevantTest(TestCase):
+	"""The `relevant` count must be subject-strict when subject_id is given.
+
+	An article tagged with subjects N and M but only relevant for M must not
+	land in N's relevant bucket — the stats must mean the same thing as
+	`/articles/?relevant=true&subject_id=N`, not "relevant for any subject"
+	(the denormalized Articles.relevant flag).
+	"""
+
+	def setUp(self):
+		cache.clear()
+		self.org, self.team = _make_org_team(
+			"A-Scoped Org", "a-scoped-stats-org"
+		)
+		self.subject_n = _make_subject(self.team, "Subject N", "a-scoped-subject-n")
+		self.subject_m = _make_subject(self.team, "Subject M", "a-scoped-subject-m")
+
+		# In both subjects, manually relevant ONLY for M.
+		self.article = _make_article(
+			"Scoped A1",
+			"https://article.example.com/scoped-1",
+			[self.team],
+			[self.subject_n, self.subject_m],
+			access="open",
+			doi="10.1000/stats-scoped-1",
+		)
+		ArticleSubjectRelevance.objects.create(
+			article=self.article, subject=self.subject_m, is_relevant=True
+		)
+
+		self.client = APIClient()
+
+	def _stats(self, **params):
+		resp = self.client.get("/articles/stats/", params)
+		self.assertEqual(resp.status_code, 200)
+		return resp.data
+
+	def _list_relevant_count(self, **params):
+		resp = self.client.get("/articles/", {"relevant": "true", **params})
+		self.assertEqual(resp.status_code, 200)
+		return resp.data["count"]
+
+	def test_relevant_is_scoped_to_subject_param(self):
+		stats_n = self._stats(subject_id=self.subject_n.id)
+		# The article IS in subject N (total counts it) but is not relevant
+		# FOR subject N.
+		self.assertEqual(stats_n["total"], 1)
+		self.assertEqual(stats_n["relevant"], 0)
+
+		stats_m = self._stats(subject_id=self.subject_m.id)
+		self.assertEqual(stats_m["total"], 1)
+		self.assertEqual(stats_m["relevant"], 1)
+
+	def test_unscoped_relevant_counts_any_subject_once(self):
+		stats = self._stats()
+		self.assertEqual(stats["total"], 1)
+		self.assertEqual(stats["relevant"], 1)
+
+	def test_stats_relevant_matches_list_relevant_count(self):
+		"""The contract: stats counts == what the equivalent list returns."""
+		for params in (
+			{},
+			{"subject_id": self.subject_n.id},
+			{"subject_id": self.subject_m.id},
+		):
+			self.assertEqual(
+				self._stats(**params)["relevant"],
+				self._list_relevant_count(**params),
+				f"stats/list relevant mismatch for params {params}",
+			)
+
+	def test_ml_consensus_relevant_is_subject_scoped(self):
+		"""ML-driven relevance is also per subject: a consensus prediction
+		for subject N must not make the article relevant for subject M."""
+		self.subject_n.auto_predict = True
+		self.subject_n.save()
+		ml_article = _make_article(
+			"Scoped ML A2",
+			"https://article.example.com/scoped-2",
+			[self.team],
+			[self.subject_n, self.subject_m],
+			access="open",
+			doi="10.1000/stats-scoped-2",
+		)
+		MLPredictions.objects.create(
+			article=ml_article,
+			subject=self.subject_n,
+			algorithm="pubmed_bert",
+			model_version="test_v1",
+			probability_score=0.95,
+			predicted_relevant=True,
+		)
+
+		stats_n = self._stats(subject_id=self.subject_n.id)
+		self.assertEqual(stats_n["relevant"], 1)  # ml_article via consensus
+
+		stats_m = self._stats(subject_id=self.subject_m.id)
+		# Only the manually-relevant article; the ML prediction belongs to N.
+		self.assertEqual(stats_m["relevant"], 1)
+		self.assertEqual(
+			stats_m["relevant"], self._list_relevant_count(subject_id=self.subject_m.id)
+		)
 
 
 class ArticleStatsRoutingTest(ArticleStatsBase):

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1130,7 +1130,10 @@ class ArticleViewSet(
 	`by_subject` breakdown (`[{subject_id, subject_name, count}]`, distinct per article,
 	restricted to subjects visible to the caller). It accepts the same query parameters as
 	the list endpoint, so e.g. `/articles/stats/?team_id=1&relevant=true` scopes the counts
-	exactly like the equivalent list request. Results are cached server-side for
+	exactly like the equivalent list request. The `relevant` count uses the same semantics
+	as the list's `?relevant=true` filter: when `subject_id` is present it counts articles
+	relevant *for that subject* (manual review or ML consensus, honoring `ml_threshold`),
+	not articles merely relevant for some other subject. Results are cached server-side for
 	STATS_CACHE_TTL seconds (default 600).
 
 	# Response Fields:
@@ -1258,9 +1261,6 @@ class ArticleViewSet(
 		}
 
 		flags = qs.aggregate(
-			relevant=Count(
-				"article_id", distinct=True, filter=Q(relevant=True)
-			),
 			retracted=Count(
 				"article_id", distinct=True, filter=Q(retracted=True)
 			),
@@ -1271,12 +1271,30 @@ class ArticleViewSet(
 			),
 		)
 
+		# ``relevant`` must mean exactly what ``?relevant=true`` means on
+		# the list endpoint — scoped to subject_id and honoring ml_threshold
+		# when those params are present. The denormalized Articles.relevant
+		# flag is "relevant for ANY subject", which over-counts
+		# subject-scoped requests: an article in subject N that is only
+		# relevant for subject M would still land in N's bucket. Reuse the
+		# filter's live logic instead of duplicating it here.
+		article_filter = ArticleFilter(
+			self.request.GET, queryset=qs, request=self.request
+		)
+		relevant_count = (
+			article_filter.filter_relevant(qs, "relevant", True)
+			.order_by()
+			.values("article_id")
+			.distinct()
+			.count()
+		)
+
 		return {
 			# access groups are disjoint per article, so their distinct
 			# counts sum to the distinct total without a separate query.
 			"total": sum(access_counts.values()),
 			"by_access": by_access,
-			"relevant": flags["relevant"],
+			"relevant": relevant_count,
 			"retracted": flags["retracted"],
 			"missing_doi": flags["missing_doi"],
 			"by_subject": self._by_subject_counts(filtered_qs),


### PR DESCRIPTION
## Problem

`/articles/stats/?subject_id=N` counted the denormalized `Articles.relevant` flag, which means "relevant for **any** subject". Two consequences:

1. **Subject leakage**: an article in subject N that is only relevant for subject M still landed in N's `relevant` bucket.
2. **List divergence**: the stats docstring promises the counts "always match what the equivalent list request would return", but `/articles/?relevant=true` uses live manual+ML logic (subject-scoped, `ml_threshold`-aware) while the stats used the flag. On the dev DB the flag currently over-reports 3,352 vs the list's 816 (the flag drifts until the one-time `refresh_article_relevance` runs).

## Fix

The `relevant` bucket in `ArticleViewSet.build_stats_payload` now reuses `ArticleFilter.filter_relevant` — the exact code path behind the list's `?relevant=true` — so the two can never diverge. Manual review (`ArticleSubjectRelevance`) or ML consensus (latest prediction per (article, subject, algorithm), per-subject consensus type), scoped to `subject_id` and honoring `ml_threshold` when present. `retracted`/`missing_doi`/`by_access`/`by_subject` are unchanged, and the trials stats are unaffected (no relevance concept there).

## Cost

Measured on the dev DB at prod scale (48.7k articles, 305k predictions), warm, best of 3:

| | before (flag) | after (live) |
|---|---|---|
| unscoped | 19ms | 436ms |
| `subject_id=1` | — (wrong answer) | 277ms |

Paid once per `STATS_CACHE_TTL` window (600s) per distinct param set — the cache key already includes all params, so scoped and unscoped entries never collide.

## Tests

- Fixtures now create real `ArticleSubjectRelevance` rows instead of just setting the flag.
- New suite `ArticleStatsSubjectScopedRelevantTest`: an article in subjects N+M relevant only for M is excluded from N's bucket and counted in M's; ML-consensus relevance is subject-scoped too; and a direct `stats["relevant"] == list count` invariant check across param sets.
- Full `api` + `gregory` suites: **1,387 tests, all OK.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)