### PR TITLE
Fix category article/trial count fan-out causing prod stalls

### DIFF
--- a/CATEGORY-COUNT-FANOUT-PLAN.md
+++ b/CATEGORY-COUNT-FANOUT-PLAN.md
@@ -1,0 +1,152 @@
+# Category count fan-out — validation & fix plan
+
+**Date:** 2026-07-14
+**Symptom:** prod stuck, `BuffileRead` waits, `/categories/` and `CategoriesByTeamAndSubject`
+calls taking 3.5+ min; unrelated `/articles/` queries hung too (same Postgres, saturated disk I/O).
+
+## 1. Root cause — VALIDATED
+
+The team's diagnosis is correct. Confirmed in code:
+
+- `CategoryViewSet.get_queryset` — [django/api/views.py:1454](django/api/views.py:1454)
+- `CategoriesByTeamAndSubject.get_queryset` — [django/api/views.py:2366](django/api/views.py:2366)
+
+Both annotate `TeamCategory` with **two joined `Count(..., distinct=True)` in one query**:
+
+```python
+.annotate(
+    article_count_annotated=Count("articles", distinct=True),
+    trials_count_annotated=Count("trials", distinct=True),
+)
+```
+
+### Why it fans out
+
+`articles` and `trials` are both **independent M2M relations** on `TeamCategory`:
+
+- `Articles.team_categories` → through `articles_team_categories` ([models.py:559](django/gregory/models.py:559))
+- `Trials.team_categories` → through `trials_team_categories` ([models.py:771](django/gregory/models.py:771))
+
+Annotating both in one query makes Postgres JOIN *both* through tables to `teamcategory`
+simultaneously. There is no join condition between articles and trials, so the intermediate
+result is the **Cartesian product** `articles × trials` per category. `COUNT(DISTINCT ...)`
+then de-dupes back down — but only *after* the product has been materialised.
+
+For a category like "Myelin" (~7,300 articles) with even a few hundred trials, the
+intermediate is millions of rows. The hash-aggregate for the two `DISTINCT` counts spills to
+disk → the `BuffileRead` wait event, and minutes per call.
+
+### Why it runs twice per request
+
+Both viewsets are paginated (`CategoryViewSet` uses the default `PageNumberPagination`,
+`PAGE_SIZE=10`, [admin/settings.py:248](django/admin/settings.py:248)). DRF pagination calls
+`.count()`, which — because the queryset carries GROUP BY annotations plus `.distinct()` —
+wraps the whole thing in `SELECT COUNT(*) FROM (<fan-out query>)`. So the expensive
+aggregation executes **once for the count and once for the page**.
+
+### Why unrelated endpoints hung
+
+Two concurrent fan-out requests saturate disk I/O on the shared Postgres instance. Every other
+query (including `/articles/`) then queues on the same starved disk. This is consistent with
+the reported system-wide stall.
+
+### The handover.md contradiction
+
+`handover.md:174` ("annotation with `Count(..., distinct=True)` is fine now", from #747/#749) is
+**only half true**. A single `Count(distinct=True)` over one relation does not fan out. The
+regression at #747/#749 was the org-visibility DISTINCT-count pagination bug — a different code
+path. Two joined M2M `Count(distinct=True)` in the same query was never actually load-tested
+against a large category. The in-code comment at [views.py:1446-1453](django/api/views.py:1446)
+repeats this incorrect reassurance and should be corrected.
+
+## 2. Fix hypothesis
+
+**Replace the two joined `Count(distinct=True)` annotations with two independent correlated
+scalar subqueries over the through tables.** Each subquery counts rows in one through table for
+the current category — no cross-join, no product, no DISTINCT needed (the through tables have
+`unique_together (articles/trials, teamcategory)`, so a plain `COUNT(*)` per category already
+equals the distinct count).
+
+```python
+from django.db.models import Count, IntegerField, OuterRef, Subquery
+from django.db.models.functions import Coalesce
+from gregory.models import ArticleCategoryAssignment, TrialCategoryAssignment
+
+def _count_subquery(through_model):
+    return Coalesce(
+        Subquery(
+            through_model.objects
+            .filter(teamcategory=OuterRef("pk"))
+            .order_by()
+            .values("teamcategory")
+            .annotate(c=Count("*"))
+            .values("c"),
+            output_field=IntegerField(),
+        ),
+        0,
+    )
+
+queryset = queryset.annotate(
+    article_count_annotated=_count_subquery(ArticleCategoryAssignment),
+    trials_count_annotated=_count_subquery(TrialCategoryAssignment),
+)
+```
+
+### Why this fixes both problems
+
+1. **No fan-out.** Each subquery touches exactly one through table and returns a scalar.
+   Postgres runs them as two independent correlated index scans on the `teamcategory_id` FK —
+   O(rows in that category), not O(articles × trials). No hash-aggregate spill → no
+   `BuffileRead`.
+2. **Cheap pagination count.** The subqueries are select-only (not referenced in any
+   `filter`/`order_by` for the count query). Django's `get_count`/`get_aggregation` strips
+   select-only annotations, and the outer query no longer has a GROUP BY, so pagination's
+   `.count()` collapses to a plain `SELECT COUNT(*) FROM teamcategory WHERE ...`. The
+   fan-out no longer runs twice — it doesn't run at all in the count path.
+3. **Contract preserved.** The serializer reads `obj.article_count_annotated` /
+   `trials_count_annotated` ([serializers/__init__.py:155-167](django/api/serializers/__init__.py:155)),
+   with a `.count()` fallback for un-annotated instances. Field names are unchanged, so the
+   serializer, the `ordering_fields = [... "article_count_annotated" ...]`
+   ([views.py:1400](django/api/views.py:1400)) ordering, and the API JSON shape all stay the same.
+   Ordering by a scalar subquery annotation works in Postgres.
+
+### `.distinct()`
+
+`CategoryViewSet` ends with `.distinct()` ([views.py:1459](django/api/views.py:1459)) because the
+optional `subjects__id=` filter joins the subjects M2M and can duplicate category rows. Keep
+`.distinct()` — but it now de-dupes only the small outer category set, not a fan-out. (Optionally
+tighten to `.distinct("id")` / restructure the subjects filter as an `Exists`, but that is not
+required for the fix.)
+
+## 3. Implementation steps
+
+1. Add the `_count_subquery` helper (module-level in `api/views.py`, or a small shared util).
+2. Swap the annotation block in **both** `CategoryViewSet.get_queryset` (views.py:1454) and
+   `CategoriesByTeamAndSubject.get_queryset` (views.py:2366).
+3. Rewrite the stale comment at views.py:1446-1453 to describe the fan-out and why subqueries
+   are used.
+4. Import `ArticleCategoryAssignment`, `TrialCategoryAssignment` in views.py (verify not
+   already imported).
+
+## 4. Verification
+
+- **Existing regression test** `api/tests/test_category_count_annotations.py` must still pass
+  (counts = 5 articles / 3 trials; query count < 20). Update its annotated-queryset mirror
+  (test lines 96-101) to use the same subquery form so the test reflects production.
+- **New load-shape assertion:** add a test with a category holding many articles *and* several
+  trials, and assert the response returns without materialising the product. Best signal is an
+  `EXPLAIN` check (no `Seq Scan` hash-agg over the join) or a `CaptureQueriesContext` assertion
+  that no query contains a join of both `articles_team_categories` and `trials_team_categories`.
+- **Manual EXPLAIN on prod-like data:** run `EXPLAIN (ANALYZE, BUFFERS)` on the old vs. new
+  queryset for the "Myelin" category. Confirm the `BuffileRead` / `temp read` disk spill is gone
+  and cost drops from minutes to milliseconds.
+- Smoke-test `/categories/?category_id=<myelin>` and
+  `/categories/<team>/<subject>/` end-to-end; confirm counts match the old values.
+
+## 5. Follow-ups (out of scope for the hotfix)
+
+- Correct `handover.md:174`.
+- Audit for any other multi-relation `Count(distinct=True)` in one `.annotate()` across the
+  codebase (`grep -n "distinct=True" django/api/views.py`).
+- Consider a short statement-level `statement_timeout` on read endpoints so a single pathological
+  query can't saturate disk for the whole instance again.

--- a/django/api/tests/test_category_count_annotations.py
+++ b/django/api/tests/test_category_count_annotations.py
@@ -1,13 +1,19 @@
 """
 Regression tests for CategoryViewSet's switch from prefetching every
-article/trial row to Count(..., distinct=True) annotations.
+article/trial row to correlated subquery count annotations.
+
+The counts must NOT be computed by annotating both the articles and trials
+M2M relations with Count(..., distinct=True) in a single query: joining both
+relations at once fans out to an articles x trials cross product per
+category, which is cheap for small categories but spilled Postgres's hash
+aggregate to disk in production for a category with thousands of rows on
+each side. See api.views._category_through_count_subquery.
 
 Run with:
     docker exec gregory python manage.py test api.tests.test_category_count_annotations
 """
 
 from django.db import connection
-from django.db.models import Count
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
@@ -16,13 +22,16 @@ from django.utils.text import slugify
 from rest_framework.test import APIClient
 
 from api.serializers import CategorySerializer
+from api.views import _category_through_count_subquery
 from gregory.models import (
+	ArticleCategoryAssignment,
 	Articles,
 	Organization,
 	OrganizationApiSettings,
 	Subject,
 	Team,
 	TeamCategory,
+	TrialCategoryAssignment,
 	Trials,
 )
 
@@ -95,8 +104,12 @@ class CategoryCountAnnotationTests(TestCase):
 		article/trial counts."""
 		annotated_obj = (
 			TeamCategory.objects.annotate(
-				article_count_annotated=Count("articles", distinct=True),
-				trials_count_annotated=Count("trials", distinct=True),
+				article_count_annotated=_category_through_count_subquery(
+					ArticleCategoryAssignment
+				),
+				trials_count_annotated=_category_through_count_subquery(
+					TrialCategoryAssignment
+				),
 			)
 			.get(pk=self.category.pk)
 		)
@@ -114,3 +127,55 @@ class CategoryCountAnnotationTests(TestCase):
 		)
 		self.assertEqual(annotated_payload["article_count_total"], 5)
 		self.assertEqual(annotated_payload["trials_count_total"], 3)
+
+	def test_no_query_joins_both_through_tables(self):
+		"""Guards against reintroducing the fan-out regression: no single
+		query in the request should join both articles_team_categories and
+		trials_team_categories, since that produces an articles x trials
+		cross product per category (fine for a handful of rows, but spilled
+		Postgres's hash aggregate to disk in production for a category with
+		thousands of articles and trials)."""
+		# Give the category enough rows on both sides that a cross product
+		# would be detectable (25 x 15 = 375 vs. 25 + 15 = 40 if summed).
+		for i in range(20):
+			article = Articles.objects.create(
+				title=f"Fanout Guard Article {i}",
+				link=f"https://example.com/fanout-guard-article-{i}",
+				published_date=timezone.now(),
+			)
+			article.team_categories.add(self.category)
+		for i in range(12):
+			trial = Trials.objects.create(
+				title=f"Fanout Guard Trial {i}",
+				link=f"https://example.com/fanout-guard-trial-{i}",
+				published_date=timezone.now(),
+			)
+			trial.team_categories.add(self.category)
+
+		url = reverse("categories-list")
+		with CaptureQueriesContext(connection) as ctx:
+			response = self.client.get(url, {"category_id": self.category.id})
+		self.assertEqual(response.status_code, 200)
+
+		results = response.data["results"] if "results" in response.data else response.data
+		payload = results[0]
+		self.assertEqual(payload["article_count_total"], 25)
+		self.assertEqual(payload["trials_count_total"], 15)
+
+		# The fan-out bug's signature is a single query that JOINs BOTH
+		# through tables at once (Count("articles"/"trials", distinct=True)
+		# in one annotate() compiles to two JOINs into the same FROM
+		# clause). Other queries in this request legitimately JOIN one of
+		# these tables alone (e.g. authors_count), which is fine — only
+		# joining both together produces the articles x trials cross
+		# product. The fix references each through table via its own
+		# independent correlated subquery (FROM ... WHERE teamcategory_id =
+		# outer.id), never via JOIN at all.
+		for query in ctx.captured_queries:
+			sql = query["sql"]
+			joins_articles = 'JOIN "articles_team_categories"' in sql
+			joins_trials = 'JOIN "trials_team_categories"' in sql
+			self.assertFalse(
+				joins_articles and joins_trials,
+				f"Query joins both through tables, reintroducing the fan-out: {sql}",
+			)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1488,7 +1488,15 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 			trials_count_annotated=_category_through_count_subquery(TrialCategoryAssignment),
 		)
 
-		return queryset.distinct()
+		# No .distinct() needed: the count annotations are now correlated
+		# subqueries (no JOIN), team is select_related via FK, subjects is
+		# prefetch_related (a separate query), and subjects__id=<single id>
+		# filters the default M2M through table, which has a unique
+		# constraint on (teamcategory, subject) — none of these can produce
+		# duplicate category rows. Adding .distinct() back would force the
+		# paginator's count() down a DISTINCT-over-all-columns path,
+		# undermining the cheap-count fix above.
+		return queryset
 
 	def get_serializer_context(self):
 		"""Add author parameters to serializer context"""

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -57,10 +57,12 @@ from gregory.classes import SciencePaper, ClinicalTrial
 from gregory.utils.trial_field_normalizers import TrialRecruitmentStatus
 from gregory.models import (
 	Articles,
+	ArticleCategoryAssignment,
 	ArticleOrgContent,
 	ArticleSubjectRelevance,
 	ArticleTrialReference,
 	Trials,
+	TrialCategoryAssignment,
 	TrialOrgContent,
 	Sources,
 	Authors,
@@ -1344,6 +1346,34 @@ class ArticleViewSet(
 ###
 
 
+def _category_through_count_subquery(through_model):
+	"""Correlated scalar count of a category's rows in a single M2M through
+	table (article or trial category assignments).
+
+	Annotating a category with Count("articles", distinct=True) AND
+	Count("trials", distinct=True) in the same query joins both M2M
+	relations at once, producing an articles x trials cross product per
+	category before DISTINCT dedups it — for a category with thousands of
+	rows on each side that intermediate result is large enough to spill
+	Postgres's hash aggregate to disk. A correlated subquery per relation
+	counts each through table independently (no cross join), and because
+	each through table already has a unique_together on
+	(article/trial, teamcategory), a plain COUNT(*) here already equals the
+	distinct count.
+	"""
+	return Coalesce(
+		Subquery(
+			through_model.objects.filter(teamcategory=OuterRef("pk"))
+			.order_by()
+			.values("teamcategory")
+			.annotate(c=Count("*"))
+			.values("c"),
+			output_field=IntegerField(),
+		),
+		0,
+	)
+
+
 class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 	"""
 	List all categories in the database with optional filters for team and subject.
@@ -1404,7 +1434,7 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 
 	def get_queryset(self):
 		"""
-		Article/trial counts are computed with Count(..., distinct=True)
+		Article/trial counts are computed with correlated subquery
 		annotations (see below) rather than prefetching the full related
 		querysets, so a page of categories doesn't materialise every
 		article/trial row just to produce two integers.
@@ -1443,17 +1473,19 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 			if len(ids) > 0:
 				queryset = queryset.filter(id__in=ids)
 
-		# Counts are computed via Count(..., distinct=True) annotations rather
-		# than prefetching every article/trial row for the category: a large
+		# Counts are computed via correlated subqueries rather than
+		# prefetching every article/trial row for the category: a large
 		# category (e.g. ~7,300 articles) would otherwise materialise
 		# thousands of rows just to produce two integers. See the identical
-		# pattern in CategoriesByTeamAndSubject.get_queryset. Annotation-based
-		# COUNT with a JOIN is fine post-#747/#749 — it was only the
-		# unrelated org-visibility DISTINCT-count pagination bug that was
-		# ever slow.
+		# pattern in CategoriesByTeamAndSubject.get_queryset. Do NOT switch
+		# this back to annotating both Count("articles", distinct=True) and
+		# Count("trials", distinct=True) in one query — joining both M2M
+		# relations at once fans out to an articles x trials cross product
+		# per category, which spilled Postgres's hash aggregate to disk in
+		# production (see _category_through_count_subquery docstring).
 		queryset = queryset.select_related("team").prefetch_related("subjects").annotate(
-			article_count_annotated=Count("articles", distinct=True),
-			trials_count_annotated=Count("trials", distinct=True),
+			article_count_annotated=_category_through_count_subquery(ArticleCategoryAssignment),
+			trials_count_annotated=_category_through_count_subquery(TrialCategoryAssignment),
 		)
 
 		return queryset.distinct()
@@ -2363,11 +2395,16 @@ class CategoriesByTeamAndSubject(viewsets.ModelViewSet):
 				id=team_id, organization_id__in=self.request.visible_org_ids
 			).exists():
 				raise Http404
+		# See CategoryViewSet.get_queryset / _category_through_count_subquery:
+		# do NOT annotate both relations with Count(..., distinct=True) in
+		# one query — that fans out to an articles x trials cross product
+		# per category and spilled Postgres's hash aggregate to disk in
+		# production.
 		return (
 			TeamCategory.objects.filter(team__id=team_id, subjects__id=subject_id)
 			.annotate(
-				article_count_annotated=Count("articles", distinct=True),
-				trials_count_annotated=Count("trials", distinct=True),
+				article_count_annotated=_category_through_count_subquery(ArticleCategoryAssignment),
+				trials_count_annotated=_category_through_count_subquery(TrialCategoryAssignment),
 			)
 			.order_by("-id")
 		)


### PR DESCRIPTION
## Summary
- `CategoryViewSet` and `CategoriesByTeamAndSubject` annotated `TeamCategory` with `Count("articles", distinct=True)` and `Count("trials", distinct=True)` in the **same** query. Since `articles` and `trials` are two independent M2M relations, joining both at once produces an `articles x trials` cross product per category before `DISTINCT` dedups it — for a large category (e.g. ~7,300 articles) this spilled Postgres's hash aggregate to disk (`BuffileRead` waits), saturating I/O and stalling unrelated queries on prod.
- DRF pagination's `.count()` then wrapped the same expensive fan-out in a second `SELECT COUNT(*) FROM (...)`, running it twice per request.
- Replaces both annotations with independent correlated scalar subqueries over the through tables (`ArticleCategoryAssignment` / `TrialCategoryAssignment`) — each counts its own relation with no cross join, and no GROUP BY on the outer query so pagination's count collapses to a cheap `SELECT COUNT(*) FROM teamcategory WHERE ...`.
- Drops the trailing `.distinct()` on `CategoryViewSet.get_queryset()`: it's no longer needed (count annotations are now correlated subqueries, `team` is select_related via FK, `subjects` is prefetch_related, and `subjects__id=<single id>` filters a uniquely-constrained M2M through table — none of these can duplicate rows), and keeping it forced the paginator's `.count()` through a `SELECT DISTINCT` over every column instead of a plain `COUNT(*)`.
- Corrects the stale in-code comment claiming this pattern was "fine now" post-#747/#749 — that fix addressed a different bug (org-visibility DISTINCT-count pagination); the two-relation join fan-out was never load-tested against a large category. `handover.md:174` makes the same stale claim, but `handover.md` is an untracked file at the repo root (not committed to git), so it can't be part of this or any PR diff — that correction is called out as an explicit out-of-scope follow-up in the plan doc below and needs to be applied directly by whoever maintains that file locally.
- Full root-cause analysis and fix rationale: [CATEGORY-COUNT-FANOUT-PLAN.md](../blob/fix/category-count-fanout/CATEGORY-COUNT-FANOUT-PLAN.md)

## Test plan
- [x] `api.tests.test_category_count_annotations` (3 tests, including a new regression guard asserting no query joins both through tables together) — pass
- [x] Full `api` app suite (652 tests) — pass, no regressions
- [ ] Manual `EXPLAIN (ANALYZE, BUFFERS)` against prod-scale data (e.g. the "Myelin" category, id 89) to confirm the disk spill is gone — recommend running before/after merge on a prod-like dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)