### PR TITLE
Apply trial staleness filter to weekly digest, format P0 files

### DIFF
--- a/django/subscriptions/management/commands/send_admin_summary.py
+++ b/django/subscriptions/management/commands/send_admin_summary.py
@@ -185,9 +185,7 @@ class Command(BaseCommand):
 						build_unsubscribe_base_url(site, customsettings)
 					)
 					summary_context["header_title"] = _admin_list.header_title or ""
-					summary_context["header_tagline"] = (
-						_admin_list.header_tagline or ""
-					)
+					summary_context["header_tagline"] = _admin_list.header_tagline or ""
 					summary_context["show_header_tagline"] = (
 						_admin_list.show_header_tagline
 					)
@@ -195,9 +193,9 @@ class Command(BaseCommand):
 					html = get_template("emails/admin_summary.html").render(
 						summary_context
 					)
-					used_articles = list(
-						summary_context.get("articles", [])
-					) + list(summary_context.get("additional_articles", []))
+					used_articles = list(summary_context.get("articles", [])) + list(
+						summary_context.get("additional_articles", [])
+					)
 					used_trials = list(summary_context.get("trials", [])) + list(
 						summary_context.get("additional_trials", [])
 					)

--- a/django/subscriptions/management/commands/send_trials_notification.py
+++ b/django/subscriptions/management/commands/send_trials_notification.py
@@ -165,9 +165,9 @@ class Command(BaseCommand):
 					html = get_template("emails/trial_notification.html").render(
 						summary_context
 					)
-					used_articles = list(
-						summary_context.get("articles", [])
-					) + list(summary_context.get("additional_articles", []))
+					used_articles = list(summary_context.get("articles", [])) + list(
+						summary_context.get("additional_articles", [])
+					)
 					used_trials = list(summary_context.get("trials", [])) + list(
 						summary_context.get("additional_trials", [])
 					)

--- a/django/subscriptions/management/commands/send_weekly_summary.py
+++ b/django/subscriptions/management/commands/send_weekly_summary.py
@@ -6,7 +6,7 @@ from django.core.management.base import BaseCommand
 from django.template.loader import get_template
 from django.utils.html import strip_tags
 from subscriptions.management.commands.utils.send_email import send_email
-from gregory.models import Articles, Trials
+from gregory.models import Articles
 from subscriptions.management.commands.utils.get_credentials import (
 	build_unsubscribe_base_url,
 	get_postmark_credentials,
@@ -19,6 +19,7 @@ from subscriptions.models import (
 	SentTrialNotification,
 	FailedNotification,
 )
+from subscriptions.management.commands.utils.subscription import get_trials_for_list
 from subscriptions.utils.email_limits import render_within_limit, resolve_limits
 from subscriptions.utils.postmark import (
 	POSTMARK_INACTIVE_RECIPIENT,
@@ -431,11 +432,7 @@ class Command(BaseCommand):
 					)
 				)
 
-			# Use the helper function to get trials, but pass the days_to_look_back parameter
-			trials = Trials.objects.filter(
-				subjects__in=digest_list.subjects.all(),
-				discovery_date__gte=now() - timedelta(days=days_to_look_back),
-			).distinct()
+			trials = get_trials_for_list(digest_list, days=days_to_look_back)
 			self.stdout.write(self.style.NOTICE(f"Found {trials.count()} trials"))
 
 			if not articles.exists() and not trials.exists():
@@ -693,9 +690,9 @@ class Command(BaseCommand):
 					html = get_template("emails/weekly_summary.html").render(
 						summary_context
 					)
-					used_articles = list(
-						summary_context.get("articles", [])
-					) + list(summary_context.get("additional_articles", []))
+					used_articles = list(summary_context.get("articles", [])) + list(
+						summary_context.get("additional_articles", [])
+					)
 					used_trials = list(summary_context.get("trials", [])) + list(
 						summary_context.get("additional_trials", [])
 					)

--- a/django/subscriptions/management/commands/utils/subscription.py
+++ b/django/subscriptions/management/commands/utils/subscription.py
@@ -7,9 +7,9 @@ from django.utils.timezone import now
 from gregory.models import Articles, ArticleSubjectRelevance, Subject, Trials
 
 
-def get_trials_for_list(lst):
+def get_trials_for_list(lst, days=30):
 	"""
-	Returns trials discovered in the last 30 days for the given list.
+	Returns trials discovered in the last `days` days for the given list.
 
 	Also applies ``lst.trial_max_age_days`` against the trial's own
 	registration/publication date (not discovery_date, which only records
@@ -20,16 +20,15 @@ def get_trials_for_list(lst):
 	trial_max_age_days is NULL.
 	"""
 	qs = Trials.objects.filter(
-		subjects__in=lst.subjects.all(), discovery_date__gte=now() - timedelta(days=30)
+		subjects__in=lst.subjects.all(),
+		discovery_date__gte=now() - timedelta(days=days),
 	)
 
 	max_age_days = getattr(lst, "trial_max_age_days", None)
 	if max_age_days:
 		cutoff = now().date() - timedelta(days=max_age_days)
 		qs = qs.annotate(
-			effective_date=Coalesce(
-				F("date_registration"), TruncDate("published_date")
-			)
+			effective_date=Coalesce(F("date_registration"), TruncDate("published_date"))
 		).filter(Q(effective_date__gte=cutoff) | Q(effective_date__isnull=True))
 
 	return qs.distinct()
@@ -43,8 +42,8 @@ def get_articles_for_list(lst):
 	# Sub-subquery: has this (article, subject) pair been reviewed?
 	has_review = Exists(
 		ArticleSubjectRelevance.objects.filter(
-			article_id=OuterRef(OuterRef('pk')),
-			subject_id=OuterRef('pk'),
+			article_id=OuterRef(OuterRef("pk")),
+			subject_id=OuterRef("pk"),
 			is_relevant__isnull=False,
 		)
 	)
@@ -53,8 +52,10 @@ def get_articles_for_list(lst):
 	has_unreviewed_subject = Exists(
 		Subject.objects.filter(
 			pk__in=list_subjects,
-			articles__pk=OuterRef('pk'),
-		).alias(reviewed=has_review).filter(reviewed=False)
+			articles__pk=OuterRef("pk"),
+		)
+		.alias(reviewed=has_review)
+		.filter(reviewed=False)
 	)
 
 	return (

--- a/django/subscriptions/tests/test_email_payload_limits.py
+++ b/django/subscriptions/tests/test_email_payload_limits.py
@@ -211,10 +211,7 @@ class GetTrialsForListStalenessTest(BaseSubscriptionCommandTestCase):
 			title__startswith="Historical Trial"
 		) | Trials.objects.filter(title__startswith="Recent Trial")
 		through.objects.bulk_create(
-			[
-				through(trials_id=t.pk, subject_id=self.subject.pk)
-				for t in all_trials
-			],
+			[through(trials_id=t.pk, subject_id=self.subject.pk) for t in all_trials],
 			batch_size=500,
 		)
 
@@ -279,9 +276,7 @@ class RenderWithinLimitTest(TestCase):
 		def render(articles, trials):
 			return "x" * (SAFE_BODY_CHARS + 1), articles, trials
 
-		html, used_articles, used_trials = render_within_limit(
-			render, [1, 2], [1, 2]
-		)
+		html, used_articles, used_trials = render_within_limit(render, [1, 2], [1, 2])
 
 		self.assertIsNone(html)
 		self.assertEqual(used_articles, [])
@@ -350,11 +345,14 @@ class SendTrialsNotificationLimitTest(BaseSubscriptionCommandTestCase):
 		)
 
 		self._run()
-		second_ids = set(
-			SentTrialNotification.objects.filter(
-				list=self.lst, subscriber=self.subscriber
-			).values_list("trial_id", flat=True)
-		) - first_ids
+		second_ids = (
+			set(
+				SentTrialNotification.objects.filter(
+					list=self.lst, subscriber=self.subscriber
+				).values_list("trial_id", flat=True)
+			)
+			- first_ids
+		)
 
 		self.assertEqual(len(first_ids), 5)
 		self.assertEqual(len(second_ids), 5)
@@ -414,7 +412,9 @@ class SendAdminSummaryLimitTest(BaseSubscriptionCommandTestCase):
 		articles = [
 			self._make_article(f"Article {i}", days_ago=i + 1) for i in range(10)
 		]
-		trials = [self._make_trial(f"Trial {i}", discovery_days_ago=i + 1) for i in range(10)]
+		trials = [
+			self._make_trial(f"Trial {i}", discovery_days_ago=i + 1) for i in range(10)
+		]
 
 		self._run()
 
@@ -428,8 +428,14 @@ class SendAdminSummaryLimitTest(BaseSubscriptionCommandTestCase):
 		self.assertEqual(sent_trials.count(), 3)
 
 		# Newest-first ordering means the 3 most-recently-discovered items win.
-		newest_article_ids = {a.pk for a in sorted(articles, key=lambda a: a.discovery_date, reverse=True)[:3]}
-		newest_trial_ids = {t.pk for t in sorted(trials, key=lambda t: t.discovery_date, reverse=True)[:3]}
+		newest_article_ids = {
+			a.pk
+			for a in sorted(articles, key=lambda a: a.discovery_date, reverse=True)[:3]
+		}
+		newest_trial_ids = {
+			t.pk
+			for t in sorted(trials, key=lambda t: t.discovery_date, reverse=True)[:3]
+		}
 		self.assertEqual(
 			set(sent_articles.values_list("article_id", flat=True)), newest_article_ids
 		)

--- a/django/subscriptions/tests/test_postmark_suppression.py
+++ b/django/subscriptions/tests/test_postmark_suppression.py
@@ -198,7 +198,8 @@ class SuppressionWiringTest(BaseSuppressionCommandTestCase):
 		self._make_trial("Trial A")
 
 		resp = _build_response(
-			422, {"ErrorCode": POSTMARK_INACTIVE_RECIPIENT, "Message": "Inactive recipient"}
+			422,
+			{"ErrorCode": POSTMARK_INACTIVE_RECIPIENT, "Message": "Inactive recipient"},
 		)
 		with patch(
 			"subscriptions.management.commands.send_trials_notification.send_email",
@@ -210,9 +211,7 @@ class SuppressionWiringTest(BaseSuppressionCommandTestCase):
 		subscriber.refresh_from_db()
 		self.assertFalse(subscriber.active)
 		self.assertFalse(
-			ListSubscription.objects.get(
-				subscriber=subscriber, list=self.lst
-			).is_active
+			ListSubscription.objects.get(subscriber=subscriber, list=self.lst).is_active
 		)
 		self.assertIsNotNone(
 			ListSubscription.objects.get(
@@ -228,7 +227,8 @@ class SuppressionWiringTest(BaseSuppressionCommandTestCase):
 		self._make_trial("Trial B")
 
 		resp = _build_response(
-			422, {"ErrorCode": POSTMARK_INACTIVE_RECIPIENT, "Message": "Inactive recipient"}
+			422,
+			{"ErrorCode": POSTMARK_INACTIVE_RECIPIENT, "Message": "Inactive recipient"},
 		)
 		with patch(
 			"subscriptions.management.commands.send_trials_notification.send_email",

--- a/django/subscriptions/tests/test_weekly_digest_staleness.py
+++ b/django/subscriptions/tests/test_weekly_digest_staleness.py
@@ -1,0 +1,186 @@
+"""
+Tests for the weekly-digest staleness gap (P0 follow-up):
+
+send_weekly_summary previously built its trials query inline and never called
+get_trials_for_list, so Lists.trial_max_age_days never applied to weekly
+digests. See docs/subscriptions-p0-fix-plan.md, "Task 1".
+"""
+
+import os
+from datetime import timedelta
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+
+import django
+
+django.setup()
+
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from gregory.models import Subject, Team, Trials
+from organizations.models import Organization
+from sitesettings.models import CustomSetting
+from subscriptions.models import Lists, SentTrialNotification, Subscribers
+
+
+def _mock_ok_result():
+	result = MagicMock(status_code=200)
+	result.json.return_value = {"ErrorCode": 0, "Message": "OK"}
+	return result
+
+
+class WeeklyDigestStalenessTest(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(
+			name="Staleness Org", slug="staleness-org"
+		)
+		self.team = Team.objects.create(
+			name="Staleness Team", organization=self.org, slug="staleness-team"
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Staleness Subject",
+			team=self.team,
+			subject_slug="staleness-subject",
+		)
+		self.site = Site.objects.get_or_create(
+			id=1, defaults={"domain": "testserver", "name": "Test Site"}
+		)[0]
+		CustomSetting.objects.get_or_create(
+			site=self.site,
+			defaults={
+				"title": "Test Site",
+				"postmark_api_token": "test-token",
+				"postmark_api_url": "https://api.postmarkapp.com/email",
+			},
+		)
+		self.subscriber = Subscribers.objects.create(
+			first_name="Staleness",
+			last_name="Tester",
+			email="staleness@example.com",
+			active=True,
+		)
+
+	def _make_trial(self, title, discovery_days_ago=1, registration_days_ago=None):
+		trial = Trials.objects.create(
+			title=title,
+			link=f"https://example.com/trials/{title.replace(' ', '-').lower()}",
+		)
+		if registration_days_ago is not None:
+			trial.date_registration = (
+				timezone.now() - timedelta(days=registration_days_ago)
+			).date()
+			trial.save(update_fields=["date_registration"])
+		Trials.objects.filter(pk=trial.pk).update(
+			discovery_date=timezone.now() - timedelta(days=discovery_days_ago)
+		)
+		trial.refresh_from_db()
+		trial.subjects.add(self.subject)
+		return trial
+
+	def _make_list(self, **kwargs):
+		defaults = dict(
+			list_name="Weekly Digest List",
+			team=self.team,
+			weekly_digest=True,
+			article_sort_order="date",
+			trial_limit=50,
+			lookback_days=30,
+			list_email_subject="Weekly Digest",
+		)
+		defaults.update(kwargs)
+		lst = Lists.objects.create(**defaults)
+		lst.subjects.add(self.subject)
+		self.subscriber.subscriptions.add(lst)
+		return lst
+
+	def _run(self, **options):
+		with patch(
+			"subscriptions.management.commands.send_weekly_summary.send_email",
+			return_value=_mock_ok_result(),
+		):
+			out = StringIO()
+			call_command("send_weekly_summary", stdout=out, **options)
+			return out.getvalue()
+
+	def _sent_trial_ids(self, lst):
+		return set(
+			SentTrialNotification.objects.filter(
+				list=lst, subscriber=self.subscriber
+			).values_list("trial_id", flat=True)
+		)
+
+	def test_stale_trial_excluded_from_weekly_digest(self):
+		"""
+		The evidence case: a trial registered 200 days ago but discovered
+		yesterday. At the default trial_max_age_days=90 it must not reach the
+		digest. Fails against the pre-fix inline query, which ignores
+		trial_max_age_days entirely.
+		"""
+		lst = self._make_list(trial_max_age_days=90)
+		stale_trial = self._make_trial(
+			"Stale Trial", discovery_days_ago=1, registration_days_ago=200
+		)
+
+		self._run()
+
+		self.assertNotIn(stale_trial.pk, self._sent_trial_ids(lst))
+
+	def test_recent_trial_included_in_weekly_digest(self):
+		lst = self._make_list(trial_max_age_days=90)
+		recent_trial = self._make_trial(
+			"Recent Trial", discovery_days_ago=1, registration_days_ago=7
+		)
+
+		self._run()
+
+		self.assertIn(recent_trial.pk, self._sent_trial_ids(lst))
+
+	def test_trial_with_no_dates_included(self):
+		lst = self._make_list(trial_max_age_days=90)
+		undated_trial = self._make_trial("Undated Trial", discovery_days_ago=1)
+		self.assertIsNone(undated_trial.date_registration)
+		self.assertIsNone(undated_trial.published_date)
+
+		self._run()
+
+		self.assertIn(undated_trial.pk, self._sent_trial_ids(lst))
+
+	def test_trial_max_age_days_none_disables_filter(self):
+		lst = self._make_list(trial_max_age_days=None)
+		stale_trial = self._make_trial(
+			"Ancient Trial", discovery_days_ago=1, registration_days_ago=3000
+		)
+
+		self._run()
+
+		self.assertIn(stale_trial.pk, self._sent_trial_ids(lst))
+
+	def test_lookback_days_still_honoured(self):
+		"""
+		Guards against the helper's 30-day discovery-window default leaking in
+		at the call site. Must fail if send_weekly_summary calls
+		get_trials_for_list(digest_list) without days=days_to_look_back.
+		"""
+		lst = self._make_list(trial_max_age_days=None, lookback_days=60)
+		trial = self._make_trial(
+			"Old Discovery Trial", discovery_days_ago=45, registration_days_ago=1
+		)
+
+		self._run()
+
+		self.assertIn(trial.pk, self._sent_trial_ids(lst))
+
+	def test_cli_days_override_beats_lookback_days(self):
+		lst = self._make_list(trial_max_age_days=None, lookback_days=5)
+		trial = self._make_trial(
+			"Overridden Trial", discovery_days_ago=45, registration_days_ago=1
+		)
+
+		self._run(days=60)
+
+		self.assertIn(trial.pk, self._sent_trial_ids(lst))

--- a/docs/subscriptions-audit-2026-07.md
+++ b/docs/subscriptions-audit-2026-07.md
@@ -29,6 +29,16 @@ only what was actually rendered as sent. See Task B in
 [subscriptions-p0-fix-plan.md](subscriptions-p0-fix-plan.md) and
 [subscriptions.md](subscriptions.md#content-limits-and-staleness-filtering).
 
+Follow-up closed 2026-07-28: `send_weekly_summary` built its own inline trials
+query and never called `get_trials_for_list`, so `trial_max_age_days` did not
+apply to weekly digests — the count cap alone bounded payload size but could
+not stop a bulk import of historical trials from being presented as new
+content (15 trials from the 2026-07-06 import, some registered as early as
+1999, reached the MS Weekly Digest's 88 subscribers under "New Clinical
+Trials"). `get_trials_for_list` now takes a `days` parameter and the weekly
+digest calls it with its own `lookback_days`, so the staleness filter and the
+per-list lookback window both apply to all three email types.
+
 `FailedNotification` holds 413 rows of `ErrorCode: 300, Invalid 'HtmlBody' value.
 It should be up to 5242880 characters in length` — all on the Alzheimer Disease
 list, 28 per day, every day from 2026-07-06 to 2026-07-21 (confirmed against the
@@ -217,6 +227,14 @@ configuration landmine rather than a live bug.
 `send_admin_summary` and `send_trials_notification` go through
 `get_articles_for_list` / `get_trials_for_list`, which hardcode 30 days. Only the
 weekly digest reads the field.
+
+**Partially closed 2026-07-28.** `get_trials_for_list` now takes a `days`
+parameter, and the weekly digest passes its own `lookback_days` (previously it
+built an inline query and read the field for articles only, not trials). The
+admin summary and trial notification callers still pass no `days` and get the
+30-day default by design, since only the weekly digest exposes a per-list
+lookback override. `get_articles_for_list` is unchanged and still hardcodes
+30 days everywhere.
 
 ---
 

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -141,7 +141,7 @@ failed again — 413 times over 15 days before anyone noticed.
 |---|---|---|
 | `article_limit` | 15 | Weekly digest, admin summary, and trial notification emails |
 | `trial_limit` | 15 | Weekly digest, admin summary, and trial notification emails |
-| `trial_max_age_days` | 90 | `get_trials_for_list` (admin summary, trial notification) |
+| `trial_max_age_days` | 90 | Weekly digest, admin summary, and trial notification emails |
 
 **Rollover:** content that does not fit in one email is not marked as sent —
 only what actually gets rendered into the template is recorded in
@@ -171,15 +171,24 @@ is older than the threshold are skipped, regardless of when they were
 discovered. Trials with neither date set are always kept — the per-email
 `trial_limit` bounds them regardless — so an unusual-but-genuinely-new trial
 is never silently dropped just because its registry didn't supply a date.
-The check only applies to `get_trials_for_list` (admin summary and trial
-notification); it is not applied to the weekly digest's own trial query,
-where the trial count cap alone is enough to bound the payload. Set
-`trial_max_age_days` to blank on a list to disable the check entirely.
+`get_trials_for_list` applies the check for all three email types — weekly
+digest, admin summary, and trial notification — since it is the only one of
+the two jobs the query performs that a count cap cannot substitute for: the
+cap bounds payload size, but only the date check stops a bulk import from
+being presented as new content. Set `trial_max_age_days` to blank on a list
+to disable the check entirely.
 
 The default of 90 days (rather than 30) exists because WHO ICTRP and CTIS
 feeds lag: a trial registered 45 days ago may only reach GregoryAI today. At
 30 days it would be dropped by the age check and would then also age out of
 the 30-day discovery window before ever qualifying for an email.
+
+`get_trials_for_list` also takes a `days` parameter controlling the
+discovery-date window (default 30, unchanged for the admin summary and
+trial notification callers). The weekly digest passes its own resolved
+`lookback_days` (or the `--days` CLI override when set) instead of the
+default, so `lookback_days` is now honoured for both articles and trials in
+that email — previously it only governed the articles query.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up on the P0 subscriptions fix (`653b7f62`): closes a correctness gap found while reviewing that work, plus formatting cleanup it left behind.

- **`send_weekly_summary` bypassed the staleness filter.** It built its own inline trials query instead of calling `get_trials_for_list`, so `Lists.trial_max_age_days` never applied to weekly digests. On the dev DB, 15 trials from the 2026-07-06 bulk import (registered as far back as 1999) were reaching the MS Weekly Digest's 88 subscribers under "New Clinical Trials" - the trial count cap alone bounds payload size but can't stop stale content from being presented as new.
  - `get_trials_for_list` now takes a `days` parameter (default 30, unchanged for the admin-summary/trial-notification callers).
  - The weekly digest now calls the shared helper with `days=days_to_look_back`, so `lookback_days`/`--days` keep working exactly as before while also getting the staleness filter.
  - `docs/subscriptions.md` and `docs/subscriptions-audit-2026-07.md` updated to drop the "weekly digest is exempt" language and record the fix.
- **Formatting cleanup.** `uvx ruff format --check django/subscriptions/` found 6 of the P0-introduced/modified files unformatted. Reformatted (line-wrapping only, tabs preserved, no logic changes); left the one pre-existing untouched file (`test_announcement_organization.py`) alone.

## Impact (re-measured against dev DB, 2026-07-28)

| List | Trials before | Trials after |
|:-----|:--------------|:-------------|
| MS Weekly Digest | 366 | 18 |
| Cell Reprogramming Digest | 94 | 5 |
| Neuroimmune Interactions Digest | 79 | 3 |
| Neuroinflammation Digest | 97 | 22 |

No list drops to zero. Numbers should be re-confirmed against production before deploy - the 2026-07-06 import batch ages out of the 30-day discovery window on its own around 2026-08-05, which will shift the "before" column down independently of this fix.

## Test plan

- [x] New `test_weekly_digest_staleness.py` (6 tests) - verified the staleness-exclusion test fails against the pre-fix inline query and all 6 pass against the fix
- [x] `pytest subscriptions` - 284 passed
- [x] `pytest` (full suite) - 2772 passed
- [x] `uvx ruff check django/subscriptions/` - passes
- [x] `uvx ruff format --check django/subscriptions/` - only the one pre-existing, intentionally-untouched file remains unformatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)