### PR TITLE
Strip HTML from WHO ICTRP trial fields at ingest

### DIFF
--- a/WHO-HTML-CLEANUP-PLAN.md
+++ b/WHO-HTML-CLEANUP-PLAN.md
@@ -1,0 +1,171 @@
+# Plan: strip HTML at ingest for WHO ICTRP trial fields
+
+Executor plan (written for Sonnet). Small, self-contained. **Prerequisite for
+`INCLUSION-GENDER-NORMALIZATION-PLAN.md`** — do this one first, so the sex normalizer
+never has to strip markup itself.
+
+Evidence: dev DB (= prod) audit, 2026-07-20.
+
+## The problem
+
+`importWHOXML` stores WHO ICTRP field text verbatim. Several source registries embed
+HTML in their XML, so raw markup lands in the database and renders as literal `<br>` /
+`<b>` anywhere these fields are displayed.
+
+Affected columns and row counts (tag-whitelist match, dev DB):
+
+| Column | Rows with HTML |
+|:---|---:|
+| `inclusion_criteria` | 3,128 |
+| `exclusion_criteria` | 2,944 |
+| `condition` | 2,446 |
+| `intervention` | 2,016 |
+| `primary_outcome` | 1,456 |
+| `secondary_outcome` | ~1,368 |
+| `inclusion_gender` | 756 |
+| `study_design` | ~237 |
+| `title` / `scientific_title` | 11 each |
+| `source_support` | 2 |
+
+It is **not** one registry — six ICTRP source registers contribute
+(`inclusion_criteria` breakdown: EU Clinical Trials Register 753, IRCT 516, ChiCTR 500,
+NL-OMON 468, ANZCTR 255, ISRCTN 206). They all arrive through the same importer, so
+there is exactly **one** place to fix.
+
+Tags observed: `br` (dominant), `b`, `p`, `a`, `li`, `ul`, `tr`, `td`. HTML entities also
+appear but are rare (`&amp;` 23, `&lt;`/`&gt;` 27, `&nbsp;` 15, numeric `&#…` 135).
+
+## Two traps — read before writing code
+
+**1. `summary` must NOT be cleaned.** 13,162 trials have HTML in `summary`, and it is
+**intentional**: the CTIS feedreader composes a labeled block
+(`<b>Trial number</b>: …<br/><b>Overall trial status</b>: …`) and the EUCTR RSS summary
+is HTML including `<a href>` links. That field is rendered as HTML by consumers.
+Stripping it would destroy the display summary. **Exclude `summary` from every part of
+this change.**
+
+**2. A naive `<[a-zA-Z/][^>]*>` regex corrupts real text.** Some registries use angle
+brackets as quotation marks or placeholders — e.g. a Chinese trial's criteria reading
+`…with reference to diagnostic criteria <the guide of diagnosis and treatment>…`, and
+literal `\<TAB\>` markers. Measured naive-only (i.e. false-positive) matches: 35 in
+`inclusion_criteria`, 4 in `primary_outcome`, 1 in `exclusion_criteria`. A naive strip
+would silently delete those words from the criteria text.
+
+**Therefore: parse HTML, don't regex it.** The repo already has the right tool —
+`gregory.utils.text_utils.cleanHTML` (BeautifulSoup `.get_text()`), used elsewhere.
+BeautifulSoup leaves non-tag angle-bracket text alone, which is exactly the behaviour
+needed.
+
+## Implementation
+
+### 1. A shared cleaner (`gregory/utils/text_utils.py`)
+
+`cleanHTML` alone is not sufficient: `get_text()` on `"A<br>B"` yields `"AB"` — words
+run together. Add a sibling that is safe for these fields:
+
+```python
+def clean_field_html(value: str | None) -> str | None:
+	"""Plain text from a registry field that may contain HTML.
+
+	Block/line-break tags become whitespace before extraction so "A<br>B" yields
+	"A B", not "AB". Entities are unescaped by the parser. Whitespace is collapsed
+	and the result stripped; returns None for empty/blank input so callers keep the
+	"absent field" semantics.
+
+	Uses a real parser (not a regex): several ICTRP registries use angle brackets as
+	quotation marks (e.g. "criteria <the guide of diagnosis and treatment>"), which a
+	tag-shaped regex would delete. See WHO-HTML-CLEANUP-PLAN.md.
+	"""
+```
+
+Steps: return `None` for falsy/blank; `BeautifulSoup(value, "html.parser")`; replace
+`br`, `p`, `li`, `tr`, `div` (and their closers) with a space via
+`soup.find_all(...)` + `replace_with(" ")` or by inserting separators; `get_text(" ")`;
+`re.sub(r"\s+", " ", …).strip()`; return `None` if the result is empty.
+
+Do **not** modify `cleanHTML` — other callers depend on its current behaviour.
+
+### 2. Apply at ingest (`importWHOXML.py`)
+
+`get_text` (~line 45) is the single choke point — every one of these fields is read
+through it:
+
+```python
+def get_text(self, trial, tag_name):
+	element = trial.find(tag_name)
+	if element is not None and element.text is not None:
+		return clean_field_html(element.text)   # was: " ".join(element.text.split()).strip()
+	return None
+```
+
+`clean_field_html` already collapses whitespace, so it subsumes the existing behaviour.
+This covers every field the importer reads — including ones not in the table above, which
+is fine and desirable.
+
+**Check the other importers before finishing**: grep `feedreader_trials.py` (EU CTIS RSS)
+and `feedreader_trials_ctgov.py` for the same fields. CTIS's `EUTrialParser.parse_summary`
+already regex-extracts values out of HTML, and `summary` is deliberately HTML — so the
+expectation is *no change needed there*. Confirm and note it; don't refactor them.
+
+### 3. One-time backfill: `clean_trial_html`
+
+New management command, idempotent, `--dry-run`, modeled on
+`backfill_clean_titles` (the article-title precedent).
+
+- Columns to clean (**explicit list — `summary` is absent by design**):
+  `title`, `scientific_title`, `inclusion_criteria`, `exclusion_criteria`, `condition`,
+  `intervention`, `primary_outcome`, `secondary_outcome`, `study_design`,
+  `inclusion_gender`, `source_support`.
+- Selection: rows where any of those columns matches a **whitelisted-tag** regex
+  (`</?(br|b|p|a|i|u|em|strong|li|ul|ol|div|span|table|tr|td|th|hr|sub|sup|font)( [^>]*)?/?>`,
+  case-insensitive) — narrow selection avoids rewriting ~thousands of untouched rows.
+- For each row, run `clean_field_html` per column; write only columns that actually
+  changed.
+- **Use `bulk_update` in batches (1000), never `trial.save()`** — `save()` fans out to
+  `sync_trial_countries()` and every normalizer. **Exception:** `inclusion_gender` feeds
+  `inclusion_gender_normalized` in the *next* plan; since that field doesn't exist yet
+  when this runs, `bulk_update` is safe here. Add a comment saying so, and note that
+  after the gender plan lands, re-running this command would need
+  `backfill_trial_normalized_fields --field inclusion_gender` afterwards.
+- `.only(...)` + `.iterator(chunk_size=2000)` to bound memory.
+- Report per column: rows scanned, rows changed. `--dry-run` prints a few before/after
+  samples and writes nothing.
+
+## Tests
+
+- `clean_field_html`: `"A<br>B"` → `"A B"` (**not** `"AB"`); nested/attributed tags
+  (`<a href="…">x</a>`) → `"x"`; entities (`&amp;`, `&nbsp;`, `&#39;`) unescaped;
+  whitespace collapsed; `None`/`""`/whitespace-only → `None`;
+  **`"criteria <the guide of diagnosis and treatment> apply"` is preserved verbatim**
+  (the false-positive guard — this is the test that justifies not using a regex);
+  `"\<TAB\>"` preserved.
+- The real fixtures: `"<br>Female: yes<br>Male: yes<br>"` → `"Female: yes Male: yes"`.
+- `importWHOXML`: a trial whose XML contains `<br>` in criteria is stored clean;
+  existing importer tests still pass.
+- Command: cleans the listed columns; **leaves `summary` untouched** (explicit test with
+  an HTML-bearing summary); idempotent (second run changes 0 rows); `--dry-run` writes
+  nothing; uses `bulk_update` (assert no `Trials.save()` — query-count or patched save).
+
+## Runbook
+
+1. `clean_trial_html --dry-run` — review the before/after samples and per-column counts.
+2. Run for real. Dev, then prod. No migration.
+3. Spot-check: `SELECT count(*) FROM trials WHERE inclusion_criteria ~* '</?br…'` → 0,
+   and `SELECT count(*) FROM trials WHERE summary ~ '<'` → still ~13k (proof `summary`
+   was left alone).
+4. Then start `INCLUSION-GENDER-NORMALIZATION-PLAN.md`, whose mapping table gets simpler
+   (the HTML variants collapse into the plain ones once this has run — but keep them in
+   the table anyway, see that plan's note).
+
+## Out of scope
+
+- Cleaning `summary` (intentional HTML).
+- Article-side HTML (separate corpus, separate precedent in `backfill_clean_titles`).
+- Rewriting CTIS/CTGov importers (they don't leak — verify, then leave alone).
+- Any normalization work; this change only removes markup.
+
+## Process checklist
+
+- Branch off up-to-date `main` in `~/Labs/gregory`; never commit to `main`.
+- Full test suite before committing.
+- After review: push fixes, resolve each addressed PR comment thread on GitHub.

--- a/django/gregory/management/commands/clean_trial_html.py
+++ b/django/gregory/management/commands/clean_trial_html.py
@@ -1,0 +1,147 @@
+"""One-time (idempotent, re-runnable) backfill that strips HTML markup from WHO
+ICTRP trial text fields already in the database.
+
+importWHOXML now cleans every field it reads at ingest time (see
+gregory.utils.text_utils.clean_field_html), but rows imported before that change
+still hold raw markup (<br>, <b>, <a href="...">, ...) from six different ICTRP
+source registries. This command applies the same cleaning to those existing rows.
+
+`summary` is deliberately excluded: the CTIS feedreader composes a labeled HTML
+block (`<b>Trial number</b>: ...<br/>...`) and the EUCTR RSS summary embeds
+`<a href>` links — both are rendered as HTML by consumers. Cleaning it would
+destroy the display summary. See WHO-HTML-CLEANUP-PLAN.md.
+
+Selection is narrowed to rows where some column matches a whitelisted-tag regex
+(gregory.utils.text_utils.ALLOWED_TAGS), so the far larger set of rows with no
+HTML at all is never touched.
+
+Only the columns that actually changed are written, one bulk_update per column,
+never Trials.save() -- save() fans out to sync_trial_countries() and every
+registered field normalizer (~3+ queries per row); see backfill_trial_countries.py
+/ backfill_trial_sponsors.py for the same reasoning.
+
+inclusion_gender is safe to bulk_update here: this command runs BEFORE
+INCLUSION-GENDER-NORMALIZATION-PLAN.md's inclusion_gender_normalized field exists.
+If this command is ever re-run after that field lands, follow it with
+`backfill_trial_normalized_fields --field inclusion_gender` -- bulk_update bypasses
+save(), so it would not recompute that normalizer.
+"""
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from gregory.models import Trials
+from gregory.utils.text_utils import ALLOWED_TAGS, clean_field_html
+
+# summary is intentionally absent -- see module docstring.
+COLUMNS = [
+	"title",
+	"scientific_title",
+	"inclusion_criteria",
+	"exclusion_criteria",
+	"condition",
+	"intervention",
+	"primary_outcome",
+	"secondary_outcome",
+	"study_design",
+	"inclusion_gender",
+	"source_support",
+]
+
+# Same whitelist the cleaner itself treats as real markup, so row selection can't
+# diverge from what clean_field_html actually strips.
+TAG_PATTERN = r"</?(" + "|".join(ALLOWED_TAGS) + r")(\s[^<>]*)?/?>"
+
+
+class Command(BaseCommand):
+	help = "Strip HTML markup from WHO ICTRP trial text fields already in the database (summary excluded by design)."
+
+	def add_arguments(self, parser):
+		parser.add_argument(
+			"--batch-size",
+			type=int,
+			default=1000,
+			help="Rows per bulk_update batch (default: 1000).",
+		)
+		parser.add_argument(
+			"--dry-run",
+			action="store_true",
+			help="Report what would change without saving.",
+		)
+
+	def handle(self, *args, **options):
+		batch_size = max(options["batch_size"], 1)
+		dry_run = options["dry_run"]
+
+		selection_q = Q()
+		for col in COLUMNS:
+			selection_q |= Q(**{f"{col}__iregex": TAG_PATTERN})
+
+		queryset = (
+			Trials.objects.filter(selection_q)
+			.only("trial_id", *COLUMNS)
+			.order_by("trial_id")
+		)
+
+		scanned = 0
+		rows_changed = 0
+		column_changed_counts = {col: 0 for col in COLUMNS}
+		dirty_by_column = {col: [] for col in COLUMNS}
+		samples = []
+
+		def flush(col):
+			if dirty_by_column[col]:
+				Trials.objects.bulk_update(
+					dirty_by_column[col], [col], batch_size=batch_size
+				)
+				dirty_by_column[col] = []
+
+		for trial in queryset.iterator(chunk_size=2000):
+			scanned += 1
+			row_changed = False
+			for col in COLUMNS:
+				raw = getattr(trial, col)
+				if not raw:
+					continue
+				cleaned = clean_field_html(raw)
+				if cleaned is None and col == "title":
+					# title is NOT NULL; never blank it even if it were all markup.
+					continue
+				if cleaned == raw:
+					continue
+
+				row_changed = True
+				column_changed_counts[col] += 1
+				if dry_run:
+					if len(samples) < 10:
+						samples.append((trial.trial_id, col, raw, cleaned))
+				else:
+					dirty_by_column[col].append(
+						Trials(trial_id=trial.trial_id, **{col: cleaned})
+					)
+					if len(dirty_by_column[col]) >= batch_size:
+						flush(col)
+
+			if row_changed:
+				rows_changed += 1
+
+		if not dry_run:
+			for col in COLUMNS:
+				flush(col)
+
+		prefix = "Would change" if dry_run else "Changed"
+		self.stdout.write(
+			self.style.SUCCESS(
+				f"Scanned {scanned} trial(s) matching the HTML-tag selection. "
+				f"{prefix} {rows_changed} row(s)."
+			)
+		)
+		for col in COLUMNS:
+			count = column_changed_counts[col]
+			if count:
+				self.stdout.write(f"  {col}: {count}")
+
+		if dry_run and samples:
+			self.stdout.write("\nSample changes (up to 10):")
+			for trial_id, col, before, after in samples:
+				self.stdout.write(f"  trial {trial_id} / {col}:\n    - {before!r}\n    + {after!r}")

--- a/django/gregory/management/commands/importWHOXML.py
+++ b/django/gregory/management/commands/importWHOXML.py
@@ -9,6 +9,7 @@ from gregory.utils.registry_utils import (
 	canonical_link,
 	merge_countries_by_source,
 )
+from gregory.utils.text_utils import clean_field_html
 import datetime
 import xml.etree.ElementTree as ET
 import pytz
@@ -45,8 +46,7 @@ class Command(BaseCommand):
 	def get_text(self, trial, tag_name):
 		element = trial.find(tag_name)
 		if element is not None and element.text is not None:
-			# Strip leading and trailing whitespace and normalize whitespace within
-			return " ".join(element.text.split()).strip()
+			return clean_field_html(element.text)
 		return None
 
 	def _safe_change_reason(self, reason: str) -> str:

--- a/django/gregory/tests/management/test_clean_trial_html.py
+++ b/django/gregory/tests/management/test_clean_trial_html.py
@@ -1,0 +1,108 @@
+"""Tests for the clean_trial_html management command.
+
+Run:
+	docker exec gregory python manage.py test gregory.tests.management.test_clean_trial_html
+"""
+
+import os
+from io import StringIO
+from unittest import mock
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+django.setup()
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from gregory.models import Trials
+
+
+class CleanTrialHtmlCommandTest(TestCase):
+	def run_command(self, **kwargs):
+		out, err = StringIO(), StringIO()
+		call_command("clean_trial_html", stdout=out, stderr=err, **kwargs)
+		return out.getvalue(), err.getvalue()
+
+	def _make_trial(self, n, **fields):
+		trial = Trials.objects.create(
+			title=fields.pop("title", f"Trial {n}"),
+			link=f"https://example.com/clean-trial-html-{n}",
+		)
+		if fields:
+			Trials.objects.filter(pk=trial.pk).update(**fields)
+			trial.refresh_from_db()
+		return trial
+
+	def test_cleans_html_from_listed_columns(self):
+		trial = self._make_trial(
+			1,
+			inclusion_criteria="Age &gt;18<br>Confirmed diagnosis<br>",
+			inclusion_gender="<br>Female: yes<br>Male: yes<br>",
+			condition="<p>Multiple Sclerosis</p>",
+		)
+		out, _ = self.run_command()
+		trial.refresh_from_db()
+		self.assertEqual(trial.inclusion_criteria, "Age >18 Confirmed diagnosis")
+		self.assertEqual(trial.inclusion_gender, "Female: yes Male: yes")
+		self.assertEqual(trial.condition, "Multiple Sclerosis")
+		self.assertIn("inclusion_criteria: 1", out)
+		self.assertIn("inclusion_gender: 1", out)
+		self.assertIn("condition: 1", out)
+
+	def test_summary_is_never_touched(self):
+		"""summary is intentional HTML (CTIS/EUCTR compose it deliberately) and must
+		never be cleaned, even when other columns on the same row have HTML."""
+		trial = self._make_trial(
+			2,
+			summary="<b>Trial number</b>: 123<br/>Overall status: Recruiting",
+			condition="<br>Multiple Sclerosis<br>",
+		)
+		original_summary = trial.summary
+		self.run_command()
+		trial.refresh_from_db()
+		self.assertEqual(trial.summary, original_summary)
+		self.assertIn("<br", trial.summary)
+		self.assertEqual(trial.condition, "Multiple Sclerosis")
+
+	def test_clean_row_is_left_unchanged(self):
+		trial = self._make_trial(
+			3,
+			inclusion_criteria="No markup here at all",
+		)
+		self.run_command()
+		trial.refresh_from_db()
+		self.assertEqual(trial.inclusion_criteria, "No markup here at all")
+
+	def test_dry_run_writes_nothing(self):
+		trial = self._make_trial(4, condition="<br>Multiple Sclerosis<br>")
+		original = trial.condition
+		out, _ = self.run_command(**{"dry_run": True})
+		trial.refresh_from_db()
+		self.assertEqual(trial.condition, original)
+		self.assertIn("Would change 1 row(s)", out)
+
+	def test_idempotent_second_run_changes_nothing(self):
+		self._make_trial(5, condition="<br>Multiple Sclerosis<br>")
+		self.run_command()
+		out, _ = self.run_command()
+		self.assertIn("Changed 0 row(s)", out)
+
+	def test_does_not_blank_non_nullable_title(self):
+		"""title is NOT NULL; if it were ever all markup, cleaning must not blank it."""
+		trial = self._make_trial(6, title="<br>")
+		# The command's selection query only looks at listed columns via title too,
+		# so this row is picked up; title must survive unblanked.
+		self.run_command()
+		trial.refresh_from_db()
+		self.assertEqual(trial.title, "<br>")
+
+	def test_uses_bulk_update_not_save(self):
+		"""bulk_update bypasses Trials.save() (which fans out to
+		sync_trial_countries() and every field normalizer); this command must never
+		call save() on a Trials instance."""
+		self._make_trial(7, condition="<br>Multiple Sclerosis<br>")
+		with mock.patch.object(Trials, "save", autospec=True) as mocked_save:
+			self.run_command()
+		mocked_save.assert_not_called()

--- a/django/gregory/tests/test_text_utils.py
+++ b/django/gregory/tests/test_text_utils.py
@@ -1,0 +1,68 @@
+"""
+Tests for gregory.utils.text_utils.clean_field_html.
+
+Run:
+  docker exec gregory python manage.py test gregory.tests.test_text_utils
+"""
+
+import os
+import unittest
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+django.setup()
+
+from gregory.utils.text_utils import clean_field_html
+
+
+class CleanFieldHtmlTest(unittest.TestCase):
+	def test_br_becomes_space_not_concatenation(self):
+		self.assertEqual(clean_field_html("A<br>B"), "A B")
+
+	def test_nested_attributed_tag_extracts_text(self):
+		self.assertEqual(clean_field_html('<a href="https://example.org">x</a>'), "x")
+
+	def test_entities_are_unescaped(self):
+		self.assertEqual(clean_field_html("a &amp; b"), "a & b")
+		self.assertEqual(clean_field_html("a&nbsp;b"), "a b")
+		self.assertEqual(clean_field_html("it&#39;s ok"), "it's ok")
+
+	def test_whitespace_is_collapsed_and_stripped(self):
+		self.assertEqual(clean_field_html("  A   B  "), "A B")
+
+	def test_empty_and_blank_input_returns_none(self):
+		self.assertIsNone(clean_field_html(None))
+		self.assertIsNone(clean_field_html(""))
+		self.assertIsNone(clean_field_html("   "))
+
+	def test_angle_brackets_used_as_quotation_marks_are_preserved(self):
+		# The false-positive guard: some ICTRP registries use angle brackets as
+		# quotation marks, not markup. A tag-shaped regex would delete this text;
+		# a real parser must leave it alone. This is why clean_field_html parses
+		# HTML instead of regexing it.
+		text = "criteria <the guide of diagnosis and treatment> apply"
+		self.assertEqual(clean_field_html(text), text)
+
+	def test_literal_tab_marker_is_preserved(self):
+		text = r"\<TAB\>"
+		self.assertEqual(clean_field_html(text), text)
+
+	def test_real_fixture_inclusion_gender(self):
+		text = "<br>Female: yes<br>Male: yes<br>"
+		self.assertEqual(clean_field_html(text), "Female: yes Male: yes")
+
+	def test_block_tags_preserve_inner_text(self):
+		self.assertEqual(
+			clean_field_html("<p>para1</p><p>para2</p>"), "para1 para2"
+		)
+		self.assertEqual(
+			clean_field_html("<ul><li>one</li><li>two</li></ul>"), "one two"
+		)
+		self.assertEqual(
+			clean_field_html("<tr><td>a</td><td>b</td></tr>"), "a b"
+		)
+
+	def test_no_markup_returns_unchanged_text(self):
+		text = "plain text with no markup at all, just words"
+		self.assertEqual(clean_field_html(text), text)

--- a/django/gregory/tests/test_who_importer.py
+++ b/django/gregory/tests/test_who_importer.py
@@ -122,3 +122,57 @@ class WHOResultsUrlLinkTest(TestCase):
 		self.assertEqual(
 			t.results_url_link, "https://www.isrctn.com/ISRCTN22222222#results"
 		)
+
+
+_WHO_XML_HTML_TEMPLATE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<Trials_central>
+  <Trial>
+    <TrialID>{trial_id}</TrialID>
+    <Public_title>Test Trial HTML Cleaning</Public_title>
+    <Scientific_title>Scientific Test Trial</Scientific_title>
+    <Primary_sponsor>Test Sponsor</Primary_sponsor>
+    <Date_registration>2023-01-15</Date_registration>
+    <web_address>https://trialsearch.who.int/Trial2.aspx?TrialID={trial_id}</web_address>
+    <Inclusion_Criteria>{inclusion_criteria}</Inclusion_Criteria>
+    <Inclusion_gender>{inclusion_gender}</Inclusion_gender>
+  </Trial>
+</Trials_central>
+"""
+
+
+class WHOHTMLCleaningTest(TestCase):
+	def setUp(self):
+		self.source = _who_source()
+
+	def test_html_markup_is_stripped_at_ingest(self):
+		# Real WHO ICTRP XML entity-encodes embedded HTML (&lt;br&gt;), since a raw
+		# unescaped <br> would be parsed as a child element, not text content.
+		xml = _WHO_XML_HTML_TEMPLATE.format(
+			trial_id="ISRCTN33333333",
+			inclusion_criteria="Age &gt;18&lt;br&gt;Confirmed diagnosis&lt;br&gt;",
+			inclusion_gender="&lt;br&gt;Female: yes&lt;br&gt;Male: yes&lt;br&gt;",
+		)
+		_run_import(xml, self.source.source_id)
+		t = Trials.objects.get(identifiers__isrctn="ISRCTN33333333")
+		self.assertEqual(t.inclusion_criteria, "Age >18 Confirmed diagnosis")
+		self.assertEqual(t.inclusion_gender, "Female: yes Male: yes")
+		self.assertNotIn("<br>", t.inclusion_criteria)
+		self.assertNotIn("<br>", t.inclusion_gender)
+
+	def test_angle_bracket_quotation_marks_are_preserved(self):
+		xml = _WHO_XML_HTML_TEMPLATE.format(
+			trial_id="ISRCTN44444444",
+			inclusion_criteria=(
+				"Diagnosis with reference to diagnostic criteria "
+				"&lt;the guide of diagnosis and treatment&gt; required"
+			),
+			inclusion_gender="Both",
+		)
+		_run_import(xml, self.source.source_id)
+		t = Trials.objects.get(identifiers__isrctn="ISRCTN44444444")
+		self.assertEqual(
+			t.inclusion_criteria,
+			"Diagnosis with reference to diagnostic criteria "
+			"<the guide of diagnosis and treatment> required",
+		)

--- a/django/gregory/utils/text_utils.py
+++ b/django/gregory/utils/text_utils.py
@@ -1,6 +1,7 @@
 import re
+import warnings
 import stopwords
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, MarkupResemblesLocatorWarning
 
 # Define some cleaning procedures:
 REPLACE_BY_SPACE_RE = re.compile(r"[/(){}\[\]\|@,;]")
@@ -103,3 +104,78 @@ def cleanHTML(input):
 	if not input:
 		return ""
 	return BeautifulSoup(input, "html.parser").get_text()
+
+
+BLOCK_TAGS = ("br", "p", "li", "tr", "div")
+
+# Tags actually seen in WHO ICTRP registry fields. Shared with backfill_clean_titles'
+# sibling command (clean_trial_html) so row selection uses the same whitelist as the
+# cleaner itself.
+ALLOWED_TAGS = BLOCK_TAGS + (
+	"b", "a", "i", "u", "em", "strong", "ul", "ol", "table", "td", "th", "hr",
+	"sub", "sup", "font", "span",
+)
+
+# html.parser treats *any* "<word word...>" as a tag, which would swallow angle
+# brackets some registries use as quotation marks (e.g. "criteria <the guide of
+# diagnosis and treatment>"). Only whitelisted tags are parsed as markup; everything
+# else is escaped to literal text before parsing so the parser can't misread it.
+_ALLOWED_TAG_RE = re.compile(
+	r"</?(?:" + "|".join(ALLOWED_TAGS) + r")(?:\s[^<>]*)?/?>",
+	re.IGNORECASE,
+)
+
+
+def _escape_non_tag_angle_brackets(text):
+	"""Escape < and > outside whitelisted tags so a parser treats them as literal
+	characters rather than markup."""
+	out = []
+	pos = 0
+	for match in _ALLOWED_TAG_RE.finditer(text):
+		out.append(text[pos:match.start()].replace("<", "&lt;").replace(">", "&gt;"))
+		out.append(match.group(0))
+		pos = match.end()
+	out.append(text[pos:].replace("<", "&lt;").replace(">", "&gt;"))
+	return "".join(out)
+
+
+def clean_field_html(value):
+	"""
+	Plain text from a registry field that may contain HTML.
+
+	Block/line-break tags become whitespace before extraction so "A<br>B" yields
+	"A B", not "AB" (plain get_text() would run the words together). Entities are
+	unescaped by the parser. Whitespace is collapsed and the result stripped;
+	returns None for empty/blank input so callers keep the "absent field" semantics.
+
+	Uses a real parser (not a regex): several ICTRP registries use angle brackets as
+	quotation marks (e.g. "criteria <the guide of diagnosis and treatment>"), which a
+	tag-shaped regex would delete. See WHO-HTML-CLEANUP-PLAN.md.
+
+	Arguments
+	---------
+	value: a string that may contain HTML, or None
+
+	Output
+	------
+	return: plain text, or None if input is empty/blank or becomes empty after cleaning
+	"""
+	if not value or not isinstance(value, str) or not value.strip():
+		return None
+
+	escaped = _escape_non_tag_angle_brackets(value)
+	# Most fields have no HTML at all; plain text can still trip bs4's "resembles a
+	# filename/URL" heuristic, which is irrelevant here (input is always XML field
+	# text, never a path to open).
+	with warnings.catch_warnings():
+		warnings.simplefilter("ignore", MarkupResemblesLocatorWarning)
+		soup = BeautifulSoup(escaped, "html.parser")
+	# unwrap (not replace_with): these tags can carry inner text (<p>, <li>, ...),
+	# so only the tag markup becomes a space -- the content must stay.
+	for tag in soup.find_all(BLOCK_TAGS):
+		tag.insert_before(" ")
+		tag.unwrap()
+
+	text = soup.get_text(" ")
+	text = MULTIPLE_SPACES_RE.sub(" ", text).strip()
+	return text or None


### PR DESCRIPTION
## Summary

- WHO ICTRP's XML importer (`importWHOXML`) stored field text verbatim, so embedded HTML from six source registries (`<br>`, `<b>`, `<a>`, `<p>`, `<li>`, `<tr>`/`<td>`, ...) landed in the DB and rendered as literal markup wherever these fields are displayed.
- Adds `gregory.utils.text_utils.clean_field_html`: a BeautifulSoup-based cleaner (not a regex) that strips a whitelist of known tags, unescapes HTML entities, and collapses whitespace, while preserving angle-bracket text some registries use as literal quotation marks (e.g. `criteria <the guide of diagnosis and treatment>`) — a naive tag-shaped regex would have deleted that text.
- Wires the cleaner into `importWHOXML.get_text`, the single choke point every field is read through, so new imports are clean automatically.
- `summary` is deliberately excluded everywhere in this change — the CTIS feedreader and EUCTR RSS compose it as real HTML by design (labeled `<b>`/`<br>` blocks, `<a href>` links), and it's rendered as HTML by consumers.
- Adds `clean_trial_html`, a one-time idempotent backfill management command for rows imported before this change. Uses `bulk_update` per column (never `Trials.save()`, which would fan out to `sync_trial_countries()` and every field normalizer) and supports `--dry-run`.
- Confirmed (and left alone) that CTIS and ClinicalTrials.gov importers don't need the same fix: CTIS extracts fields via a `[^<]+` regex against its RSS summary HTML, which structurally can't capture a tag; ClinicalTrials.gov's fields come from its JSON API as plain text.

## Notable implementation details

The plan this PR implements assumed BeautifulSoup would leave non-tag angle-bracket text alone by default. In practice `html.parser` treats any `<word word...>` as a tag (with the words as boolean attributes) and strips it via `get_text()`. Fixed by pre-escaping any `<`/`>` that isn't part of a recognized whitelisted tag, so only real markup is parsed as such — the rest passes through as literal text.

Also caught that `Tag.replace_with(" ")` on `<p>`/`<li>`/`<div>` etc. deletes the tag's *inner text* along with it, not just the tag boundary — switched to `insert_before(" ")` + `unwrap()` so content is preserved and only the tag markup becomes whitespace.

## Test plan

- [x] New unit tests for `clean_field_html` covering `<br>` spacing, nested/attributed tags, entity unescaping, the angle-bracket-as-quotation-mark false-positive guard, and block-tag content preservation (`gregory/tests/test_text_utils.py`)
- [x] Importer tests confirming HTML is cleaned at ingest and angle-bracket text is preserved (`gregory/tests/test_who_importer.py`)
- [x] Command tests: cleans listed columns, `summary` never touched, dry-run writes nothing, idempotent on second run, uses `bulk_update` not `save()`, never blanks the non-nullable `title` column (`gregory/tests/management/test_clean_trial_html.py`)
- [x] Full test suite: 2220 tests pass
- [x] Ran `clean_trial_html` for real against the dev DB (mirrors prod): 3,652 rows changed, second run changes 0 (idempotent), spot-checked that no target column still matches the tag pattern and `summary` still has ~13k rows containing `<` (untouched, as intended)
- [ ] **Not yet run against production** — needs a deliberate follow-up before/after deploy, per the runbook in `WHO-HTML-CLEANUP-PLAN.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)