### PR TITLE
Serialize only the latest ML prediction per (subject, algorithm)

### DIFF
--- a/django/api/tests/test_ml_predictions_payload.py
+++ b/django/api/tests/test_ml_predictions_payload.py
@@ -1,0 +1,114 @@
+"""
+Regression tests for the ArticleViewSet/ArticleSearchView ml_predictions
+payload fix: only the latest prediction per (subject, algorithm) should be
+serialized, matching the "current relevance" semantics introduced in PR #748.
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_ml_predictions_payload
+"""
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from gregory.models import (
+	Articles,
+	MLPredictions,
+	Organization,
+	OrganizationApiSettings,
+	Subject,
+	Team,
+)
+
+
+def _make_prediction(article, subject, algorithm, probability, created_date):
+	pred = MLPredictions.objects.create(
+		article=article,
+		subject=subject,
+		algorithm=algorithm,
+		probability_score=probability,
+		predicted_relevant=True,
+	)
+	MLPredictions.objects.filter(pk=pred.pk).update(created_date=created_date)
+	pred.refresh_from_db()
+	return pred
+
+
+class ArticleMlPredictionsPayloadTests(TestCase):
+	def setUp(self):
+		self.organization = Organization.objects.create(
+			name="ML Payload Org", slug="ml-payload-org"
+		)
+		OrganizationApiSettings.objects.filter(organization=self.organization).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="ML Payload Team", slug="ml-payload-team", organization=self.organization
+		)
+		self.subject = Subject.objects.create(
+			subject_name="ML Payload Subject",
+			subject_slug="ml-payload-subject",
+			team=self.team,
+		)
+		self.article = Articles.objects.create(
+			title="ML Payload Article",
+			summary="Article used to test ml_predictions payload filtering.",
+			link="https://example.com/ml-payload-article",
+			published_date=timezone.now(),
+		)
+		self.article.teams.add(self.team)
+		self.article.subjects.add(self.subject)
+		self.client = APIClient()
+
+	def test_only_latest_prediction_per_subject_and_algorithm_is_serialized(self):
+		now = timezone.now()
+		_make_prediction(
+			self.article, self.subject, "lgbm_tfidf", 0.4, now - timedelta(days=10)
+		)
+		latest = _make_prediction(
+			self.article, self.subject, "lgbm_tfidf", 0.9, now
+		)
+
+		response = self.client.get(f"/articles/{self.article.pk}/")
+		self.assertEqual(response.status_code, 200)
+		predictions = response.data["ml_predictions"]
+		self.assertEqual(len(predictions), 1)
+		self.assertEqual(predictions[0]["id"], latest.pk)
+		self.assertAlmostEqual(predictions[0]["probability_score"], 0.9)
+
+	def test_predictions_from_two_algorithms_both_serialized(self):
+		now = timezone.now()
+		bert_pred = _make_prediction(
+			self.article, self.subject, "pubmed_bert", 0.7, now
+		)
+		lgbm_pred = _make_prediction(
+			self.article, self.subject, "lgbm_tfidf", 0.6, now
+		)
+
+		response = self.client.get(f"/articles/{self.article.pk}/")
+		self.assertEqual(response.status_code, 200)
+		predictions = response.data["ml_predictions"]
+		self.assertEqual(len(predictions), 2)
+		ids = {p["id"] for p in predictions}
+		self.assertEqual(ids, {bert_pred.pk, lgbm_pred.pk})
+
+	def test_search_view_also_serializes_latest_only(self):
+		now = timezone.now()
+		_make_prediction(
+			self.article, self.subject, "lstm", 0.3, now - timedelta(days=5)
+		)
+		latest = _make_prediction(self.article, self.subject, "lstm", 0.95, now)
+
+		url = reverse("article-search")
+		response = self.client.get(
+			url, {"team_id": self.team.id, "subject_id": self.subject.id}
+		)
+		self.assertEqual(response.status_code, 200)
+		results = response.data["results"]
+		self.assertEqual(len(results), 1)
+		predictions = results[0]["ml_predictions"]
+		self.assertEqual(len(predictions), 1)
+		self.assertEqual(predictions[0]["id"], latest.pk)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -44,6 +44,7 @@ from datetime import datetime, timedelta
 from django.db.models import (
 	Count,
 	Exists,
+	Max,
 	Q,
 	Prefetch,
 	OuterRef,
@@ -187,6 +188,34 @@ class BulkExportThrottleMixin:
 		if request_bypasses_pagination(self.request):
 			return [ScopedRateThrottle()]
 		return super().get_throttles()
+
+
+def _latest_ml_predictions_queryset():
+	"""``MLPredictions`` queryset restricted to the latest row per
+	(article, subject, algorithm), for use as a serializer prefetch.
+
+	Since PR #748, "current" ML relevance is latest-per-(subject, algorithm)
+	only — a retired model_version's stale score must not keep showing up
+	in the API forever. Same tie-inclusive Max(created_date) correlated
+	subquery as ``Articles.is_ml_relevant_for_subject``, generalised to
+	correlate on article_id too (that method fixes article/subject and
+	correlates only on algorithm). Index-backed by ``mlpred_art_subj_date_idx``.
+	Full prediction history is never deleted; it stays reachable via the
+	admin/DB for anyone who needs it.
+	"""
+	latest_date_per_group = (
+		MLPredictions.objects.filter(
+			article_id=OuterRef("article_id"),
+			subject_id=OuterRef("subject_id"),
+			algorithm=OuterRef("algorithm"),
+		)
+		.values("algorithm")
+		.annotate(latest=Max("created_date"))
+		.values("latest")[:1]
+	)
+	return MLPredictions.objects.filter(
+		created_date=Subquery(latest_date_per_group)
+	).select_related("subject")
 
 
 class OrgVisibilityMixin:
@@ -1164,7 +1193,7 @@ class ArticleViewSet(
 	queryset = Articles.objects.all().prefetch_related(
 		Prefetch(
 			"ml_predictions_detail",
-			queryset=MLPredictions.objects.select_related("subject"),
+			queryset=_latest_ml_predictions_queryset(),
 		),
 		"authors",
 		Prefetch("teams", queryset=Team.objects.prefetch_related("members")),
@@ -2416,7 +2445,7 @@ class ArticleSearchView(BulkExportThrottleMixin, generics.ListAPIView):
 			queryset = queryset.prefetch_related(
 				Prefetch(
 					"ml_predictions_detail",
-					queryset=MLPredictions.objects.select_related("subject"),
+					queryset=_latest_ml_predictions_queryset(),
 				),
 				"authors",
 				Prefetch("teams", queryset=Team.objects.prefetch_related("members")),


### PR DESCRIPTION
## Summary
- `ArticleViewSet`/`ArticleSearchView` prefetched the entire `ml_predictions_detail` history (305k rows, growing every pipeline run) — an article that went through several retrains serialized every historical prediction.
- Semantically wrong too: since PR #748, "current" ML relevance means the latest prediction per (subject, algorithm), so the API payload should match what the relevance logic actually uses.
- Fix: `_latest_ml_predictions_queryset()` — a tie-inclusive `Max(created_date)` correlated subquery copied from `Articles.is_ml_relevant_for_subject`, generalised to correlate on `article_id` as well as `subject_id`/`algorithm`. Index-backed by `mlpred_art_subj_date_idx`. Used in both `Prefetch("ml_predictions_detail", ...)` call sites (`ArticleViewSet.queryset`, `ArticleSearchView.get_queryset`).
- History is never deleted — full prediction history stays reachable via the admin/DB. Did not add an opt-in "full history" API param since that wasn't asked for; happy to add one if needed.

## Test plan
- [x] New `ArticleMlPredictionsPayloadTests`: an article with two predictions for the same (subject, algorithm) at different `created_date` serializes only the newer one; an article with predictions from two algorithms serializes both; same behavior verified through `ArticleSearchView`.
- [x] Full `api gregory` suite: 1386 tests OK (throwaway container, serial, per handover instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)