### PR TITLE
Part B: setUpTestData refactor, TransactionTestCase fix, lazy ML imports

### DIFF
--- a/django/api/tests/test_enhanced_filters.py
+++ b/django/api/tests/test_enhanced_filters.py
@@ -17,23 +17,24 @@ from django.utils import timezone
 class TrialFilterTests(TestCase):
 	"""Test cases for enhanced trial filtering"""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		# Create test organization, team and subject
-		self.organization = Organization.objects.create(
+		cls.organization = Organization.objects.create(
 			name="Test Organization", slug="trial-filter-org"
 		)
-		OrganizationApiSettings.objects.filter(organization=self.organization).update(
+		OrganizationApiSettings.objects.filter(organization=cls.organization).update(
 			make_api_public=True
 		)
-		self.team = Team.objects.create(
-			name="Test Team", slug="trial-filter-team", organization=self.organization
+		cls.team = Team.objects.create(
+			name="Test Team", slug="trial-filter-team", organization=cls.organization
 		)
-		self.subject = Subject.objects.create(
-			subject_name="Test Subject", subject_slug="test-subject", team=self.team
+		cls.subject = Subject.objects.create(
+			subject_name="Test Subject", subject_slug="test-subject", team=cls.team
 		)
 
 		# Create test trials with various fields
-		self.trial1 = Trials.objects.create(
+		cls.trial1 = Trials.objects.create(
 			title="COVID-19 Vaccine Trial",
 			summary="Testing efficacy of mRNA vaccines for coronavirus.",
 			link="https://example.com/trial1",
@@ -52,10 +53,10 @@ class TrialFilterTests(TestCase):
 			inclusion_agemax="65",
 			inclusion_gender="All",
 		)
-		self.trial1.teams.add(self.team)
-		self.trial1.subjects.add(self.subject)
+		cls.trial1.teams.add(cls.team)
+		cls.trial1.subjects.add(cls.subject)
 
-		self.trial2 = Trials.objects.create(
+		cls.trial2 = Trials.objects.create(
 			title="Multiple Sclerosis Treatment Trial",
 			summary="New MS medication phase 2 study.",
 			link="https://example.com/trial2",
@@ -74,9 +75,10 @@ class TrialFilterTests(TestCase):
 			inclusion_agemax="60",
 			inclusion_gender="Female",
 		)
-		self.trial2.teams.add(self.team)
-		self.trial2.subjects.add(self.subject)
+		cls.trial2.teams.add(cls.team)
+		cls.trial2.subjects.add(cls.subject)
 
+	def setUp(self):
 		self.client = APIClient()
 
 	def test_trial_id_filter(self):
@@ -277,30 +279,31 @@ class TrialFilterTests(TestCase):
 class AuthorFilterTests(TestCase):
 	"""Test cases for enhanced author filtering"""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		# Clear any existing authors to avoid interference
 		Authors.objects.all().delete()
 
 		# Public org so anonymous API calls can see the data
-		self.org = Organization.objects.create(
+		cls.org = Organization.objects.create(
 			name="Author Filter Org", slug="author-filter-org"
 		)
-		OrganizationApiSettings.objects.filter(organization=self.org).update(
+		OrganizationApiSettings.objects.filter(organization=cls.org).update(
 			make_api_public=True
 		)
-		self.team = Team.objects.create(
-			name="Author Filter Team", slug="author-filter-team", organization=self.org
+		cls.team = Team.objects.create(
+			name="Author Filter Team", slug="author-filter-team", organization=cls.org
 		)
 
 		# Create test authors
-		self.author1 = Authors.objects.create(
+		cls.author1 = Authors.objects.create(
 			family_name="Smith",
 			given_name="John",
 			full_name="John Smith",
 			ORCID="0000-0000-0000-0001",
 			country="US",
 		)
-		self.author2 = Authors.objects.create(
+		cls.author2 = Authors.objects.create(
 			family_name="Doe",
 			given_name="Jane",
 			full_name="Jane Doe",
@@ -309,14 +312,15 @@ class AuthorFilterTests(TestCase):
 		)
 
 		# Link each author through an article in the public team so visibility filter passes
-		for author in [self.author1, self.author2]:
+		for author in [cls.author1, cls.author2]:
 			a = Articles.objects.create(
 				title=f"Article for {author.full_name}",
 				link=f"https://example.com/{author.ORCID}",
 			)
-			a.teams.add(self.team)
+			a.teams.add(cls.team)
 			a.authors.add(author)
 
+	def setUp(self):
 		self.client = APIClient()
 
 	def test_orcid_filter(self):

--- a/django/api/tests/test_monthly_relevant_counts.py
+++ b/django/api/tests/test_monthly_relevant_counts.py
@@ -36,78 +36,82 @@ MAY = datetime(2025, 5, 15, 12, 0, tzinfo=dt_timezone.utc)
 class MonthlyRelevantCountsTest(TestCase):
 	maxDiff = None
 
-	def setUp(self):
-		self.client = APIClient()
-
+	@classmethod
+	def setUpTestData(cls):
 		org = Organization.objects.create(name="Relevant Org", slug="relevant-org")
 		OrganizationApiSettings.objects.filter(organization=org).update(
 			make_api_public=True
 		)
-		self.team = Team.objects.create(
+		cls.team = Team.objects.create(
 			organization=org, name="Relevant Team", slug="relevant-team"
 		)
-		self.subject = Subject.objects.create(
-			team=self.team, subject_name="Relevant Subj", subject_slug="relevant-subj"
+		cls.subject = Subject.objects.create(
+			team=cls.team, subject_name="Relevant Subj", subject_slug="relevant-subj"
 		)
-		self.category = TeamCategory.objects.create(
-			team=self.team,
+		cls.category = TeamCategory.objects.create(
+			team=cls.team,
 			category_name="Relevant Category",
 			category_slug="relevant-category",
 		)
-		self.category.subjects.add(self.subject)
+		cls.category.subjects.add(cls.subject)
 
 		# April: three relevant articles flagged by overlapping models plus one
 		# without predictions. The naive per-model sum is 5 (lstm 2 + pubmed_bert 2
 		# + lgbm_tfidf 1) while only 4 articles exist and only 3 are relevant.
-		a_multi = self._article("Multi-model overlap", APRIL)
-		self._predict(a_multi, "lstm", 0.9)
-		self._predict(a_multi, "pubmed_bert", 0.85)
+		a_multi = cls._article("Multi-model overlap", APRIL)
+		cls._predict(a_multi, "lstm", 0.9)
+		cls._predict(a_multi, "pubmed_bert", 0.85)
 
-		a_multi2 = self._article("Multi-model overlap low scores", APRIL)
-		self._predict(a_multi2, "lstm", 0.55)
-		self._predict(a_multi2, "lgbm_tfidf", 0.6)
+		a_multi2 = cls._article("Multi-model overlap low scores", APRIL)
+		cls._predict(a_multi2, "lstm", 0.55)
+		cls._predict(a_multi2, "lgbm_tfidf", 0.6)
 
-		a_single = self._article("Single model", APRIL.replace(day=12))
-		self._predict(a_single, "pubmed_bert", 0.95)
+		a_single = cls._article("Single model", APRIL.replace(day=12))
+		cls._predict(a_single, "pubmed_bert", 0.95)
 
-		self._article("No predictions April", APRIL.replace(day=22))
+		cls._article("No predictions April", APRIL.replace(day=22))
 
 		# March: one article relevant at the default threshold but not at 0.8.
-		a_march = self._article("March borderline", MARCH)
-		self._predict(a_march, "lgbm_tfidf", 0.7)
+		a_march = cls._article("March borderline", MARCH)
+		cls._predict(a_march, "lgbm_tfidf", 0.7)
 
 		# May: nothing relevant — a below-threshold article, one with no
 		# predictions, and one whose latest prediction dropped below threshold.
-		a_low = self._article("Below threshold", MAY)
-		self._predict(a_low, "lstm", 0.2)
+		a_low = cls._article("Below threshold", MAY)
+		cls._predict(a_low, "lstm", 0.2)
 
-		self._article("No predictions May", MAY.replace(day=18))
+		cls._article("No predictions May", MAY.replace(day=18))
 
-		a_superseded = self._article("Superseded prediction", MAY.replace(day=20))
-		old = self._predict(a_superseded, "lgbm_tfidf", 0.9, model_version="v1")
+		a_superseded = cls._article("Superseded prediction", MAY.replace(day=20))
+		old = cls._predict(a_superseded, "lgbm_tfidf", 0.9, model_version="v1")
 		MLPredictions.objects.filter(pk=old.pk).update(
 			created_date=now() - timedelta(days=10)
 		)
-		self._predict(a_superseded, "lgbm_tfidf", 0.2, model_version="v2")
+		cls._predict(a_superseded, "lgbm_tfidf", 0.2, model_version="v2")
 
 		# Relevant but without a publication date: must not produce a null month
 		# bucket in the relevant series.
-		a_nodate = self._article("No published date", None)
-		self._predict(a_nodate, "lstm", 0.99)
+		a_nodate = cls._article("No published date", None)
+		cls._predict(a_nodate, "lstm", 0.99)
 
-	def _article(self, title, published_date):
+	def setUp(self):
+		self.client = APIClient()
+
+	@classmethod
+	def _article(cls, title, published_date):
 		article = Articles.objects.create(
 			title=title,
 			link=f"https://example.com/{title.lower().replace(' ', '-')}",
 			published_date=published_date,
 		)
-		article.team_categories.add(self.category)
+		article.team_categories.add(cls.category)
 		return article
 
-	def _predict(self, article, algorithm, score, model_version="v1"):
+	@classmethod
+	def _predict(cls, article, algorithm, score, model_version="v1"):
 		return MLPredictions.objects.create(
 			article=article,
-			subject=self.subject,
+			subject=cls.subject,
 			algorithm=algorithm,
 			model_version=model_version,
 			probability_score=score,

--- a/django/api/tests/test_multi_subject_filter.py
+++ b/django/api/tests/test_multi_subject_filter.py
@@ -17,64 +17,66 @@ from gregory.models import (
 class ArticleMultiSubjectFilterTests(TestCase):
 	"""Tests for the ?subjects= AND-filter on /articles/"""
 
-	def setUp(self):
-		self.client = APIClient()
-
-		self.org = Organization.objects.create(name="Test Org", slug="ms-filter-org")
-		OrganizationApiSettings.objects.filter(organization=self.org).update(
+	@classmethod
+	def setUpTestData(cls):
+		cls.org = Organization.objects.create(name="Test Org", slug="ms-filter-org")
+		OrganizationApiSettings.objects.filter(organization=cls.org).update(
 			make_api_public=True
 		)
-		self.team = Team.objects.create(
-			name="Test Team", slug="test-team-ms", organization=self.org
+		cls.team = Team.objects.create(
+			name="Test Team", slug="test-team-ms", organization=cls.org
 		)
 
-		self.subject_a = Subject.objects.create(
+		cls.subject_a = Subject.objects.create(
 			subject_name="Subject A",
 			subject_slug="subject-a",
-			team=self.team,
+			team=cls.team,
 		)
-		self.subject_b = Subject.objects.create(
+		cls.subject_b = Subject.objects.create(
 			subject_name="Subject B",
 			subject_slug="subject-b",
-			team=self.team,
+			team=cls.team,
 		)
-		self.subject_c = Subject.objects.create(
+		cls.subject_c = Subject.objects.create(
 			subject_name="Subject C",
 			subject_slug="subject-c",
-			team=self.team,
+			team=cls.team,
 		)
 
 		# article_ab  → subjects A + B
-		self.article_ab = Articles.objects.create(
+		cls.article_ab = Articles.objects.create(
 			title="Article AB",
 			link="https://example.com/ab",
 		)
-		self.article_ab.subjects.add(self.subject_a, self.subject_b)
-		self.article_ab.teams.add(self.team)
+		cls.article_ab.subjects.add(cls.subject_a, cls.subject_b)
+		cls.article_ab.teams.add(cls.team)
 
 		# article_a   → subject A only
-		self.article_a = Articles.objects.create(
+		cls.article_a = Articles.objects.create(
 			title="Article A",
 			link="https://example.com/a",
 		)
-		self.article_a.subjects.add(self.subject_a)
-		self.article_a.teams.add(self.team)
+		cls.article_a.subjects.add(cls.subject_a)
+		cls.article_a.teams.add(cls.team)
 
 		# article_b   → subject B only
-		self.article_b = Articles.objects.create(
+		cls.article_b = Articles.objects.create(
 			title="Article B",
 			link="https://example.com/b",
 		)
-		self.article_b.subjects.add(self.subject_b)
-		self.article_b.teams.add(self.team)
+		cls.article_b.subjects.add(cls.subject_b)
+		cls.article_b.teams.add(cls.team)
 
 		# article_abc → subjects A + B + C
-		self.article_abc = Articles.objects.create(
+		cls.article_abc = Articles.objects.create(
 			title="Article ABC",
 			link="https://example.com/abc",
 		)
-		self.article_abc.subjects.add(self.subject_a, self.subject_b, self.subject_c)
-		self.article_abc.teams.add(self.team)
+		cls.article_abc.subjects.add(cls.subject_a, cls.subject_b, cls.subject_c)
+		cls.article_abc.teams.add(cls.team)
+
+	def setUp(self):
+		self.client = APIClient()
 
 	# ------------------------------------------------------------------
 	# AND semantics – must include exactly the articles in both A and B
@@ -220,64 +222,66 @@ class ArticleMultiSubjectFilterTests(TestCase):
 class ArticleSubjectAnyFilterTests(TestCase):
 	"""Tests for the ?subjects_any= OR-filter on /articles/"""
 
-	def setUp(self):
-		self.client = APIClient()
-
-		self.org = Organization.objects.create(name="Any Org", slug="any-filter-org")
-		OrganizationApiSettings.objects.filter(organization=self.org).update(
+	@classmethod
+	def setUpTestData(cls):
+		cls.org = Organization.objects.create(name="Any Org", slug="any-filter-org")
+		OrganizationApiSettings.objects.filter(organization=cls.org).update(
 			make_api_public=True
 		)
-		self.team = Team.objects.create(
-			name="Any Team", slug="any-team-ms", organization=self.org
+		cls.team = Team.objects.create(
+			name="Any Team", slug="any-team-ms", organization=cls.org
 		)
 
-		self.subject_a = Subject.objects.create(
+		cls.subject_a = Subject.objects.create(
 			subject_name="Any Subject A",
 			subject_slug="any-subject-a",
-			team=self.team,
+			team=cls.team,
 		)
-		self.subject_b = Subject.objects.create(
+		cls.subject_b = Subject.objects.create(
 			subject_name="Any Subject B",
 			subject_slug="any-subject-b",
-			team=self.team,
+			team=cls.team,
 		)
-		self.subject_c = Subject.objects.create(
+		cls.subject_c = Subject.objects.create(
 			subject_name="Any Subject C",
 			subject_slug="any-subject-c",
-			team=self.team,
+			team=cls.team,
 		)
 
 		# article_a  → subject A only
-		self.article_a = Articles.objects.create(
+		cls.article_a = Articles.objects.create(
 			title="Any Article A",
 			link="https://example.com/any-a",
 		)
-		self.article_a.subjects.add(self.subject_a)
-		self.article_a.teams.add(self.team)
+		cls.article_a.subjects.add(cls.subject_a)
+		cls.article_a.teams.add(cls.team)
 
 		# article_b  → subject B only
-		self.article_b = Articles.objects.create(
+		cls.article_b = Articles.objects.create(
 			title="Any Article B",
 			link="https://example.com/any-b",
 		)
-		self.article_b.subjects.add(self.subject_b)
-		self.article_b.teams.add(self.team)
+		cls.article_b.subjects.add(cls.subject_b)
+		cls.article_b.teams.add(cls.team)
 
 		# article_c  → subject C only
-		self.article_c = Articles.objects.create(
+		cls.article_c = Articles.objects.create(
 			title="Any Article C",
 			link="https://example.com/any-c",
 		)
-		self.article_c.subjects.add(self.subject_c)
-		self.article_c.teams.add(self.team)
+		cls.article_c.subjects.add(cls.subject_c)
+		cls.article_c.teams.add(cls.team)
 
 		# article_ab → subjects A + B
-		self.article_ab = Articles.objects.create(
+		cls.article_ab = Articles.objects.create(
 			title="Any Article AB",
 			link="https://example.com/any-ab",
 		)
-		self.article_ab.subjects.add(self.subject_a, self.subject_b)
-		self.article_ab.teams.add(self.team)
+		cls.article_ab.subjects.add(cls.subject_a, cls.subject_b)
+		cls.article_ab.teams.add(cls.team)
+
+	def setUp(self):
+		self.client = APIClient()
 
 	def test_or_match_returns_articles_in_either_subject(self):
 		"""?subjects_any=A,B returns all articles tagged with A or B."""
@@ -331,51 +335,53 @@ class ArticleSubjectAnyFilterTests(TestCase):
 class TrialMultiSubjectFilterTests(TestCase):
 	"""Tests for the ?subjects= AND-filter on /trials/"""
 
-	def setUp(self):
-		self.client = APIClient()
-
-		self.org = Organization.objects.create(name="Trial Org", slug="ms-trial-org")
-		OrganizationApiSettings.objects.filter(organization=self.org).update(
+	@classmethod
+	def setUpTestData(cls):
+		cls.org = Organization.objects.create(name="Trial Org", slug="ms-trial-org")
+		OrganizationApiSettings.objects.filter(organization=cls.org).update(
 			make_api_public=True
 		)
-		self.team = Team.objects.create(
-			name="Trial Team", slug="trial-team-slug", organization=self.org
+		cls.team = Team.objects.create(
+			name="Trial Team", slug="trial-team-slug", organization=cls.org
 		)
 
-		self.subject_a = Subject.objects.create(
+		cls.subject_a = Subject.objects.create(
 			subject_name="Trial Subject A",
 			subject_slug="trial-subject-a",
-			team=self.team,
+			team=cls.team,
 		)
-		self.subject_b = Subject.objects.create(
+		cls.subject_b = Subject.objects.create(
 			subject_name="Trial Subject B",
 			subject_slug="trial-subject-b",
-			team=self.team,
+			team=cls.team,
 		)
 
-		self.trial_ab = Trials.objects.create(
+		cls.trial_ab = Trials.objects.create(
 			title="Trial AB",
 			link="https://example.com/trial-ab",
 			published_date=timezone.now(),
 		)
-		self.trial_ab.subjects.add(self.subject_a, self.subject_b)
-		self.trial_ab.teams.add(self.team)
+		cls.trial_ab.subjects.add(cls.subject_a, cls.subject_b)
+		cls.trial_ab.teams.add(cls.team)
 
-		self.trial_a = Trials.objects.create(
+		cls.trial_a = Trials.objects.create(
 			title="Trial A",
 			link="https://example.com/trial-a",
 			published_date=timezone.now(),
 		)
-		self.trial_a.subjects.add(self.subject_a)
-		self.trial_a.teams.add(self.team)
+		cls.trial_a.subjects.add(cls.subject_a)
+		cls.trial_a.teams.add(cls.team)
 
-		self.trial_b = Trials.objects.create(
+		cls.trial_b = Trials.objects.create(
 			title="Trial B",
 			link="https://example.com/trial-b",
 			published_date=timezone.now(),
 		)
-		self.trial_b.subjects.add(self.subject_b)
-		self.trial_b.teams.add(self.team)
+		cls.trial_b.subjects.add(cls.subject_b)
+		cls.trial_b.teams.add(cls.team)
+
+	def setUp(self):
+		self.client = APIClient()
 
 	def test_and_match_returns_correct_trials(self):
 		"""?subjects=A,B returns only trial_ab."""
@@ -423,64 +429,66 @@ class TrialMultiSubjectFilterTests(TestCase):
 class TrialSubjectAnyFilterTests(TestCase):
 	"""Tests for the ?subjects_any= OR-filter on /trials/"""
 
-	def setUp(self):
-		self.client = APIClient()
-
-		self.org = Organization.objects.create(name="Trial Any Org", slug="any-trial-org")
-		OrganizationApiSettings.objects.filter(organization=self.org).update(
+	@classmethod
+	def setUpTestData(cls):
+		cls.org = Organization.objects.create(name="Trial Any Org", slug="any-trial-org")
+		OrganizationApiSettings.objects.filter(organization=cls.org).update(
 			make_api_public=True
 		)
-		self.team = Team.objects.create(
-			name="Trial Any Team", slug="trial-any-team", organization=self.org
+		cls.team = Team.objects.create(
+			name="Trial Any Team", slug="trial-any-team", organization=cls.org
 		)
 
-		self.subject_a = Subject.objects.create(
+		cls.subject_a = Subject.objects.create(
 			subject_name="Trial Any Subject A",
 			subject_slug="trial-any-subject-a",
-			team=self.team,
+			team=cls.team,
 		)
-		self.subject_b = Subject.objects.create(
+		cls.subject_b = Subject.objects.create(
 			subject_name="Trial Any Subject B",
 			subject_slug="trial-any-subject-b",
-			team=self.team,
+			team=cls.team,
 		)
-		self.subject_c = Subject.objects.create(
+		cls.subject_c = Subject.objects.create(
 			subject_name="Trial Any Subject C",
 			subject_slug="trial-any-subject-c",
-			team=self.team,
+			team=cls.team,
 		)
 
-		self.trial_a = Trials.objects.create(
+		cls.trial_a = Trials.objects.create(
 			title="Trial Any A",
 			link="https://example.com/trial-any-a",
 			published_date=timezone.now(),
 		)
-		self.trial_a.subjects.add(self.subject_a)
-		self.trial_a.teams.add(self.team)
+		cls.trial_a.subjects.add(cls.subject_a)
+		cls.trial_a.teams.add(cls.team)
 
-		self.trial_b = Trials.objects.create(
+		cls.trial_b = Trials.objects.create(
 			title="Trial Any B",
 			link="https://example.com/trial-any-b",
 			published_date=timezone.now(),
 		)
-		self.trial_b.subjects.add(self.subject_b)
-		self.trial_b.teams.add(self.team)
+		cls.trial_b.subjects.add(cls.subject_b)
+		cls.trial_b.teams.add(cls.team)
 
-		self.trial_c = Trials.objects.create(
+		cls.trial_c = Trials.objects.create(
 			title="Trial Any C",
 			link="https://example.com/trial-any-c",
 			published_date=timezone.now(),
 		)
-		self.trial_c.subjects.add(self.subject_c)
-		self.trial_c.teams.add(self.team)
+		cls.trial_c.subjects.add(cls.subject_c)
+		cls.trial_c.teams.add(cls.team)
 
-		self.trial_ab = Trials.objects.create(
+		cls.trial_ab = Trials.objects.create(
 			title="Trial Any AB",
 			link="https://example.com/trial-any-ab",
 			published_date=timezone.now(),
 		)
-		self.trial_ab.subjects.add(self.subject_a, self.subject_b)
-		self.trial_ab.teams.add(self.team)
+		cls.trial_ab.subjects.add(cls.subject_a, cls.subject_b)
+		cls.trial_ab.teams.add(cls.team)
+
+	def setUp(self):
+		self.client = APIClient()
 
 	def test_or_match_returns_trials_in_either_subject(self):
 		"""?subjects_any=A,B returns all trials tagged with A or B."""

--- a/django/gregory/ml/__init__.py
+++ b/django/gregory/ml/__init__.py
@@ -25,7 +25,11 @@ def __getattr__(name):
 	import importlib
 
 	module = importlib.import_module(module_name)
-	return getattr(module, name)
+	value = getattr(module, name)
+	# Cache in the module namespace so later lookups hit it directly instead
+	# of re-running __getattr__ (plain attribute access checks globals() first).
+	globals()[name] = value
+	return value
 
 
 def __dir__():

--- a/django/gregory/ml/__init__.py
+++ b/django/gregory/ml/__init__.py
@@ -6,11 +6,27 @@ including wrappers for different model architectures, training pipelines, and ev
 It also provides utilities for pseudo-labeling and semi-supervised learning.
 """
 
-# Export public API
-from gregory.ml.trainer import get_trainer
-from gregory.ml.pseudo import (
-	generate_pseudo_labels,
-	save_pseudo_csv,
-	get_pseudo_label_stats,
-	load_and_filter_pseudo_labels,
-)
+# Public API is loaded lazily (PEP 562): `import gregory.ml` alone must not
+# drag in tensorflow/torch/transformers/lightgbm via trainer.py's wrapper
+# imports. Those load only when one of these names is actually accessed.
+_LAZY_ATTRS = {
+	"get_trainer": "gregory.ml.trainer",
+	"generate_pseudo_labels": "gregory.ml.pseudo",
+	"save_pseudo_csv": "gregory.ml.pseudo",
+	"get_pseudo_label_stats": "gregory.ml.pseudo",
+	"load_and_filter_pseudo_labels": "gregory.ml.pseudo",
+}
+
+
+def __getattr__(name):
+	module_name = _LAZY_ATTRS.get(name)
+	if module_name is None:
+		raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+	import importlib
+
+	module = importlib.import_module(module_name)
+	return getattr(module, name)
+
+
+def __dir__():
+	return sorted(list(globals()) + list(_LAZY_ATTRS))

--- a/django/gregory/tests/management/test_feedreader_articles.py
+++ b/django/gregory/tests/management/test_feedreader_articles.py
@@ -17,7 +17,7 @@ import os
 from datetime import timedelta
 from unittest.mock import patch, Mock
 
-from django.test import TestCase, TransactionTestCase, override_settings
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from django.core.exceptions import MultipleObjectsReturned
 from organizations.models import Organization
@@ -304,30 +304,31 @@ class TestCrossRefIntegration(TestCase):
 			self.assertIsNone(crossref_check)
 
 
-class TestCrossRefDataUpdates(TransactionTestCase):
+class TestCrossRefDataUpdates(TestCase):
 	"""Test CrossRef data updates for existing articles."""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		"""Set up test data."""
-		self.organization = Organization.objects.create(name="Test Organization")
-		self.team = Team.objects.create(
-			slug="test-team", organization=self.organization
+		cls.organization = Organization.objects.create(name="Test Organization")
+		cls.team = Team.objects.create(
+			slug="test-team", organization=cls.organization
 		)
-		self.subject = Subject.objects.create(
-			subject_name="Test Subject", subject_slug="test-subject", team=self.team
+		cls.subject = Subject.objects.create(
+			subject_name="Test Subject", subject_slug="test-subject", team=cls.team
 		)
-		self.source = Sources.objects.create(
+		cls.source = Sources.objects.create(
 			name="Test Source",
 			link="https://example.com/feed.xml",
 			method="rss",
 			source_for="science paper",
 			active=True,
-			team=self.team,
-			subject=self.subject,
+			team=cls.team,
+			subject=cls.subject,
 		)
-		self.site = Site.objects.create(domain="test.example.com", name="Test Site")
-		self.custom_setting = CustomSetting.objects.create(
-			site=self.site, title="Test Gregory", admin_email="admin@test.example.com"
+		cls.site = Site.objects.create(domain="test.example.com", name="Test Site")
+		cls.custom_setting = CustomSetting.objects.create(
+			site=cls.site, title="Test Gregory", admin_email="admin@test.example.com"
 		)
 
 	@patch.dict(os.environ, {"DOMAIN_NAME": "test.example.com"})
@@ -704,26 +705,27 @@ class TestCrossRefDataUpdates(TransactionTestCase):
 		self.assertEqual(new_article.access, "unknown")
 
 
-class TestArticleCreationAndUpdate(TransactionTestCase):
+class TestArticleCreationAndUpdate(TestCase):
 	"""Test article creation and update logic."""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		"""Set up test data."""
-		self.organization = Organization.objects.create(name="Test Organization")
-		self.team = Team.objects.create(
-			slug="test-team", organization=self.organization
+		cls.organization = Organization.objects.create(name="Test Organization")
+		cls.team = Team.objects.create(
+			slug="test-team", organization=cls.organization
 		)
-		self.subject = Subject.objects.create(
-			subject_name="Test Subject", subject_slug="test-subject", team=self.team
+		cls.subject = Subject.objects.create(
+			subject_name="Test Subject", subject_slug="test-subject", team=cls.team
 		)
-		self.source = Sources.objects.create(
+		cls.source = Sources.objects.create(
 			name="Test Source",
 			link="https://example.com/feed.xml",
 			method="rss",
 			source_for="science paper",
 			active=True,
-			team=self.team,
-			subject=self.subject,
+			team=cls.team,
+			subject=cls.subject,
 		)
 
 	def test_create_new_article_with_doi(self):
@@ -837,19 +839,20 @@ class TestArticleCreationAndUpdate(TransactionTestCase):
 		self.assertEqual(existing_article, article1)
 
 
-class TestAuthorProcessing(TransactionTestCase):
+class TestAuthorProcessing(TestCase):
 	"""Test author creation, deduplication, and linking."""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		"""Set up test data."""
-		self.organization = Organization.objects.create(name="Test Organization")
-		self.team = Team.objects.create(
-			slug="test-team", organization=self.organization
+		cls.organization = Organization.objects.create(name="Test Organization")
+		cls.team = Team.objects.create(
+			slug="test-team", organization=cls.organization
 		)
-		self.subject = Subject.objects.create(
-			subject_name="Test Subject", subject_slug="test-subject", team=self.team
+		cls.subject = Subject.objects.create(
+			subject_name="Test Subject", subject_slug="test-subject", team=cls.team
 		)
-		self.article = Articles.objects.create(
+		cls.article = Articles.objects.create(
 			title="Test Article for Authors", link="https://example.com/test-authors"
 		)
 
@@ -1012,45 +1015,46 @@ class TestErrorHandling(TestCase):
 		app: None for app in ["gregory", "organizations", "sitesettings", "sites"]
 	}
 )
-class TestFeedreaderArticlesIntegration(TransactionTestCase):
+class TestFeedreaderArticlesIntegration(TestCase):
 	"""Integration tests for the complete feedreader process."""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		"""Set up test data."""
 		# Create organization and team
-		self.organization = Organization.objects.create(name="Test Organization")
-		self.team = Team.objects.create(
-			slug="test-team", organization=self.organization
+		cls.organization = Organization.objects.create(name="Test Organization")
+		cls.team = Team.objects.create(
+			slug="test-team", organization=cls.organization
 		)
-		self.subject = Subject.objects.create(
-			subject_name="Test Subject", subject_slug="test-subject", team=self.team
+		cls.subject = Subject.objects.create(
+			subject_name="Test Subject", subject_slug="test-subject", team=cls.team
 		)
 
 		# Create test sources
-		self.pubmed_source = Sources.objects.create(
+		cls.pubmed_source = Sources.objects.create(
 			name="Test PubMed Source",
 			link="https://pubmed.ncbi.nlm.nih.gov/rss/search/?term=test",
 			method="rss",
 			source_for="science paper",
 			active=True,
-			team=self.team,
-			subject=self.subject,
+			team=cls.team,
+			subject=cls.subject,
 		)
 
-		self.regular_source = Sources.objects.create(
+		cls.regular_source = Sources.objects.create(
 			name="Test Regular Source",
 			link="https://example.com/feed.xml",
 			method="rss",
 			source_for="science paper",
 			active=True,
-			team=self.team,
-			subject=self.subject,
+			team=cls.team,
+			subject=cls.subject,
 		)
 
 		# Create site settings
-		self.site = Site.objects.create(domain="test.example.com", name="Test Site")
-		self.custom_setting = CustomSetting.objects.create(
-			site=self.site, title="Test Gregory", admin_email="admin@test.example.com"
+		cls.site = Site.objects.create(domain="test.example.com", name="Test Site")
+		cls.custom_setting = CustomSetting.objects.create(
+			site=cls.site, title="Test Gregory", admin_email="admin@test.example.com"
 		)
 
 	@patch.dict(os.environ, {"DOMAIN_NAME": "test.example.com"})
@@ -1231,20 +1235,22 @@ class TestFeedreaderArticlesIntegration(TransactionTestCase):
 class TestNatureFeedProcessor(TestCase):
 	"""Test Nature.com feed processor functionality."""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		"""Set up test data."""
-		self.organization = Organization.objects.create(name="Test Organization")
-		self.team = Team.objects.create(
-			slug="test-team", organization=self.organization
+		cls.organization = Organization.objects.create(name="Test Organization")
+		cls.team = Team.objects.create(
+			slug="test-team", organization=cls.organization
 		)
-		self.subject = Subject.objects.create(
-			subject_name="Test Subject", subject_slug="test-subject", team=self.team
+		cls.subject = Subject.objects.create(
+			subject_name="Test Subject", subject_slug="test-subject", team=cls.team
 		)
-		self.site = Site.objects.create(domain="test.example.com", name="Test Site")
-		self.custom_setting = CustomSetting.objects.create(
-			site=self.site, title="Test Gregory Site", admin_email="admin@test.com"
+		cls.site = Site.objects.create(domain="test.example.com", name="Test Site")
+		cls.custom_setting = CustomSetting.objects.create(
+			site=cls.site, title="Test Gregory Site", admin_email="admin@test.com"
 		)
 
+	def setUp(self):
 		from gregory.management.commands.feedreader_articles import (
 			NatureFeedProcessor,
 			Command,
@@ -1379,20 +1385,22 @@ class TestNatureFeedProcessor(TestCase):
 class TestSagePublicationsFeedProcessor(TestCase):
 	"""Test SAGE Publications feed processor functionality."""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		"""Set up test data."""
-		self.organization = Organization.objects.create(name="Test Organization")
-		self.team = Team.objects.create(
-			slug="test-team", organization=self.organization
+		cls.organization = Organization.objects.create(name="Test Organization")
+		cls.team = Team.objects.create(
+			slug="test-team", organization=cls.organization
 		)
-		self.subject = Subject.objects.create(
-			subject_name="Test Subject", subject_slug="test-subject", team=self.team
+		cls.subject = Subject.objects.create(
+			subject_name="Test Subject", subject_slug="test-subject", team=cls.team
 		)
-		self.site = Site.objects.create(domain="test.example.com", name="Test Site")
-		self.custom_setting = CustomSetting.objects.create(
-			site=self.site, title="Test Gregory Site", admin_email="admin@test.com"
+		cls.site = Site.objects.create(domain="test.example.com", name="Test Site")
+		cls.custom_setting = CustomSetting.objects.create(
+			site=cls.site, title="Test Gregory Site", admin_email="admin@test.com"
 		)
 
+	def setUp(self):
 		from gregory.management.commands.feedreader_articles import (
 			SagePublicationsFeedProcessor,
 			Command,

--- a/django/gregory/tests/management/test_predict_articles.py
+++ b/django/gregory/tests/management/test_predict_articles.py
@@ -34,22 +34,23 @@ class TestPredictArticlesCommand(TestCase):
 	Tests for the predict_articles management command argument parsing and validation.
 	"""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		# Create organization, team, subjects
-		self.organization = Organization.objects.create(name="Test Organization")
-		self.team = Team.objects.create(
-			slug="test-team", organization=self.organization
+		cls.organization = Organization.objects.create(name="Test Organization")
+		cls.team = Team.objects.create(
+			slug="test-team", organization=cls.organization
 		)
-		self.subject = Subject.objects.create(
+		cls.subject = Subject.objects.create(
 			subject_name="Test Subject",
 			subject_slug="test-subject",
-			team=self.team,
+			team=cls.team,
 			auto_predict=True,
 		)
-		self.non_auto_subject = Subject.objects.create(
+		cls.non_auto_subject = Subject.objects.create(
 			subject_name="Non-Auto Subject",
 			subject_slug="non-auto-subject",
-			team=self.team,
+			team=cls.team,
 			auto_predict=False,
 		)
 
@@ -102,19 +103,20 @@ class TestGetArticles(TestCase):
 	Tests for the get_articles helper function.
 	"""
 
-	def setUp(self):
-		self.organization = Organization.objects.create(name="Test Organization")
-		self.team = Team.objects.create(
-			slug="test-team", organization=self.organization
+	@classmethod
+	def setUpTestData(cls):
+		cls.organization = Organization.objects.create(name="Test Organization")
+		cls.team = Team.objects.create(
+			slug="test-team", organization=cls.organization
 		)
-		self.subject = Subject.objects.create(
+		cls.subject = Subject.objects.create(
 			subject_name="Test Subject",
 			subject_slug="test-subject",
-			team=self.team,
+			team=cls.team,
 			auto_predict=True,
 		)
-		self.algorithm = "pubmed_bert"
-		self.model_version = "v1.0"
+		cls.algorithm = "pubmed_bert"
+		cls.model_version = "v1.0"
 
 	def test_get_articles_basic_filtering(self):
 		"""Test that articles are correctly filtered by subject."""
@@ -459,26 +461,29 @@ class TestPrepareText(TestCase):
 @patch("gregory.management.commands.predict_articles.load_model")
 @patch("gregory.management.commands.predict_articles.prepare_text")
 class TestRunPredictionsFor(TestCase):
-	def setUp(self):
-		self.command = Command()
-		self.organization = Organization.objects.create(name="Test Organization")
-		self.team = Team.objects.create(
-			slug="test-team", organization=self.organization
+	@classmethod
+	def setUpTestData(cls):
+		cls.organization = Organization.objects.create(name="Test Organization")
+		cls.team = Team.objects.create(
+			slug="test-team", organization=cls.organization
 		)
-		self.subject = Subject.objects.create(
+		cls.subject = Subject.objects.create(
 			subject_name="Test Subject",
 			subject_slug="test-subject",
-			team=self.team,
+			team=cls.team,
 			auto_predict=True,
 		)
-		self.article1 = Articles.objects.create(
+		cls.article1 = Articles.objects.create(
 			title="Article 1", link="http://example.com/1", summary="Test summary 1"
 		)
-		self.article1.subjects.add(self.subject)
-		self.article2 = Articles.objects.create(
+		cls.article1.subjects.add(cls.subject)
+		cls.article2 = Articles.objects.create(
 			title="Article 2", link="http://example.com/2", summary="Test summary 2"
 		)
-		self.article2.subjects.add(self.subject)
+		cls.article2.subjects.add(cls.subject)
+
+	def setUp(self):
+		self.command = Command()
 		self.options = {
 			"model_version": None,
 			"lookback_days": 90,

--- a/django/gregory/tests/test_article_relevance.py
+++ b/django/gregory/tests/test_article_relevance.py
@@ -19,34 +19,35 @@ from gregory.relevance import recompute_article_relevance
 class RecomputeArticleRelevanceTestCase(TestCase):
 	"""Flag matrix: manual relevance, ML consensus per ml_consensus_type, and non-matches."""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		org = Organization.objects.create(name="Relevance Test Org")
-		self.team = Team.objects.create(organization=org, name="Relevance Team", slug="relevance-team")
-		self.subject_any = Subject.objects.create(
+		cls.team = Team.objects.create(organization=org, name="Relevance Team", slug="relevance-team")
+		cls.subject_any = Subject.objects.create(
 			subject_name="Any Subject",
 			subject_slug="any-subject",
-			team=self.team,
+			team=cls.team,
 			auto_predict=True,
 			ml_consensus_type="any",
 		)
-		self.subject_majority = Subject.objects.create(
+		cls.subject_majority = Subject.objects.create(
 			subject_name="Majority Subject",
 			subject_slug="majority-subject",
-			team=self.team,
+			team=cls.team,
 			auto_predict=True,
 			ml_consensus_type="majority",
 		)
-		self.subject_all = Subject.objects.create(
+		cls.subject_all = Subject.objects.create(
 			subject_name="All Subject",
 			subject_slug="all-subject",
-			team=self.team,
+			team=cls.team,
 			auto_predict=True,
 			ml_consensus_type="all",
 		)
-		self.subject_no_auto_predict = Subject.objects.create(
+		cls.subject_no_auto_predict = Subject.objects.create(
 			subject_name="No Auto Predict Subject",
 			subject_slug="no-auto-predict-subject",
-			team=self.team,
+			team=cls.team,
 			auto_predict=False,
 			ml_consensus_type="any",
 		)
@@ -219,21 +220,22 @@ class RecomputeArticleRelevanceTestCase(TestCase):
 class ArticleRelevanceSignalTestCase(TestCase):
 	"""post_save/post_delete signals keep Articles.relevant in sync automatically."""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		org = Organization.objects.create(name="Signal Relevance Org")
-		self.team = Team.objects.create(organization=org, name="Signal Relevance Team", slug="signal-relevance-team")
-		self.subject = Subject.objects.create(
+		cls.team = Team.objects.create(organization=org, name="Signal Relevance Team", slug="signal-relevance-team")
+		cls.subject = Subject.objects.create(
 			subject_name="Signal Subject",
 			subject_slug="signal-subject",
-			team=self.team,
+			team=cls.team,
 			auto_predict=True,
 			ml_consensus_type="any",
 		)
-		self.article = Articles.objects.create(
+		cls.article = Articles.objects.create(
 			title="Signal relevance article",
 			link="https://example.com/sig-rel-1",
 		)
-		self.article.subjects.add(self.subject)
+		cls.article.subjects.add(cls.subject)
 
 	def _refresh(self):
 		self.article.refresh_from_db()
@@ -313,29 +315,30 @@ class RecomputeArticleRelevanceLatestPredictionTestCase(TestCase):
 	threshold, so an article stayed relevant forever once a since-retired
 	model_version had scored it high."""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		org = Organization.objects.create(name="Latest Prediction Relevance Org")
-		self.team = Team.objects.create(
+		cls.team = Team.objects.create(
 			organization=org, name="Latest Prediction Team", slug="latest-prediction-team"
 		)
-		self.subject_any = Subject.objects.create(
+		cls.subject_any = Subject.objects.create(
 			subject_name="Latest Any Subject",
 			subject_slug="latest-any-subject",
-			team=self.team,
+			team=cls.team,
 			auto_predict=True,
 			ml_consensus_type="any",
 		)
-		self.subject_majority = Subject.objects.create(
+		cls.subject_majority = Subject.objects.create(
 			subject_name="Latest Majority Subject",
 			subject_slug="latest-majority-subject",
-			team=self.team,
+			team=cls.team,
 			auto_predict=True,
 			ml_consensus_type="majority",
 		)
-		self.subject_all = Subject.objects.create(
+		cls.subject_all = Subject.objects.create(
 			subject_name="Latest All Subject",
 			subject_slug="latest-all-subject",
-			team=self.team,
+			team=cls.team,
 			auto_predict=True,
 			ml_consensus_type="all",
 		)

--- a/django/gregory/tests/test_ml_score_signal.py
+++ b/django/gregory/tests/test_ml_score_signal.py
@@ -14,16 +14,17 @@ from gregory.models import Articles, MLPredictions, Subject, Team
 class MlScoreSignalTestCase(TestCase):
 	"""Signal on MLPredictions.post_save updates article.ml_score."""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		org = Organization.objects.create(name="Test Org")
-		self.team = Team.objects.create(organization=org, slug="sig-test-team")
-		self.subject_a = Subject.objects.create(
-			subject_name="Subject A", subject_slug="subject-a", team=self.team
+		cls.team = Team.objects.create(organization=org, slug="sig-test-team")
+		cls.subject_a = Subject.objects.create(
+			subject_name="Subject A", subject_slug="subject-a", team=cls.team
 		)
-		self.subject_b = Subject.objects.create(
-			subject_name="Subject B", subject_slug="subject-b", team=self.team
+		cls.subject_b = Subject.objects.create(
+			subject_name="Subject B", subject_slug="subject-b", team=cls.team
 		)
-		self.article = Articles.objects.create(
+		cls.article = Articles.objects.create(
 			title="Signal test article",
 			link="https://example.com/sig1",
 		)
@@ -199,33 +200,34 @@ class MlScoreSignalTestCase(TestCase):
 class BackfillMlScoresCommandTestCase(TestCase):
 	"""backfill_ml_scores management command."""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		org = Organization.objects.create(name="Backfill Org")
 		team = Team.objects.create(organization=org, slug="backfill-team")
-		self.subject = Subject.objects.create(
+		cls.subject = Subject.objects.create(
 			subject_name="Backfill Subject", subject_slug="backfill-sub", team=team
 		)
 
-		self.art_with_preds = Articles.objects.create(
+		cls.art_with_preds = Articles.objects.create(
 			title="Article with predictions",
 			link="https://example.com/b1",
 		)
-		self.art_no_preds = Articles.objects.create(
+		cls.art_no_preds = Articles.objects.create(
 			title="Article without predictions",
 			link="https://example.com/b2",
 		)
 
 		now = timezone.now()
 		older = MLPredictions.objects.create(
-			article=self.art_with_preds,
-			subject=self.subject,
+			article=cls.art_with_preds,
+			subject=cls.subject,
 			algorithm="pubmed_bert",
 			model_version="v1",
 			probability_score=0.4,
 		)
 		newer = MLPredictions.objects.create(
-			article=self.art_with_preds,
-			subject=self.subject,
+			article=cls.art_with_preds,
+			subject=cls.subject,
 			algorithm="pubmed_bert",
 			model_version="v2",
 			probability_score=0.8,

--- a/django/subscriptions/tests/test_announcement_duplicate.py
+++ b/django/subscriptions/tests/test_announcement_duplicate.py
@@ -176,37 +176,39 @@ class TestDuplicateSkipsSendingStatus(_BaseTest):
 class TestDuplicateOrgScopeEnforcement(TestCase):
 	"""Org-scope rules govern which announcements a non-superuser may duplicate."""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		# Org A — owns the source announcement
 		org_a = Organization.objects.create(name="Org A")
 		team_a = Team.objects.create(
 			organization=org_a, name="Team A", slug="team-a-dup"
 		)
-		self.lst_a = Lists.objects.create(list_name="List A", team=team_a)
+		cls.lst_a = Lists.objects.create(list_name="List A", team=team_a)
 
 		# Org B — the acting user belongs only to this org
-		self.org_b = Organization.objects.create(name="Org B")
+		cls.org_b = Organization.objects.create(name="Org B")
 		team_b = Team.objects.create(
-			organization=self.org_b, name="Team B", slug="team-b-dup"
+			organization=cls.org_b, name="Team B", slug="team-b-dup"
 		)
-		self.lst_b = Lists.objects.create(list_name="List B", team=team_b)
+		cls.lst_b = Lists.objects.create(list_name="List B", team=team_b)
 
 		# Non-superuser staff who belongs only to org B
-		self.user_b = User.objects.create_user(
+		cls.user_b = User.objects.create_user(
 			username="user_b_auth",
 			password="pass",
 			email="user_b_auth@example.com",
 			is_staff=True,
 		)
-		self.user_b.user_permissions.add(
+		cls.user_b.user_permissions.add(
 			Permission.objects.get(codename="add_announcement"),
 			Permission.objects.get(codename="change_announcement"),
 			Permission.objects.get(codename="view_announcement"),
 		)
 		from organizations.models import OrganizationUser
 
-		OrganizationUser.objects.create(organization=self.org_b, user=self.user_b)
+		OrganizationUser.objects.create(organization=cls.org_b, user=cls.user_b)
 
+	def setUp(self):
 		self.client = Client()
 		self.client.force_login(self.user_b)
 

--- a/django/subscriptions/tests/test_announcement_organization.py
+++ b/django/subscriptions/tests/test_announcement_organization.py
@@ -79,11 +79,12 @@ class TestModelRequiresOrganization(TestCase):
 class TestFormDefaultSingleOrgUser(TestCase):
 	"""Single-org user: form initial = their org, field disabled."""
 
-	def setUp(self):
-		self.org = Organization.objects.create(name="Only Org")
-		team = Team.objects.create(organization=self.org, name="T", slug="t-single")
-		self.lst = Lists.objects.create(list_name="L", team=team)
-		self.user = _staff_user_in_org("single_org_user", self.org)
+	@classmethod
+	def setUpTestData(cls):
+		cls.org = Organization.objects.create(name="Only Org")
+		team = Team.objects.create(organization=cls.org, name="T", slug="t-single")
+		cls.lst = Lists.objects.create(list_name="L", team=team)
+		cls.user = _staff_user_in_org("single_org_user", cls.org)
 
 	def _make_form(self):
 		req = MagicMock()
@@ -103,31 +104,32 @@ class TestFormDefaultSingleOrgUser(TestCase):
 class TestFormDefaultMultiOrgUser(TestCase):
 	"""Multi-org user: initial = first org by PK, field enabled."""
 
-	def setUp(self):
-		self.org_a = Organization.objects.create(name="AAA Org")
-		self.org_b = Organization.objects.create(name="BBB Org")
+	@classmethod
+	def setUpTestData(cls):
+		cls.org_a = Organization.objects.create(name="AAA Org")
+		cls.org_b = Organization.objects.create(name="BBB Org")
 		team_a = Team.objects.create(
-			organization=self.org_a, name="TA", slug="ta-multi"
+			organization=cls.org_a, name="TA", slug="ta-multi"
 		)
 		team_b = Team.objects.create(
-			organization=self.org_b, name="TB", slug="tb-multi"
+			organization=cls.org_b, name="TB", slug="tb-multi"
 		)
 		Lists.objects.create(list_name="LA", team=team_a)
 		Lists.objects.create(list_name="LB", team=team_b)
 
-		self.user = User.objects.create_user(
+		cls.user = User.objects.create_user(
 			username="multi_org",
 			password="pass",
 			email="multi@example.com",
 			is_staff=True,
 		)
-		self.user.user_permissions.add(
+		cls.user.user_permissions.add(
 			Permission.objects.get(codename="add_announcement"),
 			Permission.objects.get(codename="change_announcement"),
 			Permission.objects.get(codename="view_announcement"),
 		)
-		OrganizationUser.objects.create(organization=self.org_a, user=self.user)
-		OrganizationUser.objects.create(organization=self.org_b, user=self.user)
+		OrganizationUser.objects.create(organization=cls.org_a, user=cls.user)
+		OrganizationUser.objects.create(organization=cls.org_b, user=cls.user)
 
 	def _make_form(self):
 		req = MagicMock()
@@ -149,15 +151,16 @@ class TestFormDefaultMultiOrgUser(TestCase):
 class TestFormDefaultSuperuserWithMembership(TestCase):
 	"""Superuser in org B: initial is org B even when org A has lower PK."""
 
-	def setUp(self):
-		self.org_a = Organization.objects.create(name="A-Lower-PK")
-		self.org_b = Organization.objects.create(name="B-Higher-PK")
+	@classmethod
+	def setUpTestData(cls):
+		cls.org_a = Organization.objects.create(name="A-Lower-PK")
+		cls.org_b = Organization.objects.create(name="B-Higher-PK")
 
-		self.superuser = User.objects.create_superuser(
+		cls.superuser = User.objects.create_superuser(
 			username="su_member", password="pass", email="su_member@example.com"
 		)
 		# Superuser is a member only of org B.
-		OrganizationUser.objects.create(organization=self.org_b, user=self.superuser)
+		OrganizationUser.objects.create(organization=cls.org_b, user=cls.superuser)
 
 	def _make_form(self):
 		req = MagicMock()
@@ -173,10 +176,11 @@ class TestFormDefaultSuperuserWithMembership(TestCase):
 class TestFormDefaultSuperuserNoMembership(TestCase):
 	"""Superuser with no OrganizationUser: initial = first org by PK."""
 
-	def setUp(self):
-		self.org = Organization.objects.create(name="First Org")
+	@classmethod
+	def setUpTestData(cls):
+		cls.org = Organization.objects.create(name="First Org")
 		Organization.objects.create(name="Second Org")
-		self.superuser = User.objects.create_superuser(
+		cls.superuser = User.objects.create_superuser(
 			username="su_nomember", password="pass", email="su_nomember@example.com"
 		)
 
@@ -200,31 +204,32 @@ class TestFormDefaultSuperuserNoMembership(TestCase):
 class TestFormListsScopedToSelectedOrg(TestCase):
 	"""Multi-org user: when org=A is posted, only lists of org A are in choices."""
 
-	def setUp(self):
-		self.org_a = Organization.objects.create(name="Scope A")
-		self.org_b = Organization.objects.create(name="Scope B")
+	@classmethod
+	def setUpTestData(cls):
+		cls.org_a = Organization.objects.create(name="Scope A")
+		cls.org_b = Organization.objects.create(name="Scope B")
 		team_a = Team.objects.create(
-			organization=self.org_a, name="SA", slug="sa-scope"
+			organization=cls.org_a, name="SA", slug="sa-scope"
 		)
 		team_b = Team.objects.create(
-			organization=self.org_b, name="SB", slug="sb-scope"
+			organization=cls.org_b, name="SB", slug="sb-scope"
 		)
-		self.list_a = Lists.objects.create(list_name="List A", team=team_a)
-		self.list_b = Lists.objects.create(list_name="List B", team=team_b)
+		cls.list_a = Lists.objects.create(list_name="List A", team=team_a)
+		cls.list_b = Lists.objects.create(list_name="List B", team=team_b)
 
-		self.user = User.objects.create_user(
+		cls.user = User.objects.create_user(
 			username="scope_user",
 			password="pass",
 			email="scope@example.com",
 			is_staff=True,
 		)
-		self.user.user_permissions.add(
+		cls.user.user_permissions.add(
 			Permission.objects.get(codename="add_announcement"),
 			Permission.objects.get(codename="change_announcement"),
 			Permission.objects.get(codename="view_announcement"),
 		)
-		OrganizationUser.objects.create(organization=self.org_a, user=self.user)
-		OrganizationUser.objects.create(organization=self.org_b, user=self.user)
+		OrganizationUser.objects.create(organization=cls.org_a, user=cls.user)
+		OrganizationUser.objects.create(organization=cls.org_b, user=cls.user)
 
 	def test_lists_scoped_to_selected_org(self):
 		req = MagicMock()
@@ -245,19 +250,20 @@ class TestFormListsScopedToSelectedOrg(TestCase):
 class TestFormRejectsCrossOrgList(TestCase):
 	"""Submitting a list from org B when org=A raises ValidationError on 'lists'."""
 
-	def setUp(self):
-		self.org_a = Organization.objects.create(name="CrossA")
-		self.org_b = Organization.objects.create(name="CrossB")
+	@classmethod
+	def setUpTestData(cls):
+		cls.org_a = Organization.objects.create(name="CrossA")
+		cls.org_b = Organization.objects.create(name="CrossB")
 		team_a = Team.objects.create(
-			organization=self.org_a, name="CA", slug="ca-cross"
+			organization=cls.org_a, name="CA", slug="ca-cross"
 		)
 		team_b = Team.objects.create(
-			organization=self.org_b, name="CB", slug="cb-cross"
+			organization=cls.org_b, name="CB", slug="cb-cross"
 		)
-		self.list_a = Lists.objects.create(list_name="Good List", team=team_a)
-		self.list_b = Lists.objects.create(list_name="Bad List", team=team_b)
+		cls.list_a = Lists.objects.create(list_name="Good List", team=team_a)
+		cls.list_b = Lists.objects.create(list_name="Bad List", team=team_b)
 
-		self.superuser = User.objects.create_superuser(
+		cls.superuser = User.objects.create_superuser(
 			username="cross_su", password="pass", email="cross_su@example.com"
 		)
 
@@ -292,15 +298,18 @@ class TestFormRejectsCrossOrgList(TestCase):
 class TestChangelistShowsListlessDrafts(TestCase):
 	"""Draft with no lists for org A must appear in org-A user's changelist."""
 
-	def setUp(self):
-		self.org = Organization.objects.create(name="CL Org")
-		self.user = _staff_user_in_org("cl_user", self.org)
-		self.ann = Announcement.objects.create(
+	@classmethod
+	def setUpTestData(cls):
+		cls.org = Organization.objects.create(name="CL Org")
+		cls.user = _staff_user_in_org("cl_user", cls.org)
+		cls.ann = Announcement.objects.create(
 			subject="Listless Draft",
 			body="<p>x</p>",
-			organization=self.org,
+			organization=cls.org,
 		)
 		# No lists added.
+
+	def setUp(self):
 		self.client = Client()
 		self.client.force_login(self.user)
 
@@ -314,15 +323,18 @@ class TestChangelistShowsListlessDrafts(TestCase):
 class TestChangelistHidesOtherOrg(TestCase):
 	"""Announcement for org B must not appear in org-A user's changelist."""
 
-	def setUp(self):
-		self.org_a = Organization.objects.create(name="Hide A")
-		self.org_b = Organization.objects.create(name="Hide B")
-		self.user_a = _staff_user_in_org("hide_user_a", self.org_a)
-		self.ann_b = Announcement.objects.create(
+	@classmethod
+	def setUpTestData(cls):
+		cls.org_a = Organization.objects.create(name="Hide A")
+		cls.org_b = Organization.objects.create(name="Hide B")
+		cls.user_a = _staff_user_in_org("hide_user_a", cls.org_a)
+		cls.ann_b = Announcement.objects.create(
 			subject="Org B Ann",
 			body="<p>x</p>",
-			organization=self.org_b,
+			organization=cls.org_b,
 		)
+
+	def setUp(self):
 		self.client = Client()
 		self.client.force_login(self.user_a)
 
@@ -341,12 +353,17 @@ class TestChangelistHidesOtherOrg(TestCase):
 class TestGetReadonlyFieldsLocksOrganizationPostSend(TestCase):
 	"""organization must be in readonly_fields when status='sent'."""
 
-	def setUp(self):
-		self.org = Organization.objects.create(name="RO Org")
-		self.admin = AnnouncementAdmin(Announcement, admin_site)
-		self.superuser = User.objects.create_superuser(
+	@classmethod
+	def setUpTestData(cls):
+		cls.org = Organization.objects.create(name="RO Org")
+		cls.superuser = User.objects.create_superuser(
 			username="ro_su", password="pass", email="ro_su@example.com"
 		)
+
+	def setUp(self):
+		# AnnouncementAdmin isn't deep-copyable (holds a reference to the
+		# admin site registry), so it can't live in setUpTestData.
+		self.admin = AnnouncementAdmin(Announcement, admin_site)
 
 	def test_readonly_includes_organization_post_send(self):
 		ann = Announcement(
@@ -382,25 +399,26 @@ class TestSendValidationBlocksCrossOrgList(TestCase):
 	"""validate_announcement_send_config must block when a list belongs to
 	a different org than the announcement."""
 
-	def setUp(self):
-		self.org_a = Organization.objects.create(name="SVA Org A")
-		self.org_b = Organization.objects.create(name="SVA Org B")
+	@classmethod
+	def setUpTestData(cls):
+		cls.org_a = Organization.objects.create(name="SVA Org A")
+		cls.org_b = Organization.objects.create(name="SVA Org B")
 		team_a = Team.objects.create(
-			organization=self.org_a, name="SVA A", slug="sva-a"
+			organization=cls.org_a, name="SVA A", slug="sva-a"
 		)
 		team_b = Team.objects.create(
-			organization=self.org_b, name="SVA B", slug="sva-b"
+			organization=cls.org_b, name="SVA B", slug="sva-b"
 		)
-		self.list_a = Lists.objects.create(list_name="SV List A", team=team_a)
-		self.list_b = Lists.objects.create(list_name="SV List B", team=team_b)
+		cls.list_a = Lists.objects.create(list_name="SV List A", team=team_a)
+		cls.list_b = Lists.objects.create(list_name="SV List B", team=team_b)
 
-		self.ann = Announcement.objects.create(
+		cls.ann = Announcement.objects.create(
 			subject="SV Ann",
 			body="<p>hello</p>",
-			organization=self.org_a,
+			organization=cls.org_a,
 		)
-		self.ann.lists.add(self.list_a)
-		self.ann.lists.add(self.list_b)  # cross-org
+		cls.ann.lists.add(cls.list_a)
+		cls.ann.lists.add(cls.list_b)  # cross-org
 
 	def _make_site(self, domain="ex.com"):
 		s = MagicMock()
@@ -445,31 +463,33 @@ class TestSendValidationBlocksCrossOrgList(TestCase):
 class TestDuplicateInheritsSourceOrganization(TestCase):
 	"""duplicate_announcements copies organization from source, not from actor."""
 
-	def setUp(self):
-		self.org_a = Organization.objects.create(name="DupOrg A")
-		self.org_b = Organization.objects.create(name="DupOrg B")
+	@classmethod
+	def setUpTestData(cls):
+		cls.org_a = Organization.objects.create(name="DupOrg A")
+		cls.org_b = Organization.objects.create(name="DupOrg B")
 		team_a = Team.objects.create(
-			organization=self.org_a, name="DA", slug="da-dup-org"
+			organization=cls.org_a, name="DA", slug="da-dup-org"
 		)
 		team_b = Team.objects.create(
-			organization=self.org_b, name="DB", slug="db-dup-org"
+			organization=cls.org_b, name="DB", slug="db-dup-org"
 		)
-		self.list_a = Lists.objects.create(list_name="DupList A", team=team_a)
-		self.list_b = Lists.objects.create(list_name="DupList B", team=team_b)
+		cls.list_a = Lists.objects.create(list_name="DupList A", team=team_a)
+		cls.list_b = Lists.objects.create(list_name="DupList B", team=team_b)
 
 		# Multi-org user (member of both A and B; first org by PK is A).
-		self.user = User.objects.create_superuser(
+		cls.user = User.objects.create_superuser(
 			username="dup_su", password="pass", email="dup_su@example.com"
 		)
 		# Source is in org_a.
-		self.source = Announcement.objects.create(
+		cls.source = Announcement.objects.create(
 			subject="Source in A",
 			body="<p>x</p>",
-			organization=self.org_a,
+			organization=cls.org_a,
 			status="sent",
 		)
-		self.source.lists.add(self.list_a)
+		cls.source.lists.add(cls.list_a)
 
+	def setUp(self):
 		self.client = Client()
 		self.client.force_login(self.user)
 
@@ -496,21 +516,23 @@ class TestDuplicateActionBlocksSourceUserCannotSee(TestCase):
 	"""duplicate_announcements on a source in org B, run by user in org A only:
 	no row is created because the changelist queryset excludes it."""
 
-	def setUp(self):
-		self.org_a = Organization.objects.create(name="Block A")
-		self.org_b = Organization.objects.create(name="Block B")
-		team_b = Team.objects.create(organization=self.org_b, name="BlkB", slug="blk-b")
-		self.list_b = Lists.objects.create(list_name="BlkList B", team=team_b)
+	@classmethod
+	def setUpTestData(cls):
+		cls.org_a = Organization.objects.create(name="Block A")
+		cls.org_b = Organization.objects.create(name="Block B")
+		team_b = Team.objects.create(organization=cls.org_b, name="BlkB", slug="blk-b")
+		cls.list_b = Lists.objects.create(list_name="BlkList B", team=team_b)
 
-		self.user_a = _staff_user_in_org("blk_user_a", self.org_a)
-		self.source_b = Announcement.objects.create(
+		cls.user_a = _staff_user_in_org("blk_user_a", cls.org_a)
+		cls.source_b = Announcement.objects.create(
 			subject="Blocked Source",
 			body="<p>x</p>",
-			organization=self.org_b,
+			organization=cls.org_b,
 			status="sent",
 		)
-		self.source_b.lists.add(self.list_b)
+		cls.source_b.lists.add(cls.list_b)
 
+	def setUp(self):
 		self.client = Client()
 		self.client.force_login(self.user_a)
 
@@ -537,14 +559,19 @@ class TestSaveModelFallbackForMissingOrganization(TestCase):
 	"""save_model sets organization from user's first OrganizationUser when
 	obj.organization_id is None (defensive path)."""
 
-	def setUp(self):
-		self.org = Organization.objects.create(name="Fallback Org")
+	@classmethod
+	def setUpTestData(cls):
+		cls.org = Organization.objects.create(name="Fallback Org")
 		team = Team.objects.create(
-			organization=self.org, name="FB Team", slug="fb-team"
+			organization=cls.org, name="FB Team", slug="fb-team"
 		)
 		Lists.objects.create(list_name="FB List", team=team)
 
-		self.user = _staff_user_in_org("fb_user", self.org)
+		cls.user = _staff_user_in_org("fb_user", cls.org)
+
+	def setUp(self):
+		# AnnouncementAdmin isn't deep-copyable (holds a reference to the
+		# admin site registry), so it can't live in setUpTestData.
 		self.admin = AnnouncementAdmin(Announcement, admin_site)
 
 	def test_save_model_fallback_sets_org(self):
@@ -573,20 +600,25 @@ class TestFormInitHandlesReadonlyOrgAndLists(TestCase):
 	form's __init__ must not blow up trying to scope queryset/initial on
 	those missing fields."""
 
-	def setUp(self):
-		self.org = Organization.objects.create(name="Readonly Init Org")
-		team = Team.objects.create(organization=self.org, name="RI", slug="ri-team")
-		self.lst = Lists.objects.create(list_name="RI List", team=team)
-		self.admin = AnnouncementAdmin(Announcement, admin_site)
-		self.superuser = User.objects.create_superuser(
+	@classmethod
+	def setUpTestData(cls):
+		cls.org = Organization.objects.create(name="Readonly Init Org")
+		team = Team.objects.create(organization=cls.org, name="RI", slug="ri-team")
+		cls.lst = Lists.objects.create(list_name="RI List", team=team)
+		cls.superuser = User.objects.create_superuser(
 			username="ri_su", password="pass", email="ri_su@example.com"
 		)
-		self.ann = Announcement.objects.create(
+		cls.ann = Announcement.objects.create(
 			subject="Sent Init Ann",
 			body="<p>x</p>",
 			status="sent",
-			organization=self.org,
+			organization=cls.org,
 		)
+
+	def setUp(self):
+		# AnnouncementAdmin isn't deep-copyable (holds a reference to the
+		# admin site registry), so it can't live in setUpTestData.
+		self.admin = AnnouncementAdmin(Announcement, admin_site)
 
 	def test_form_init_does_not_keyerror_on_sent(self):
 		req = MagicMock()

--- a/django/subscriptions/tests/test_announcements.py
+++ b/django/subscriptions/tests/test_announcements.py
@@ -39,14 +39,15 @@ class AnnouncementStrTest(TestCase):
 
 
 class AnnouncementRecipientUniqueTogetherTest(TestCase):
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		org = Organization.objects.create(name="Test Org")
 		team = Team.objects.create(organization=org, name="Team A", slug="team-a")
-		self.lst = Lists.objects.create(list_name="Weekly", team=team)
-		self.ann = Announcement.objects.create(
+		cls.lst = Lists.objects.create(list_name="Weekly", team=team)
+		cls.ann = Announcement.objects.create(
 			subject="Notice", body="<p>Hi</p>", organization=org
 		)
-		self.sub = Subscribers.objects.create(
+		cls.sub = Subscribers.objects.create(
 			first_name="Alice", last_name="Smith", email="alice@example.com"
 		)
 
@@ -82,24 +83,29 @@ class AnnouncementRecipientUniqueTogetherTest(TestCase):
 
 
 class RenderAnnouncementEmailContextTest(TestCase):
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		org = Organization.objects.create(name="Ctx Org")
-		self.team = Team.objects.create(
+		cls.team = Team.objects.create(
 			organization=org, name="Ctx Team", slug="ctx-team"
 		)
-		self.lst = Lists.objects.create(list_name="Digest", team=self.team)
-		self.ann = Announcement.objects.create(
+		cls.lst = Lists.objects.create(list_name="Digest", team=cls.team)
+		cls.ann = Announcement.objects.create(
 			subject="Test Email",
 			body="<p>Hello</p>",
 			header_title="My Title",
 			header_tagline="My Tagline",
 			organization=org,
 		)
-		self.site = Site.objects.get_or_create(
+		cls.site = Site.objects.get_or_create(
 			id=1, defaults={"domain": "example.com", "name": "Example"}
 		)[0]
-		self.site.domain = "example.com"
-		self.site.save()
+		cls.site.domain = "example.com"
+		cls.site.save()
+
+	def setUp(self):
+		# AnnouncementAdmin isn't deep-copyable (holds a reference to the
+		# admin site registry), so it can't live in setUpTestData.
 		self.admin = AnnouncementAdmin(Announcement, admin_site)
 
 	def _render_and_capture_context(self, **kwargs):
@@ -145,15 +151,18 @@ class RenderAnnouncementEmailContextTest(TestCase):
 
 
 class SendViewRedirectTest(TestCase):
-	def setUp(self):
-		self.superuser = User.objects.create_superuser(
+	@classmethod
+	def setUpTestData(cls):
+		cls.superuser = User.objects.create_superuser(
 			username="admin", password="password", email="admin@example.com"
 		)
-		self.org = Organization.objects.create(name="Send Org")
-		self.team = Team.objects.create(
-			organization=self.org, name="Send Team", slug="send-team"
+		cls.org = Organization.objects.create(name="Send Org")
+		cls.team = Team.objects.create(
+			organization=cls.org, name="Send Team", slug="send-team"
 		)
-		self.lst = Lists.objects.create(list_name="News", team=self.team)
+		cls.lst = Lists.objects.create(list_name="News", team=cls.team)
+
+	def setUp(self):
 		self.client = Client()
 		self.client.force_login(self.superuser)
 
@@ -196,35 +205,38 @@ class SendViewRedirectTest(TestCase):
 class SendViewSubjectNormalisationTest(TestCase):
 	"""send_view must strip any leading [TEST] prefix from the subject on live sends."""
 
-	def setUp(self):
-		self.superuser = User.objects.create_superuser(
+	@classmethod
+	def setUpTestData(cls):
+		cls.superuser = User.objects.create_superuser(
 			username="admin2", password="password", email="admin2@example.com"
 		)
-		self.org = Organization.objects.create(name="Norm Org")
-		self.team = Team.objects.create(
-			organization=self.org, name="Norm Team", slug="norm-team"
+		cls.org = Organization.objects.create(name="Norm Org")
+		cls.team = Team.objects.create(
+			organization=cls.org, name="Norm Team", slug="norm-team"
 		)
 		# Give the list a Site + CustomSetting so the validation gate passes.
-		self.norm_site = Site.objects.get_or_create(
+		cls.norm_site = Site.objects.get_or_create(
 			id=20, defaults={"domain": "norm.example.com", "name": "Norm"}
 		)[0]
-		self.norm_site.domain = "norm.example.com"
-		self.norm_site.save()
+		cls.norm_site.domain = "norm.example.com"
+		cls.norm_site.save()
 		CustomSetting.objects.get_or_create(
-			site=self.norm_site,
+			site=cls.norm_site,
 			defaults={"title": "Norm CS", "api_domain": "api.norm.example.com"},
 		)
-		self.lst = Lists.objects.create(
-			list_name="Norm List", team=self.team, site=self.norm_site
+		cls.lst = Lists.objects.create(
+			list_name="Norm List", team=cls.team, site=cls.norm_site
 		)
-		self.sub = Subscribers.objects.create(
+		cls.sub = Subscribers.objects.create(
 			first_name="Carol", last_name="Danvers", email="carol@example.com"
 		)
 		ListSubscription.objects.create(
-			subscriber=self.sub, list=self.lst, is_active=True
+			subscriber=cls.sub, list=cls.lst, is_active=True
 		)
-		self.sub.active = True
-		self.sub.save()
+		cls.sub.active = True
+		cls.sub.save()
+
+	def setUp(self):
 		self.client = Client()
 		self.client.force_login(self.superuser)
 
@@ -266,10 +278,15 @@ class SendViewSubjectNormalisationTest(TestCase):
 class RenderAnnouncementTaglineAndPreheaderTest(TestCase):
 	"""Tests for show_header_tagline and preheader_text rendering."""
 
-	def setUp(self):
+	@classmethod
+	def setUpTestData(cls):
 		org = Organization.objects.create(name="Tag Org")
 		team = Team.objects.create(organization=org, name="Tag Team", slug="tag-team")
-		self.lst = Lists.objects.create(list_name="Tag List", team=team)
+		cls.lst = Lists.objects.create(list_name="Tag List", team=team)
+
+	def setUp(self):
+		# AnnouncementAdmin isn't deep-copyable (holds a reference to the
+		# admin site registry), so it can't live in setUpTestData.
 		self.admin = AnnouncementAdmin(Announcement, admin_site)
 
 	def _render(self, **ann_kwargs):
@@ -336,33 +353,37 @@ class RenderAnnouncementTaglineAndPreheaderTest(TestCase):
 class _SendValidationBase(TestCase):
 	"""Shared setUp for validation-gate tests."""
 
-	def setUp(self):
-		self.superuser = User.objects.create_superuser(
+	@classmethod
+	def setUpTestData(cls):
+		cls.superuser = User.objects.create_superuser(
 			username="val_admin", password="password", email="val_admin@example.com"
 		)
-		self.org = Organization.objects.create(name="Val Org")
-		self.team = Team.objects.create(
-			organization=self.org, name="Val Team", slug="val-team"
+		cls.org = Organization.objects.create(name="Val Org")
+		cls.team = Team.objects.create(
+			organization=cls.org, name="Val Team", slug="val-team"
 		)
 
 		# Site used by tests
-		self.site = Site.objects.get_or_create(
+		cls.site = Site.objects.get_or_create(
 			id=10, defaults={"domain": "val.example.com", "name": "Val Example"}
 		)[0]
-		self.site.domain = "val.example.com"
-		self.site.save()
+		cls.site.domain = "val.example.com"
+		cls.site.save()
 
-		# Default valid CustomSetting — individual tests may mutate api_domain or delete it.
-		self.cs = CustomSetting.objects.create(
-			site=self.site,
+		# Default valid CustomSetting — individual tests mutate api_domain or
+		# delete it; the per-test transaction rollback restores this row
+		# before the next test's setUp runs.
+		cls.cs = CustomSetting.objects.create(
+			site=cls.site,
 			title="Val CS",
 			api_domain="api.val.example.com",
 		)
 
-		self.lst = Lists.objects.create(
-			list_name="Val List", team=self.team, site=self.site
+		cls.lst = Lists.objects.create(
+			list_name="Val List", team=cls.team, site=cls.site
 		)
 
+	def setUp(self):
 		self.client = Client()
 		self.client.force_login(self.superuser)
 


### PR DESCRIPTION
## Summary

Follow-up to #796 (Part A — config wins, already merged). This is Part B of the CI-speed-up effort: the targeted test-code refactor.

- **B1** — Converted `setUp` → `setUpTestData` in the plan's 10 heaviest-churn test files (plus `test_feedreader_articles.py`, folded in with B3). Real per-file review, not mechanical: only converted classes with genuinely shared, read-only-across-the-class fixtures and more than one test method (a single-test class gets zero speed benefit from `setUpTestData`, so those were left alone to avoid diff noise). Found one non-obvious constraint along the way: `AnnouncementAdmin` instances aren't deep-copyable (they hold a reference to the admin site registry — `TypeError: cannot pickle 'module' object`), so those stay in `setUp`; same for `Client()`/`APIClient()`, which should get fresh login state per test rather than being shared.
- **B3** — Investigated the sole `TransactionTestCase` usage (4 classes in `test_feedreader_articles.py`, which also had the heaviest single-file `setUp` cost). Found no `on_commit` callbacks, no IntegrityError-continuation pattern, and no threading in the command under test — nothing that needs real commits or the truncate-between-tests semantics `TransactionTestCase` pays for. Converted all 4 to `TestCase`; the file's 52 tests still pass.
- **B2** — `gregory/ml/__init__.py` now resolves `get_trainer`/`pseudo.*` via a PEP 562 `__getattr__` instead of eagerly importing `trainer.py` (which imports all three wrappers → tensorflow + torch + transformers + lightgbm) at package-import time. A bare `import gregory.ml`, or importing one wrapper submodule directly, no longer drags in the other two frameworks. `train_models.py`'s top-level `from gregory.ml import get_trainer` is unaffected (it genuinely needs all three).

## Test plan
- [x] Each B1 file's tests run immediately after converting it, individually.
- [x] `test_feedreader_articles.py`'s 52 tests pass both after the `TransactionTestCase→TestCase` conversion and after the subsequent `setUpTestData` refactor.
- [x] ML test files (`test_ml_factory.py`, `test_train_models.py`, `test_predict_articles*.py`, `test_pseudo.py`, `test_summariser.py`, `test_bert_wrapper.py`) pass after the lazy-import change; verified directly that `import gregory.ml` no longer loads tensorflow until an attribute is actually accessed.
- [x] Full suite green: 2698 passed, ~87s (down from ~97-99s after Part A alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)