### PR TITLE
Whitelist TeamSerializer fields instead of exposing __all__

### DIFF
--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -40,7 +40,11 @@ def get_site():
 class TeamSerializer(serializers.ModelSerializer):
 	class Meta:
 		model = Team
-		fields = "__all__"
+		# Explicit whitelist -- `__all__` leaked `members` (Django auth User
+		# IDs of everyone on the team) to any API caller. `site` is an
+		# internal FK used for outbound email sending, not something API
+		# consumers need.
+		fields = ["id", "name", "slug", "organization", "is_active"]
 
 
 class SubjectsSerializer(serializers.ModelSerializer):

--- a/django/api/tests/test_team_serializer_fields.py
+++ b/django/api/tests/test_team_serializer_fields.py
@@ -1,0 +1,51 @@
+"""
+Regression test: TeamSerializer must not leak `members` (Django auth User
+IDs of everyone on the team) or other internal fields via `fields = "__all__"`.
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_team_serializer_fields
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from organizations.models import Organization
+from rest_framework.test import APIClient
+
+from gregory.models import OrganizationApiSettings, Team
+
+User = get_user_model()
+
+
+class TeamSerializerFieldWhitelistTests(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(
+			name="Team Fields Org", slug="team-fields-org"
+		)
+		OrganizationApiSettings.objects.filter(organization=self.org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			organization=self.org, name="Team Fields Team", slug="team-fields-team"
+		)
+		self.user = User.objects.create_user(
+			username="team-fields-member", password="unused"
+		)
+		self.team.members.add(self.user)
+		self.client = APIClient()
+
+	def test_members_not_in_list_response(self):
+		resp = self.client.get("/teams/")
+		self.assertEqual(resp.status_code, 200)
+		payload = resp.data["results"][0]
+		self.assertNotIn("members", payload)
+
+	def test_members_not_in_detail_response(self):
+		resp = self.client.get(f"/teams/{self.team.id}/")
+		self.assertEqual(resp.status_code, 200)
+		self.assertNotIn("members", resp.data)
+
+	def test_expected_public_fields_present(self):
+		resp = self.client.get(f"/teams/{self.team.id}/")
+		self.assertEqual(resp.status_code, 200)
+		for field in ("id", "name", "slug", "organization", "is_active"):
+			self.assertIn(field, resp.data)


### PR DESCRIPTION
## Summary
- `TeamSerializer` used `fields = "__all__"` on `Team`, which included the `members` M2M — Django auth `User` IDs of everyone on the team — in every `/teams/` list/detail response.
- Replaced with an explicit whitelist: `id`, `name`, `slug`, `organization`, `is_active`. Also drops `site` (an internal FK used for outbound email sending — not something API consumers need).
- Grepped for other `TeamSerializer` usages: it's nested exactly once, in `ArticleSerializer.teams`. No consumer reads the removed `members`/`site` keys.
- Note (not fixed here, out of scope): `ArticleViewSet`/`ArticleSearchView` prefetch `Team.objects.prefetch_related("members")` for the nested teams field — that prefetch is now dead weight since `members` is no longer serialized. Flagging for a follow-up cleanup rather than touching those files here, since PR #754 (task 1 of this batch) already has open changes on the same lines.

## Test plan
- [x] New `TeamSerializerFieldWhitelistTests`: asserts `members` absent from both list and detail `/teams/` responses, and the expected public fields are present
- [x] Full `api gregory` suite: 1393 tests OK (throwaway container, serial, per handover instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)