### PR TITLE
Fix unmapped country/status values found in prod backfill (follow-up to #769)

### DIFF
--- a/django/gregory/tests/test_trial_country_normalization.py
+++ b/django/gregory/tests/test_trial_country_normalization.py
@@ -88,6 +88,40 @@ def test_none_and_other_literals_are_dropped():
 	assert [row["country"] for row in rows] == ["FR"]
 
 
+def test_common_names_that_differ_from_django_countries_iso_long_name():
+	"""These surfaced as 'Unmapped trial country value' during the prod backfill: WHO
+	ICTRP sends the common name, but django_countries' own fallback lookup only matches
+	the ISO official long name (e.g. "Viet Nam", "Taiwan (Province of China)"), so each
+	needed its own alias table entry."""
+	rows = normalize_countries(
+		{
+			"ictrp": (
+				"Moldova;Republic of Moldova;Moldova, Republic of;"
+				"Taiwan;Macedonia;Macedonia, the former Yugoslav Republic of;"
+				"The former Yugoslav Republic of Macedonia;The Former Yugoslav Rep of Macedonia;"
+				"Republic of Serbia;Venezuela;Syria;Vietnam;"
+				"Korea (the Democratic Peoples Republic of);Korea, Democratic People's Republic of;"
+				"Virgin Islands"
+			)
+		},
+		None,
+		None,
+		None,
+	)
+	codes = sorted(row["country"] for row in rows)
+	assert codes == ["KP", "MD", "MK", "RS", "SY", "TW", "VE", "VI", "VN"]
+
+
+def test_iran_islamic_republic_orphan_fragment_maps_to_iran():
+	"""'Iran, Islamic Republic of' inside a CTGov-style ', '-joined list splits into 'Iran'
+	(resolves alone, so the tokenizer's adjacency re-join never fires) and an orphaned
+	'Islamic Republic of' fragment; both must resolve to IR."""
+	rows = normalize_countries(
+		{"ctgov": "France, Iran, Islamic Republic of, Germany"}, None, None, None
+	)
+	assert sorted(row["country"] for row in rows) == ["DE", "FR", "IR"]
+
+
 def test_unmapped_value_is_logged_and_dropped(caplog):
 	with caplog.at_level("INFO", logger="gregory.utils.trial_field_normalizers"):
 		rows = normalize_countries(

--- a/django/gregory/tests/test_trial_recruitment_status_normalization.py
+++ b/django/gregory/tests/test_trial_recruitment_status_normalization.py
@@ -47,6 +47,8 @@ EXACT_MATCH_CASES = [
 	("ongoing, recruitment ended", TrialRecruitmentStatus.ACTIVE_NOT_RECRUITING),
 	# Not recruiting (WHO's generic status — its own bucket, see module docstring)
 	("not recruiting", TrialRecruitmentStatus.NOT_RECRUITING),
+	# Not recruiting (EU CTIS per-country: authorisation declined)
+	("not authorised", TrialRecruitmentStatus.NOT_RECRUITING),
 	# Suspended
 	("suspended", TrialRecruitmentStatus.SUSPENDED),
 	("temporarily halted", TrialRecruitmentStatus.SUSPENDED),

--- a/django/gregory/utils/trial_field_normalizers.py
+++ b/django/gregory/utils/trial_field_normalizers.py
@@ -235,6 +235,10 @@ _RECRUITMENT_STATUS_EXACT_MATCHES: dict[str, str] = {
 	# not say whether the trial is pre-start, ongoing, or done, so folding it into
 	# active_not_recruiting would overclaim.
 	"not recruiting": TrialRecruitmentStatus.NOT_RECRUITING,  # WHO ICTRP
+	# EU CTIS per-country regulatory decision: the member state declined authorisation, so
+	# the trial will not recruit there — distinct from "authorised" (approved, recruitment
+	# state otherwise unstated) below, which maps to UNKNOWN instead.
+	"not authorised": TrialRecruitmentStatus.NOT_RECRUITING,  # EU CTIS country_status
 	# Suspended
 	"suspended": TrialRecruitmentStatus.SUSPENDED,  # CT.gov
 	"temporarily halted": TrialRecruitmentStatus.SUSPENDED,  # WHO
@@ -372,6 +376,12 @@ _COUNTRY_EXACT_MATCHES: dict[str, str] = {
 	# Iran
 	"iran (islamic republic of)": "IR",
 	"iran": "IR",
+	# Orphan fragment: in a CTGov-style ", "-joined list, "Iran, Islamic Republic of" splits
+	# into "Iran" (already resolves alone, so the tokenizer's adjacency re-join never fires —
+	# see _tokenize_countries_value) and this leftover "Islamic Republic of" segment. Mapping
+	# it directly to IR is simpler than special-casing the re-join condition; the duplicate
+	# IR from "Iran" collapses away in normalize_countries' final dedup.
+	"islamic republic of": "IR",
 	# Czechia
 	"czechia": "CZ",
 	"czech republic": "CZ",
@@ -379,6 +389,10 @@ _COUNTRY_EXACT_MATCHES: dict[str, str] = {
 	"south korea": "KR",
 	"korea, republic of": "KR",
 	"republic of korea": "KR",
+	# North Korea (django_countries' own name, "Korea (the Democratic People's Republic of)",
+	# doesn't match either spelling actually sent by WHO ICTRP)
+	"korea (the democratic peoples republic of)": "KP",
+	"korea, democratic people's republic of": "KP",
 	# Russia
 	"russia": "RU",
 	"russian federation": "RU",
@@ -389,6 +403,23 @@ _COUNTRY_EXACT_MATCHES: dict[str, str] = {
 	"china": "CN",
 	"people's republic of china": "CN",
 	"chian": "CN",  # typo, seen verbatim in WHO ICTRP export
+	# Common names that differ from django_countries' ISO official long name (which the
+	# _name_to_code_lookup() fallback matches against), seen verbatim in WHO ICTRP exports.
+	"moldova": "MD",
+	"republic of moldova": "MD",
+	"moldova, republic of": "MD",
+	"taiwan": "TW",  # django_countries: "Taiwan (Province of China)"
+	"macedonia": "MK",  # django_countries: "North Macedonia"
+	"macedonia, the former yugoslav republic of": "MK",
+	"the former yugoslav republic of macedonia": "MK",
+	"the former yugoslav rep of macedonia": "MK",
+	"republic of serbia": "RS",
+	"venezuela": "VE",  # django_countries: "Venezuela (Bolivarian Republic of)"
+	"syria": "SY",  # django_countries: "Syrian Arab Republic"
+	"vietnam": "VN",  # django_countries: "Viet Nam"
+	# Ambiguous without a qualifier (could be US or British Virgin Islands); defaults to the
+	# U.S. territory as the more commonly reported one in trial site/recruitment data.
+	"virgin islands": "VI",
 	# One-off WHO ICTRP noise
 	"modalvia": "MD",  # typo for Moldova
 	"bosnial and herzegovina": "BA",  # typo for Bosnia and Herzegovina


### PR DESCRIPTION
## Summary

Follow-up to #769 (merged). Running `backfill_trial_normalized_fields` in prod logged a batch of `Unmapped trial country value` / `Unmapped trial recruitment status value` entries — this PR adds the missing mappings.

**Root cause for the country values**: `django_countries`' own name lookup (the tokenizer's fallback for spellings not in the alias table) stores ISO *official long names* — e.g. `Viet Nam`, `Taiwan (Province of China)`, `Moldova (the Republic of)`, `Syrian Arab Republic` — which don't match the common names WHO ICTRP actually sends (`Vietnam`, `Taiwan`, `Moldova`, `Syria`). Added each as an explicit alias:

- Moldova, Taiwan, Macedonia (→ North Macedonia's code `MK`), Venezuela, Syria, Vietnam, Serbia
- North Korea, in both spellings observed (`Korea (the Democratic Peoples Republic of)` and `Korea, Democratic People's Republic of`)
- Virgin Islands — ambiguous without a qualifier (could be US or British); defaulted to the U.S. territory as the more commonly reported one in trial data

**One tokenizer edge case**: `Iran, Islamic Republic of` inside a comma-joined list splits into `Iran` (already resolves on its own, so the adjacency re-join in `_tokenize_countries_value` never fires) plus an orphaned `Islamic Republic of` fragment. Mapped the fragment directly to `IR` rather than reworking the re-join condition — the resulting duplicate `IR` collapses in `normalize_countries`' final dedup.

**One recruitment-status gap**: `'Not authorised'` (an EU CTIS per-country regulatory decision — the member state declined authorisation) now maps to `NOT_RECRUITING`, distinct from the existing `'authorised'` → `UNKNOWN` mapping (approved, recruitment state otherwise unstated).

**Unchanged, working as designed**: `'Other'` and `'Former Serbia and Montenegro'` also appeared in the prod log but are intentionally left unmapped (see the existing comment in `_COUNTRY_EXACT_MATCHES`) — `'Other'` isn't a country, and the 1990s state has no clean current ISO code. Both are dropped after being logged, exactly as intended.

## Test plan

- [x] Added `test_common_names_that_differ_from_django_countries_iso_long_name` and `test_iran_islamic_republic_orphan_fragment_maps_to_iran` in `gregory/tests/test_trial_country_normalization.py`
- [x] Added the `"not authorised"` case to `EXACT_MATCH_CASES` in `gregory/tests/test_trial_recruitment_status_normalization.py`
- [x] `python -m pytest gregory api` — 1800 passed (full suite, re-run after cherry-picking onto current `main`)
- [x] `python manage.py makemigrations --check --dry-run` — no drift (no model changes in this PR)

## Next step

Re-run `backfill_trial_normalized_fields` in prod after this merges and deploys, and check the unmapped-value log again for any further gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)