### PR TITLE
Align /trials/stats buckets with normalized recruitment status

### DIFF
--- a/django/api/tests/test_trials_stats.py
+++ b/django/api/tests/test_trials_stats.py
@@ -20,6 +20,23 @@ paginated list request. The stats now live on their own routed action
   - routing: /trials/stats/ resolves to the action and /trials/<pk>/
     detail lookups still work
 
+Buckets are counted on ``recruitment_status_normalized`` (the canonical vocabulary in
+``gregory.utils.trial_field_normalizers``), not the raw ``recruitment_status`` column, so
+this suite also locks in:
+
+  - per-registry spelling variants of the same canonical status ("RECRUITING",
+    "Recruiting", "Ongoing, recruiting") all land in the same bucket
+  - WHO's generic "Not recruiting" lands in its own ``not_recruiting`` bucket, not
+    ``active_not_recruiting``
+  - CT.gov's "UNKNOWN" lands in ``unknown``; its expanded-access "AVAILABLE" lands in
+    ``other``
+  - a null ``recruitment_status`` lands in ``no_status``
+  - every canonical ``TrialRecruitmentStatus`` key is present in the response even when
+    its count is 0, and none of the old ad-hoc keys (available/not_available/
+    withheld/authorised) survive
+  - the ``recruitment_status_normalized`` and ``phase_normalized`` query params scope the
+    totals end-to-end (the filtering itself comes free via ``filter_queryset``)
+
 Run with:
     docker exec gregory python manage.py test api.tests.test_trials_stats
 """
@@ -36,6 +53,7 @@ from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
 from gregory.models import OrganizationApiSettings, Subject, Team, Trials
+from gregory.utils.trial_field_normalizers import TrialRecruitmentStatus
 
 
 def _make_org_team(name, slug, public=True):
@@ -51,8 +69,10 @@ def _make_subject(team, name, slug):
 	return Subject.objects.create(team=team, subject_name=name, subject_slug=slug)
 
 
-def _make_trial(title, link, status, teams, subjects=()):
-	trial = Trials.objects.create(title=title, link=link, recruitment_status=status)
+def _make_trial(title, link, status, teams, subjects=(), phase=None):
+	trial = Trials.objects.create(
+		title=title, link=link, recruitment_status=status, phase=phase
+	)
 	for team in teams:
 		trial.teams.add(team)
 	for subject in subjects:
@@ -369,3 +389,99 @@ class TrialStatsRoutingTest(TrialStatsBase):
 		resp = self.client.get(f"/trials/{self.t1.trial_id}/")
 		self.assertEqual(resp.status_code, 200)
 		self.assertEqual(resp.data["trial_id"], self.t1.trial_id)
+
+
+class TrialStatsNormalizedBucketsTest(TrialStatsBase):
+	"""Buckets are counted on recruitment_status_normalized, the canonical vocabulary in
+	gregory.utils.trial_field_normalizers — not a second hand-rolled spelling list."""
+
+	def test_recruiting_spelling_variants_all_land_in_recruiting(self):
+		# "RECRUITING" (CT.gov upper-case) and "Ongoing, recruiting" (EU CTIS) both
+		# normalize to the same canonical bucket as the fixture's "Recruiting".
+		_make_trial("R1", "https://trial.example.com/r1", "RECRUITING", [self.team])
+		_make_trial(
+			"R2", "https://trial.example.com/r2", "Ongoing, recruiting", [self.team]
+		)
+		resp = self.client.get("/trials/stats/", {"team_id": self.team.id})
+		self.assertEqual(resp.status_code, 200)
+		# t1, t2 ("Recruiting") + R1 + R2 = 4.
+		self.assertEqual(resp.data["recruiting"], 4)
+
+	def test_who_not_recruiting_lands_in_not_recruiting_not_active(self):
+		_make_trial(
+			"NR", "https://trial.example.com/nr", "Not recruiting", [self.team]
+		)
+		resp = self.client.get("/trials/stats/", {"team_id": self.team.id})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data["not_recruiting"], 1)
+		# WHO's generic status doesn't say the trial is active — it must not be folded
+		# into active_not_recruiting.
+		self.assertEqual(resp.data["active_not_recruiting"], 0)
+
+	def test_ctgov_unknown_lands_in_unknown_bucket(self):
+		_make_trial("UNK", "https://trial.example.com/unk", "UNKNOWN", [self.team])
+		resp = self.client.get("/trials/stats/", {"team_id": self.team.id})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data["unknown"], 1)
+
+	def test_ctgov_available_lands_in_other_bucket(self):
+		_make_trial("AV", "https://trial.example.com/av", "AVAILABLE", [self.team])
+		resp = self.client.get("/trials/stats/", {"team_id": self.team.id})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data["other"], 1)
+
+	def test_null_recruitment_status_lands_in_no_status(self):
+		_make_trial(
+			"NoStatus", "https://trial.example.com/nostatus", None, [self.team]
+		)
+		resp = self.client.get("/trials/stats/", {"team_id": self.team.id})
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data["no_status"], 1)
+
+	def test_every_canonical_key_present_even_when_zero(self):
+		# other_team has only t4 (TERMINATED), so most buckets are 0 here — the point is
+		# that the zero-count keys are still in the payload, not omitted.
+		resp = self.client.get("/trials/stats/", {"team_id": self.other_team.id})
+		self.assertEqual(resp.status_code, 200)
+		for value in TrialRecruitmentStatus.values:
+			self.assertIn(value, resp.data)
+		self.assertEqual(resp.data["recruiting"], 0)
+		self.assertEqual(resp.data["terminated"], 1)
+		# The old hand-rolled keys must not survive the rewrite.
+		for stale_key in ("available", "not_available", "withheld", "authorised"):
+			self.assertNotIn(stale_key, resp.data)
+
+
+class TrialStatsNormalizedFilterScopingTest(TrialStatsBase):
+	"""/trials/stats/ scopes totals via the normalized-field filters too — those filters
+	come free through filter_queryset, but must be exercised end-to-end."""
+
+	def test_recruitment_status_normalized_filter_scopes_totals(self):
+		_make_trial(
+			"CTIS-R",
+			"https://trial.example.com/ctis-r",
+			"Ongoing, recruiting",
+			[self.team],
+		)
+		resp = self.client.get(
+			"/trials/stats/", {"recruitment_status_normalized": "recruiting"}
+		)
+		self.assertEqual(resp.status_code, 200)
+		# t1, t2 ("Recruiting") + the CTIS trial above = 3; t3/t4 are excluded.
+		self.assertEqual(resp.data["total"], 3)
+		self.assertEqual(resp.data["recruiting"], 3)
+
+	def test_phase_normalized_filter_scopes_totals(self):
+		_make_trial(
+			"P3",
+			"https://trial.example.com/p3",
+			"Recruiting",
+			[self.team],
+			phase="Phase 3",
+		)
+		resp = self.client.get("/trials/stats/", {"phase_normalized": "phase_3"})
+		self.assertEqual(resp.status_code, 200)
+		# None of the fixture trials (t1-t4) have a phase set, so only the trial created
+		# above matches.
+		self.assertEqual(resp.data["total"], 1)
+		self.assertEqual(resp.data["recruiting"], 1)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -54,6 +54,7 @@ from django.db.models import (
 )
 from django.db.models.functions import Coalesce
 from gregory.classes import SciencePaper, ClinicalTrial
+from gregory.utils.trial_field_normalizers import TrialRecruitmentStatus
 from gregory.models import (
 	Articles,
 	ArticleOrgContent,
@@ -1660,15 +1661,22 @@ class TrialViewSet(
 	- **all_results** - set to 'true' to bypass pagination and get all results (useful for CSV export)
 
 	# Stats Endpoint:
-	`GET /trials/stats/` returns recruitment-status totals (total, recruiting, completed, …)
-	plus a `by_subject` breakdown (`[{subject_id, subject_name, count}]`, distinct per trial,
-	restricted to subjects visible to the caller) computed over the filtered queryset. It
-	accepts the same query parameters as the list endpoint, so e.g.
-	`/trials/stats/?team_id=1&status=Recruiting` scopes the totals exactly like the
-	equivalent list request. Results are cached server-side for STATS_CACHE_TTL seconds
-	(default 600). **Breaking change:** the `stats` block that used to be embedded in
-	every paginated list response has moved here — list responses no longer include it, and
-	clients that relied on `response.data["stats"]` must call `/trials/stats/` instead.
+	`GET /trials/stats/` returns `total`, `no_status` (recruitment_status_normalized is
+	null), one key per `TrialRecruitmentStatus` bucket — `not_yet_recruiting`, `recruiting`,
+	`enrolling_by_invitation`, `active_not_recruiting`, `not_recruiting`, `suspended`,
+	`completed`, `terminated`, `withdrawn`, `unknown`, `other` (always present, 0 when
+	empty) — plus a `by_subject` breakdown (`[{subject_id, subject_name, count}]`, distinct
+	per trial, restricted to subjects visible to the caller) computed over the filtered
+	queryset. Buckets are counted on `recruitment_status_normalized`, the same canonical
+	vocabulary as the `recruitment_status_normalized` filter, not on the raw
+	`recruitment_status` string — see docs/trials-field-normalization.md. It accepts the
+	same query parameters as the list endpoint, so e.g.
+	`/trials/stats/?team_id=1&recruitment_status_normalized=recruiting` scopes the totals
+	exactly like the equivalent list request. Results are cached server-side for
+	STATS_CACHE_TTL seconds (default 600). **Breaking change:** the `stats` block that used
+	to be embedded in every paginated list response has moved here — list responses no
+	longer include it, and clients that relied on `response.data["stats"]` must call
+	`/trials/stats/` instead.
 
 	# Registry Identifier Parameters:
 	Each accepts one or more comma-separated values and returns trials matching *any* of them
@@ -1772,11 +1780,12 @@ class TrialViewSet(
 
 	@action(detail=False, methods=["get"], url_path="stats")
 	def stats(self, request):
-		"""Recruitment-status totals over the filtered queryset.
+		"""Recruitment-status totals (by ``recruitment_status_normalized``) over the
+		filtered queryset.
 
 		Accepts the same query parameters as the list endpoint (team_id,
-		subject_id, status, search, registry identifiers, …) and the same
-		org-visibility scoping, so the totals always match what the
+		subject_id, recruitment_status_normalized, search, registry identifiers, …)
+		and the same org-visibility scoping, so the totals always match what the
 		equivalent list request would return. Cached server-side; see
 		``CachedStatsActionMixin``.
 		"""
@@ -1785,35 +1794,28 @@ class TrialViewSet(
 	def build_stats_payload(self, filtered_qs):
 		# Single aggregation query — clear ordering to prevent GROUP BY pollution.
 		# distinct=True guards against double-counting a trial visible under two teams.
+		# Aggregates on recruitment_status_normalized (not the raw recruitment_status
+		# column): the raw column has dozens of per-registry spellings, so grouping on
+		# it directly would require re-deriving the same mapping trial_field_normalizers
+		# already owns. See docs/trials-field-normalization.md.
 		status_counts = {
-			item["recruitment_status"]: item["count"]
+			item["recruitment_status_normalized"]: item["count"]
 			for item in filtered_qs.order_by()
-			.values("recruitment_status")
+			.values("recruitment_status_normalized")
 			.annotate(count=Count("trial_id", distinct=True))
 		}
 
-		def _sum(*keys):
-			return sum(status_counts.get(k, 0) for k in keys)
-
-		return {
+		# Every canonical key is emitted even when its count is 0, so the frontend gets
+		# a stable shape. Iterate the enum rather than hardcoding the key list here —
+		# a bucket added to TrialRecruitmentStatus is picked up automatically.
+		payload = {
 			"total": sum(status_counts.values()),
 			"no_status": status_counts.get(None, 0),
-			"recruiting": _sum("Recruiting", "RECRUITING"),
-			"active_not_recruiting": _sum(
-				"ACTIVE_NOT_RECRUITING", "Not recruiting", "Not Recruiting"
-			),
-			"not_yet_recruiting": _sum("NOT_YET_RECRUITING"),
-			"completed": _sum("COMPLETED"),
-			"enrolling_by_invitation": _sum("ENROLLING_BY_INVITATION"),
-			"terminated": _sum("TERMINATED"),
-			"suspended": _sum("SUSPENDED"),
-			"withdrawn": _sum("WITHDRAWN"),
-			"available": _sum("AVAILABLE"),
-			"not_available": _sum("Not Available"),
-			"withheld": _sum("WITHHELD"),
-			"authorised": _sum("Authorised"),
-			"by_subject": self._by_subject_counts(filtered_qs),
 		}
+		for value in TrialRecruitmentStatus.values:
+			payload[value] = status_counts.get(value, 0)
+		payload["by_subject"] = self._by_subject_counts(filtered_qs)
+		return payload
 
 
 ###

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -167,7 +167,7 @@ GET /articles/?team_id=1&subjects=1,3&published_date_after=2022-06-01&format=csv
 | Teams | `GET /teams/{id}/subjects/{subject_id}/categories/` | `id`, `subject_id` (path) | |
 | Trials | `GET /trials/` | `team_id`, `subject_id`, `category_id`, `source_id`, `status`, `search`, `ordering`, trial-specific filters, pagination | See parameter details below |
 | Trials | `GET /trials/{id}/` | `id` (path) | |
-| Trials | `GET /trials/stats/` | Same filters as `GET /trials/` | Recruitment-status totals plus `by_subject` over the filtered set. Replaces the `stats` block formerly embedded in `GET /trials/` list responses (breaking change). Cached for `STATS_CACHE_TTL` seconds |
+| Trials | `GET /trials/stats/` | Same filters as `GET /trials/` | Totals per `recruitment_status_normalized` bucket (not_yet_recruiting, recruiting, enrolling_by_invitation, active_not_recruiting, not_recruiting, suspended, completed, terminated, withdrawn, unknown, other — always present, 0 when empty) plus `no_status` and `by_subject` over the filtered set. Replaces the `stats` block formerly embedded in `GET /trials/` list responses (breaking change). Cached for `STATS_CACHE_TTL` seconds |
 | Trials | `GET /trials/search/` | `team_id` *(req)*, `subject_id` *(req)*, `title`, `summary`, `search`, `status`, `format`, `all_results` | See [trial-search-api.md](trial-search-api.md) |
 | Trials | `POST /trials/search/` | Same fields in request body | |
 | Email templates | `GET /emails/` | None | Template preview dashboard |

--- a/docs/trials-field-normalization.md
+++ b/docs/trials-field-normalization.md
@@ -289,6 +289,14 @@ workflow above. Idempotent: rerunning after the DB is caught up updates nothing.
 4. Optional: review the OTHER list(s) the backfill prints, extend the relevant mapping
    table, deploy, rerun the backfill (or use the admin action) to pick up the new mappings.
 
+`GET /trials/stats/` (`TrialViewSet.build_stats_payload`) aggregates on
+`recruitment_status_normalized`, so its counts are only meaningful **after** step 3 runs.
+Before the backfill, every existing row has `recruitment_status_normalized = NULL` (the
+column doesn't get a value until `Trials.save()` or the backfill computes it), so the
+entire pre-backfill trial set shows up in the `no_status` bucket rather than
+`recruiting`/`completed`/etc. — expect `no_status` to hold the bulk of `total` immediately
+after migrating, until the backfill catches the table up.
+
 ## Extension recipe: study_type
 
 This design is meant to repeat directly for the next raw field with a messy multi-registry


### PR DESCRIPTION
## Problem (reported by the frontend team)

`GET /trials/stats/` grouped by the **raw** `recruitment_status` column and hand-rolled its own bucket mapping from hardcoded registry spellings — a second normalizer that diverged from the canonical vocabulary shipped in #765, so stats buckets didn't line up with the new `?recruitment_status_normalized=` list filter:

- `recruiting` missed EU CTIS `"Ongoing, recruiting"` and `"Authorised, recruiting"`
- WHO's generic `"Not recruiting"` was wrongly folded into `active_not_recruiting`
- `completed` missed CTIS `"Ended"`; `suspended` missed `"Temporarily halted"` / `TEMPORARILY_NOT_AVAILABLE`
- CT.gov `UNKNOWN` (1,760 rows in prod-shaped data) landed in **no bucket**, only in `total`
- ad-hoc keys `available` / `not_available` / `withheld` / `authorised` matched nothing in the canonical vocabulary

## Fix

`build_stats_payload` now aggregates on `recruitment_status_normalized` (same single query, distinct trial count) and emits one key per `TrialRecruitmentStatus` value, iterated from the enum so future buckets are picked up automatically. Stats totals now match the equivalent filtered list request exactly. `by_subject`, caching and org-visibility scoping are unchanged.

## ⚠️ Breaking payload change (frontend)

| | Keys |
|---|---|
| **Removed** | `available`, `not_available`, `withheld`, `authorised` (those trials now count under `other` / `unknown`) |
| **Added** | `not_recruiting`, `unknown`, `other` |
| **Unchanged** | `total`, `no_status`, `not_yet_recruiting`, `recruiting`, `enrolling_by_invitation`, `active_not_recruiting`, `suspended`, `completed`, `terminated`, `withdrawn`, `by_subject` |

All canonical keys are always present (0 when empty) for a stable shape.

Builds on the normalized fields that landed in #765. **Caveat:** counts are only meaningful after the one-time `backfill_trial_normalized_fields` run — before it, pre-existing rows have a null normalized value and show up in `no_status` (documented in `docs/trials-field-normalization.md`).

## Testing

Full suite: **1916 passed + 65 subtests, 0 failures** (+8 new tests: spelling variants converge into one bucket, WHO "Not recruiting" stays out of `active_not_recruiting`, `UNKNOWN` → `unknown`, `AVAILABLE` → `other`, null → `no_status`, stable key shape, and end-to-end filter scoping via `?recruitment_status_normalized=` and `?phase_normalized=` on the stats endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)