### PR TITLE
fix: honor POST-body filters on article/trial/author search endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ docker-compose.override.yml
 scripts/merge_pdf_links.py
 .gitignore
 scripts/download_pdfs.py
+_brain-regeneration\ mockups/

--- a/django/api/tests/test_search_post_filters.py
+++ b/django/api/tests/test_search_post_filters.py
@@ -1,0 +1,402 @@
+"""
+Regression tests for BodyParamsAsQueryParamsMixin: POST-body filters on the
+article/trial/author search endpoints must behave identically to the same
+filters sent on the query string, for every ArticleFilter/TrialFilter/
+AuthorFilter field — not just the hand-plumbed title/summary/search/status
+params. Before this fix, DjangoFilterBackend/OrderingFilter only ever read
+request.query_params, so a filter sent in a POST body was silently dropped
+and the response came back unfiltered (a wrong 200, not an error).
+"""
+
+from datetime import date
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from gregory.models import (
+	ArticleSubjectRelevance,
+	Articles,
+	Authors,
+	Organization,
+	OrganizationApiSettings,
+	Subject,
+	Team,
+	Trials,
+)
+
+
+class ArticleSearchPostFilterTests(TestCase):
+	def setUp(self):
+		self.client = APIClient()
+		self.org = Organization.objects.create(
+			name="Search POST Filter Org", slug="search-post-filter-org"
+		)
+		OrganizationApiSettings.objects.filter(organization=self.org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="Search POST Filter Team",
+			slug="search-post-filter-team",
+			organization=self.org,
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Search POST Filter Subject",
+			subject_slug="search-post-filter-subject",
+			team=self.team,
+		)
+		self.other_subject = Subject.objects.create(
+			subject_name="Search POST Filter Other Subject",
+			subject_slug="search-post-filter-other-subject",
+			team=self.team,
+		)
+
+		def make_article(title, link, pub_date, subjects=(self.subject,)):
+			a = Articles.objects.create(title=title, link=link)
+			a.published_date = pub_date
+			a.save(update_fields=["published_date"])
+			a.teams.add(self.team)
+			for s in subjects:
+				a.subjects.add(s)
+			return a
+
+		self.a_2022 = make_article(
+			"Article 2022", "https://example.com/pf-1", timezone.make_aware(
+				timezone.datetime(2022, 6, 1, 9, 0)
+			)
+		)
+		self.a_2023 = make_article(
+			"Article 2023", "https://example.com/pf-2", timezone.make_aware(
+				timezone.datetime(2023, 6, 1, 9, 0)
+			)
+		)
+		self.a_2024 = make_article(
+			"Article 2024", "https://example.com/pf-3", timezone.make_aware(
+				timezone.datetime(2024, 6, 1, 9, 0)
+			)
+		)
+		self.a_both_subjects = make_article(
+			"Article Both Subjects",
+			"https://example.com/pf-4",
+			timezone.make_aware(timezone.datetime(2023, 7, 1, 9, 0)),
+			subjects=(self.subject, self.other_subject),
+		)
+
+		ArticleSubjectRelevance.objects.create(
+			article=self.a_2023, subject=self.subject, is_relevant=True
+		)
+
+		self.base_params = {"team_id": self.team.id, "subject_id": self.subject.id}
+
+	def _get(self, extra):
+		url = reverse("article-search")
+		return self.client.get(url, {**self.base_params, **extra})
+
+	def _post(self, extra):
+		url = reverse("article-search")
+		return self.client.post(url, {**self.base_params, **extra}, format="json")
+
+	def test_published_date_range_post_matches_get(self):
+		params = {
+			"published_date_after": "2023-01-01",
+			"published_date_before": "2023-12-31",
+		}
+		get_resp = self._get(params)
+		post_resp = self._post(params)
+
+		self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+		self.assertEqual(post_resp.status_code, status.HTTP_200_OK)
+
+		get_ids = {r["article_id"] for r in get_resp.data["results"]}
+		post_ids = {r["article_id"] for r in post_resp.data["results"]}
+
+		self.assertEqual(get_ids, post_ids)
+		self.assertIn(self.a_2023.article_id, post_ids)
+		self.assertIn(self.a_both_subjects.article_id, post_ids)
+		self.assertNotIn(self.a_2022.article_id, post_ids)
+		self.assertNotIn(self.a_2024.article_id, post_ids)
+
+	def test_published_date_after_ignored_pre_fix_regression(self):
+		"""Without the fix this POST would return every article for the team/subject."""
+		post_resp = self._post({"published_date_after": "2024-01-01"})
+		self.assertEqual(post_resp.status_code, status.HTTP_200_OK)
+		post_ids = {r["article_id"] for r in post_resp.data["results"]}
+		self.assertEqual(post_ids, {self.a_2024.article_id})
+
+	def test_relevant_boolean_post_matches_get(self):
+		params = {"relevant": "true"}
+		get_resp = self._get(params)
+		post_resp = self._post(params)
+
+		self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+		self.assertEqual(post_resp.status_code, status.HTTP_200_OK)
+
+		get_ids = {r["article_id"] for r in get_resp.data["results"]}
+		post_ids = {r["article_id"] for r in post_resp.data["results"]}
+
+		self.assertEqual(get_ids, post_ids)
+		self.assertEqual(post_ids, {self.a_2023.article_id})
+
+	def test_subjects_list_body_value_matches_csv_query_string(self):
+		"""A JSON list body value must be equivalent to a comma-joined query string."""
+		subject_ids = [self.subject.id, self.other_subject.id]
+		get_resp = self._get({"subjects": ",".join(str(i) for i in subject_ids)})
+		post_resp = self._post({"subjects": subject_ids})
+
+		self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+		self.assertEqual(post_resp.status_code, status.HTTP_200_OK)
+
+		get_ids = {r["article_id"] for r in get_resp.data["results"]}
+		post_ids = {r["article_id"] for r in post_resp.data["results"]}
+
+		self.assertEqual(get_ids, post_ids)
+		self.assertEqual(post_ids, {self.a_both_subjects.article_id})
+
+	def test_query_string_wins_over_body(self):
+		"""Same key in both places: the query-string value takes precedence."""
+		url = reverse("article-search")
+		response = self.client.post(
+			url + "?published_date_after=2024-01-01",
+			{**self.base_params, "published_date_after": "2022-01-01"},
+			format="json",
+		)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = {r["article_id"] for r in response.data["results"]}
+		self.assertEqual(ids, {self.a_2024.article_id})
+
+	def test_title_search_still_works_on_post(self):
+		"""Regression: title/summary/search still work now that the manual
+		get_queryset handling was removed in favor of ArticleFilter."""
+		response = self._post({"title": "2024"})
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = {r["article_id"] for r in response.data["results"]}
+		self.assertEqual(ids, {self.a_2024.article_id})
+
+	def test_ordering_still_validated_on_post(self):
+		"""Regression: garbage ordering values are ignored, not applied blindly."""
+		response = self._post({"ordering": "nonexistent_field"})
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+	def test_missing_required_parameters_contract_unchanged(self):
+		url = reverse("article-search")
+		response = self.client.post(url, {}, format="json")
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+		response = self.client.post(
+			url, {"team_id": 999999, "subject_id": self.subject.id}, format="json"
+		)
+		self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class TrialSearchPostFilterTests(TestCase):
+	def setUp(self):
+		self.client = APIClient()
+		self.org = Organization.objects.create(
+			name="Trial Search POST Filter Org", slug="trial-search-post-filter-org"
+		)
+		OrganizationApiSettings.objects.filter(organization=self.org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="Trial Search POST Filter Team",
+			slug="trial-search-post-filter-team",
+			organization=self.org,
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Trial Search POST Filter Subject",
+			subject_slug="trial-search-post-filter-subject",
+			team=self.team,
+		)
+
+		def make_trial(title, link, date_registration, phase=None, has_results=False):
+			t = Trials.objects.create(
+				title=title,
+				link=link,
+				date_registration=date_registration,
+				phase=phase,
+				results_posted=has_results,
+			)
+			t.teams.add(self.team)
+			t.subjects.add(self.subject)
+			return t
+
+		self.t_2023 = make_trial(
+			"Trial 2023", "https://example.com/tpf-1", date(2023, 6, 1)
+		)
+		self.t_2024 = make_trial(
+			"Trial 2024",
+			"https://example.com/tpf-2",
+			date(2024, 6, 1),
+			phase="Phase 2",
+			has_results=True,
+		)
+
+		self.base_params = {"team_id": self.team.id, "subject_id": self.subject.id}
+
+	def _get(self, extra):
+		url = reverse("trial-search")
+		return self.client.get(url, {**self.base_params, **extra})
+
+	def _post(self, extra):
+		url = reverse("trial-search")
+		return self.client.post(url, {**self.base_params, **extra}, format="json")
+
+	def test_date_registration_range_post_matches_get(self):
+		params = {
+			"date_registration_after": "2024-01-01",
+			"date_registration_before": "2024-12-31",
+		}
+		get_resp = self._get(params)
+		post_resp = self._post(params)
+
+		self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+		self.assertEqual(post_resp.status_code, status.HTTP_200_OK)
+
+		get_ids = {r["trial_id"] for r in get_resp.data["results"]}
+		post_ids = {r["trial_id"] for r in post_resp.data["results"]}
+
+		self.assertEqual(get_ids, post_ids)
+		self.assertEqual(post_ids, {self.t_2024.trial_id})
+
+	def test_has_results_boolean_post_matches_get(self):
+		params = {"has_results": "true"}
+		get_resp = self._get(params)
+		post_resp = self._post(params)
+
+		self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+		self.assertEqual(post_resp.status_code, status.HTTP_200_OK)
+
+		get_ids = {r["trial_id"] for r in get_resp.data["results"]}
+		post_ids = {r["trial_id"] for r in post_resp.data["results"]}
+
+		self.assertEqual(get_ids, post_ids)
+		self.assertEqual(post_ids, {self.t_2024.trial_id})
+
+	def test_phase_normalized_post_matches_get(self):
+		params = {"phase_normalized": "phase_2"}
+		get_resp = self._get(params)
+		post_resp = self._post(params)
+
+		self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+		self.assertEqual(post_resp.status_code, status.HTTP_200_OK)
+
+		get_ids = {r["trial_id"] for r in get_resp.data["results"]}
+		post_ids = {r["trial_id"] for r in post_resp.data["results"]}
+
+		self.assertEqual(get_ids, post_ids)
+		self.assertEqual(post_ids, {self.t_2024.trial_id})
+
+	def test_date_registration_after_ignored_pre_fix_regression(self):
+		"""Without the fix this POST would return every trial for the team/subject."""
+		post_resp = self._post({"date_registration_after": "2024-01-01"})
+		self.assertEqual(post_resp.status_code, status.HTTP_200_OK)
+		post_ids = {r["trial_id"] for r in post_resp.data["results"]}
+		self.assertEqual(post_ids, {self.t_2024.trial_id})
+
+	def test_status_search_still_works_on_post(self):
+		"""Regression: status is a legacy CharFilter alias for recruitment_status;
+		still works now the manual get_queryset handling was removed."""
+		Trials.objects.filter(pk=self.t_2023.pk).update(
+			recruitment_status="Recruiting"
+		)
+		response = self._post({"status": "Recruiting"})
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = {r["trial_id"] for r in response.data["results"]}
+		self.assertEqual(ids, {self.t_2023.trial_id})
+
+	def test_missing_required_parameters_contract_unchanged(self):
+		url = reverse("trial-search")
+		response = self.client.post(url, {}, format="json")
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+		response = self.client.post(
+			url, {"team_id": 999999, "subject_id": self.subject.id}, format="json"
+		)
+		self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class AuthorSearchPostFilterTests(TestCase):
+	def setUp(self):
+		self.client = APIClient()
+		self.org = Organization.objects.create(
+			name="Author Search POST Filter Org",
+			slug="author-search-post-filter-org",
+		)
+		OrganizationApiSettings.objects.filter(organization=self.org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="Author Search POST Filter Team",
+			slug="author-search-post-filter-team",
+			organization=self.org,
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Author Search POST Filter Subject",
+			subject_slug="author-search-post-filter-subject",
+			team=self.team,
+		)
+
+		self.author_pt = Authors.objects.create(
+			given_name="Ines", family_name="Silva", country="PT"
+		)
+		self.author_us = Authors.objects.create(
+			given_name="John", family_name="Doe", country="US"
+		)
+
+		article = Articles.objects.create(
+			title="Author POST Filter Article",
+			link="https://example.com/apf-1",
+			published_date=timezone.now(),
+		)
+		article.authors.add(self.author_pt, self.author_us)
+		article.teams.add(self.team)
+		article.subjects.add(self.subject)
+
+		self.base_params = {"team_id": self.team.id, "subject_id": self.subject.id}
+
+	def _get(self, extra):
+		url = reverse("author-search")
+		return self.client.get(url, {**self.base_params, **extra})
+
+	def _post(self, extra):
+		url = reverse("author-search")
+		return self.client.post(url, {**self.base_params, **extra}, format="json")
+
+	def test_country_post_matches_get(self):
+		"""country is only reachable via AuthorFilter (no manual get_queryset
+		handling ever existed for it), so this is the clearest proof the mixin
+		is what makes POST-body filters work at all."""
+		params = {"country": "PT"}
+		get_resp = self._get(params)
+		post_resp = self._post(params)
+
+		self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+		self.assertEqual(post_resp.status_code, status.HTTP_200_OK)
+
+		get_ids = {r["author_id"] for r in get_resp.data["results"]}
+		post_ids = {r["author_id"] for r in post_resp.data["results"]}
+
+		self.assertEqual(get_ids, post_ids)
+		self.assertEqual(post_ids, {self.author_pt.author_id})
+
+	def test_country_ignored_pre_fix_regression(self):
+		"""Without the fix this POST would return every author for the team/subject."""
+		post_resp = self._post({"country": "PT"})
+		self.assertEqual(post_resp.status_code, status.HTTP_200_OK)
+		post_ids = {r["author_id"] for r in post_resp.data["results"]}
+		self.assertEqual(post_ids, {self.author_pt.author_id})
+
+	def test_full_name_still_works_on_post(self):
+		"""Regression: full_name is handled directly in get_queryset (unchanged
+		by this fix); confirm it still narrows results on POST."""
+		response = self._post({"full_name": "ines"})
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = {r["author_id"] for r in response.data["results"]}
+		self.assertEqual(ids, {self.author_pt.author_id})
+
+	def test_missing_required_parameters_contract_unchanged(self):
+		url = reverse("author-search")
+		response = self.client.post(url, {}, format="json")
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -242,6 +242,38 @@ class BulkExportThrottleMixin:
 		return super().get_throttles()
 
 
+class BodyParamsAsQueryParamsMixin:
+	"""Make POST-body params visible to DRF's filter backends.
+
+	DjangoFilterBackend and OrderingFilter read request.query_params only, so on
+	a POST every filterset param used to be dropped silently and the response
+	came back unfiltered — a wrong 200, not an error. Merging the body into
+	query_params gives GET and POST a single code path.
+
+	An explicit query-string value wins over the same key in the body, so the
+	documented `POST /search/?filters...` workaround keeps working unchanged.
+	"""
+
+	def initial(self, request, *args, **kwargs):
+		super().initial(request, *args, **kwargs)
+		if request.method != "POST":
+			return
+		data = request.data
+		if not hasattr(data, "items"):  # not a JSON object / form payload
+			return
+		merged = request.query_params.copy()  # a mutable QueryDict
+		items = data.lists() if hasattr(data, "lists") else data.items()
+		for key, value in items:
+			if key in merged:
+				continue  # query string wins
+			if isinstance(value, (list, tuple)):
+				merged.setlist(key, [str(v) for v in value if v is not None])
+			elif value is not None:
+				merged[key] = str(value)
+		merged._mutable = False
+		request._request.GET = merged
+
+
 def _latest_ml_predictions_queryset():
 	"""``MLPredictions`` queryset restricted to the latest row per
 	(article, subject, algorithm), for use as a serializer prefetch.
@@ -2953,7 +2985,9 @@ class CategoriesByTeamAndSubject(viewsets.ModelViewSet):
 		)
 
 
-class ArticleSearchView(CSVStreamingMixin, BulkExportThrottleMixin, generics.ListAPIView):
+class ArticleSearchView(
+	BodyParamsAsQueryParamsMixin, CSVStreamingMixin, BulkExportThrottleMixin, generics.ListAPIView
+):
 	"""
 	Advanced search for articles by title and abstract (summary).
 
@@ -2992,9 +3026,11 @@ class ArticleSearchView(CSVStreamingMixin, BulkExportThrottleMixin, generics.Lis
 	permission_classes = [
 		permissions.AllowAny
 	]  # Allow access to anyone since we require team_id and subject_id
-	# `search` is parsed by build_search_q in get_queryset (and by ArticleFilter
-	# for GET query params). DRF's SearchFilter is omitted so it can't AND a
-	# naive token match on top and break boolean queries. See ArticleViewSet.
+	# `search` is parsed by build_search_q inside ArticleFilter.filter_search,
+	# for both GET query params and POST body (merged in by
+	# BodyParamsAsQueryParamsMixin). DRF's SearchFilter is omitted so it can't
+	# AND a naive token match on top and break boolean queries. See
+	# ArticleViewSet.
 	filter_backends = [
 		django_filters.DjangoFilterBackend,
 		filters.OrderingFilter,
@@ -3194,7 +3230,9 @@ class ArticleSearchView(CSVStreamingMixin, BulkExportThrottleMixin, generics.Lis
 		return self.list(request, *args, **kwargs)
 
 
-class TrialSearchView(CSVStreamingMixin, BulkExportThrottleMixin, generics.ListAPIView):
+class TrialSearchView(
+	BodyParamsAsQueryParamsMixin, CSVStreamingMixin, BulkExportThrottleMixin, generics.ListAPIView
+):
 	"""
 	Advanced search for clinical trials by title, summary, and recruitment status.
 
@@ -3234,9 +3272,11 @@ class TrialSearchView(CSVStreamingMixin, BulkExportThrottleMixin, generics.ListA
 	permission_classes = [
 		permissions.AllowAny
 	]  # Allow access to anyone since we require team_id and subject_id
-	# `search` is parsed by build_search_q in get_queryset (and by TrialFilter
-	# for GET query params). DRF's SearchFilter is omitted so it can't AND a
-	# naive token match on top and break boolean queries. See ArticleViewSet.
+	# `search` is parsed by build_search_q inside TrialFilter.filter_search, for
+	# both GET query params and POST body (merged in by
+	# BodyParamsAsQueryParamsMixin). DRF's SearchFilter is omitted so it can't
+	# AND a naive token match on top and break boolean queries. See
+	# ArticleViewSet.
 	filter_backends = [
 		django_filters.DjangoFilterBackend,
 		filters.OrderingFilter,
@@ -3432,7 +3472,7 @@ class TrialSearchView(CSVStreamingMixin, BulkExportThrottleMixin, generics.ListA
 		return self.list(request, *args, **kwargs)
 
 
-class AuthorSearchView(generics.ListAPIView):
+class AuthorSearchView(BodyParamsAsQueryParamsMixin, generics.ListAPIView):
 	"""
 	Advanced search for authors by full name.
 

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -109,7 +109,6 @@ from api.filters import (
 	SubjectFilter,
 	SponsorFilter,
 )
-from api.utils.search import build_search_q
 from rest_framework.response import Response
 from django.http import Http404, StreamingHttpResponse
 from rest_framework.views import APIView
@@ -3080,20 +3079,6 @@ class ArticleSearchView(
 			)
 			queryset = Articles.objects.filter(Exists(match_subq))
 
-			# Apply additional filters
-			title = params.get("title")
-			summary = params.get("summary")
-			search = params.get("search")
-
-			if title:
-				queryset = queryset.filter(utitle__contains=title.upper())
-			if summary:
-				queryset = queryset.filter(usummary__contains=summary.upper())
-			if search:
-				q = build_search_q(search)
-				if q is not None:
-					queryset = queryset.filter(q)
-
 			# Prefetch related objects to avoid N+1 queries
 			queryset = queryset.prefetch_related(
 				Prefetch(
@@ -3137,25 +3122,6 @@ class ArticleSearchView(
 				"ArticleSearchView: ignoring malformed search params (%s)", e
 			)
 			return Articles.objects.none()
-
-	def filter_queryset(self, queryset):
-		"""
-		Filter the queryset and handle ordering from both GET and POST requests.
-		"""
-		# First apply standard filters
-		queryset = super().filter_queryset(queryset)
-
-		# Handle ordering for POST requests manually (OrderingFilter only checks query_params by default)
-		if self.request.method == "POST":
-			ordering = self.request.data.get("ordering")
-			if ordering:
-				# Validate that ordering field is in allowed fields
-				if ordering.lstrip("-") in [
-					f.replace("-", "") for f in self.ordering_fields
-				]:
-					queryset = queryset.order_by(ordering)
-
-		return queryset
 
 	def post(self, request, *args, **kwargs):
 		# For POST requests, validate required parameters
@@ -3336,30 +3302,6 @@ class TrialSearchView(
 		match_subq = Trials.objects.filter(pk=OuterRef("pk"), teams=team, subjects=subject)
 		queryset = Trials.objects.filter(Exists(match_subq))
 
-		# Apply additional filters
-		title = params.get("title")
-		summary = params.get("summary")
-		search = params.get("search")
-		status = params.get("status")
-
-		try:
-			if title:
-				queryset = queryset.filter(utitle__contains=title.upper())
-			if summary:
-				queryset = queryset.filter(usummary__contains=summary.upper())
-			if search:
-				q = build_search_q(search)
-				if q is not None:
-					queryset = queryset.filter(q)
-		except (AttributeError, TypeError, ValueError) as e:
-			logging.getLogger(__name__).warning(
-				"TrialSearchView: ignoring malformed search params (%s)", e
-			)
-			return Trials.objects.none()
-
-		if status:
-			queryset = queryset.filter(recruitment_status=status)
-
 		# Prefetch related objects to avoid N+1 queries
 		queryset = queryset.prefetch_related(
 			"sources", "team_categories", "article_references__article", "trial_countries"
@@ -3377,25 +3319,6 @@ class TrialSearchView(
 					to_attr="_prefetched_org_contents",
 				)
 			)
-
-		return queryset
-
-	def filter_queryset(self, queryset):
-		"""
-		Filter the queryset and handle ordering from both GET and POST requests.
-		"""
-		# First apply standard filters
-		queryset = super().filter_queryset(queryset)
-
-		# Handle ordering for POST requests manually (OrderingFilter only checks query_params by default)
-		if self.request.method == "POST":
-			ordering = self.request.data.get("ordering")
-			if ordering:
-				# Validate that ordering field is in allowed fields
-				if ordering.lstrip("-") in [
-					f.replace("-", "") for f in self.ordering_fields
-				]:
-					queryset = queryset.order_by(ordering)
 
 		return queryset
 

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -2999,8 +2999,13 @@ class ArticleSearchView(
 	"""
 	Advanced search for articles by title and abstract (summary).
 
-	This endpoint accepts both GET and POST requests with team_id and subject_id parameters,
-	along with optional search parameters.
+	This endpoint accepts both GET and POST requests with team_id and subject_id
+	parameters, along with optional search parameters. Every filter on
+	ArticleFilter works identically on both verbs — for GET, put them on the
+	query string; for POST, put them in the JSON body. BodyParamsAsQueryParamsMixin
+	merges the body into query_params before filtering, so both paths run
+	through the same DjangoFilterBackend/OrderingFilter code; if the same key is
+	set in both places, the query string wins.
 
 	Parameters (can be sent as query params for GET or in request body for POST):
 	- title: Search only in title field
@@ -3013,16 +3018,14 @@ class ArticleSearchView(
 	- all_results: Set to 'true' to retrieve all results without pagination (useful for CSV export)
 	- ordering: Order results by field (e.g., -discovery_date, -published_date, title, article_id)
 
-	Query-string-only parameters — every filter on ArticleFilter also applies
-	here, e.g. published_date_after / published_date_before, relevant, subjects,
+	Every other ArticleFilter field also applies here, e.g.
+	published_date_after / published_date_before, relevant, subjects,
 	open_access:
 	- Published in 2023: /articles/search/?team_id=1&subject_id=1&published_date_after=2023-01-01&published_date_before=2023-12-31
 
-	These come from DjangoFilterBackend, which reads request.query_params only,
-	so they work on GET and on POST — but only from the URL. Sent in a POST
-	*body* they are silently ignored, leaving the response unfiltered by them
-	(the body's title/summary/search still apply). Put filters on the query
-	string, even when POSTing.
+	Prefer GET where practical — it's cacheable and linkable. POST exists for
+	`search` strings with long boolean expressions that would exceed practical
+	URL length limits.
 
 	Results are ordered by discovery date (newest first) by default.
 
@@ -3211,8 +3214,13 @@ class TrialSearchView(
 	"""
 	Advanced search for clinical trials by title, summary, and recruitment status.
 
-	This endpoint accepts both GET and POST requests with team_id and subject_id parameters,
-	along with optional search parameters.
+	This endpoint accepts both GET and POST requests with team_id and subject_id
+	parameters, along with optional search parameters. Every filter on
+	TrialFilter works identically on both verbs — for GET, put them on the query
+	string; for POST, put them in the JSON body. BodyParamsAsQueryParamsMixin
+	merges the body into query_params before filtering, so both paths run
+	through the same DjangoFilterBackend/OrderingFilter code; if the same key is
+	set in both places, the query string wins.
 
 	Parameters (can be sent as query params for GET or in request body for POST):
 	- title: Search only in title field
@@ -3226,16 +3234,14 @@ class TrialSearchView(
 	- all_results: Set to 'true' to retrieve all results without pagination (useful for CSV export)
 	- ordering: Order results by field (e.g., -discovery_date, -published_date, title, trial_id, -last_updated)
 
-	Query-string-only parameters — every filter on TrialFilter also applies here,
-	e.g. date_registration_after / date_registration_before, has_results,
+	Every other TrialFilter field also applies here, e.g.
+	date_registration_after / date_registration_before, has_results,
 	phase_normalized, country, sponsor_id:
 	- Registered in 2024: /trials/search/?team_id=1&subject_id=1&date_registration_after=2024-01-01&date_registration_before=2024-12-31
 
-	These come from DjangoFilterBackend, which reads request.query_params only,
-	so they work on GET and on POST — but only from the URL. Sent in a POST
-	*body* they are silently ignored, leaving the response unfiltered by them
-	(the body's title/summary/search/status still apply). Put filters on the
-	query string, even when POSTing.
+	Prefer GET where practical — it's cacheable and linkable. POST exists for
+	`search` strings with long boolean expressions that would exceed practical
+	URL length limits.
 
 	Results are ordered by discovery date (newest first) by default.
 

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -251,6 +251,10 @@ class BodyParamsAsQueryParamsMixin:
 
 	An explicit query-string value wins over the same key in the body, so the
 	documented `POST /search/?filters...` workaround keeps working unchanged.
+	This precedence only applies to keys the filter backends actually read from
+	query_params — it does NOT extend to team_id/subject_id (and full_name on
+	AuthorSearchView), which the views read directly from request.data on POST
+	for validation, before this mixin's merge is even consulted.
 
 	List-valued body params (`{"subjects": [1, 3]}`, or repeated keys in a
 	form-encoded body) are joined into a single comma-separated string rather
@@ -3004,8 +3008,10 @@ class ArticleSearchView(
 	ArticleFilter works identically on both verbs — for GET, put them on the
 	query string; for POST, put them in the JSON body. BodyParamsAsQueryParamsMixin
 	merges the body into query_params before filtering, so both paths run
-	through the same DjangoFilterBackend/OrderingFilter code; if the same key is
-	set in both places, the query string wins.
+	through the same DjangoFilterBackend/OrderingFilter code; if the same filter
+	key is set in both places, the query string wins. team_id and subject_id are
+	the exception: get_queryset() always reads them straight from request.data
+	on POST for validation, regardless of what's on the query string.
 
 	Parameters (can be sent as query params for GET or in request body for POST):
 	- title: Search only in title field
@@ -3219,8 +3225,10 @@ class TrialSearchView(
 	TrialFilter works identically on both verbs — for GET, put them on the query
 	string; for POST, put them in the JSON body. BodyParamsAsQueryParamsMixin
 	merges the body into query_params before filtering, so both paths run
-	through the same DjangoFilterBackend/OrderingFilter code; if the same key is
-	set in both places, the query string wins.
+	through the same DjangoFilterBackend/OrderingFilter code; if the same filter
+	key is set in both places, the query string wins. team_id and subject_id are
+	the exception: get_queryset() always reads them straight from request.data
+	on POST for validation, regardless of what's on the query string.
 
 	Parameters (can be sent as query params for GET or in request body for POST):
 	- title: Search only in title field

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -251,6 +251,15 @@ class BodyParamsAsQueryParamsMixin:
 
 	An explicit query-string value wins over the same key in the body, so the
 	documented `POST /search/?filters...` workaround keeps working unchanged.
+
+	List-valued body params (`{"subjects": [1, 3]}`, or repeated keys in a
+	form-encoded body) are joined into a single comma-separated string rather
+	than set as a repeated query key. This codebase's list filters are all
+	``BaseInFilter``/``ChoiceInFilter`` subclasses, whose form field reads a
+	single CSV-formatted value — confirmed empirically that a repeated query
+	key (`?subjects=1&subjects=3`) silently collapses to just the last value,
+	while `?subjects=1,3` parses correctly. Comma-joining is what actually
+	reaches the filterset intact.
 	"""
 
 	def initial(self, request, *args, **kwargs):
@@ -266,7 +275,7 @@ class BodyParamsAsQueryParamsMixin:
 			if key in merged:
 				continue  # query string wins
 			if isinstance(value, (list, tuple)):
-				merged.setlist(key, [str(v) for v in value if v is not None])
+				merged[key] = ",".join(str(v) for v in value if v is not None)
 			elif value is not None:
 				merged[key] = str(value)
 		merged._mutable = False

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -160,11 +160,11 @@ GET /articles/?team_id=1&subjects=1,3&published_date_after=2022-06-01&format=csv
 | Articles | `GET /articles/{id}/` | `id` (path) | |
 | Articles | `GET /articles/stats/` | Same filters as `GET /articles/` | Aggregate counts over the filtered set: `total`, `by_access` (NULL folded into `unknown`), `relevant`, `retracted`, `missing_doi`, `by_subject`. Cached for `STATS_CACHE_TTL` seconds |
 | Articles | `GET /articles/search/` | `team_id` *(req)*, `subject_id` *(req)*, `title`, `summary`, `search`, `format`, `all_results`, plus every `GET /articles/` filter (`published_date_after`, `published_date_before`, `relevant`, `subjects`, …) | See [Search endpoints](#search-endpoints) below |
-| Articles | `POST /articles/search/` | Request **body** accepts a subset: `team_id`, `subject_id`, `title`, `summary`, `search`, `ordering`, `page`, `page_size`, `all_results`. Filters must go on the **query string** (they work there on POST too) | Filters sent in the body are **silently ignored** — see [GET vs POST](#get-vs-post-on-search-endpoints) |
+| Articles | `POST /articles/search/` | Request **body** accepts the same fields as `GET /articles/search/`: `team_id`, `subject_id`, `title`, `summary`, `search`, `ordering`, `page`, `page_size`, `all_results`, plus every `GET /articles/` filter | See [GET vs POST](#get-vs-post-on-search-endpoints) |
 | Authors | `GET /authors/` | `author_id`, `full_name`, `orcid`, `country`, `sort_by`, `order`, `team_id`, `subject_id`, `category_slug`, `date_from`, `date_to`, `timeframe` | See [authors-api.md](authors-api.md) |
 | Authors | `GET /authors/{id}/` | `id` (path) | |
 | Authors | `GET /authors/search/` | `team_id` *(req)*, `subject_id` *(req)*, `full_name`, `format`, `all_results`, plus every `GET /authors/` filter (`author_id`, `orcid`, `country`, `given_name`, `family_name`) | See [Search endpoints](#search-endpoints) below |
-| Authors | `POST /authors/search/` | Request **body** accepts a subset: `team_id`, `subject_id`, `full_name`, `page`, `page_size`, `all_results`. Filters must go on the **query string** (they work there on POST too) | Filters sent in the body are **silently ignored** — see [GET vs POST](#get-vs-post-on-search-endpoints). Results are always ordered by `author_id`; this endpoint has no `ordering` support |
+| Authors | `POST /authors/search/` | Request **body** accepts the same fields as `GET /authors/search/`: `team_id`, `subject_id`, `full_name`, `page`, `page_size`, `all_results`, plus every `GET /authors/` filter | See [GET vs POST](#get-vs-post-on-search-endpoints). Results are always ordered by `author_id`; this endpoint has no `ordering` support |
 | Authors | `GET /authors/by_team_subject/` | `team_id` *(req)*, `subject_id` *(req)* | |
 | Authors | `GET /authors/by_team_category/` | `team_id` *(req)*, `category_slug` or `category_id` *(req)* | |
 | Authors | `GET /authors/{id}/coauthors/` | `id` (path) | Co-authors of the given author |
@@ -184,7 +184,7 @@ GET /articles/?team_id=1&subjects=1,3&published_date_after=2022-06-01&format=csv
 | Trials | `GET /trials/{id}/` | `id` (path) | |
 | Trials | `GET /trials/stats/` | Same filters as `GET /trials/` | Totals per `recruitment_status_normalized` bucket (not_yet_recruiting, recruiting, enrolling_by_invitation, active_not_recruiting, not_recruiting, suspended, completed, terminated, withdrawn, unknown, other — always present, 0 when empty) plus `no_status`, `by_subject`, `by_phase` (per `TrialPhase` + `no_phase`), `by_region` (per `TrialRegion` + `no_region`), `by_country` (`[{country, count}]`, null-country entry last), `by_year` (`[{year, count}]`, null-year entry last), `by_sponsor` (top 25 `[{sponsor_id, slug, name, sponsor_type, count}]`) + `no_sponsor`, `by_sponsor_type` (per `SponsorType` + `no_type`), `by_modality` (per `CategoryModality` + `no_modality`, joined over `team_categories.modality` — **not** a partition of `total`: a trial in two categories of different modalities is counted once per modality, and `no_modality` conflates "no category at all" with "category not yet curated with a modality"), `by_study_type` (per `TrialStudyType` + `no_study_type`; `no_study_type` is large — ~13.2k globally — mostly legacy rows with no `source_register` rather than a normalization gap), and `by_sex` (per `TrialSexEligibility` + `no_sex_data`; `no_sex_data` is large — ~46% globally — same legacy-rows caveat as `no_study_type`) over the filtered set. Replaces the `stats` block formerly embedded in `GET /trials/` list responses (breaking change). Cached for `STATS_CACHE_TTL` seconds |
 | Trials | `GET /trials/search/` | `team_id` *(req)*, `subject_id` *(req)*, `title`, `summary`, `search`, `status`, `format`, `all_results`, plus every `GET /trials/` filter (`date_registration_after`, `date_registration_before`, `phase_normalized`, `country`, …) | See [Search endpoints](#search-endpoints) below |
-| Trials | `POST /trials/search/` | Request **body** accepts a subset: `team_id`, `subject_id`, `title`, `summary`, `search`, `status`, `ordering`, `page`, `page_size`, `all_results`. Filters must go on the **query string** (they work there on POST too) | Filters sent in the body are **silently ignored** — see [GET vs POST](#get-vs-post-on-search-endpoints) |
+| Trials | `POST /trials/search/` | Request **body** accepts the same fields as `GET /trials/search/`: `team_id`, `subject_id`, `title`, `summary`, `search`, `status`, `ordering`, `page`, `page_size`, `all_results`, plus every `GET /trials/` filter | See [GET vs POST](#get-vs-post-on-search-endpoints) |
 | Trials | `GET /trials/sites/` | Same filters as `GET /trials/`, plus `latitude__isnull` (`true`/`false`) | Flat, paginated `TrialSite` listing across the filtered trial set: `{trial_id, name, city, country, latitude, longitude}` per row — for a site-level pin map. `trial_sites` itself is detail-only (appears on `GET /trials/{id}/`, never on the list/CSV/search responses). Pagination is mandatory here — `?all_results=true` returns 400; max `page_size` is 500 |
 | Email templates | `GET /emails/` | None | Template preview dashboard |
 | Email templates | `GET /emails/preview/{template_name}/` | `template_name` (path) | |
@@ -202,10 +202,10 @@ search parameters than the plain list endpoints.
 
 **Shared contract:**
 
-- Both **GET** (query params) and **POST** (JSON body) are supported, but the
-  JSON body accepts **only a subset** of the fields — filters must go on the
-  query string either way. See [GET vs POST](#get-vs-post-on-search-endpoints).
-  Prefer GET unless your `search` string would be too long for a URL.
+- Both **GET** (query params) and **POST** (JSON body) are supported, and
+  accept the same fields — see [GET vs POST](#get-vs-post-on-search-endpoints).
+  Prefer GET where practical: it's cacheable and linkable. POST exists mainly
+  for a `search` string too long or awkward to put in a URL.
 - `team_id` **and** `subject_id` are **required**. The subject must belong to the
   team.
 - Results are paginated (default `page_size` 10, max 100) and ordered by
@@ -215,50 +215,57 @@ search parameters than the plain list endpoints.
 
 **Search parameters:**
 
-The **Read from** column says *where* each parameter is picked up. Query-string
-parameters work on GET and on POST alike — but only from the URL, never from the
-JSON body. See [GET vs POST](#get-vs-post-on-search-endpoints).
+Every parameter below works identically on GET (query string) and POST (JSON
+body) — see [GET vs POST](#get-vs-post-on-search-endpoints) for how that's
+implemented and the one precedence rule to know.
 
-| Parameter | Endpoints | Read from | Description |
-|:----------|:----------|:----------|:------------|
-| `title` | articles, trials | query string **or** body | Match in the title only (case-insensitive, partial). |
-| `summary` | articles, trials | query string **or** body | Match in the summary/abstract only. |
-| `search` | articles, trials | query string **or** body | Match in title **or** summary (supports boolean operators, e.g. `a OR b`). |
-| `status` | trials | query string **or** body | Case-insensitive exact match on the raw `recruitment_status` string (e.g. `Recruiting`). For the canonical vocabulary use `recruitment_status_normalized` on `GET /trials/`. |
-| `full_name` | authors | query string **or** body | Match on the author's full name (case-insensitive, partial). |
-| `page`, `page_size`, `all_results` | all | query string **or** body | Pagination. `FlexiblePagination` checks the POST body for all three. |
-| `ordering` | articles, trials | query string **or** body | The article/trial search views read `ordering` from the POST body in their own `filter_queryset`. Not supported on `/authors/search/`, which always orders by `author_id`. |
-| `published_date_after` / `published_date_before` | articles | **query string only** | Publication date range — same semantics as on `GET /articles/`. |
-| `date_registration_after` / `date_registration_before` | trials | **query string only** | Registration date range — same semantics as on `GET /trials/`. |
-| Any other list-endpoint filter | articles, trials, authors | **query string only** | `relevant`, `subjects`, `open_access`, `phase_normalized`, `country`, `sponsor_id`, `orcid`, … — the search endpoints mount the same `ArticleFilter` / `TrialFilter` / `AuthorFilter` as the list endpoints, so every filter defined there applies. |
+| Parameter | Endpoints | GET | POST | Description |
+|:----------|:----------|:---:|:----:|:------------|
+| `title` | articles, trials | ✅ | ✅ | Match in the title only (case-insensitive, partial). |
+| `summary` | articles, trials | ✅ | ✅ | Match in the summary/abstract only. |
+| `search` | articles, trials | ✅ | ✅ | Match in title **or** summary (supports boolean operators, e.g. `a OR b`). |
+| `status` | trials | ✅ | ✅ | Case-insensitive exact match on the raw `recruitment_status` string (e.g. `Recruiting`). For the canonical vocabulary use `recruitment_status_normalized` on `GET /trials/`. |
+| `full_name` | authors | ✅ | ✅ | Match on the author's full name (case-insensitive, partial). |
+| `page`, `page_size`, `all_results` | all | ✅ | ✅ | Pagination. `FlexiblePagination` checks the POST body for all three. |
+| `ordering` | articles, trials | ✅ | ✅ | Not supported on `/authors/search/`, which always orders by `author_id`. |
+| `published_date_after` / `published_date_before` | articles | ✅ | ✅ | Publication date range — same semantics as on `GET /articles/`. |
+| `date_registration_after` / `date_registration_before` | trials | ✅ | ✅ | Registration date range — same semantics as on `GET /trials/`. |
+| Any other list-endpoint filter | articles, trials, authors | ✅ | ✅ | `relevant`, `subjects`, `open_access`, `phase_normalized`, `country`, `sponsor_id`, `orcid`, … — the search endpoints mount the same `ArticleFilter` / `TrialFilter` / `AuthorFilter` as the list endpoints, so every filter defined there applies. |
 
 #### GET vs POST on search endpoints
 
-Search terms (`title`, `summary`, `search`, `status`, `full_name`) and the
-ordering/pagination options are read from the request body on POST, so those
-work either way. **Every other filter is applied by django-filter, which only
-ever reads the query string** — so when one is sent in a POST body it is
-silently dropped and you get an unfiltered `200`, not an error.
+`/articles/search/`, `/trials/search/` and `/authors/search/` accept the same
+fields on GET and POST. On POST, `BodyParamsAsQueryParamsMixin` merges the JSON
+body into the request's query params before django-filter and `OrderingFilter`
+run, so both verbs share one filtering code path. The one precedence rule: **if
+a key is set in both places, the query-string value wins.**
+
+A list-valued body field (e.g. `{"subjects": [1, 3]}`) is joined into a
+comma-separated string before merging, matching the query-string form
+(`?subjects=1,3`) that `BaseInFilter`-based fields expect.
 
 ```bash
-# 32 trials
 GET /trials/search/?team_id=1&subject_id=1&date_registration_after=2024-01-01&date_registration_before=2024-01-31
 
-# 6,249 trials — the date range is ignored, no warning
 POST /trials/search/
 {"team_id": 1, "subject_id": 1, "date_registration_after": "2024-01-01", "date_registration_before": "2024-01-31"}
 ```
 
-`/authors/search/` behaves the same way — `?country=PT` narrows 241,936 authors
-to 140 on GET, while the same key in a POST body returns all 241,936.
+Both return the same trials.
 
-Because the failure is silent, **use GET whenever you need any filter beyond the
-search terms and pagination.** POST exists for queries whose `search` string is
-too long or awkward to put in a URL; filters can still be passed on the query
-string of a POST request, where django-filter will see them:
+> **Changelog:** before this fix, POST only read `title`/`summary`/`search`/
+> `status`/`ordering`/pagination from the body; every other filter (e.g.
+> `date_registration_after`, `relevant`, `country`) was silently dropped and the
+> POST returned an unfiltered `200`. If you previously worked around this by
+> putting filters on the query string of a POST request, that still works
+> (query string wins), but it's no longer required.
+
+Prefer GET where practical — it's cacheable and linkable. POST exists for
+`search` strings with long boolean expressions that would exceed practical URL
+length limits:
 
 ```bash
-POST /articles/search/?published_date_after=2024-01-01
+POST /articles/search/
 {"team_id": 1, "subject_id": 1, "search": "<very long boolean query>"}
 ```
 

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -237,8 +237,14 @@ implemented and the one precedence rule to know.
 `/articles/search/`, `/trials/search/` and `/authors/search/` accept the same
 fields on GET and POST. On POST, `BodyParamsAsQueryParamsMixin` merges the JSON
 body into the request's query params before django-filter and `OrderingFilter`
-run, so both verbs share one filtering code path. The one precedence rule: **if
-a key is set in both places, the query-string value wins.**
+run, so both verbs share one filtering code path. The one precedence rule for
+those filter/ordering/pagination keys: **if a key is set in both places, the
+query-string value wins.**
+
+`team_id` and `subject_id` (and `full_name` on `/authors/search/`) are the
+exception — the views read those directly from the JSON body on POST for
+required-parameter validation, before the merge is consulted, so a query-string
+value alongside them has no effect on POST.
 
 A list-valued body field (e.g. `{"subjects": [1, 3]}`) is joined into a
 comma-separated string before merging, matching the query-string form


### PR DESCRIPTION
## Summary

`/articles/search/`, `/trials/search/` and `/authors/search/` accept both GET and POST, but on POST every filter defined on `ArticleFilter`/`TrialFilter`/`AuthorFilter` (`relevant`, `subjects`, `date_registration_after`/`before`, `has_results`, `phase_normalized`, `country`, `sponsor_id`, ...) was silently dropped — `DjangoFilterBackend` and `OrderingFilter` only ever read `request.query_params`, never the JSON body. The result was a wrong `200`, not an error:

```
GET  /trials/search/?team_id=1&subject_id=1&date_registration_after=2024-01-01&date_registration_before=2024-01-31   ->    32 trials
POST /trials/search/  {"team_id":1,"subject_id":1,"date_registration_after":"2024-01-01","date_registration_before":"2024-01-31"}  ->  6249 trials
```

- Adds `BodyParamsAsQueryParamsMixin`, which merges POST-body params into `request.query_params` before the filter backends run (query string wins on key collisions), and applies it to `ArticleSearchView`, `TrialSearchView`, `AuthorSearchView` so GET and POST share one filtering code path.
- Removes the now-dead manual `title`/`summary`/`search`/`status`/`ordering` handling in those views (own commit, revertible independently).
- Fixes a subtlety found while verifying the mixin: list-valued body params (`{"subjects": [1, 3]}`) must be comma-joined, not sent as repeated query keys — this codebase's list filters are all `BaseInFilter`/`ChoiceInFilter` subclasses, and a repeated key silently collapses to just the last value under their default widget.
- Updates `docs/03-api-and-rss-feeds.md` and the `ArticleSearchView`/`TrialSearchView` docstrings to describe the corrected (and now symmetric) GET/POST behaviour, with a changelog note.
- POST is kept (not deprecated) — it exists for `search` strings too long for a URL. GET remains preferable elsewhere since it's cacheable and linkable.

## Test plan

- [x] New `django/api/tests/test_search_post_filters.py` (18 tests): GET/POST parity for `published_date_after`/`before`, `relevant`, `date_registration_after`/`before`, `has_results`, `phase_normalized`, `country`; list-valued `subjects` vs comma-joined query string; query-string-wins-over-body precedence; regressions for `title`/`summary`/`status`/`ordering`/the 400/404 contract.
- [x] Full `api` suite: 804 tests, all green except one pre-existing, unrelated failure in `test_visibility_stats.py` (confirmed present on `main` before this branch — a query-count-off-by-one in stats caching, not something this PR touches).
- [x] Confirmed no in-repo frontend consumers of these POST endpoints exist that would be affected by filters suddenly being honored.

## Note for reviewers

This is a behavior change on a public endpoint: any POST body that happened to include an extra key matching a filter name (a stray `relevant`, a leftover field) will now have that filter applied where it previously didn't. That's the intended fix, but flagging it since it isn't a pure no-op for every possible caller.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>