### PR TITLE
Fix DOI pipeline: extract DOIs from URLs, PubMed API, and backfill

### DIFF
--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -14,7 +14,7 @@ import logging
 from simple_history.admin import SimpleHistoryAdmin  # Import SimpleHistoryAdmin
 from .admin_filters import DateRangeFilter, SourceHealthFilter
 from django.db import models, transaction  # Add this import for models.Count
-from django.db.models import OuterRef, Subquery
+from django.db.models import OuterRef, Q, Subquery
 from django.utils import timezone
 from django import forms
 from django.utils.html import format_html, mark_safe
@@ -643,6 +643,26 @@ class ArticleAdminForm(forms.ModelForm):
 				)
 
 
+class DoiAssignedFilter(admin.SimpleListFilter):
+	"""Filter articles by whether they carry a DOI (articles-missing-doi audit)."""
+
+	title = "DOI assigned"
+	parameter_name = "doi_assigned"
+
+	def lookups(self, request, model_admin):
+		return (
+			("yes", "Yes"),
+			("no", "No"),
+		)
+
+	def queryset(self, request, queryset):
+		if self.value() == "no":
+			return queryset.filter(Q(doi__isnull=True) | Q(doi=""))
+		if self.value() == "yes":
+			return queryset.exclude(Q(doi__isnull=True) | Q(doi=""))
+		return queryset
+
+
 class ArticleAdmin(OrganizationFilterMixin, SourceBulkActionMixin, SimpleHistoryAdmin):
 	form = ArticleAdminForm
 	source_for_values = ["science paper", "news article"]
@@ -711,6 +731,7 @@ class ArticleAdmin(OrganizationFilterMixin, SourceBulkActionMixin, SimpleHistory
 		("teams", OrganizationRestrictedFieldListFilter),
 		("subjects", OrganizationRestrictedFieldListFilter),
 		("sources", OrganizationRestrictedFieldListFilter),
+		DoiAssignedFilter,
 	]
 	raw_id_fields = ("authors",)
 

--- a/django/gregory/management/commands/backfill_missing_doi.py
+++ b/django/gregory/management/commands/backfill_missing_doi.py
@@ -78,7 +78,9 @@ class Command(BaseCommand):
 			.filter(Q(doi__isnull=True) | Q(doi=""))
 			.order_by("article_id")
 		)
-		if limit:
+		# `is not None` (not truthiness): --limit 0 must select zero rows, not
+		# fall through to the full queryset.
+		if limit is not None:
 			queryset = queryset[:limit]
 
 		articles = list(queryset)

--- a/django/gregory/management/commands/backfill_missing_doi.py
+++ b/django/gregory/management/commands/backfill_missing_doi.py
@@ -1,0 +1,169 @@
+"""
+One-time backfill for the ~747 science-paper articles ingested without a DOI
+before the ingestion fix (articles-missing-doi). Investigation found three
+buckets:
+
+  - ~226 have the DOI literally embedded in the article URL (Springer, PNAS,
+    doi.org/dx.doi.org redirects, ...).
+  - ~166 are PubMed links whose DOI can be resolved via the PMID through NCBI
+    E-utilities.
+  - ~355 are repositories/theses with genuinely no DOI (out of scope; these
+    land in the "not found" bucket and are left alone).
+
+For each DOI-less ``kind="science paper"`` article, tries in order:
+  1. ``extract_doi_from_url(article.link)``
+  2. the PubMed PMID -> DOI API, for pubmed.ncbi.nlm.nih.gov links
+  3. the existing CrossRef title search (``gregory.functions.get_doi``)
+
+A found DOI is assigned through ``assign_doi_or_merge`` (the same
+collision-safe guard ``find_doi`` uses) so a DOI that another article already
+holds merges the two rows instead of tripping the unique constraint.
+
+Selection deliberately ignores the ``doi_lookup_next_check`` backoff used by
+``find_doi`` -- most of these 747 rows have already exhausted their CrossRef
+title-search retries and would otherwise never be picked up again.
+
+Run:
+	docker exec gregory python manage.py backfill_missing_doi --dry-run
+	docker exec gregory python manage.py backfill_missing_doi --limit 50
+	docker exec gregory python manage.py backfill_missing_doi
+"""
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import Q
+
+import gregory.functions as greg
+from gregory.models import Articles
+from gregory.services.article_merge import assign_doi_or_merge
+from gregory.utils.doi_utils import extract_doi_from_url, resolve_doi_from_pubmed_url
+from gregory.utils.enrichment import clear_marker
+
+METHOD_LABELS = {
+	"url": "Resolved via URL",
+	"pubmed": "Resolved via PubMed",
+	"crossref": "Resolved via CrossRef",
+	"not_found": "Not found",
+}
+
+
+class Command(BaseCommand):
+	help = (
+		"Backfill missing DOIs for science-paper articles, trying the article "
+		"URL, the PubMed PMID API, and a CrossRef title search in that order."
+	)
+
+	def add_arguments(self, parser):
+		parser.add_argument(
+			"--dry-run",
+			action="store_true",
+			help="Report what would be assigned without writing to the database.",
+		)
+		parser.add_argument(
+			"--limit",
+			type=int,
+			default=None,
+			help="Only process the first N matching articles (useful for testing).",
+		)
+
+	def handle(self, *args, **options):
+		dry_run = options["dry_run"]
+		limit = options["limit"]
+
+		# due_filter is deliberately NOT applied: most of these rows have
+		# already exhausted their find_doi backoff and would never be
+		# reselected otherwise.
+		queryset = (
+			Articles.objects.filter(kind="science paper")
+			.filter(Q(doi__isnull=True) | Q(doi=""))
+			.order_by("article_id")
+		)
+		if limit:
+			queryset = queryset[:limit]
+
+		articles = list(queryset)
+		counts = {"url": 0, "pubmed": 0, "crossref": 0, "not_found": 0}
+
+		for article in articles:
+			doi, method = self._resolve_doi(article)
+
+			if not doi:
+				counts["not_found"] += 1
+				self.log(f"[not found] article {article.article_id}: {article.title}")
+				continue
+
+			counts[method] += 1
+
+			if dry_run:
+				self.stdout.write(
+					self.style.SUCCESS(
+						f"[dry-run:{method}] article {article.article_id} "
+						f"({article.title}) -> {doi}"
+					)
+				)
+				continue
+
+			with transaction.atomic():
+				# save=False so the DOI and the cleared backoff marker persist
+				# in a single save on the no-collision path, mirroring find_doi.
+				survivor, merged = assign_doi_or_merge(article, doi, save=False)
+				clear_marker(survivor, "doi_lookup", save=False)
+				survivor.save()
+
+			if merged:
+				self.stdout.write(
+					self.style.WARNING(
+						f"[{method}] article {article.article_id}: DOI {doi} already "
+						f"existed -- merged into article {survivor.article_id}."
+					)
+				)
+			else:
+				self.stdout.write(
+					self.style.SUCCESS(
+						f"[{method}] article {survivor.article_id}: assigned DOI {doi}."
+					)
+				)
+
+		self._print_summary(counts, dry_run)
+
+	def _resolve_doi(self, article):
+		"""Try each resolution method in order. Returns (doi, method_key) or (None, None)."""
+		doi = extract_doi_from_url(article.link)
+		if doi:
+			return doi, "url"
+
+		if article.link and "pubmed.ncbi.nlm.nih.gov" in article.link.lower():
+			doi = resolve_doi_from_pubmed_url(article.link)
+			if doi:
+				return doi, "pubmed"
+
+		try:
+			doi = greg.get_doi(article.title)
+		except Exception as e:
+			self.stdout.write(
+				self.style.WARNING(
+					f"CrossRef lookup failed for article {article.article_id} "
+					f"('{article.title}'): {e}. Skipping."
+				)
+			)
+			doi = None
+		if doi:
+			return doi, "crossref"
+
+		return None, None
+
+	def log(self, message):
+		self.stdout.write(message)
+
+	def _print_summary(self, counts, dry_run):
+		self.stdout.write("")
+		self.stdout.write(self.style.MIGRATE_HEADING("Summary"))
+		for key in ("url", "pubmed", "crossref", "not_found"):
+			self.stdout.write(f"  {METHOD_LABELS[key]}: {counts[key]}")
+		total_resolved = counts["url"] + counts["pubmed"] + counts["crossref"]
+		self.stdout.write(f"  Total resolved: {total_resolved}")
+		self.stdout.write(f"  Total processed: {total_resolved + counts['not_found']}")
+		if dry_run:
+			self.stdout.write(
+				self.style.WARNING("Dry run -- no changes were written to the database.")
+			)

--- a/django/gregory/management/commands/feedreader_articles.py
+++ b/django/gregory/management/commands/feedreader_articles.py
@@ -10,6 +10,7 @@ from django.db import transaction
 from django.utils import timezone
 from gregory.classes import SciencePaper
 from gregory.services.article_merge import assign_doi_or_merge
+from gregory.utils.doi_utils import extract_doi_from_url, resolve_doi_from_pubmed_url
 from gregory.utils.registry_utils import merge_links
 from sitesettings.models import CustomSetting
 import feedparser
@@ -72,6 +73,22 @@ class FeedProcessor(ABC):
 	def extract_doi(self, entry: dict) -> str:
 		"""Extract DOI from feed entry."""
 		pass
+
+	def extract_doi_with_fallback(self, entry: dict) -> Optional[str]:
+		"""Resolve the DOI for an entry, falling back to the article URL.
+
+		Every subclass implements ``extract_doi`` against its own feed-specific
+		field (dc:identifier, guid, prism:doi, ...). When that yields nothing —
+		notably every entry routed to ``DefaultFeedProcessor``, whose
+		``extract_doi`` always returns ``None`` — fall back to pulling a DOI
+		straight out of the entry's link (e.g. doi.org redirects, or publisher
+		URLs with the DOI embedded in the path). This is a concrete method on
+		the base class so every processor benefits without overriding anything.
+		"""
+		doi = self.extract_doi(entry)
+		if doi:
+			return doi
+		return extract_doi_from_url(entry.get("link"))
 
 	def extract_basic_fields(self, entry: dict) -> dict:
 		"""Extract common fields that are the same across all feed types."""
@@ -169,10 +186,17 @@ class PubMedFeedProcessor(FeedProcessor):
 		return summary
 
 	def extract_doi(self, entry: dict) -> str:
-		"""Extract DOI from PubMed feed entry."""
-		if entry.get("dc_identifier", "").startswith("doi:"):
-			return entry["dc_identifier"].replace("doi:", "")
-		return None
+		"""Extract DOI from PubMed feed entry.
+
+		Primary source is ``dc:identifier`` (``doi:10.xxxx/...``). When that's
+		absent — many PubMed RSS entries don't carry it — fall back to
+		resolving the DOI from the PMID in the entry's link via NCBI
+		E-utilities (see ``gregory.utils.doi_utils.resolve_doi_from_pubmed_url``).
+		"""
+		dc_identifier = entry.get("dc_identifier") or ""
+		if dc_identifier.startswith("doi:"):
+			return dc_identifier.replace("doi:", "")
+		return resolve_doi_from_pubmed_url(entry.get("link"))
 
 
 class FasebFeedProcessor(FeedProcessor):
@@ -607,7 +631,7 @@ class Command(GregoryBaseCommand):
 		if (processor.extract_summary(entry) or "").strip():
 			# The filter already saw a real summary; the exclusion is final.
 			return False, None
-		doi = processor.extract_doi(entry)
+		doi = processor.extract_doi_with_fallback(entry)
 		if not doi:
 			return False, None
 
@@ -649,7 +673,7 @@ class Command(GregoryBaseCommand):
 
 		# Extract feed-specific fields
 		raw_summary = processor.extract_summary(entry)
-		doi = processor.extract_doi(entry)
+		doi = processor.extract_doi_with_fallback(entry)
 
 		# Clean and store the original feed summary
 		feed_summary = (

--- a/django/gregory/tests/management/test_backfill_missing_doi.py
+++ b/django/gregory/tests/management/test_backfill_missing_doi.py
@@ -167,6 +167,21 @@ class BackfillMissingDoiCommandTest(TestCase):
 		output = out.getvalue()
 		self.assertIn("Total processed: 1", output)
 
+	def test_limit_zero_processes_no_rows(self):
+		# --limit 0 must select zero rows, not fall through to the full queryset.
+		out = StringIO()
+		with patch(PUBMED_RESOLVE_TARGET, return_value=None), patch(
+			GET_DOI_TARGET, return_value=None
+		):
+			call_command(
+				"backfill_missing_doi", "--dry-run", "--limit", "0", stdout=out
+			)
+		output = out.getvalue()
+		self.assertIn("Total processed: 0", output)
+		# Nothing was written or even attempted.
+		self.url_case.refresh_from_db()
+		self.assertFalse(self.url_case.doi)
+
 	def test_crossref_network_failure_is_caught_and_counted_as_not_found(self):
 		out = StringIO()
 		with patch(PUBMED_RESOLVE_TARGET, return_value=None), patch(

--- a/django/gregory/tests/management/test_backfill_missing_doi.py
+++ b/django/gregory/tests/management/test_backfill_missing_doi.py
@@ -1,0 +1,201 @@
+"""
+Tests for the backfill_missing_doi management command (articles-missing-doi
+fix, phase 2).
+
+All network calls (PubMed E-utilities, CrossRef) are mocked -- these tests
+never hit a real external API.
+
+Run:
+	docker exec gregory python manage.py test gregory.tests.management.test_backfill_missing_doi
+"""
+
+import os
+from io import StringIO
+from unittest.mock import patch
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+django.setup()
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from gregory.models import Articles
+
+GET_DOI_TARGET = "gregory.management.commands.backfill_missing_doi.greg.get_doi"
+PUBMED_RESOLVE_TARGET = (
+	"gregory.management.commands.backfill_missing_doi.resolve_doi_from_pubmed_url"
+)
+
+
+class BackfillMissingDoiCommandTest(TestCase):
+	def setUp(self):
+		# Bucket 1: DOI embedded in a Springer article URL.
+		self.url_case = Articles.objects.create(
+			title="Springer article with URL DOI",
+			link="https://link.springer.com/article/10.1007/s10484-026-09800-x",
+			kind="science paper",
+		)
+		# Bucket 1b: DOI embedded via a doi.org resolver link.
+		self.doi_org_case = Articles.objects.create(
+			title="DOI resolver link",
+			link="https://doi.org/10.3109/some.identifier",
+			kind="science paper",
+		)
+		# Bucket 2: PubMed link, resolved via PMID.
+		self.pubmed_case = Articles.objects.create(
+			title="PubMed article",
+			link="https://pubmed.ncbi.nlm.nih.gov/38812345/",
+			kind="science paper",
+		)
+		# Bucket 3: no URL/PubMed signal, resolved via CrossRef title search.
+		self.crossref_case = Articles.objects.create(
+			title="Repository entry resolvable via CrossRef",
+			link="https://hdl.handle.net/10520/EJC-1234abcd",
+			kind="science paper",
+		)
+		# Bucket 4: genuinely no DOI anywhere.
+		self.not_found_case = Articles.objects.create(
+			title="Genuinely DOI-less thesis",
+			link="https://hdl.handle.net/10520/EJC-9999zzzz",
+			kind="science paper",
+		)
+		# Control: already has a DOI, must never be touched.
+		self.has_doi_case = Articles.objects.create(
+			title="Already has a DOI",
+			link="https://example.com/already-has-doi",
+			doi="10.9999/already-has-doi",
+			kind="science paper",
+		)
+		# Control: not a science paper, must be excluded from selection.
+		self.news_case = Articles.objects.create(
+			title="A news article",
+			link="https://hdl.handle.net/10520/EJC-news",
+			kind="news article",
+		)
+
+	def _crossref_side_effect(self, title):
+		if title == self.crossref_case.title:
+			return "10.5555/crossref-resolved"
+		return None
+
+	def run_command(self, *extra_args):
+		out = StringIO()
+		with patch(
+			PUBMED_RESOLVE_TARGET,
+			side_effect=lambda link: (
+				"10.1234/pubmed-resolved"
+				if "38812345" in (link or "")
+				else None
+			),
+		), patch(GET_DOI_TARGET, side_effect=self._crossref_side_effect):
+			call_command("backfill_missing_doi", *extra_args, stdout=out)
+		return out.getvalue()
+
+	def test_resolves_url_embedded_doi(self):
+		self.run_command()
+		self.url_case.refresh_from_db()
+		self.assertEqual(
+			self.url_case.doi, "10.1007/s10484-026-09800-x"
+		)
+
+	def test_resolves_doi_org_resolver_link(self):
+		self.run_command()
+		self.doi_org_case.refresh_from_db()
+		self.assertEqual(self.doi_org_case.doi, "10.3109/some.identifier")
+
+	def test_resolves_pubmed_via_pmid(self):
+		self.run_command()
+		self.pubmed_case.refresh_from_db()
+		self.assertEqual(self.pubmed_case.doi, "10.1234/pubmed-resolved")
+
+	def test_resolves_via_crossref_title_search_as_last_resort(self):
+		self.run_command()
+		self.crossref_case.refresh_from_db()
+		self.assertEqual(self.crossref_case.doi, "10.5555/crossref-resolved")
+
+	def test_leaves_genuinely_doi_less_article_untouched(self):
+		self.run_command()
+		self.not_found_case.refresh_from_db()
+		self.assertFalse(self.not_found_case.doi)
+
+	def test_does_not_touch_article_that_already_has_a_doi(self):
+		self.run_command()
+		self.has_doi_case.refresh_from_db()
+		self.assertEqual(self.has_doi_case.doi, "10.9999/already-has-doi")
+
+	def test_excludes_non_science_paper_kind(self):
+		self.run_command()
+		self.news_case.refresh_from_db()
+		self.assertFalse(self.news_case.doi)
+
+	def test_dry_run_does_not_write(self):
+		self.run_command("--dry-run")
+		self.url_case.refresh_from_db()
+		self.doi_org_case.refresh_from_db()
+		self.pubmed_case.refresh_from_db()
+		self.crossref_case.refresh_from_db()
+		self.assertFalse(self.url_case.doi)
+		self.assertFalse(self.doi_org_case.doi)
+		self.assertFalse(self.pubmed_case.doi)
+		self.assertFalse(self.crossref_case.doi)
+
+	def test_dry_run_reports_summary(self):
+		output = self.run_command("--dry-run")
+		self.assertIn("Resolved via URL: 2", output)
+		self.assertIn("Resolved via PubMed: 1", output)
+		self.assertIn("Resolved via CrossRef: 1", output)
+		self.assertIn("Not found: 1", output)
+		self.assertIn("Dry run", output)
+
+	def test_summary_counts_on_real_run(self):
+		output = self.run_command()
+		self.assertIn("Resolved via URL: 2", output)
+		self.assertIn("Resolved via PubMed: 1", output)
+		self.assertIn("Resolved via CrossRef: 1", output)
+		self.assertIn("Not found: 1", output)
+
+	def test_limit_option_restricts_batch_size(self):
+		out = StringIO()
+		with patch(PUBMED_RESOLVE_TARGET, return_value=None), patch(
+			GET_DOI_TARGET, return_value=None
+		):
+			call_command(
+				"backfill_missing_doi", "--dry-run", "--limit", "1", stdout=out
+			)
+		output = out.getvalue()
+		self.assertIn("Total processed: 1", output)
+
+	def test_crossref_network_failure_is_caught_and_counted_as_not_found(self):
+		out = StringIO()
+		with patch(PUBMED_RESOLVE_TARGET, return_value=None), patch(
+			GET_DOI_TARGET, side_effect=ConnectionError("network down")
+		):
+			call_command("backfill_missing_doi", "--dry-run", stdout=out)
+		output = out.getvalue()
+		self.assertIn("CrossRef lookup failed", output)
+
+	def test_collision_merges_into_existing_article(self):
+		"""If the resolved DOI already belongs to another article, the rows
+		merge instead of tripping the unique constraint (assign_doi_or_merge)."""
+		Articles.objects.create(
+			title="Existing article with the same DOI",
+			link="https://example.com/existing",
+			doi="10.1007/s10484-026-09800-x",
+			kind="science paper",
+		)
+		out = StringIO()
+		with patch(PUBMED_RESOLVE_TARGET, return_value=None), patch(
+			GET_DOI_TARGET, return_value=None
+		):
+			call_command(
+				"backfill_missing_doi",
+				"--limit",
+				"1000",
+				stdout=out,
+			)
+		# The url_case article should have been merged away (or itself survive
+		# and hold the DOI) -- either way exactly one article holds the DOI.
+		matches = Articles.objects.filter(doi__iexact="10.1007/s10484-026-09800-x")
+		self.assertEqual(matches.count(), 1)

--- a/django/gregory/tests/test_doi_assigned_filter.py
+++ b/django/gregory/tests/test_doi_assigned_filter.py
@@ -1,0 +1,81 @@
+"""
+Tests for the "DOI assigned" admin list filter (articles-missing-doi, phase 3).
+
+Run:
+	docker exec gregory python manage.py test gregory.tests.test_doi_assigned_filter
+"""
+
+import os
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+django.setup()
+
+from django.test import TestCase
+
+from gregory.admin import ArticleAdmin, DoiAssignedFilter
+from gregory.models import Articles
+
+
+class DoiAssignedFilterTests(TestCase):
+	def setUp(self):
+		self.with_doi = Articles.objects.create(
+			title="Has a DOI",
+			link="https://example.com/with-doi",
+			doi="10.1234/example",
+			kind="science paper",
+		)
+		self.with_empty_doi = Articles.objects.create(
+			title="Empty string DOI",
+			link="https://example.com/empty-doi",
+			doi="",
+			kind="science paper",
+		)
+		self.without_doi = Articles.objects.create(
+			title="No DOI",
+			link="https://example.com/no-doi",
+			doi=None,
+			kind="science paper",
+		)
+
+	def test_lookups_are_yes_no(self):
+		filter_instance = DoiAssignedFilter(
+			request=None, params={}, model=Articles, model_admin=ArticleAdmin
+		)
+		self.assertEqual(
+			filter_instance.lookups(None, None), (("yes", "Yes"), ("no", "No"))
+		)
+
+	def test_no_filters_to_null_or_empty_doi(self):
+		filter_instance = DoiAssignedFilter(
+			request=None,
+			params={"doi_assigned": ["no"]},
+			model=Articles,
+			model_admin=ArticleAdmin,
+		)
+		result = filter_instance.queryset(None, Articles.objects.all())
+		self.assertIn(self.with_empty_doi, result)
+		self.assertIn(self.without_doi, result)
+		self.assertNotIn(self.with_doi, result)
+
+	def test_yes_filters_to_articles_with_a_doi(self):
+		filter_instance = DoiAssignedFilter(
+			request=None,
+			params={"doi_assigned": ["yes"]},
+			model=Articles,
+			model_admin=ArticleAdmin,
+		)
+		result = filter_instance.queryset(None, Articles.objects.all())
+		self.assertIn(self.with_doi, result)
+		self.assertNotIn(self.with_empty_doi, result)
+		self.assertNotIn(self.without_doi, result)
+
+	def test_registered_on_article_admin(self):
+		self.assertIn(DoiAssignedFilter, ArticleAdmin.list_filter)
+
+	def test_no_value_returns_full_queryset(self):
+		filter_instance = DoiAssignedFilter(
+			request=None, params={}, model=Articles, model_admin=ArticleAdmin
+		)
+		result = filter_instance.queryset(None, Articles.objects.all())
+		self.assertEqual(result.count(), Articles.objects.count())

--- a/django/gregory/tests/test_doi_assigned_filter.py
+++ b/django/gregory/tests/test_doi_assigned_filter.py
@@ -47,12 +47,17 @@ class DoiAssignedFilterTests(TestCase):
 		)
 
 	def test_no_filters_to_null_or_empty_doi(self):
+		# Django's SimpleListFilter takes params as lists and stores value[-1],
+		# so a single-element list is the correct request shape here; assert
+		# value() resolves to the scalar "no" to prove the branch is exercised
+		# (rather than silently short-circuiting on an unexpected value).
 		filter_instance = DoiAssignedFilter(
 			request=None,
 			params={"doi_assigned": ["no"]},
 			model=Articles,
 			model_admin=ArticleAdmin,
 		)
+		self.assertEqual(filter_instance.value(), "no")
 		result = filter_instance.queryset(None, Articles.objects.all())
 		self.assertIn(self.with_empty_doi, result)
 		self.assertIn(self.without_doi, result)
@@ -65,6 +70,7 @@ class DoiAssignedFilterTests(TestCase):
 			model=Articles,
 			model_admin=ArticleAdmin,
 		)
+		self.assertEqual(filter_instance.value(), "yes")
 		result = filter_instance.queryset(None, Articles.objects.all())
 		self.assertIn(self.with_doi, result)
 		self.assertNotIn(self.with_empty_doi, result)

--- a/django/gregory/tests/test_doi_utils.py
+++ b/django/gregory/tests/test_doi_utils.py
@@ -1,0 +1,236 @@
+"""
+Tests for gregory.utils.doi_utils: URL-based DOI extraction and the PubMed
+PMID -> DOI resolver.
+
+Run:
+	docker exec gregory python manage.py test gregory.tests.test_doi_utils
+"""
+
+import os
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+django.setup()
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from gregory.utils.doi_utils import (
+	extract_doi_from_url,
+	extract_pmid_from_url,
+	resolve_doi_from_pmid,
+	resolve_doi_from_pubmed_url,
+)
+
+
+class ExtractDoiFromUrlTests(TestCase):
+	"""Positive cases: URLs that should yield a DOI."""
+
+	def test_springer_article_url(self):
+		url = "https://link.springer.com/article/10.1007/s10484-026-09800-x"
+		self.assertEqual(
+			extract_doi_from_url(url), "10.1007/s10484-026-09800-x"
+		)
+
+	def test_doi_org_resolver(self):
+		url = "https://doi.org/10.3109/some.identifier"
+		self.assertEqual(
+			extract_doi_from_url(url), "10.3109/some.identifier"
+		)
+
+	def test_dx_doi_org_resolver(self):
+		url = "https://dx.doi.org/10.3109/another.identifier"
+		self.assertEqual(
+			extract_doi_from_url(url), "10.3109/another.identifier"
+		)
+
+	def test_doi_org_resolver_with_www(self):
+		url = "https://www.doi.org/10.1000/xyz"
+		self.assertEqual(extract_doi_from_url(url), "10.1000/xyz")
+
+	def test_pnas_doi_abs_with_query_string(self):
+		url = "https://www.pnas.org/doi/abs/10.1073/pnas.2422928122?af=R"
+		self.assertEqual(
+			extract_doi_from_url(url), "10.1073/pnas.2422928122"
+		)
+
+	def test_doi_with_trailing_slash(self):
+		url = "https://doi.org/10.1007/s00332-025-10234-8/"
+		self.assertEqual(
+			extract_doi_from_url(url), "10.1007/s00332-025-10234-8"
+		)
+
+	def test_doi_with_trailing_fragment(self):
+		url = "https://link.springer.com/article/10.1007/s10484-026-09800-x#section"
+		self.assertEqual(
+			extract_doi_from_url(url), "10.1007/s10484-026-09800-x"
+		)
+
+	def test_doi_is_lowercased(self):
+		url = "https://doi.org/10.1007/S10484-026-09800-X"
+		self.assertEqual(
+			extract_doi_from_url(url), "10.1007/s10484-026-09800-x"
+		)
+
+	def test_doi_embedded_with_other_query_params(self):
+		url = "https://example.com/content/10.1177/21582440251334940?ai=2b4&mi=x"
+		self.assertEqual(
+			extract_doi_from_url(url), "10.1177/21582440251334940"
+		)
+
+
+class ExtractDoiFromUrlNegativeTests(TestCase):
+	"""Negative cases: repository URLs with no DOI must return None."""
+
+	def test_hdl_handle_net(self):
+		url = "https://hdl.handle.net/10520/EJC-1234abcd"
+		self.assertIsNone(extract_doi_from_url(url))
+
+	def test_arxiv(self):
+		url = "https://arxiv.org/abs/2501.12345"
+		self.assertIsNone(extract_doi_from_url(url))
+
+	def test_hal_science(self):
+		url = "https://hal.science/hal-04123456"
+		self.assertIsNone(extract_doi_from_url(url))
+
+	def test_escholarship(self):
+		url = "https://escholarship.org/uc/item/1a2b3c4d"
+		self.assertIsNone(extract_doi_from_url(url))
+
+	def test_empty_url(self):
+		self.assertIsNone(extract_doi_from_url(""))
+
+	def test_none_url(self):
+		self.assertIsNone(extract_doi_from_url(None))
+
+	def test_plain_url_no_doi(self):
+		self.assertIsNone(extract_doi_from_url("https://example.com/some/page"))
+
+
+class ExtractPmidFromUrlTests(TestCase):
+	def test_extracts_pmid(self):
+		self.assertEqual(
+			extract_pmid_from_url("https://pubmed.ncbi.nlm.nih.gov/38812345/"),
+			"38812345",
+		)
+
+	def test_no_trailing_slash(self):
+		self.assertEqual(
+			extract_pmid_from_url("https://pubmed.ncbi.nlm.nih.gov/38812345"),
+			"38812345",
+		)
+
+	def test_no_pmid_in_non_pubmed_url(self):
+		self.assertIsNone(extract_pmid_from_url("https://example.com/article/1"))
+
+	def test_empty_url(self):
+		self.assertIsNone(extract_pmid_from_url(""))
+
+	def test_none_url(self):
+		self.assertIsNone(extract_pmid_from_url(None))
+
+
+class ResolveDoiFromPmidTests(TestCase):
+	"""All network calls mocked -- never hit the real NCBI API in tests."""
+
+	def _mock_response(self, payload, status_ok=True):
+		response = MagicMock()
+		response.json.return_value = payload
+		if not status_ok:
+			response.raise_for_status.side_effect = Exception("HTTP error")
+		return response
+
+	def test_resolves_doi_from_esummary_payload(self):
+		payload = {
+			"result": {
+				"38812345": {
+					"articleids": [
+						{"idtype": "pubmed", "value": "38812345"},
+						{"idtype": "doi", "value": "10.1234/example.doi"},
+					]
+				}
+			}
+		}
+		with patch(
+			"gregory.utils.doi_utils.requests.get",
+			return_value=self._mock_response(payload),
+		) as mock_get:
+			doi = resolve_doi_from_pmid("38812345")
+		self.assertEqual(doi, "10.1234/example.doi")
+		mock_get.assert_called_once()
+		_, kwargs = mock_get.call_args
+		self.assertEqual(kwargs["params"]["id"], "38812345")
+		self.assertEqual(kwargs["params"]["db"], "pubmed")
+
+	def test_no_doi_in_articleids(self):
+		payload = {
+			"result": {
+				"38812345": {
+					"articleids": [{"idtype": "pubmed", "value": "38812345"}]
+				}
+			}
+		}
+		with patch(
+			"gregory.utils.doi_utils.requests.get",
+			return_value=self._mock_response(payload),
+		):
+			doi = resolve_doi_from_pmid("38812345")
+		self.assertIsNone(doi)
+
+	def test_network_failure_returns_none(self):
+		with patch(
+			"gregory.utils.doi_utils.requests.get",
+			side_effect=ConnectionError("network down"),
+		):
+			doi = resolve_doi_from_pmid("38812345")
+		self.assertIsNone(doi)
+
+	def test_http_error_returns_none(self):
+		with patch(
+			"gregory.utils.doi_utils.requests.get",
+			return_value=self._mock_response({}, status_ok=False),
+		):
+			doi = resolve_doi_from_pmid("38812345")
+		self.assertIsNone(doi)
+
+	def test_malformed_payload_returns_none(self):
+		with patch(
+			"gregory.utils.doi_utils.requests.get",
+			return_value=self._mock_response({"unexpected": "shape"}),
+		):
+			doi = resolve_doi_from_pmid("38812345")
+		self.assertIsNone(doi)
+
+	def test_empty_pmid_short_circuits_without_network_call(self):
+		with patch("gregory.utils.doi_utils.requests.get") as mock_get:
+			doi = resolve_doi_from_pmid("")
+		self.assertIsNone(doi)
+		mock_get.assert_not_called()
+
+
+class ResolveDoiFromPubmedUrlTests(TestCase):
+	def test_full_pipeline(self):
+		payload = {
+			"result": {
+				"38812345": {
+					"articleids": [{"idtype": "doi", "value": "10.1234/example.doi"}]
+				}
+			}
+		}
+		response = MagicMock()
+		response.json.return_value = payload
+		with patch(
+			"gregory.utils.doi_utils.requests.get", return_value=response
+		):
+			doi = resolve_doi_from_pubmed_url(
+				"https://pubmed.ncbi.nlm.nih.gov/38812345/"
+			)
+		self.assertEqual(doi, "10.1234/example.doi")
+
+	def test_non_pubmed_url_short_circuits_without_network_call(self):
+		with patch("gregory.utils.doi_utils.requests.get") as mock_get:
+			doi = resolve_doi_from_pubmed_url("https://example.com/article/1")
+		self.assertIsNone(doi)
+		mock_get.assert_not_called()

--- a/django/gregory/tests/test_doi_utils.py
+++ b/django/gregory/tests/test_doi_utils.py
@@ -19,9 +19,30 @@ from django.test import TestCase
 from gregory.utils.doi_utils import (
 	extract_doi_from_url,
 	extract_pmid_from_url,
+	normalize_doi,
 	resolve_doi_from_pmid,
 	resolve_doi_from_pubmed_url,
 )
+
+
+class NormalizeDoiTests(TestCase):
+	def test_lowercases(self):
+		self.assertEqual(normalize_doi("10.1234/ABC-XYZ"), "10.1234/abc-xyz")
+
+	def test_strips_trailing_slash(self):
+		self.assertEqual(normalize_doi("10.1234/abc/"), "10.1234/abc")
+
+	def test_strips_trailing_punctuation(self):
+		self.assertEqual(normalize_doi("10.1234/abc)."), "10.1234/abc")
+
+	def test_strips_surrounding_whitespace(self):
+		self.assertEqual(normalize_doi("  10.1234/abc  "), "10.1234/abc")
+
+	def test_none_returns_none(self):
+		self.assertIsNone(normalize_doi(None))
+
+	def test_empty_returns_none(self):
+		self.assertIsNone(normalize_doi(""))
 
 
 class ExtractDoiFromUrlTests(TestCase):
@@ -163,6 +184,25 @@ class ResolveDoiFromPmidTests(TestCase):
 		_, kwargs = mock_get.call_args
 		self.assertEqual(kwargs["params"]["id"], "38812345")
 		self.assertEqual(kwargs["params"]["db"], "pubmed")
+
+	def test_resolved_doi_is_normalized(self):
+		# The esummary API can return mixed-case or trailing-noise DOIs; the
+		# stored value must match the canonical form extract_doi_from_url yields.
+		payload = {
+			"result": {
+				"38812345": {
+					"articleids": [
+						{"idtype": "doi", "value": "10.1234/Example.DOI "},
+					]
+				}
+			}
+		}
+		with patch(
+			"gregory.utils.doi_utils.requests.get",
+			return_value=self._mock_response(payload),
+		):
+			doi = resolve_doi_from_pmid("38812345")
+		self.assertEqual(doi, "10.1234/example.doi")
 
 	def test_no_doi_in_articleids(self):
 		payload = {

--- a/django/gregory/tests/test_feedreader_doi_fallback.py
+++ b/django/gregory/tests/test_feedreader_doi_fallback.py
@@ -1,0 +1,186 @@
+"""
+Tests for the base FeedProcessor URL-based DOI fallback and the PubMed PMID
+fallback (articles-missing-doi fix).
+
+Covers:
+  - FeedProcessor.extract_doi_with_fallback uses the subclass extract_doi
+    result when present, and falls back to extract_doi_from_url otherwise
+  - DefaultFeedProcessor-routed entries (the majority of the 226
+    URL-embedded-DOI bucket) now resolve a DOI via the link
+  - PubMedFeedProcessor.extract_doi resolves via PMID when dc:identifier is
+    absent, and never calls the network when dc:identifier is present
+  - process_feed_entry uses the fallback-aware extraction
+
+Run:
+	docker exec gregory python manage.py test gregory.tests.test_feedreader_doi_fallback
+"""
+
+import os
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+django.setup()
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from gregory.management.commands.feedreader_articles import (
+	Command,
+	DefaultFeedProcessor,
+	PubMedFeedProcessor,
+	SpringerLinkFeedProcessor,
+)
+
+
+class ExtractDoiWithFallbackTests(TestCase):
+	def setUp(self):
+		self.mock_command = MagicMock()
+
+	def test_uses_subclass_result_when_present(self):
+		processor = SpringerLinkFeedProcessor(self.mock_command)
+		entry = {
+			"id": "10.1007/s00332-025-10234-8",
+			"link": "https://link.springer.com/article/10.1007/s00332-025-10234-8",
+		}
+		self.assertEqual(
+			processor.extract_doi_with_fallback(entry),
+			"10.1007/s00332-025-10234-8",
+		)
+
+	def test_falls_back_to_url_when_subclass_yields_nothing(self):
+		# DefaultFeedProcessor.extract_doi always returns None -- this is the
+		# processor that every URL-embedded-DOI-but-unrecognized-feed article
+		# (the 226-article bucket) was routed through.
+		processor = DefaultFeedProcessor(self.mock_command)
+		entry = {
+			"title": "Some article",
+			"link": "https://link.springer.com/article/10.1007/s10484-026-09800-x",
+		}
+		self.assertEqual(
+			processor.extract_doi_with_fallback(entry),
+			"10.1007/s10484-026-09800-x",
+		)
+
+	def test_doi_org_link_resolved_via_default_processor(self):
+		processor = DefaultFeedProcessor(self.mock_command)
+		entry = {"title": "Some article", "link": "https://doi.org/10.3109/xyz"}
+		self.assertEqual(
+			processor.extract_doi_with_fallback(entry), "10.3109/xyz"
+		)
+
+	def test_returns_none_when_neither_source_has_a_doi(self):
+		processor = DefaultFeedProcessor(self.mock_command)
+		entry = {
+			"title": "Thesis repository entry",
+			"link": "https://hdl.handle.net/10520/EJC-1234abcd",
+		}
+		self.assertIsNone(processor.extract_doi_with_fallback(entry))
+
+	def test_missing_link_does_not_raise(self):
+		processor = DefaultFeedProcessor(self.mock_command)
+		entry = {"title": "No link here"}
+		self.assertIsNone(processor.extract_doi_with_fallback(entry))
+
+
+class PubMedExtractDoiTests(TestCase):
+	def setUp(self):
+		self.processor = PubMedFeedProcessor(MagicMock())
+
+	def test_dc_identifier_present_never_calls_network(self):
+		entry = {
+			"dc_identifier": "doi:10.1234/example.doi",
+			"link": "https://pubmed.ncbi.nlm.nih.gov/38812345/",
+		}
+		with patch("gregory.utils.doi_utils.requests.get") as mock_get:
+			doi = self.processor.extract_doi(entry)
+		self.assertEqual(doi, "10.1234/example.doi")
+		mock_get.assert_not_called()
+
+	def test_falls_back_to_pmid_resolution_when_dc_identifier_missing(self):
+		entry = {"link": "https://pubmed.ncbi.nlm.nih.gov/38812345/"}
+		payload = {
+			"result": {
+				"38812345": {
+					"articleids": [{"idtype": "doi", "value": "10.5678/resolved.doi"}]
+				}
+			}
+		}
+		response = MagicMock()
+		response.json.return_value = payload
+		with patch(
+			"gregory.utils.doi_utils.requests.get", return_value=response
+		):
+			doi = self.processor.extract_doi(entry)
+		self.assertEqual(doi, "10.5678/resolved.doi")
+
+	def test_network_failure_returns_none_not_raise(self):
+		entry = {"link": "https://pubmed.ncbi.nlm.nih.gov/38812345/"}
+		with patch(
+			"gregory.utils.doi_utils.requests.get",
+			side_effect=ConnectionError("down"),
+		):
+			doi = self.processor.extract_doi(entry)
+		self.assertIsNone(doi)
+
+	def test_no_pmid_in_link_returns_none_without_network_call(self):
+		entry = {"link": "https://pubmed.ncbi.nlm.nih.gov/rss/search/xyz"}
+		with patch("gregory.utils.doi_utils.requests.get") as mock_get:
+			doi = self.processor.extract_doi(entry)
+		self.assertIsNone(doi)
+		mock_get.assert_not_called()
+
+
+class ProcessFeedEntryUsesFallbackTests(TestCase):
+	"""Integration-style check that process_feed_entry itself benefits from
+	the fallback, not just extract_doi_with_fallback in isolation."""
+
+	def setUp(self):
+		self.command = Command()
+		self.command.tzinfos = {}
+
+	def test_default_processor_entry_gets_doi_from_link(self):
+		from gregory.models import Sources, Team, Subject
+		from organizations.models import Organization
+
+		org = Organization.objects.create(name="Test Org")
+		team = Team.objects.create(organization=org, slug="test-team")
+		subject = Subject.objects.create(
+			subject_name="Test Subject", subject_slug="test-subject", team=team
+		)
+		source = Sources.objects.create(
+			name="Obscure Publisher Feed",
+			method="rss",
+			source_for="science paper",
+			active=True,
+			team=team,
+			subject=subject,
+			link="https://obscure-publisher.example/feed.xml",
+		)
+		processor = self.command.get_feed_processor(source.link)
+		self.assertIsInstance(processor, DefaultFeedProcessor)
+
+		entry = {
+			"title": "An article with a URL-embedded DOI",
+			"link": "https://link.springer.com/article/10.1007/s99999-026-00000-1",
+			"published": "Mon, 05 Jan 2026 10:00:00 GMT",
+			"summary": "A summary.",
+		}
+
+		from gregory.classes import SciencePaper
+
+		def fake_refresh(paper_self):
+			paper_self.abstract = "CrossRef abstract"
+			return None
+
+		with patch.object(
+			SciencePaper, "refresh", autospec=True, side_effect=fake_refresh
+		):
+			self.command.process_feed_entry(entry, source, processor)
+
+		from gregory.models import Articles
+
+		article = Articles.objects.get(
+			link="https://link.springer.com/article/10.1007/s99999-026-00000-1"
+		)
+		self.assertEqual(article.doi, "10.1007/s99999-026-00000-1")

--- a/django/gregory/utils/doi_utils.py
+++ b/django/gregory/utils/doi_utils.py
@@ -1,0 +1,128 @@
+"""
+Best-effort DOI extraction from an article URL.
+
+Used as a fallback when a feed doesn't carry the DOI in a dedicated field
+(dc:identifier, prism:doi, guid, ...): many publisher links embed the DOI
+directly in the path (Springer, PNAS "doi/abs/", generic doi.org redirects),
+so before giving up we try to pull `10.NNNN/...` straight out of the URL.
+
+See ARTICLES-MISSING-DOI-PLAN (root cause 1/2) for the ingestion bug this
+closes: articles from feeds without a dedicated processor fell through to
+``DefaultFeedProcessor.extract_doi`` which always returned ``None``, even
+though the DOI was sitting in the link the whole time.
+"""
+
+import logging
+import re
+from urllib.parse import urlparse
+
+import requests
+
+# A DOI prefix is "10." followed by a 4-9 digit registrant code, then a slash
+# and a suffix. The suffix is greedy up to whitespace/quote/angle-bracket/
+# `?`/`#` so we don't swallow a trailing query string or HTML fragment.
+_DOI_PATTERN = re.compile(r"10\.\d{4,9}/[^\s?#\"'<>]+")
+
+# e.g. https://pubmed.ncbi.nlm.nih.gov/38812345/
+_PMID_LINK_PATTERN = re.compile(r"pubmed\.ncbi\.nlm\.nih\.gov/(\d+)")
+
+_ESUMMARY_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
+
+# Trailing characters that are almost always URL/markup noise rather than
+# part of the DOI suffix itself.
+_TRAILING_PUNCTUATION = ".,;:!)]}"
+
+_DOI_RESOLVER_HOSTS = {"doi.org", "dx.doi.org"}
+
+
+def _strip_trailing_punctuation(doi: str) -> str:
+	"""Strip trailing punctuation and slashes that aren't part of the DOI."""
+	return doi.rstrip(_TRAILING_PUNCTUATION).rstrip("/")
+
+
+def extract_doi_from_url(url: str) -> str | None:
+	"""Best-effort extraction of a bare DOI from an article URL.
+
+	Handles:
+	  - DOI resolver links (``https://doi.org/10.1007/...``,
+	    ``https://dx.doi.org/10.1007/...``): the DOI is the URL path.
+	  - DOIs embedded anywhere else in the path/query (Springer article pages,
+	    PNAS ``doi/abs/10.1073/...?af=R``, SAGE ``doi/abs/10.1177/...``, etc.):
+	    matched with a ``10.\\d{4,9}/...`` regex, with any trailing query
+	    string/fragment and punctuation stripped off.
+
+	Returns a clean, lowercased, bare DOI (no scheme, no trailing slash), or
+	``None`` when nothing DOI-shaped is found. Non-DOI repository URLs
+	(hdl.handle.net, arxiv.org, hal.science, escholarship.org, ...) naturally
+	return ``None`` since they never contain a ``10.xxxx/...`` segment.
+	"""
+	if not url:
+		return None
+
+	parsed = urlparse(url)
+	hostname = (parsed.hostname or "").lower()
+	if hostname.startswith("www."):
+		hostname = hostname[4:]
+
+	if hostname in _DOI_RESOLVER_HOSTS:
+		path = parsed.path.lstrip("/")
+		if path:
+			doi = _strip_trailing_punctuation(path)
+			if doi.lower().startswith("10.") and "/" in doi:
+				return doi.lower()
+		# Fall through to the generic regex in case the resolver URL is
+		# malformed (e.g. the DOI ended up in the query string instead).
+
+	match = _DOI_PATTERN.search(url)
+	if not match:
+		return None
+
+	doi = _strip_trailing_punctuation(match.group(0))
+	if not doi or "/" not in doi:
+		return None
+	return doi.lower()
+
+
+def extract_pmid_from_url(url: str | None) -> str | None:
+	"""Pull the numeric PMID out of a pubmed.ncbi.nlm.nih.gov article link."""
+	if not url:
+		return None
+	match = _PMID_LINK_PATTERN.search(url)
+	return match.group(1) if match else None
+
+
+def resolve_doi_from_pmid(pmid: str) -> str | None:
+	"""Resolve a DOI for a PubMed ID via NCBI E-utilities' ``esummary``.
+
+	Defensive by design: any network failure, non-2xx response, or
+	unexpected payload shape returns ``None`` rather than raising, so a single
+	flaky lookup never aborts a feed run or a backfill batch.
+	"""
+	if not pmid:
+		return None
+	try:
+		response = requests.get(
+			_ESUMMARY_URL,
+			params={"db": "pubmed", "id": pmid, "retmode": "json"},
+			timeout=10,
+		)
+		response.raise_for_status()
+		data = response.json()
+		article_ids = data.get("result", {}).get(pmid, {}).get("articleids", [])
+		for article_id in article_ids:
+			if article_id.get("idtype") == "doi":
+				value = article_id.get("value")
+				return value.strip() if value else None
+	except Exception as e:
+		logging.debug(f"Failed to resolve DOI via PMID {pmid}: {e}")
+	return None
+
+
+def resolve_doi_from_pubmed_url(url: str | None) -> str | None:
+	"""Resolve a DOI from a PubMed article URL by extracting the PMID and
+	querying NCBI E-utilities. Returns ``None`` if the URL has no PMID or the
+	lookup fails."""
+	pmid = extract_pmid_from_url(url)
+	if not pmid:
+		return None
+	return resolve_doi_from_pmid(pmid)

--- a/django/gregory/utils/doi_utils.py
+++ b/django/gregory/utils/doi_utils.py
@@ -40,6 +40,21 @@ def _strip_trailing_punctuation(doi: str) -> str:
 	return doi.rstrip(_TRAILING_PUNCTUATION).rstrip("/")
 
 
+def normalize_doi(doi: str | None) -> str | None:
+	"""Normalise a DOI to the canonical stored form: stripped, lowercased, no
+	trailing punctuation/slash. Returns ``None`` for empty input.
+
+	Kept consistent across every extraction path (URL parsing and PMID
+	resolution) so two sources can't produce DOIs that differ only by case or
+	trailing URL/markup noise and slip past the case-insensitive uniqueness
+	guard.
+	"""
+	if not doi:
+		return None
+	doi = _strip_trailing_punctuation(doi.strip())
+	return doi.lower() or None
+
+
 def extract_doi_from_url(url: str) -> str | None:
 	"""Best-effort extraction of a bare DOI from an article URL.
 
@@ -69,7 +84,7 @@ def extract_doi_from_url(url: str) -> str | None:
 		if path:
 			doi = _strip_trailing_punctuation(path)
 			if doi.lower().startswith("10.") and "/" in doi:
-				return doi.lower()
+				return normalize_doi(doi)
 		# Fall through to the generic regex in case the resolver URL is
 		# malformed (e.g. the DOI ended up in the query string instead).
 
@@ -80,7 +95,7 @@ def extract_doi_from_url(url: str) -> str | None:
 	doi = _strip_trailing_punctuation(match.group(0))
 	if not doi or "/" not in doi:
 		return None
-	return doi.lower()
+	return normalize_doi(doi)
 
 
 def extract_pmid_from_url(url: str | None) -> str | None:
@@ -111,8 +126,9 @@ def resolve_doi_from_pmid(pmid: str) -> str | None:
 		article_ids = data.get("result", {}).get(pmid, {}).get("articleids", [])
 		for article_id in article_ids:
 			if article_id.get("idtype") == "doi":
-				value = article_id.get("value")
-				return value.strip() if value else None
+				# Normalise so a PMID-resolved DOI is stored in the same
+				# canonical form as a URL-parsed one (see normalize_doi).
+				return normalize_doi(article_id.get("value"))
 	except Exception as e:
 		logging.debug(f"Failed to resolve DOI via PMID {pmid}: {e}")
 	return None


### PR DESCRIPTION
## Problem

747 articles were ingested with no DOI, many where the DOI was sitting right in the article URL (e.g. `https://link.springer.com/article/10.1007/...`). Volume is growing (~50–87 new DOI-less papers/month across 2026), so the pipeline is actively creating them.

### Root causes
1. **Processor selected by feed source URL, not article URL.** `get_feed_processor(source.link)` picks the handler from the source feed. Publisher articles arriving via aggregator feeds (PubMed, BASE, institutional) never reach their publisher processor and fall through to `DefaultFeedProcessor.extract_doi()`, which always returns `None`.
2. **No generic URL→DOI fallback.** The base `extract_doi` never parsed `10.NNNN/…` out of the link, even though 226/747 (30%) contain the DOI in the URL.
3. **Fragile PubMed extraction.** `PubMedFeedProcessor` only read `dc:identifier`; when absent it gave up, with no PMID→API fallback (166 PubMed links affected).
4. **`find_doi` couldn't rescue them** — CrossRef exact-title match only, and most rows had exhausted their retry attempts.

## Changes

**Phase 1 — ingestion**
- New `gregory/utils/doi_utils.py`: `extract_doi_from_url()` (doi.org/dx.doi.org resolvers + embedded DOIs in publisher paths, query/punctuation stripping, rejects non-DOI repo URLs) and PMID→DOI via NCBI E-utilities (network-failure-safe).
- New `FeedProcessor.extract_doi_with_fallback()` on the base class → falls back to the article URL for every processor; both call sites wired to it.
- `PubMedFeedProcessor.extract_doi` resolves via PMID when `dc:identifier` is missing.

**Phase 2 — backfill**
- New `backfill_missing_doi` management command: URL → PubMed API → CrossRef title search, assigned through the dedup-safe `assign_doi_or_merge`, ignoring the exhausted backoff. Supports `--dry-run` and `--limit`. Not yet run against real data.

**Monitoring**
- `DoiAssignedFilter` (Yes/No) added to `ArticleAdmin` so `/admin/gregory/articles/` can filter articles with no DOI.

## Testing
New unit tests for `doi_utils`, the feedreader URL fallback, the admin filter, and the backfill command (all network calls mocked). Full `gregory` suite passes (1080 tests). No model migration (no model fields changed).

## Rollout note
After merge, run a dry pass before touching data:
```
docker exec gregory python manage.py backfill_missing_doi --dry-run --limit 50
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)