### PR TITLE
merge_authors: store ORCID as bare ID without https://orcid.org/

### DIFF
--- a/django/gregory/management/commands/merge_authors.py
+++ b/django/gregory/management/commands/merge_authors.py
@@ -46,13 +46,15 @@ class Command(BaseCommand):
 		# Remove whitespace
 		orcid = orcid.strip()
 
-		# Extract the ORCID ID using regex
+		# Extract the ORCID ID using regex (check digit may be 'x'/'X')
 		# Matches patterns like: 0000-0000-0000-0000
-		orcid_pattern = r"(\d{4}-\d{4}-\d{4}-\d{3}[\dX])"
+		orcid_pattern = r"(\d{4}-\d{4}-\d{4}-\d{3}[\dXx])"
 		match = re.search(orcid_pattern, orcid)
 
 		if match:
-			orcid_id = match.group(1)
+			# Standardize to uppercase so lowercase check digits ("...09x")
+			# canonicalize the same as "...09X"
+			orcid_id = match.group(1).upper()
 			http_variant = f"http://orcid.org/{orcid_id}"
 			https_variant = f"https://orcid.org/{orcid_id}"
 			return orcid_id, http_variant, https_variant
@@ -60,6 +62,19 @@ class Command(BaseCommand):
 			# If no standard ORCID ID found, treat the input as-is
 			# This handles edge cases where the ORCID might be malformed
 			return orcid, orcid, orcid
+
+	def orcid_search_variants(self, orcid_id):
+		"""
+		All URL/bare forms that gregory.functions.normalize_orcid collapses
+		back down to orcid_id: with/without scheme, with/without "www.",
+		and with/without a trailing slash.
+		"""
+		variants = {orcid_id, f"{orcid_id}/"}
+		for scheme in ("http://", "https://", ""):
+			for host in ("orcid.org/", "www.orcid.org/"):
+				variants.add(f"{scheme}{host}{orcid_id}")
+				variants.add(f"{scheme}{host}{orcid_id}/")
+		return variants
 
 	def handle(self, *args, **options):
 		orcid = options["orcid"]
@@ -74,21 +89,14 @@ class Command(BaseCommand):
 		if not orcid.strip():
 			raise CommandError("ORCID cannot be empty.")
 
-		# Normalize the ORCID to find both http and https variants
-		orcid_id, http_variant, https_variant = self.normalize_orcid(orcid)
+		# Normalize the ORCID to a bare canonical ID
+		orcid_id, _, _ = self.normalize_orcid(orcid)
 
 		if not orcid_id:
 			raise CommandError(f"Invalid ORCID format: {orcid}")
 
-		# Find all authors storing this ORCID as a bare ID or as a URL variant
-		orcid_variants = {orcid_id, http_variant, https_variant}
-		if http_variant != orcid_id:
-			orcid_variants.update(
-				{
-					f"http://www.orcid.org/{orcid_id}",
-					f"https://www.orcid.org/{orcid_id}",
-				}
-			)
+		# Find all authors storing this ORCID as a bare ID or as any URL variant
+		orcid_variants = self.orcid_search_variants(orcid_id)
 
 		authors_with_orcid = (
 			Authors.objects.filter(ORCID__in=orcid_variants)

--- a/django/gregory/management/commands/merge_authors.py
+++ b/django/gregory/management/commands/merge_authors.py
@@ -1,12 +1,12 @@
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from gregory.models import Authors
-from django.db.models import Q, Count
+from django.db.models import Count
 import re
 
 
 class Command(BaseCommand):
-	help = "Merges authors with the same ORCID. Provide an ORCID as argument to merge all authors with that ORCID into one. Handles both http and https ORCID variants."
+	help = "Merges authors with the same ORCID. Provide an ORCID as argument to merge all authors with that ORCID into one. Matches http and https URL variants and stores the ORCID as the bare ID (without https://orcid.org/)."
 
 	def add_arguments(self, parser):
 		parser.add_argument(
@@ -22,7 +22,7 @@ class Command(BaseCommand):
 		parser.add_argument(
 			"--keep-author",
 			type=int,
-			help="Specify the author_id to keep when merging (default: prefers https version, then most articles, then earliest created)",
+			help="Specify the author_id to keep when merging (default: most articles, then earliest created)",
 		)
 		parser.add_argument(
 			"--force",
@@ -80,15 +80,18 @@ class Command(BaseCommand):
 		if not orcid_id:
 			raise CommandError(f"Invalid ORCID format: {orcid}")
 
-		# Find all authors with either the http or https variant of the ORCID
-		authors_query = Q(ORCID=http_variant) | Q(ORCID=https_variant)
-
-		# Also search for the raw ORCID ID in case it's stored without the URL
-		if orcid_id not in [http_variant, https_variant]:
-			authors_query |= Q(ORCID=orcid_id)
+		# Find all authors storing this ORCID as a bare ID or as a URL variant
+		orcid_variants = {orcid_id, http_variant, https_variant}
+		if http_variant != orcid_id:
+			orcid_variants.update(
+				{
+					f"http://www.orcid.org/{orcid_id}",
+					f"https://www.orcid.org/{orcid_id}",
+				}
+			)
 
 		authors_with_orcid = (
-			Authors.objects.filter(authors_query)
+			Authors.objects.filter(ORCID__in=orcid_variants)
 			.annotate(article_count=Count("articles"))
 			.order_by("-article_count", "author_id")
 		)
@@ -96,7 +99,7 @@ class Command(BaseCommand):
 		if not authors_with_orcid.exists():
 			self.stdout.write(
 				self.style.WARNING(
-					f"No authors found with ORCID: {orcid} (searched for {orcid_id}, {http_variant}, {https_variant})"
+					f"No authors found with ORCID: {orcid} (searched for {', '.join(sorted(orcid_variants))})"
 				)
 			)
 			return
@@ -109,6 +112,19 @@ class Command(BaseCommand):
 					f"{author.full_name} (ID: {author.author_id}) - ORCID stored as: {author.ORCID}"
 				)
 			)
+			if author.ORCID != orcid_id:
+				if dry_run:
+					self.stdout.write(
+						self.style.WARNING(
+							f"DRY RUN - ORCID would be normalized to: {orcid_id}"
+						)
+					)
+				else:
+					author.ORCID = orcid_id
+					author.save()
+					self.stdout.write(
+						self.style.SUCCESS(f"ORCID normalized to: {orcid_id}")
+					)
 			return
 
 		# Display found authors with their ORCID variants
@@ -118,11 +134,9 @@ class Command(BaseCommand):
 		self.stdout.write("-" * 100)
 
 		for author in authors_with_orcid:
-			https_indicator = (
-				"✓ HTTPS" if author.ORCID and "https://" in author.ORCID else "  HTTP "
-			)
+			format_indicator = "✓ ID " if author.ORCID == orcid_id else "  URL"
 			self.stdout.write(
-				f"{https_indicator} | ID: {author.author_id:5} | "
+				f"{format_indicator} | ID: {author.author_id:5} | "
 				f"Name: {author.full_name:25} | "
 				f"Articles: {author.article_count:3} | "
 				f"ORCID: {author.ORCID}"
@@ -137,24 +151,8 @@ class Command(BaseCommand):
 					f"Author with ID {keep_author_id} not found among authors with ORCID variants of {orcid_id}"
 				)
 		else:
-			# Priority: 1) HTTPS version, 2) Most articles, 3) Earliest created (lowest ID)
-			https_authors = [
-				a for a in authors_with_orcid if a.ORCID and "https://" in a.ORCID
-			]
-
-			if https_authors:
-				# Sort HTTPS authors by article count (desc) then by ID (asc)
-				https_authors.sort(key=lambda a: (-a.article_count, a.author_id))
-				author_to_keep = https_authors[0]
-				self.stdout.write(
-					f"\n📌 Prioritizing HTTPS ORCID version: {author_to_keep.ORCID}"
-				)
-			else:
-				# No HTTPS version found, use the default logic
-				author_to_keep = authors_with_orcid.first()
-				self.stdout.write(
-					f"\n⚠️  No HTTPS ORCID version found, using default selection"
-				)
+			# Priority: most articles, then earliest created (lowest ID)
+			author_to_keep = authors_with_orcid.first()
 
 		authors_to_merge = authors_with_orcid.exclude(
 			author_id=author_to_keep.author_id
@@ -173,15 +171,9 @@ class Command(BaseCommand):
 		for author in authors_to_merge:
 			self.stdout.write(f"           Merging ORCID: {author.ORCID}")
 
-		# If keeping an author with HTTP, suggest updating to HTTPS
-		if (
-			author_to_keep.ORCID
-			and "http://" in author_to_keep.ORCID
-			and "https://" not in author_to_keep.ORCID
-		):
-			suggested_https = author_to_keep.ORCID.replace("http://", "https://")
+		if author_to_keep.ORCID != orcid_id:
 			self.stdout.write(
-				f"\n💡 SUGGESTION: Consider updating the kept author's ORCID to HTTPS: {suggested_https}"
+				f"\n🔄 The kept author's ORCID will be stored as the bare ID: {orcid_id}"
 			)
 
 		if dry_run:
@@ -228,30 +220,6 @@ class Command(BaseCommand):
 			with transaction.atomic():
 				total_articles_transferred = 0
 
-				# Check if we should update the ORCID to HTTPS
-				should_update_orcid = False
-				https_orcid = None
-
-				# Look for an HTTPS version in the authors being merged
-				for author in authors_to_merge:
-					if author.ORCID and "https://" in author.ORCID:
-						https_orcid = author.ORCID
-						should_update_orcid = True
-						break
-
-				# If the author we're keeping has HTTP and we found HTTPS, update it
-				if (
-					should_update_orcid
-					and author_to_keep.ORCID
-					and "http://" in author_to_keep.ORCID
-					and "https://" not in author_to_keep.ORCID
-				):
-					old_orcid = author_to_keep.ORCID
-					author_to_keep.ORCID = https_orcid
-					self.stdout.write(
-						f"\n🔄 Updating ORCID from {old_orcid} to {https_orcid}"
-					)
-
 				for author in authors_to_merge:
 					# Get all articles associated with this author
 					articles = author.articles_set.all()
@@ -289,10 +257,9 @@ class Command(BaseCommand):
 					if not author_to_keep.orcid_check and author.orcid_check:
 						author_to_keep.orcid_check = author.orcid_check
 
-				# Save the updated author_to_keep
-				author_to_keep.save()
-
-				# Delete the duplicate authors
+				# Delete the duplicate authors before saving the kept author:
+				# a duplicate may hold the bare ORCID we are about to store, and
+				# ORCID is unique, so saving first would raise an IntegrityError
 				deleted_count = 0
 				for author in authors_to_merge:
 					self.stdout.write(
@@ -300,6 +267,14 @@ class Command(BaseCommand):
 					)
 					author.delete()
 					deleted_count += 1
+
+				# Store the ORCID as the bare ID (without https://orcid.org/)
+				if author_to_keep.ORCID != orcid_id:
+					self.stdout.write(
+						f"\n🔄 Updating ORCID from {author_to_keep.ORCID} to {orcid_id}"
+					)
+					author_to_keep.ORCID = orcid_id
+				author_to_keep.save()
 
 				self.stdout.write("\n" + "=" * 80)
 				self.stdout.write(

--- a/django/gregory/tests/test_merge_authors.py
+++ b/django/gregory/tests/test_merge_authors.py
@@ -90,6 +90,30 @@ class MergeAuthorsCommandTest(TestCase):
 		self.assertEqual(http_var, "invalid-orcid")
 		self.assertEqual(https_var, "invalid-orcid")
 
+		# Test with a lowercase check digit - should canonicalize to uppercase
+		orcid_id, http_var, https_var = cmd.normalize_orcid("0000-0000-1234-567x")
+		self.assertEqual(orcid_id, "0000-0000-1234-567X")
+		self.assertEqual(http_var, "http://orcid.org/0000-0000-1234-567X")
+		self.assertEqual(https_var, "https://orcid.org/0000-0000-1234-567X")
+
+	def test_orcid_search_variants_covers_common_storage_forms(self):
+		"""Lookups must match legacy trailing-slash and scheme-less storage forms"""
+		from gregory.management.commands.merge_authors import Command
+
+		cmd = Command()
+		orcid_id = "0000-0000-1234-5678"
+		variants = cmd.orcid_search_variants(orcid_id)
+
+		self.assertIn(orcid_id, variants)
+		self.assertIn(f"{orcid_id}/", variants)
+		self.assertIn(f"orcid.org/{orcid_id}", variants)
+		self.assertIn(f"orcid.org/{orcid_id}/", variants)
+		self.assertIn(f"www.orcid.org/{orcid_id}", variants)
+		self.assertIn(f"http://orcid.org/{orcid_id}/", variants)
+		self.assertIn(f"https://orcid.org/{orcid_id}/", variants)
+		self.assertIn(f"http://www.orcid.org/{orcid_id}/", variants)
+		self.assertIn(f"https://www.orcid.org/{orcid_id}/", variants)
+
 	def test_empty_orcid_handling(self):
 		"""Test that command properly handles empty and whitespace-only ORCID"""
 		# Test with whitespace only - this should trigger our "ORCID cannot be empty" check
@@ -217,6 +241,22 @@ class MergeAuthorsOrcidStorageTest(TestCase):
 		author.refresh_from_db()
 		self.assertEqual(author.ORCID, stored)
 		self.assertIn("ORCID would be normalized to", out.getvalue())
+
+	def test_single_author_matches_trailing_slash_and_lowercase_input(self):
+		"""A trailing-slash URL in storage must be found by a lowercase check-digit query"""
+		orcid_id = "0000-0002-1825-009X"
+		author = Authors.objects.create(
+			given_name="Ana",
+			family_name="Silva",
+			ORCID=f"https://orcid.org/{orcid_id}/",
+		)
+
+		out = StringIO()
+		call_command("merge_authors", "0000-0002-1825-009x", stdout=out)
+
+		author.refresh_from_db()
+		self.assertEqual(author.ORCID, orcid_id)
+		self.assertIn("ORCID normalized to", out.getvalue())
 
 	def test_merge_dry_run_makes_no_changes(self):
 		kept = Authors.objects.create(

--- a/django/gregory/tests/test_merge_authors.py
+++ b/django/gregory/tests/test_merge_authors.py
@@ -4,6 +4,8 @@ from django.core.management.base import CommandError
 from io import StringIO
 import uuid
 
+from gregory.models import Articles, Authors
+
 
 class MergeAuthorsCommandTest(TestCase):
 	"""Basic tests for the merge_authors command"""
@@ -119,3 +121,121 @@ class MergeAuthorsCommandTest(TestCase):
 		out = StringIO()
 		call_command("merge_authors", "not-a-valid-orcid", stdout=out)
 		self.assertIn("No authors found with ORCID", out.getvalue())
+
+
+class MergeAuthorsOrcidStorageTest(TestCase):
+	"""The merged author must end up with the bare ORCID ID, not a URL"""
+
+	ORCID_ID = "0000-0002-1825-0097"
+
+	def test_merge_stores_bare_orcid(self):
+		kept = Authors.objects.create(
+			given_name="Ana",
+			family_name="Silva",
+			ORCID=f"https://orcid.org/{self.ORCID_ID}",
+		)
+		duplicate = Authors.objects.create(
+			given_name="A.",
+			family_name="Silva",
+			ORCID=self.ORCID_ID,
+		)
+		article = Articles.objects.create(
+			title="Paper", link="https://example.com/paper"
+		)
+		article.authors.add(kept)
+
+		out = StringIO()
+		call_command("merge_authors", self.ORCID_ID, "--force", stdout=out)
+
+		kept.refresh_from_db()
+		self.assertEqual(kept.ORCID, self.ORCID_ID)
+		self.assertFalse(
+			Authors.objects.filter(author_id=duplicate.author_id).exists()
+		)
+		self.assertIn(kept, article.authors.all())
+
+	def test_merge_transfers_articles_and_stores_bare_orcid(self):
+		kept = Authors.objects.create(
+			given_name="Ana",
+			family_name="Silva",
+			ORCID=f"http://orcid.org/{self.ORCID_ID}",
+		)
+		duplicate = Authors.objects.create(
+			given_name="A.",
+			family_name="Silva",
+			ORCID=f"https://orcid.org/{self.ORCID_ID}",
+		)
+		kept_article = Articles.objects.create(
+			title="Kept paper", link="https://example.com/kept"
+		)
+		kept_article.authors.add(kept)
+		transferred_article = Articles.objects.create(
+			title="Transferred paper", link="https://example.com/transferred"
+		)
+		transferred_article.authors.add(duplicate)
+
+		out = StringIO()
+		call_command(
+			"merge_authors",
+			self.ORCID_ID,
+			"--force",
+			"--keep-author",
+			str(kept.author_id),
+			stdout=out,
+		)
+
+		kept.refresh_from_db()
+		self.assertEqual(kept.ORCID, self.ORCID_ID)
+		self.assertFalse(
+			Authors.objects.filter(author_id=duplicate.author_id).exists()
+		)
+		self.assertIn(kept, transferred_article.authors.all())
+
+	def test_single_author_orcid_is_normalized(self):
+		author = Authors.objects.create(
+			given_name="Ana",
+			family_name="Silva",
+			ORCID=f"https://orcid.org/{self.ORCID_ID}",
+		)
+
+		out = StringIO()
+		call_command("merge_authors", self.ORCID_ID, stdout=out)
+
+		author.refresh_from_db()
+		self.assertEqual(author.ORCID, self.ORCID_ID)
+		self.assertIn("ORCID normalized to", out.getvalue())
+
+	def test_single_author_dry_run_keeps_stored_orcid(self):
+		stored = f"https://orcid.org/{self.ORCID_ID}"
+		author = Authors.objects.create(
+			given_name="Ana", family_name="Silva", ORCID=stored
+		)
+
+		out = StringIO()
+		call_command("merge_authors", self.ORCID_ID, "--dry-run", stdout=out)
+
+		author.refresh_from_db()
+		self.assertEqual(author.ORCID, stored)
+		self.assertIn("ORCID would be normalized to", out.getvalue())
+
+	def test_merge_dry_run_makes_no_changes(self):
+		kept = Authors.objects.create(
+			given_name="Ana",
+			family_name="Silva",
+			ORCID=f"https://orcid.org/{self.ORCID_ID}",
+		)
+		duplicate = Authors.objects.create(
+			given_name="A.",
+			family_name="Silva",
+			ORCID=self.ORCID_ID,
+		)
+
+		out = StringIO()
+		call_command("merge_authors", self.ORCID_ID, "--dry-run", stdout=out)
+
+		kept.refresh_from_db()
+		self.assertEqual(kept.ORCID, f"https://orcid.org/{self.ORCID_ID}")
+		self.assertTrue(
+			Authors.objects.filter(author_id=duplicate.author_id).exists()
+		)
+		self.assertIn("DRY RUN - No changes will be made", out.getvalue())


### PR DESCRIPTION
## What changed

`manage.py merge_authors` now stores the merged author's ORCID as the bare ID (e.g. `0000-0002-1825-0097`) instead of the full `https://orcid.org/...` URL, matching the convention already used by `gregory.functions.normalize_orcid`.

- After a merge, the kept author's `ORCID` is always set to the bare ID.
- The old "prefer the author stored with the HTTPS URL" selection priority is gone — it only existed to pick a URL format. Default is now most articles, then lowest `author_id` (or `--keep-author`).
- If only **one** author matches and their ORCID is stored as a URL, the command normalizes it in place (respects `--dry-run`), so it doubles as a per-ORCID normalizer.
- Lookups also match `http(s)://www.orcid.org/...` variants, which occur in older data.

## Bug fix included

The old code saved the kept author with an ORCID taken from a still-existing duplicate *before* deleting that duplicate. `Authors.ORCID` is `unique=True`, so that path raised an `IntegrityError`. Duplicates are now deleted before the normalized ORCID is saved, inside the same transaction.

## Testing

Added 5 DB-backed tests in `gregory/tests/test_merge_authors.py`: merge stores the bare ID (including when a duplicate already holds it), article transfer with `--keep-author`, single-author normalization, and dry-run no-op behavior for both the single-author and merge paths. Full module run: 12 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)