### PR TITLE
Speed up CI test suite: skip migrations, fast hasher, in-memory cache

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ hashFiles('django/requirements.txt') }}
+          restore-keys: pip-
+
       - name: Install/update Python dependencies
         working-directory: django
         run: pip install --quiet -r requirements.txt

--- a/django/admin/settings_test.py
+++ b/django/admin/settings_test.py
@@ -1,0 +1,14 @@
+"""Pytest settings module — real Postgres, fast auth/cache for CI.
+
+Inherits everything from admin.settings (Postgres DATABASES, USE_TZ, secrets
+from env, ...) and only swaps the two knobs that make tests slow without
+changing test-observable behavior.
+"""
+
+from admin.settings import *
+
+# Fast hashing — tests don't need PBKDF2's ~600k iterations.
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
+# In-memory cache — no Postgres round-trips, no createcachetable needed.
+CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}

--- a/django/api/tests/test_visibility_stats.py
+++ b/django/api/tests/test_visibility_stats.py
@@ -441,19 +441,17 @@ class StatsQueryCountTest(StatsVisibilityBase):
 		"""
 		A team-scoped /stats/ call must stay within a small query budget.
 
-		Budget breakdown (cold cache, 14 queries):
+		Budget breakdown (cold cache, 8 queries with the test suite's
+		LocMemCache — CACHES in admin.settings_test — which never touches
+		the DB; production's DatabaseCache adds a cache GET/SET pair plus a
+		cull COUNT and SAVEPOINT/RELEASE, hence the generous <=15 ceiling):
 		  1 — VisibleOrgMiddleware: OrganizationApiSettings lookup
 		  1 — team visibility check (Team.objects.filter COUNT)
 		  1 — resolve team_id_list (Team VALUES)
-		  1 — cache GET (miss)
 		  4 — articles, trials, authors, subscribers COUNT DISTINCT
 		  1 — sources VALUES
-		  4 — cache SET (COUNT + SAVEPOINT + key lookup + INSERT + RELEASE)
-		= 14 queries.
+		= 8 queries.
 		"""
-		# The DatabaseCache write adds a cull COUNT plus a SAVEPOINT/RELEASE pair
-		# whose presence varies by backend/transaction mode, so allow a little
-		# slack (<=15) instead of pinning the count exactly.
 		from django.db import connection
 		from django.test.utils import CaptureQueriesContext
 
@@ -468,7 +466,9 @@ class StatsQueryCountTest(StatsVisibilityBase):
 	def test_cached_call_query_budget(self):
 		"""A cache-warm call must issue far fewer queries than a cold one."""
 		self.client.get("/stats/", {"team": self.pub_team.id})  # warm the cache
+		# 3, not 4: the test suite's LocMemCache backend answers cache GET
+		# in-process, issuing no SQL (unlike production's DatabaseCache).
 		with self.assertNumQueries(
-			4, msg="Cache hit should eliminate the count queries"
+			3, msg="Cache hit should eliminate the count queries"
 		):
 			self.client.get("/stats/", {"team": self.pub_team.id})

--- a/django/conftest.py
+++ b/django/conftest.py
@@ -24,10 +24,19 @@ database never has the wrong constraint to begin with.
 from django.db import connections
 from django.db.models.signals import post_migrate, pre_migrate
 
+# Both signals fire once per installed app (see
+# django.core.management.sql.emit_{pre,post}_migrate_signal); gate on a
+# single app label so the SQL below runs exactly once per test DB setup
+# instead of once per app.
+_GATE_APP_LABEL = "gregory"
+
 
 def _create_pg_trgm_extension(sender, **kwargs):
 	using = kwargs.get("using", "default")
-	with connections[using].cursor() as cursor:
+	connection = connections[using]
+	if sender.label != _GATE_APP_LABEL or connection.vendor != "postgresql":
+		return
+	with connection.cursor() as cursor:
 		cursor.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
 
 
@@ -49,10 +58,13 @@ _CUSTOM_INDEXES = (
 
 def _create_custom_perf_indexes(sender, **kwargs):
 	using = kwargs.get("using", "default")
-	with connections[using].cursor() as cursor:
+	connection = connections[using]
+	if sender.label != _GATE_APP_LABEL or connection.vendor != "postgresql":
+		return
+	with connection.cursor() as cursor:
 		for sql in _CUSTOM_INDEXES:
 			cursor.execute(sql)
 
 
-pre_migrate.connect(_create_pg_trgm_extension)
-post_migrate.connect(_create_custom_perf_indexes)
+pre_migrate.connect(_create_pg_trgm_extension, dispatch_uid="conftest_create_pg_trgm_extension")
+post_migrate.connect(_create_custom_perf_indexes, dispatch_uid="conftest_create_custom_perf_indexes")

--- a/django/conftest.py
+++ b/django/conftest.py
@@ -1,22 +1,58 @@
 """Pytest configuration shared across the Django test suite.
 
-The default cache backend (admin.settings) is Django's DatabaseCache, whose
-table (`gregory_cache`) is created out-of-band via `manage.py createcachetable`
-rather than by a migration. Freshly built test databases therefore lack the
-table, so any test exercising the cache fails with
-``ProgrammingError: relation "gregory_cache" does not exist``.
+``--no-migrations`` (pytest.ini) skips all migrations, including hand-written
+``RunSQL`` operations that aren't derivable from current model state:
 
-Create the cache table once, right after the test database is set up, so the
-real DatabaseCache backend behaves exactly as it does in production.
+- ``CREATE EXTENSION pg_trgm`` (gregory/migrations/0019): several models
+  declare GIN trigram indexes in their ``Meta.indexes`` (e.g.
+  ``authors_ufull_name_gin_idx``), which sync_apps still creates directly
+  from the model state — but that CREATE INDEX fails without the extension
+  in place first. Created on the ``pre_migrate`` signal, which Django fires
+  before sync_apps regardless of migration mode.
+
+- Hand-named performance indexes (gregory/migrations/0022, net of the
+  columns 0050 later superseded with ``db_index=True``) that live only as
+  raw SQL, not as ``Meta.indexes`` entries. Created on ``post_migrate``,
+  once sync_apps has built the tables they apply to.
+
+The historical migrations that only repair stale FK constraints (0005,
+0009, 0037, 0047, 0073, subscriptions/0012) are omitted here on purpose:
+they patch up databases restored from old dumps, and a syncdb-built test
+database never has the wrong constraint to begin with.
 """
 
-import pytest
-from django.core.management import call_command
+from django.db import connections
+from django.db.models.signals import post_migrate, pre_migrate
 
 
-@pytest.fixture(scope="session")
-def django_db_setup(django_db_setup, django_db_blocker):
-	with django_db_blocker.unblock():
-		# createcachetable is idempotent — a no-op if the table already exists
-		# (relevant when --reuse-db keeps the database between runs).
-		call_command("createcachetable")
+def _create_pg_trgm_extension(sender, **kwargs):
+	using = kwargs.get("using", "default")
+	with connections[using].cursor() as cursor:
+		cursor.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+
+_CUSTOM_INDEXES = (
+	"CREATE INDEX IF NOT EXISTS idx_articles_team_categories_category_id ON articles_team_categories (teamcategory_id);",
+	"CREATE INDEX IF NOT EXISTS idx_articles_team_categories_article_id ON articles_team_categories (articles_id);",
+	"CREATE INDEX IF NOT EXISTS idx_trials_team_categories_category_id ON trials_team_categories (teamcategory_id);",
+	"CREATE INDEX IF NOT EXISTS idx_trials_team_categories_trial_id ON trials_team_categories (trials_id);",
+	"CREATE INDEX IF NOT EXISTS idx_articles_authors_article_id ON articles_authors (articles_id);",
+	"CREATE INDEX IF NOT EXISTS idx_articles_authors_author_id ON articles_authors (authors_id);",
+	"CREATE INDEX IF NOT EXISTS idx_trials_discovery_date ON trials (discovery_date);",
+	"CREATE INDEX IF NOT EXISTS idx_team_categories_team_subject ON team_categories (team_id, id);",
+	"CREATE INDEX IF NOT EXISTS idx_team_categories_slug ON team_categories (category_slug);",
+	"CREATE INDEX IF NOT EXISTS idx_team_categories_team_id ON team_categories (team_id);",
+	"CREATE INDEX IF NOT EXISTS idx_articles_covering ON articles (article_id, title, published_date, discovery_date);",
+	"CREATE INDEX IF NOT EXISTS idx_trials_covering ON trials (trial_id, title, published_date, discovery_date);",
+)
+
+
+def _create_custom_perf_indexes(sender, **kwargs):
+	using = kwargs.get("using", "default")
+	with connections[using].cursor() as cursor:
+		for sql in _CUSTOM_INDEXES:
+			cursor.execute(sql)
+
+
+pre_migrate.connect(_create_pg_trgm_extension)
+post_migrate.connect(_create_custom_perf_indexes)

--- a/django/pytest.ini
+++ b/django/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = admin.settings
+DJANGO_SETTINGS_MODULE = admin.settings_test
 python_files = test_*.py tests.py
 python_classes = Test*
 python_functions = test_*
 testpaths = api gregory subscriptions indexers rss sitesettings
-addopts = --reuse-db --dist loadfile -n auto
+addopts = --reuse-db --no-migrations --dist loadfile -n auto

--- a/django/pytest.ini
+++ b/django/pytest.ini
@@ -4,4 +4,4 @@ python_files = test_*.py tests.py
 python_classes = Test*
 python_functions = test_*
 testpaths = api gregory subscriptions indexers rss sitesettings
-addopts = --reuse-db --no-migrations --dist loadfile -n auto
+addopts = --reuse-db --nomigrations --dist loadfile -n auto


### PR DESCRIPTION
## Summary
- pytest now builds the test schema via `--no-migrations` instead of replaying all 143 migrations per xdist worker DB — the dominant cost identified in the CI perf analysis (Postgres 16, ~2,383 tests, 2–4 xdist workers each rebuilding their own DB).
- New `admin.settings_test` module (inherits `admin.settings`, so Postgres/`USE_TZ`/secrets stay the same) swaps in `MD5PasswordHasher` and `LocMemCache` for tests only, avoiding PBKDF2's ~600k iterations and `DatabaseCache`'s Postgres round-trips per cache op.
- `conftest.py` no longer runs `createcachetable` (unneeded with LocMemCache). It now restores, via `pre_migrate`/`post_migrate` signal handlers, the two pieces of schema `--no-migrations` can't derive from model state alone: the `pg_trgm` extension (required by GIN trigram indexes that already live in `Meta.indexes`) and a handful of hand-named perf indexes from migration 0022 that never became `Meta.indexes` entries. Historical FK-repair migrations (0005, 0009, 0037, 0047, 0073, subscriptions/0012) are deliberately *not* replayed — they only patch constraints on databases restored from old dumps, which a freshly syncdb-built test database never has.
- `api/tests/test_visibility_stats.py::StatsQueryCountTest::test_cached_call_query_budget` updated: it asserted an exact query count tied to `DatabaseCache`'s SQL round-trip on a cache hit; under `LocMemCache` that's one fewer query. Comments in that file updated to explain the budget is cache-backend dependent.
- CI workflow: added a pip download cache keyed on `django/requirements.txt` so unchanged deps aren't re-fetched every run.

## Test plan
- [x] Full suite run inside the `gregory` dev container (Postgres 16, real backend, no mocks): `2698 passed` in ~98s (previously test databases were rebuilt from all 143 migrations per worker on every run).
- [x] Verified in isolation that removing `--no-migrations` support required restoring `pg_trgm` (was breaking every GIN-trigram-indexed table) and the four still-tested hand-named indexes (`idx_team_categories_team_id`, `idx_team_categories_team_subject`, `idx_articles_team_categories_category_id`, `idx_articles_covering`).
- [x] Confirmed via grep that no test re-enables `DatabaseCache` through `override_settings`, so removing the old `createcachetable` fixture is safe.

Part B (setUp → setUpTestData refactor, lazy ML imports, TransactionTestCase review) is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)