### PR TITLE
True streaming for CSV bulk exports + site_id filter

### DIFF
--- a/django/api/direct_streaming.py
+++ b/django/api/direct_streaming.py
@@ -237,38 +237,7 @@ class DirectStreamingCSVRenderer(CSVRenderer):
 				)
 				continue
 
-			# Create a new item with processed values
-			processed_item = {}
-
-			# Copy the item with proper string conversion
-			for key, value in item.items():
-				# Skip excluded columns
-				if key in self.EXCLUDED_COLUMNS or any(
-					key.startswith(excluded + ".") for excluded in self.EXCLUDED_COLUMNS
-				):
-					continue
-
-				# Clean text fields (remove line breaks)
-				if key in self.TEXT_FIELDS_TO_CLEAN and isinstance(value, str):
-					# Replace line breaks with spaces
-					value = value.replace("\n", " ").replace("\r", " ")
-					# Normalize multiple spaces to single spaces
-					while "  " in value:
-						value = value.replace("  ", " ")
-
-				# Handle lists and nested objects
-				if isinstance(value, (list, dict)):
-					try:
-						processed_item[key] = json.dumps(value)
-					except (TypeError, ValueError):
-						logger.error(
-							f"CSV Export: Failed to serialize key '{key}' with value '{value}' to JSON. Storing as string."
-						)
-						processed_item[key] = str(value)
-				else:
-					processed_item[key] = value
-
-			processed_data.append(processed_item)
+			processed_data.append(process_item(item))
 
 		logger.debug(f"CSV Export: Processed data has {len(processed_data)} items")
 		return processed_data
@@ -286,17 +255,7 @@ class DirectStreamingCSVRenderer(CSVRenderer):
 		for item in data:
 			all_keys.update(item.keys())
 
-		# Sort keys with preferred columns first
-		ordered_keys = []
-
-		# First add preferred columns in the specified order
-		for key in self.PREFERRED_COLUMN_ORDER:
-			if key in all_keys:
-				ordered_keys.append(key)
-				all_keys.remove(key)
-
-		# Then add remaining keys alphabetically
-		ordered_keys.extend(sorted(all_keys))
+		ordered_keys = order_columns(all_keys)
 
 		# Create the table
 		table = [ordered_keys]  # Header row
@@ -312,3 +271,115 @@ class DirectStreamingCSVRenderer(CSVRenderer):
 			f"CSV Export: Tablized data has {len(table) - 1} rows (plus header)"
 		)
 		return table
+
+
+def process_item(item):
+	"""Prepare one serialized row for CSV output.
+
+	Skips EXCLUDED_COLUMNS, strips linebreaks from TEXT_FIELDS_TO_CLEAN,
+	JSON-encodes list/dict values. Shared by the buffered renderer and the
+	streaming generator so both paths produce identical row semantics.
+	"""
+	processed_item = {}
+	for key, value in item.items():
+		if key in DirectStreamingCSVRenderer.EXCLUDED_COLUMNS or any(
+			key.startswith(excluded + ".")
+			for excluded in DirectStreamingCSVRenderer.EXCLUDED_COLUMNS
+		):
+			continue
+
+		if key in DirectStreamingCSVRenderer.TEXT_FIELDS_TO_CLEAN and isinstance(value, str):
+			value = value.replace("\n", " ").replace("\r", " ")
+			while "  " in value:
+				value = value.replace("  ", " ")
+
+		if isinstance(value, (list, dict)):
+			try:
+				processed_item[key] = json.dumps(value)
+			except (TypeError, ValueError):
+				logger.error(
+					f"CSV Export: Failed to serialize key '{key}' with value '{value}' to JSON. Storing as string."
+				)
+				processed_item[key] = str(value)
+		else:
+			processed_item[key] = value
+	return processed_item
+
+
+def order_columns(keys):
+	"""Order CSV columns: PREFERRED_COLUMN_ORDER first, remainder alphabetical."""
+	remaining = set(keys)
+	ordered = []
+	for key in DirectStreamingCSVRenderer.PREFERRED_COLUMN_ORDER:
+		if key in remaining:
+			ordered.append(key)
+			remaining.remove(key)
+	ordered.extend(sorted(remaining))
+	return ordered
+
+
+def csv_header_fields(serializer, request):
+	"""Static CSV header for a serializer, matching per-row behavior.
+
+	OrgScopedSerializerMixin pops _per_org_fields from every row when the
+	request has no org context, so the header must drop them under the same
+	condition or rows and header would misalign.
+	"""
+	from api.serializers.mixins import _resolve_per_org_fields_org
+
+	field_names = list(serializer.fields.keys())
+	per_org = list(getattr(serializer, "_per_org_fields", []))
+	if per_org and _resolve_per_org_fields_org(request) is None:
+		field_names = [name for name in field_names if name not in per_org]
+	field_names = [
+		name for name in field_names
+		if name not in DirectStreamingCSVRenderer.EXCLUDED_COLUMNS
+	]
+	return order_columns(field_names)
+
+
+def stream_csv(source, serialize_batch, header_fields, chunk_size=2000):
+	"""Yield CSV text chunks: header first, then one chunk per row batch.
+
+	``source`` is a QuerySet (streamed via .iterator(chunk_size), which
+	batches prefetch_related per chunk) or a plain list (an already-
+	paginated page). ``serialize_batch`` maps a list of model instances to
+	a list of dicts (the view passes a bound get_serializer closure).
+	"""
+	buffer = io.StringIO()
+	writer = csv.writer(
+		buffer,
+		quoting=csv.QUOTE_ALL,
+		quotechar='"',
+		doublequote=True,
+		lineterminator="\n",
+	)
+
+	def drain():
+		value = buffer.getvalue()
+		buffer.seek(0)
+		buffer.truncate(0)
+		return value
+
+	def write_batch(batch):
+		for row in serialize_batch(batch):
+			processed = process_item(row)
+			cells = []
+			for key in header_fields:
+				value = processed.get(key, "")
+				cells.append("" if value is None else str(value))
+			writer.writerow(cells)
+		return drain()
+
+	writer.writerow(header_fields)
+	yield drain()  # header goes out immediately -- TTFB is bounded by the first DB batch
+
+	rows = source.iterator(chunk_size=chunk_size) if hasattr(source, "iterator") else iter(source)
+	batch = []
+	for obj in rows:
+		batch.append(obj)
+		if len(batch) >= chunk_size:
+			yield write_batch(batch)
+			batch = []
+	if batch:
+		yield write_batch(batch)

--- a/django/api/filters.py
+++ b/django/api/filters.py
@@ -86,6 +86,7 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 	team_id = filters.NumberFilter(
 		field_name="teams__id", lookup_expr="exact", label="Team ID"
 	)
+	site_id = filters.NumberFilter(method="filter_site", label="Site ID")
 	subject_id = filters.NumberFilter(
 		field_name="subjects__id", lookup_expr="exact", label="Subject ID"
 	)
@@ -140,6 +141,7 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 			"category_id",
 			"journal_slug",
 			"team_id",
+			"site_id",
 			"subject_id",
 			"source_id",
 			"relevant",
@@ -189,6 +191,19 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 		if q is None:
 			return queryset
 		return queryset.filter(q)
+
+	def filter_site(self, queryset, name, value):
+		"""
+		Articles belonging to any team of the given Django Site.
+
+		Uses Exists() rather than a join filter: multiple teams can share a
+		site, and a plain teams__site_id filter would duplicate every article
+		that belongs to two such teams (same reasoning as OrgVisibilityMixin).
+		"""
+		subquery = queryset.model.objects.filter(
+			pk=models.OuterRef("pk"), teams__site_id=value
+		)
+		return queryset.filter(models.Exists(subquery))
 
 	def filter_journal(self, queryset, name, value):
 		"""
@@ -480,6 +495,7 @@ class TrialFilter(SubjectFilterMixin, filters.FilterSet):
 	team_id = filters.NumberFilter(
 		field_name="teams__id", lookup_expr="exact", label="Team ID"
 	)
+	site_id = filters.NumberFilter(method="filter_site", label="Site ID")
 	subject_id = filters.NumberFilter(
 		field_name="subjects__id", lookup_expr="exact", label="Subject ID"
 	)
@@ -613,6 +629,7 @@ class TrialFilter(SubjectFilterMixin, filters.FilterSet):
 			"status",
 			"recruitment_status_normalized",
 			"team_id",
+			"site_id",
 			"subject_id",
 			"category_slug",
 			"category_id",
@@ -667,6 +684,19 @@ class TrialFilter(SubjectFilterMixin, filters.FilterSet):
 		if q is None:
 			return queryset
 		return queryset.filter(q)
+
+	def filter_site(self, queryset, name, value):
+		"""
+		Trials belonging to any team of the given Django Site.
+
+		Uses Exists() rather than a join filter: multiple teams can share a
+		site, and a plain teams__site_id filter would duplicate every trial
+		that belongs to two such teams (same reasoning as OrgVisibilityMixin).
+		"""
+		subquery = queryset.model.objects.filter(
+			pk=models.OuterRef("pk"), teams__site_id=value
+		)
+		return queryset.filter(models.Exists(subquery))
 
 	def _match_identifier(self, queryset, value, keys):
 		"""Return trials whose ``identifiers`` JSON has any of ``keys`` equal

--- a/django/api/tests/test_site_filter.py
+++ b/django/api/tests/test_site_filter.py
@@ -1,0 +1,142 @@
+import csv
+import io
+
+from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from gregory.models import (
+	Articles,
+	OrganizationApiSettings,
+	Sources,
+	Team,
+	Trials,
+)
+from organizations.models import Organization
+
+
+class SiteFilterTest(TestCase):
+	"""``site_id`` filters Articles/Trials to any team attached to that
+	Django Site, deduplicating when an object belongs to multiple teams
+	sharing the same site, and respecting org visibility."""
+
+	def setUp(self):
+		self.site_a = Site.objects.create(domain="site-a.example.com", name="Site A")
+		self.site_b = Site.objects.create(domain="site-b.example.com", name="Site B")
+
+		self.user = User.objects.create_user(username="sitetest", password="12345")
+		self.public_org = Organization.objects.create(
+			name="Public Org", slug="public-org"
+		)
+		self.public_org.add_user(self.user)
+		OrganizationApiSettings.objects.update_or_create(
+			organization=self.public_org, defaults={"make_api_public": True}
+		)
+
+		self.private_org = Organization.objects.create(
+			name="Private Org", slug="private-org"
+		)
+
+		self.source = Sources.objects.create(
+			name="Site Filter Source", source_for="science paper"
+		)
+
+		# Two teams on the public org, both attached to site_a.
+		self.team1 = Team.objects.create(
+			organization=self.public_org, name="Team One", slug="team-one", site=self.site_a
+		)
+		self.team2 = Team.objects.create(
+			organization=self.public_org, name="Team Two", slug="team-two", site=self.site_a
+		)
+		# A private-org team also on site_a.
+		self.private_team = Team.objects.create(
+			organization=self.private_org,
+			name="Private Team",
+			slug="private-team",
+			site=self.site_a,
+		)
+		# A team on site_b, for the "no teams on this site" check.
+		self.team_other_site = Team.objects.create(
+			organization=self.public_org,
+			name="Other Site Team",
+			slug="other-site-team",
+			site=self.site_b,
+		)
+
+		# Article belonging to both team1 and team2 (same site) -- must not duplicate.
+		self.shared_article = Articles.objects.create(
+			title="Shared Article",
+			summary="Shared summary",
+			link="https://example.com/shared-article",
+			kind="science paper",
+		)
+		self.shared_article.sources.add(self.source)
+		self.shared_article.teams.add(self.team1, self.team2)
+
+		# Article only on the private team's site_a team.
+		self.private_article = Articles.objects.create(
+			title="Private Article",
+			summary="Private summary",
+			link="https://example.com/private-article",
+			kind="science paper",
+		)
+		self.private_article.sources.add(self.source)
+		self.private_article.teams.add(self.private_team)
+
+		# Trial mirrors the same shape.
+		self.shared_trial = Trials.objects.create(title="Shared Trial")
+		self.shared_trial.teams.add(self.team1, self.team2)
+
+		self.client = APIClient()
+		self.client.force_authenticate(user=self.user)
+		self.anon_client = APIClient()
+
+	def test_article_shared_across_teams_on_same_site_not_duplicated(self):
+		response = self.client.get(
+			reverse("articles-list"), {"site_id": self.site_a.id, "page_size": 50}
+		)
+		ids = [item["article_id"] for item in response.data["results"]]
+		self.assertEqual(ids.count(self.shared_article.article_id), 1)
+
+	def test_site_with_no_teams_returns_empty(self):
+		empty_site = Site.objects.create(domain="empty.example.com", name="Empty")
+		response = self.client.get(
+			reverse("articles-list"), {"site_id": empty_site.id}
+		)
+		self.assertEqual(response.data["count"], 0)
+
+	def test_anonymous_caller_excludes_private_org_team_on_shared_site(self):
+		response = self.anon_client.get(
+			reverse("articles-list"), {"site_id": self.site_a.id, "page_size": 50}
+		)
+		ids = {item["article_id"] for item in response.data["results"]}
+		self.assertIn(self.shared_article.article_id, ids)
+		self.assertNotIn(self.private_article.article_id, ids)
+
+	def test_site_id_csv_all_results_row_count_matches_orm_count(self):
+		# self.user is only a member of public_org, so org visibility scopes
+		# the count to public_org's teams on site_a (team1, team2) --
+		# private_team's article on the same site must not be counted.
+		expected_count = (
+			Articles.objects.filter(
+				teams__site_id=self.site_a.id, teams__organization_id=self.public_org.id
+			)
+			.distinct()
+			.count()
+		)
+		response = self.client.get(
+			reverse("articles-list"),
+			{"site_id": self.site_a.id, "format": "csv", "all_results": "true"},
+		)
+		content = b"".join(response.streaming_content).decode("utf-8")
+		rows = list(csv.reader(io.StringIO(content)))
+		self.assertEqual(len(rows) - 1, expected_count)
+
+	def test_trial_shared_across_teams_on_same_site_not_duplicated(self):
+		response = self.client.get(
+			reverse("trials-list"), {"site_id": self.site_a.id, "page_size": 50}
+		)
+		ids = [item["trial_id"] for item in response.data["results"]]
+		self.assertEqual(ids.count(self.shared_trial.trial_id), 1)

--- a/django/api/tests/test_streaming_csv.py
+++ b/django/api/tests/test_streaming_csv.py
@@ -2,10 +2,13 @@ import csv
 import io
 from django.test import TestCase
 from django.urls import reverse
-from rest_framework.test import APIClient
-from gregory.models import Articles, Team, TeamCategory, Sources
+from rest_framework.request import Request
+from rest_framework.test import APIClient, APIRequestFactory
+from gregory.models import Articles, OrganizationApiSettings, Team, TeamCategory, Sources
 from organizations.models import Organization
 from django.contrib.auth.models import User
+from api.direct_streaming import DirectStreamingCSVRenderer
+from api.serializers import ArticleSerializer
 
 
 class StreamingCSVRendererTest(TestCase):
@@ -95,3 +98,152 @@ class StreamingCSVRendererTest(TestCase):
 		# Verify the title contains 'Article 5'
 		title_index = rows[0].index("title")
 		self.assertTrue("Test Article 5" in rows[1][title_index])
+
+	def test_streamed_output_matches_legacy_renderer(self):
+		"""The batched streaming path must produce the same rows/columns as
+		fully serializing the queryset and running it through the legacy
+		buffered renderer (column order, quoting, JSON-encoded cells, text
+		cleaning all preserved)."""
+		response = self.client.get(
+			reverse("articles-list"), {"format": "csv", "all_results": "true"}
+		)
+		streamed = b"".join(response.streaming_content).decode("utf-8")
+
+		factory = APIRequestFactory()
+		wsgi_request = factory.get("/articles/?format=csv&all_results=true")
+		wsgi_request.user = self.user
+		drf_request = Request(wsgi_request)
+		drf_request.visible_org_ids = {self.organization.id}
+
+		data = ArticleSerializer(
+			Articles.objects.all().order_by("-discovery_date"),
+			many=True,
+			context={"request": drf_request},
+		).data
+		legacy = DirectStreamingCSVRenderer().render(data).decode("utf-8")
+
+		streamed_rows = sorted(csv.reader(io.StringIO(streamed)))
+		legacy_rows = sorted(csv.reader(io.StringIO(legacy)))
+		self.assertEqual(streamed_rows, legacy_rows)
+
+	def test_all_results_streams_in_multiple_batches(self):
+		"""With chunk_size smaller than the row count, the response must be
+		produced across more than one batch (header chunk + >=2 data chunks)."""
+		from api.views import ArticleViewSet
+
+		original_chunk_size = ArticleViewSet.csv_stream_chunk_size
+		ArticleViewSet.csv_stream_chunk_size = 3
+		try:
+			response = self.client.get(
+				reverse("articles-list"), {"format": "csv", "all_results": "true"}
+			)
+			self.assertTrue(response.streaming)
+			chunks = list(response.streaming_content)
+			self.assertGreater(len(chunks), 2)
+		finally:
+			ArticleViewSet.csv_stream_chunk_size = original_chunk_size
+
+	def test_header_omits_per_org_fields_with_no_org_context(self):
+		"""Anonymous callers with no team_id and no public org see neither
+		takeaways nor summary_plain_english in the header, and every data
+		row lines up with the header length."""
+		anon_client = APIClient()
+		response = anon_client.get(
+			reverse("articles-list"), {"format": "csv", "all_results": "true"}
+		)
+		content = b"".join(response.streaming_content).decode("utf-8")
+		rows = list(csv.reader(io.StringIO(content)))
+		header = rows[0]
+
+		self.assertNotIn("takeaways", header)
+		self.assertNotIn("summary_plain_english", header)
+		for row in rows[1:]:
+			self.assertEqual(len(row), len(header))
+
+	def test_header_includes_per_org_fields_with_public_team_id(self):
+		"""Per spec §6: an anonymous caller with ?team_id on a public org
+		gets the org context, so both per-org columns appear."""
+		OrganizationApiSettings.objects.update_or_create(
+			organization=self.organization, defaults={"make_api_public": True}
+		)
+		anon_client = APIClient()
+		response = anon_client.get(
+			reverse("articles-list"),
+			{"format": "csv", "all_results": "true", "team_id": self.team.id},
+		)
+		content = b"".join(response.streaming_content).decode("utf-8")
+		rows = list(csv.reader(io.StringIO(content)))
+		header = rows[0]
+
+		self.assertIn("takeaways", header)
+		self.assertIn("summary_plain_english", header)
+
+
+class StreamingCSVQueryBoundsTest(TestCase):
+	"""Bounded-batch prefetching: query count should grow with the number of
+	batches, not with the number of rows."""
+
+	def setUp(self):
+		self.source = Sources.objects.create(
+			name="Test Source", source_for="science paper"
+		)
+		self.user = User.objects.create_user(username="qbtest", password="12345")
+		self.organization = Organization.objects.create(
+			name="QB Organization", slug="qb-org"
+		)
+		self.organization.add_user(self.user)
+		self.team = Team.objects.create(
+			organization=self.organization, name="QB Team", slug="qb-team"
+		)
+		self.client = APIClient()
+		self.client.force_authenticate(user=self.user)
+
+	def _create_articles(self, count):
+		Articles.objects.all().delete()
+		for i in range(count):
+			article = Articles.objects.create(
+				title=f"QB Article {i}",
+				summary=f"QB summary {i}",
+				link=f"https://example.com/qb-article-{i}",
+				kind="science paper",
+			)
+			article.sources.add(self.source)
+			article.teams.add(self.team)
+
+	def test_query_count_bounded_by_batches_not_rows(self):
+		from django.db import connection
+		from django.test.utils import CaptureQueriesContext
+
+		from api.views import ArticleViewSet
+
+		original_chunk_size = ArticleViewSet.csv_stream_chunk_size
+		ArticleViewSet.csv_stream_chunk_size = 3
+		try:
+			self._create_articles(10)
+			with CaptureQueriesContext(connection) as small_ctx:
+				response = self.client.get(
+					reverse("articles-list"), {"format": "csv", "all_results": "true"}
+				)
+				list(response.streaming_content)
+			small_query_count = len(small_ctx.captured_queries)
+
+			self._create_articles(20)
+			with CaptureQueriesContext(connection) as large_ctx:
+				response = self.client.get(
+					reverse("articles-list"), {"format": "csv", "all_results": "true"}
+				)
+				list(response.streaming_content)
+			large_query_count = len(large_ctx.captured_queries)
+
+			# 10 rows / chunk_size 3 -> 4 batches; 20 rows -> 7 batches, i.e. 3
+			# extra batches. ArticleSerializer prefetches ~8 relations, so each
+			# extra batch costs roughly one query per prefetch (~8-10 queries).
+			# The bound here (15/batch) is generous but still an order of
+			# magnitude below what per-row (unbatched) prefetching across the
+			# 10 extra rows would cost.
+			extra_batches = 3
+			self.assertLess(
+				large_query_count - small_query_count, extra_batches * 15
+			)
+		finally:
+			ArticleViewSet.csv_stream_chunk_size = original_chunk_size

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -40,6 +40,11 @@ from api.serializers import (
 	OrganizationSerializer,
 )
 from api.pagination import FlexiblePagination, request_bypasses_pagination
+from api.direct_streaming import (
+	DirectStreamingCSVRenderer,
+	csv_header_fields,
+	stream_csv,
+)
 from datetime import datetime, timedelta
 from django.db.models import (
 	Count,
@@ -143,16 +148,47 @@ from api.utils.responses import (
 
 class CSVStreamingMixin:
 	"""
-	Viewset mixin that wraps a rendered CSV response in a StreamingHttpResponse.
+	Viewset mixin that streams CSV list responses in bounded batches.
 
-	Any viewset that supports ``?format=csv`` should inherit from this mixin so
-	that the CSV bytes are streamed rather than buffered in a single response
-	body.  The filename is derived from the request path via
-	``DirectStreamingCSVRenderer.get_filename``.
+	Intercepts list() for ?format=csv before DRF serializes the full
+	queryset: rows are serialized chunk_size at a time inside a generator
+	(prefetch_related batches per chunk via .iterator()), so memory stays
+	flat regardless of corpus size and the first byte leaves immediately.
 	"""
+
+	csv_stream_chunk_size = 2000
+
+	def list(self, request, *args, **kwargs):
+		if request.query_params.get("format", "").lower() != "csv":
+			return super().list(request, *args, **kwargs)
+
+		queryset = self.filter_queryset(self.get_queryset())
+		page = self.paginate_queryset(queryset)
+		source = page if page is not None else queryset
+
+		header_serializer = self.get_serializer()
+		header_fields = csv_header_fields(header_serializer, request)
+
+		def serialize_batch(batch):
+			return self.get_serializer(batch, many=True).data
+
+		filename = DirectStreamingCSVRenderer().get_filename({"request": request})
+		response = StreamingHttpResponse(
+			stream_csv(source, serialize_batch, header_fields, self.csv_stream_chunk_size),
+			content_type="text/csv; charset=utf-8",
+		)
+		response["Content-Disposition"] = f'attachment; filename="{filename}"'
+		# Without this nginx buffers the whole stream and the TTFB win
+		# evaporates in production.
+		response["X-Accel-Buffering"] = "no"
+		return response
 
 	def finalize_response(self, request, response, *args, **kwargs):
 		response = super().finalize_response(request, response, *args, **kwargs)
+		if getattr(response, "streaming", False):
+			return response
+		# Fallback wrap for non-list CSV responses (e.g. detail routes),
+		# which are single-object and small.
 		if request.query_params.get("format", "").lower() == "csv":
 			response.render()
 			csv_bytes = (
@@ -160,21 +196,14 @@ class CSVStreamingMixin:
 				if isinstance(response.content, bytes)
 				else response.content.encode("utf-8")
 			)
-
-			def csv_stream():
-				yield csv_bytes
-
-			from api.direct_streaming import DirectStreamingCSVRenderer
-
 			filename = DirectStreamingCSVRenderer().get_filename({"request": request})
 			streaming_response = StreamingHttpResponse(
-				streaming_content=csv_stream(),
+				streaming_content=iter([csv_bytes]),
 				content_type="text/csv; charset=utf-8",
 			)
 			streaming_response["Content-Disposition"] = (
 				f'attachment; filename="{filename}"'
 			)
-			streaming_response["Content-Type"] = "text/csv; charset=utf-8"
 			return streaming_response
 		return response
 
@@ -1134,6 +1163,7 @@ class ArticleViewSet(
 
 	# Query Parameters:
 	- **team_id** - filter by team ID
+	- **site_id** - filter by Django Site ID; returns articles belonging to any team attached to that site (see Team.site)
 	- **doi** - filter by DOI, case-insensitive; accepts a single value or a comma-separated list (e.g. `?doi=10.1/a,10.2/b`)
 	- **subject_id** - filter by subject ID (used with team_id)
 	- **subjects** - comma-separated list of subject IDs with AND semantics — returns only articles tagged with *all* listed subjects (e.g., `?subjects=1,2`)
@@ -1688,6 +1718,7 @@ class TrialViewSet(
 	# Core Query Parameters:
 	- **trial_id** - filter by specific trial ID
 	- **team_id** - filter by team ID
+	- **site_id** - filter by Django Site ID; returns trials belonging to any team attached to that site (see Team.site)
 	- **subject_id** - filter by subject ID
 	- **subjects** - comma-separated list of subject IDs with AND semantics — returns only trials tagged with *all* listed subjects (e.g., `?subjects=1,2`)
 	- **subjects_any** - comma-separated list of subject IDs with OR semantics — returns trials tagged with *any* of the listed subjects (e.g., `?subjects_any=1,2`)
@@ -2421,7 +2452,7 @@ class CategoriesByTeamAndSubject(viewsets.ModelViewSet):
 		)
 
 
-class ArticleSearchView(BulkExportThrottleMixin, generics.ListAPIView):
+class ArticleSearchView(CSVStreamingMixin, BulkExportThrottleMixin, generics.ListAPIView):
 	"""
 	Advanced search for articles by title and abstract (summary).
 
@@ -2651,7 +2682,7 @@ class ArticleSearchView(BulkExportThrottleMixin, generics.ListAPIView):
 		return self.list(request, *args, **kwargs)
 
 
-class TrialSearchView(BulkExportThrottleMixin, generics.ListAPIView):
+class TrialSearchView(CSVStreamingMixin, BulkExportThrottleMixin, generics.ListAPIView):
 	"""
 	Advanced search for clinical trials by title, summary, and recruitment status.
 

--- a/docs/csv-export.md
+++ b/docs/csv-export.md
@@ -10,6 +10,7 @@ All list endpoints that accept `format=csv` stream their results as a CSV file. 
 |:----------|:------------|
 | `format=csv` | Return CSV instead of JSON |
 | `all_results=true` | Bypass pagination and return all matching rows (recommended for exports) |
+| `site_id` | Filter to items belonging to any team attached to the given Django Site ID (see `Team.site`); useful for a multi-team install exporting a single frontend's scope without listing every team_id |
 
 ## What the export does
 
@@ -35,8 +36,15 @@ curl -X POST \
 
 # Export trial search results (GET)
 curl "https://api.example.com/api/trials/search/?team_id=1&subject_id=2&status=Recruiting&format=csv&all_results=true"
+
+# Export all articles for a site, across every team attached to it
+curl "https://api.example.com/articles/?site_id=1&format=csv&all_results=true"
 ```
+
+## Rate limiting
+
+`all_results=true` requests (whether CSV or JSON) are subject to the `bulk_export` throttle scope: 4 requests per hour per client. Paginated requests (no `all_results`) are unaffected. A build pipeline polling this endpoint repeatedly should cache the result rather than re-fetching on every run.
 
 ## Implementation notes
 
-The API uses `DirectStreamingCSVRenderer`, which generates CSV rows one at a time via a generator to minimise server memory usage. Large datasets do not require loading all rows into memory before streaming begins. See [streaming-csv-response.md](streaming-csv-response.md) for developer-level implementation details.
+Endpoints stream CSV rows in bounded batches rather than buffering the full dataset in memory before responding — the first byte (the header row) is sent as soon as the query starts returning data. See [streaming-csv-response.md](streaming-csv-response.md) for developer-level implementation details.

--- a/docs/streaming-csv-response.md
+++ b/docs/streaming-csv-response.md
@@ -2,106 +2,62 @@
 
 ## Overview
 
-This document explains the implementation of streaming CSV responses in the Gregory API. This feature allows the API to stream large datasets as CSV files without loading all data into memory at once, improving performance and reducing the likelihood of timeouts.
+This document explains how the Gregory API streams large CSV exports without loading the whole dataset into memory or holding up the first byte of the response. It replaces an earlier design note that described a middleware-based approach — that code no longer exists.
 
 ## Key Components
 
-We have implemented two approaches for streaming CSV responses:
-
-### 1. Middleware-Based Approach
-
-1. **StreamingCSVRenderer**: A custom renderer that extends `FlattenedCSVRenderer` to support streaming responses.
-2. **StreamingCSVMiddleware**: A middleware that converts regular responses to streaming responses when needed.
-3. **Django's StreamingHttpResponse**: Used to stream the response to the client.
-
-### 2. Direct Streaming Approach
-
-1. **DirectStreamingCSVRenderer**: A simpler renderer that directly returns a `StreamingHttpResponse`.
-2. **Django's StreamingHttpResponse**: Used to stream the response to the client.
+- **`api.direct_streaming.stream_csv`** — a generator that yields CSV text chunks: the header row first, then one chunk per batch of serialized rows.
+- **`api.direct_streaming.csv_header_fields`** — computes the static CSV header (column order) from a serializer's field names, applying the same per-org field rule the rows use, so header and rows always agree.
+- **`api.direct_streaming.process_item` / `order_columns`** — shared per-row cleanup (line-break stripping, JSON-encoding of list/dict values) and column-ordering logic, used identically by the streaming path and the legacy buffered renderer (`DirectStreamingCSVRenderer`, still used for single-object CSV responses).
+- **`api.views.CSVStreamingMixin`** — the viewset mixin that intercepts `list()` for `?format=csv` requests and returns a `StreamingHttpResponse` wrapping `stream_csv`.
+- **Django's `StreamingHttpResponse`** — streams the response to the client as the generator produces chunks.
 
 ## How It Works
 
-### Middleware-Based Approach
+1. `CSVStreamingMixin.list()` checks `request.query_params["format"]`. Non-CSV requests fall through to the normal DRF `list()`.
+2. For CSV requests, it builds the filtered queryset (`filter_queryset(get_queryset())`) and calls `paginate_queryset()`. If pagination applies (a `page_size` was given, or the request isn't exempted), the source is that page (a Python list, ≤100 rows). Otherwise (`all_results=true`) the source is the full queryset.
+3. The CSV header is computed once, up front, from `self.get_serializer().fields` — it's static per serializer, so there's no need to scan rows to discover columns.
+4. `stream_csv()` yields the header chunk immediately, then iterates the source in batches of `csv_stream_chunk_size` (2000 by default). For a queryset source it uses `.iterator(chunk_size=...)`, which Django batches `prefetch_related` calls against per chunk — so memory stays bounded by one batch's worth of prefetched rows, not the whole corpus. Each batch is serialized (`get_serializer(batch, many=True).data`), cleaned via `process_item`, and written into a small in-memory `csv.writer` buffer that is drained and yielded after each batch.
+5. `X-Accel-Buffering: no` is set on the response so nginx doesn't buffer the whole stream before forwarding it — without this header the time-to-first-byte win is lost in production even though Django itself streams correctly.
 
-1. The `StreamingCSVRenderer` generates CSV data row by row using a generator function
-2. The renderer stores this generator in `self.generator_function` and sets `streaming=True` on the response
-3. The middleware detects the streaming flag and creates a `StreamingHttpResponse` using the stored generator
-4. The middleware copies headers from the original response to the streaming response
+## For API Users
 
-### Direct Streaming Approach
+Any endpoint using `CSVStreamingMixin` (currently `ArticleViewSet`, `TrialViewSet`, `ArticleSearchView`, `TrialSearchView`) streams CSV responses transparently:
 
-1. The `DirectStreamingCSVRenderer` prepares data and creates a generator function for CSV rows
-2. The renderer returns a `StreamingHttpResponse` directly, bypassing the normal response flow
-3. The renderer sets appropriate headers on the streaming response
+- `/articles/?format=csv&all_results=true` — stream all articles as CSV
+- `/trials/?format=csv&all_results=true` — stream all clinical trials as CSV
+- `/articles/search/?team_id=1&subject_id=1&format=csv&all_results=true` — stream search results as CSV
 
-## Current Implementation
+Paginated CSV (`?format=csv&page_size=50`, no `all_results`) still returns exactly one page's rows plus the header — behavior here is unchanged from before this design.
 
-The current implementation uses the **Direct Streaming Approach** (`DirectStreamingCSVRenderer`) as the default for CSV responses. This approach was chosen for its simplicity and reliability.
+These endpoints support all the usual filtering parameters, including `site_id` (see `docs/csv-export.md`).
 
-### For API Users
+## For Developers
 
-Any endpoint that accepts the `format=csv` parameter will now automatically stream the response. For example:
+No special setup is required for a viewset that already inherits `CSVStreamingMixin` and DRF's `list()`/`get_queryset()`/`get_serializer()` conventions. `csv_stream_chunk_size` can be overridden per-viewset if a different batch size is needed.
 
-- `/articles/?format=csv` - Stream all articles as CSV
-- `/trials/?format=csv` - Stream all clinical trials as CSV
-- `/teams/1/articles/?format=csv` - Stream team articles as CSV
-
-These endpoints support all the usual filtering parameters.
-
-### For Developers
-
-No special setup is required - all CSV responses are automatically streamed. The StreamingCSVRenderer is registered as the default renderer for CSV responses in settings.py.
+Detail-route CSV responses (single object, not a list) are not streamed this way — `CSVStreamingMixin.finalize_response()` falls back to rendering the response normally and wrapping the resulting bytes in a single-chunk `StreamingHttpResponse`, since those responses are small.
 
 ## Benefits
 
-- **Reduced Memory Usage**: Only processes one row at a time, reducing server memory requirements
-- **Faster Initial Response**: Starts sending data immediately without waiting for all data to be processed
-- **Better for Large Datasets**: Can handle much larger datasets without timing out
-- **Same Filtering Capabilities**: Supports all the same filters as regular endpoints
-- **Seamless Integration**: Works automatically with all existing endpoints
-- **Clean Text Fields**: Line breaks in text fields (like summaries) are automatically removed for better CSV compatibility
+- **Bounded memory**: batches, not the whole queryset, are held in memory at any point.
+- **Fast time-to-first-byte**: the header (and the first data batch) is sent as soon as it's ready, instead of after the entire dataset has been rendered.
+- **Same filtering and column semantics**: column order, JSON-encoding of nested fields, and text cleaning are identical to the legacy renderer (`process_item`/`order_columns` are shared between both paths).
 
-## Implementation Details
-
-### CSV Generation
-
-2. **Cleans Text Fields**: Line breaks in text fields like summaries are removed and replaced with spaces
-3. **Row-by-Row Processing**: Data is processed one row at a time to minimize memory usage
-
-### Response Headers
-
-The streaming response includes the following headers:
+## Response Headers
 
 - `Content-Type: text/csv; charset=utf-8`
 - `Content-Disposition: attachment; filename="gregory-ai-{object_type}-{current_date}.csv"`
+- `X-Accel-Buffering: no`
 
 ## Troubleshooting
 
-### Binary Data in Response
+### High memory or slow first byte
 
-If binary data appears in the response instead of CSV content, it may indicate that:
+- Confirm the endpoint's viewset actually inherits `CSVStreamingMixin` and that `format=csv` is present in the query string — `list()` only takes the streaming path for CSV requests.
+- Check `csv_stream_chunk_size` hasn't been set unreasonably high.
+- In production, confirm `X-Accel-Buffering: no` is reaching nginx unmodified — a proxy that strips or ignores it will buffer the whole response regardless of what Django does.
 
-1. The middleware is improperly handling the generator function
-2. The content is being prematurely consumed
-3. The wrong renderer is being applied
+### Truncated CSV body
 
-**Root Cause of Binary Data Issue:**
-
-The original `StreamingCSVMiddleware` had a critical bug where it would use `response.content` directly for the streaming response, but this was already the binary representation of the generator object, not the actual CSV rows. This caused binary data to be sent to clients instead of CSV.
-
-This was fixed by:
-1. Properly storing the generator function in the renderer
-2. Having the middleware access the generator through `renderer.generator_function` 
-3. Creating the `DirectStreamingCSVRenderer` as a more robust alternative
-
-### Memory Issues
-
-If memory usage is still high despite streaming:
-
-1. Check for any code that might be collecting all rows before sending
-2. Ensure pagination is working correctly
-3. Verify that the generator function is properly yielding one row at a time
-
-## Conclusion
-
-The streaming CSV implementation significantly improves performance and reliability when exporting large datasets. The direct streaming approach provides the most robust solution and is the recommended implementation going forward.
+Exceptions raised mid-stream (e.g. a DB hiccup partway through) cannot become an HTTP 500 once the header has already been sent — the client sees a truncated body instead. This is inherent to HTTP streaming, not a bug to "fix" with pre-buffering.


### PR DESCRIPTION
## Summary

- Replaces the fully-buffered CSV export path with a generator-based streaming implementation. `CSVStreamingMixin.list()` now intercepts `?format=csv` requests before DRF serializes the full queryset, and serializes/writes rows in bounded batches via `queryset.iterator(chunk_size=2000)` (which batches `prefetch_related` per chunk). Header row is static (derived from serializer fields) and sent immediately.
- Applies to `ArticleViewSet`, `TrialViewSet`, `ArticleSearchView`, and `TrialSearchView` (all four now inherit `CSVStreamingMixin`).
- Adds `X-Accel-Buffering: no` so nginx doesn't buffer the response and erase the TTFB win in production.
- Adds a `site_id` filter to `ArticleFilter`/`TrialFilter` — returns objects belonging to any team attached to the given Django Site (via `Team.site`), using an `Exists()` subquery so multi-team-per-site setups don't produce duplicate rows. Useful for a single frontend exporting its scope without listing every `team_id`.
- Rewrites `docs/streaming-csv-response.md` (previously described a stale middleware-based design) and updates `docs/csv-export.md` with the `site_id` param and throttle note.
- Deletes the superseded `streaming-csv` / `test-streamingcsv` branches (local + `origin/streaming-csv`), a June 2025 experiment this PR supersedes.
- No migrations — nothing here touches models.

## Measured impact (dev DB, 47,488 articles, `team_id=1`)

| Metric | Before | After |
|---|---|---|
| TTFB | ~103s | ~0.06s |
| Peak memory | ~3.2GB | ~200MB |
| Row count / byte size | 47,489 rows / 254,211,138 bytes | identical |

Row content is identical between old and new paths (only a non-deterministic M2M ordering artifact in one unordered `sources` list differed byte-for-byte, unrelated to this change).

## Test plan

- [x] Extended `api/tests/test_streaming_csv.py`: legacy-renderer equivalence, multi-batch streaming, per-org header/row agreement (with and without org context), bounded query count across batch sizes.
- [x] `api/tests/test_csv_pagination.py` (paginated CSV contract) passes unmodified.
- [x] New `api/tests/test_site_filter.py`: dedup across teams sharing a site, empty-site case, org-visibility scoping for anonymous callers, CSV row count vs ORM count, trial dedup.
- [x] Full suite: `manage.py test` — 1807 tests, all passing.
- [x] Verified against the dev corpus: TTFB, peak memory, row-count/byte-size parity, and `site_id` filter counts vs. ORM counts (see table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)