### PR TITLE
Fix P1 subscription bugs: recruitment status, silent failures, Latest Research delta, featured/regular split

### DIFF
--- a/django/subscriptions/management/commands/send_admin_summary.py
+++ b/django/subscriptions/management/commands/send_admin_summary.py
@@ -178,6 +178,7 @@ class Command(BaseCommand):
 						site=site,
 						custom_settings=customsettings,
 						organization=organization,
+						confidence_threshold=_admin_list.ml_threshold,
 					)
 					# Inject unsubscribe context for the footer template
 					summary_context["list_id"] = _admin_list.list_id
@@ -201,15 +202,38 @@ class Command(BaseCommand):
 					)
 					return html, used_articles, used_trials
 
-				html_content, articles_to_be_sent, trials_to_be_sent = (
-					render_within_limit(_render, new_articles, new_trials)
-				)
+				try:
+					html_content, articles_to_be_sent, trials_to_be_sent = (
+						render_within_limit(_render, new_articles, new_trials)
+					)
+				except Exception as e:
+					reason = (
+						f"Error rendering admin summary for list "
+						f"'{admin_list.list_name}': {e}"
+					)
+					logger.error(reason)
+					FailedNotification.objects.create(
+						subscriber=subscriber, list=admin_list, reason=reason
+					)
+					continue
 
 				if html_content is None:
 					reason = (
 						f"Rendered admin summary for list '{admin_list.list_name}' "
 						f"still exceeds the safe body size after shrinking to a "
 						f"single article and a single trial."
+					)
+					logger.error(reason)
+					FailedNotification.objects.create(
+						subscriber=subscriber, list=admin_list, reason=reason
+					)
+					continue
+
+				if not articles_to_be_sent and not trials_to_be_sent:
+					reason = (
+						f"Admin summary for list '{admin_list.list_name}' organized to "
+						f"zero articles and zero trials for {subscriber.email}; "
+						f"skipping rather than sending an empty digest."
 					)
 					logger.error(reason)
 					FailedNotification.objects.create(

--- a/django/subscriptions/management/commands/send_weekly_summary.py
+++ b/django/subscriptions/management/commands/send_weekly_summary.py
@@ -19,7 +19,10 @@ from subscriptions.models import (
 	SentTrialNotification,
 	FailedNotification,
 )
-from subscriptions.management.commands.utils.subscription import get_trials_for_list
+from subscriptions.management.commands.utils.subscription import (
+	get_latest_research_by_category,
+	get_trials_for_list,
+)
 from subscriptions.utils.email_limits import render_within_limit, resolve_limits
 from subscriptions.utils.postmark import (
 	POSTMARK_INACTIVE_RECIPIENT,
@@ -435,10 +438,31 @@ class Command(BaseCommand):
 			trials = get_trials_for_list(digest_list, days=days_to_look_back)
 			self.stdout.write(self.style.NOTICE(f"Found {trials.count()} trials"))
 
-			if not articles.exists() and not trials.exists():
+			# Latest Research: new articles since the subscriber's last email,
+			# grouped by category. This is the subscriber-independent candidate
+			# pool (category membership + lookback window only); per-subscriber
+			# sent-record exclusion happens below. Honours the list's
+			# lookback_days (or --days override) rather than a fixed 30 days.
+			latest_research_map_all = get_latest_research_by_category(
+				digest_list, days=days_to_look_back
+			)
+			latest_research_categories_ordered = sorted(
+				latest_research_map_all.keys(), key=lambda c: c.category_name
+			)
+			latest_research_pairs_all = [
+				(category, article)
+				for category in latest_research_categories_ordered
+				for article in latest_research_map_all[category]
+			]
+
+			if (
+				not articles.exists()
+				and not trials.exists()
+				and not latest_research_pairs_all
+			):
 				self.stdout.write(
 					self.style.WARNING(
-						f'No articles or trials found for the weekly digest list "{digest_list.list_name}". Skipping.'
+						f'No articles, trials, or Latest Research content found for the weekly digest list "{digest_list.list_name}". Skipping.'
 					)
 				)
 				continue
@@ -461,12 +485,17 @@ class Command(BaseCommand):
 			for subscriber in subscribers:
 				# Step 5: Filter unsent articles and trials for the subscriber
 				threshold_date = now() - timedelta(days=30)
-				sent_article_ids = SentArticleNotification.objects.filter(
-					article__in=articles,
-					list=digest_list,
-					subscriber=subscriber,
-					sent_at__gte=threshold_date,
-				).values_list("article_id", flat=True)
+				# Not scoped to `article__in=articles`: the same sent-record set
+				# also gates Latest Research below, whose candidate articles come
+				# from category membership rather than the subject-matched
+				# `articles` queryset.
+				sent_article_ids = set(
+					SentArticleNotification.objects.filter(
+						list=digest_list,
+						subscriber=subscriber,
+						sent_at__gte=threshold_date,
+					).values_list("article_id", flat=True)
+				)
 				unsent_articles = articles.exclude(pk__in=sent_article_ids)
 
 				sent_trial_ids = SentTrialNotification.objects.filter(
@@ -476,6 +505,17 @@ class Command(BaseCommand):
 					sent_at__gte=threshold_date,
 				).values_list("trial_id", flat=True)
 				unsent_trials = trials.exclude(pk__in=sent_trial_ids)
+
+				# Latest Research candidates for this subscriber: exclude
+				# anything already recorded as sent (the delta definition — new
+				# since the subscriber's last email). Dedup against the main
+				# article pool happens in _render, once the main pool's final
+				# (possibly shrunk) size is known.
+				subscriber_latest_research_pairs = [
+					(category, article)
+					for category, article in latest_research_pairs_all
+					if article.pk not in sent_article_ids
+				]
 
 				# Add debugging for the filtered unsent articles
 				if debug:
@@ -521,10 +561,14 @@ class Command(BaseCommand):
 					else unsent_trials.exists()
 				)
 
-				if not has_unsent_articles and not has_unsent_trials:
+				if (
+					not has_unsent_articles
+					and not has_unsent_trials
+					and not subscriber_latest_research_pairs
+				):
 					self.stdout.write(
 						self.style.WARNING(
-							f'No new articles or trials for {subscriber.email} in list "{digest_list.list_name}".'
+							f'No new articles, trials, or Latest Research content for {subscriber.email} in list "{digest_list.list_name}".'
 						)
 					)
 					continue
@@ -657,11 +701,28 @@ class Command(BaseCommand):
 				def _render(
 					articles,
 					trials,
+					latest_research_pairs,
 					_digest_list=digest_list,
 					_subscriber=subscriber,
 					_organization=organization,
 					_utm_params=utm_params,
 				):
+					# Dedup Latest Research against the main pool for *this*
+					# attempt: organize_articles never drops an input article, so
+					# `articles` here is exactly what ends up in
+					# context["articles"] + context["additional_articles"].
+					main_pks = {a.pk for a in articles}
+					deduped_lr_pairs = [
+						(category, article)
+						for category, article in latest_research_pairs
+						if article.pk not in main_pks
+					]
+					latest_research_category_map = {}
+					for category, article in deduped_lr_pairs:
+						latest_research_category_map.setdefault(category, []).append(
+							article
+						)
+
 					summary_context = get_optimized_email_context(
 						email_type="weekly_summary",
 						articles=articles,
@@ -672,6 +733,7 @@ class Command(BaseCommand):
 						custom_settings=customsettings,
 						utm_params=_utm_params,
 						organization=_organization,
+						latest_research_category_map=latest_research_category_map,
 					)
 
 					# Inject unsubscribe context for the footer template
@@ -696,21 +758,64 @@ class Command(BaseCommand):
 					used_trials = list(summary_context.get("trials", [])) + list(
 						summary_context.get("additional_trials", [])
 					)
+					# Dedup by pk: the same article can appear under more than one
+					# category if it matches more than one category's terms.
+					used_latest_research = list(
+						{
+							article.pk: article for _, article in deduped_lr_pairs
+						}.values()
+					)
 					_context_holder["context"] = summary_context
-					return html, used_articles, used_trials
+					return html, used_articles, used_trials, used_latest_research
 
 				# Cap trials/articles so the rendered body can never exceed
 				# Postmark's size limit (audit finding 1); shrinks further if
 				# the counts above still produce an oversized body.
-				html_content, articles_to_be_sent, trials_to_be_sent = (
-					render_within_limit(_render, unsent_articles, unsent_trials)
-				)
+				try:
+					(
+						html_content,
+						articles_to_be_sent,
+						trials_to_be_sent,
+						latest_research_to_be_sent,
+					) = render_within_limit(
+						_render,
+						unsent_articles,
+						unsent_trials,
+						subscriber_latest_research_pairs,
+					)
+				except Exception as e:
+					reason = (
+						f"Error rendering weekly digest for list "
+						f"'{digest_list.list_name}': {e}"
+					)
+					logger.error(reason)
+					FailedNotification.objects.create(
+						subscriber=subscriber, list=digest_list, reason=reason
+					)
+					continue
 
 				if html_content is None:
 					reason = (
 						f"Rendered weekly digest for list '{digest_list.list_name}' "
 						f"still exceeds the safe body size after shrinking to a "
 						f"single article and a single trial."
+					)
+					logger.error(reason)
+					FailedNotification.objects.create(
+						subscriber=subscriber, list=digest_list, reason=reason
+					)
+					continue
+
+				if (
+					not articles_to_be_sent
+					and not trials_to_be_sent
+					and not latest_research_to_be_sent
+				):
+					reason = (
+						f"Weekly digest for list '{digest_list.list_name}' organized to "
+						f"zero articles, zero trials, and zero Latest Research items "
+						f"for {subscriber.email}; skipping rather than sending an "
+						f"empty digest."
 					)
 					logger.error(reason)
 					FailedNotification.objects.create(
@@ -968,9 +1073,17 @@ class Command(BaseCommand):
 							f'Weekly digest email sent to {subscriber.email} for list "{digest_list.list_name}".'
 						)
 					)
-					# Record sent notifications for articles that were actually sent in the email
+					# Record sent notifications for articles that were actually
+					# rendered in the email — both the main section and Latest
+					# Research share this table and key, so an article shown in
+					# either is suppressed from both on the next run.
+					recorded_articles = {
+						article.pk: article
+						for article in list(articles_to_be_sent)
+						+ list(latest_research_to_be_sent)
+					}
 					new_sent_count = 0
-					for article in articles_to_be_sent:
+					for article in recorded_articles.values():
 						SentArticleNotification.objects.get_or_create(
 							article=article, list=digest_list, subscriber=subscriber
 						)

--- a/django/subscriptions/management/commands/send_weekly_summary.py
+++ b/django/subscriptions/management/commands/send_weekly_summary.py
@@ -484,7 +484,12 @@ class Command(BaseCommand):
 
 			for subscriber in subscribers:
 				# Step 5: Filter unsent articles and trials for the subscriber
-				threshold_date = now() - timedelta(days=30)
+				# The sent-record lookback must be at least as wide as the
+				# content lookback window, or an article/trial sent between
+				# 30 days ago and days_to_look_back ago would be treated as
+				# unsent and resent every run (audit finding 11 — previously
+				# masked because every list defaulted to lookback_days=30).
+				threshold_date = now() - timedelta(days=max(30, days_to_look_back))
 				# Not scoped to `article__in=articles`: the same sent-record set
 				# also gates Latest Research below, whose candidate articles come
 				# from category membership rather than the subject-matched

--- a/django/subscriptions/tests/test_admin_summary_relevance_scoping.py
+++ b/django/subscriptions/tests/test_admin_summary_relevance_scoping.py
@@ -1,0 +1,190 @@
+"""
+Tests for P1 findings 4 and 5 as resolved for the admin summary (Option A —
+the featured/regular split is kept and made correct, since it drives the
+admin's "High-Confidence" vs "Needs Review" triage, unlike the weekly digest
+where the same split was invisible and was removed instead).
+
+- Finding 4: the list's `ml_threshold` was never threaded into
+  `confidence_threshold`, so the featured/regular split always used the
+  hardcoded 0.8 default regardless of what a list was configured with.
+- Finding 5: `_get_max_ml_score` must only consider ML predictions for the
+  admin list's own subjects, not any subject on any team. `send_admin_summary`
+  already prefetches `ml_predictions_detail` filtered to `subject__in`
+  `list_subjects` into `filtered_ml_predictions`, and `_get_max_ml_score`
+  prefers that attribute when present — this test guards the existing
+  correct behavior against regression.
+"""
+
+import os
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+
+import django
+
+django.setup()
+
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+from django.test import TestCase
+
+from gregory.models import Articles, MLPredictions, Subject, Team
+from organizations.models import Organization
+from sitesettings.models import CustomSetting
+from subscriptions.models import Lists, Subscribers
+
+
+def _mock_ok_result():
+	result = MagicMock(status_code=200)
+	result.json.return_value = {"ErrorCode": 0, "Message": "OK"}
+	return result
+
+
+class AdminSummaryMlThresholdTestCase(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(
+			name="Admin Threshold Org", slug="admin-threshold-org"
+		)
+		self.team = Team.objects.create(
+			name="Admin Threshold Team",
+			organization=self.org,
+			slug="admin-threshold-team",
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Admin Threshold Subject",
+			team=self.team,
+			subject_slug="admin-threshold-subject",
+		)
+		self.site = Site.objects.get_or_create(
+			id=1, defaults={"domain": "testserver", "name": "Test Site"}
+		)[0]
+		self.custom_settings = CustomSetting.objects.get_or_create(
+			site=self.site,
+			defaults={
+				"title": "Test Site",
+				"postmark_api_token": "test-token",
+				"postmark_api_url": "https://api.postmarkapp.com/email",
+			},
+		)[0]
+		self.subscriber = Subscribers.objects.create(
+			first_name="Admin",
+			last_name="Tester",
+			email="admin-threshold@example.com",
+			active=True,
+		)
+
+	def _make_article(self, title, doi=None):
+		return Articles.objects.create(
+			title=title,
+			link=f"https://example.com/articles/{title.replace(' ', '-').lower()}",
+			doi=doi or f"10.6666/{title.replace(' ', '-').lower()}",
+		)
+
+	def _run_and_capture_context(self, **command_kwargs):
+		captured = {}
+		real_get_template = __import__(
+			"django.template.loader", fromlist=["get_template"]
+		).get_template
+
+		def fake_get_template(template_name, using=None):
+			tmpl = real_get_template(template_name, using=using)
+			original_render = tmpl.render
+
+			def capturing_render(context=None, request=None):
+				if isinstance(context, dict):
+					captured.update(context)
+				return original_render(context, request)
+
+			tmpl.render = capturing_render
+			return tmpl
+
+		with (
+			patch(
+				"subscriptions.management.commands.send_admin_summary.send_email",
+				return_value=_mock_ok_result(),
+			),
+			patch(
+				"subscriptions.management.commands.send_admin_summary.get_template",
+				side_effect=fake_get_template,
+			),
+		):
+			out = StringIO()
+			call_command("send_admin_summary", stdout=out, **command_kwargs)
+
+		return captured
+
+	def test_list_ml_threshold_below_default_features_article_default_would_not(self):
+		"""Regression: a list configured at ml_threshold=0.6 must feature an
+		article scoring 0.7 — the hardcoded 0.8 default would not. Must fail
+		against current code, which never passes confidence_threshold."""
+		admin_list = Lists.objects.create(
+			list_name="Low Threshold Admin List",
+			admin_summary=True,
+			team=self.team,
+			ml_threshold=0.6,
+			list_email_subject="Admin Summary",
+		)
+		admin_list.subjects.add(self.subject)
+		self.subscriber.subscriptions.add(admin_list)
+
+		article = self._make_article("Mid Confidence Article")
+		article.subjects.add(self.subject)
+		MLPredictions.objects.create(
+			article=article,
+			subject=self.subject,
+			algorithm="pubmed_bert",
+			model_version="v1",
+			probability_score=0.7,
+			predicted_relevant=True,
+		)
+
+		ctx = self._run_and_capture_context()
+
+		featured = list(ctx.get("articles", []))
+		self.assertIn(article, featured)
+
+	def test_ml_prediction_for_subject_outside_list_does_not_feature_article(self):
+		"""An article's only high-confidence ML prediction belongs to a
+		subject that is NOT one of the admin list's subjects (e.g. another
+		team's subject) — it must not be featured on the strength of that
+		prediction. This currently passes because send_admin_summary already
+		prefetches ml_predictions_detail scoped to the list's own subjects;
+		this test guards that scoping against regression."""
+		admin_list = Lists.objects.create(
+			list_name="Scoped Admin List",
+			admin_summary=True,
+			team=self.team,
+			ml_threshold=0.8,
+			list_email_subject="Admin Summary",
+		)
+		admin_list.subjects.add(self.subject)
+		self.subscriber.subscriptions.add(admin_list)
+
+		other_team = Team.objects.create(
+			name="Other Team", organization=self.org, slug="other-team-admin"
+		)
+		other_subject = Subject.objects.create(
+			subject_name="Other Team Subject",
+			team=other_team,
+			subject_slug="other-team-subject-admin",
+		)
+
+		article = self._make_article("Cross Team Article")
+		article.subjects.add(self.subject, other_subject)
+		# High-confidence prediction, but for a subject outside this list.
+		MLPredictions.objects.create(
+			article=article,
+			subject=other_subject,
+			algorithm="pubmed_bert",
+			model_version="v1",
+			probability_score=0.95,
+			predicted_relevant=True,
+		)
+
+		ctx = self._run_and_capture_context()
+
+		featured = list(ctx.get("articles", []))
+		needs_review = list(ctx.get("additional_articles", []))
+		self.assertNotIn(article, featured)
+		self.assertIn(article, needs_review)

--- a/django/subscriptions/tests/test_content_organizer_trials.py
+++ b/django/subscriptions/tests/test_content_organizer_trials.py
@@ -1,0 +1,133 @@
+"""
+Tests for EmailContentOrganizer.organize_trials' recruiting/not-recruiting split.
+
+Regression coverage for the bug where the split matched
+`"recruit" in str(t.recruitment_status).lower()` against the raw registry string,
+which also matches "Not Recruiting", "NOT_YET_RECRUITING", "ACTIVE_NOT_RECRUITING",
+"Ongoing, recruitment ended" and "Authorised, recruitment pending". The fix splits
+on `recruitment_status_normalized == "recruiting"` instead, and treats a NULL
+normalized status (the normalizer didn't recognise the raw value) as not-recruiting
+rather than guessing from the raw string.
+"""
+
+import os
+from datetime import timedelta
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+
+import django
+
+django.setup()
+
+from django.test import TestCase
+from django.utils import timezone
+
+from gregory.models import Trials
+from templates.emails.components.content_organizer import EmailContentOrganizer
+
+
+class TestOrganizeTrialsRecruitmentSplit(TestCase):
+	def setUp(self):
+		self.organizer = EmailContentOrganizer(email_type="weekly_summary")
+
+	def _make_trial(self, title, raw_status, days_ago=1):
+		return Trials.objects.create(
+			title=title,
+			link=f"https://example.com/trials/{title.replace(' ', '-').lower()}",
+			discovery_date=timezone.now() - timedelta(days=days_ago),
+			recruitment_status=raw_status,
+		)
+
+	# ── Regressions: raw strings that used to false-match "recruit" ──────────
+
+	def test_not_recruiting_lands_in_regular(self):
+		trial = self._make_trial("Not Recruiting Trial", "Not Recruiting")
+		result = self.organizer.organize_trials([trial])
+		self.assertIn(trial, result["regular_trials"])
+		self.assertNotIn(trial, result["featured_trials"])
+
+	def test_not_yet_recruiting_lands_in_regular(self):
+		trial = self._make_trial("Not Yet Recruiting Trial", "NOT_YET_RECRUITING")
+		result = self.organizer.organize_trials([trial])
+		self.assertIn(trial, result["regular_trials"])
+		self.assertNotIn(trial, result["featured_trials"])
+
+	def test_active_not_recruiting_lands_in_regular(self):
+		trial = self._make_trial("Active Not Recruiting Trial", "ACTIVE_NOT_RECRUITING")
+		result = self.organizer.organize_trials([trial])
+		self.assertIn(trial, result["regular_trials"])
+		self.assertNotIn(trial, result["featured_trials"])
+
+	def test_ongoing_recruitment_ended_lands_in_regular(self):
+		trial = self._make_trial(
+			"Ongoing Recruitment Ended Trial", "Ongoing, recruitment ended"
+		)
+		result = self.organizer.organize_trials([trial])
+		self.assertIn(trial, result["regular_trials"])
+		self.assertNotIn(trial, result["featured_trials"])
+
+	def test_authorised_recruitment_pending_lands_in_regular(self):
+		trial = self._make_trial(
+			"Authorised Recruitment Pending Trial", "Authorised, recruitment pending"
+		)
+		result = self.organizer.organize_trials([trial])
+		self.assertIn(trial, result["regular_trials"])
+		self.assertNotIn(trial, result["featured_trials"])
+
+	# ── Genuinely recruiting raw/normalized pairs land in featured ───────────
+
+	def test_recruiting_variants_land_in_featured(self):
+		raw_values = [
+			"RECRUITING",
+			"Recruiting",
+			"Ongoing, recruiting",
+			"Authorised, recruiting",
+		]
+		for raw in raw_values:
+			with self.subTest(raw=raw):
+				trial = self._make_trial(f"Trial {raw}", raw)
+				result = self.organizer.organize_trials([trial])
+				self.assertIn(trial, result["featured_trials"])
+				self.assertNotIn(trial, result["regular_trials"])
+
+	# ── Unset normalized status: treated as not-recruiting, no guessing ──────
+
+	def test_unrecognised_raw_status_treated_as_not_recruiting(self):
+		# A raw value the normalizer doesn't recognise as "recruiting" but that
+		# still contains the substring "recruit" — this is exactly the case the
+		# old substring match got wrong.
+		trial = self._make_trial(
+			"Weird Status Trial", "Some Unrecognised Recruit Status"
+		)
+		result = self.organizer.organize_trials([trial])
+		self.assertNotEqual(trial.recruitment_status_normalized, "recruiting")
+		self.assertNotIn(trial, result["featured_trials"])
+		self.assertIn(trial, result["regular_trials"])
+
+	def test_blank_raw_status_treated_as_not_recruiting(self):
+		trial = self._make_trial("No Status Trial", None)
+		self.assertIsNone(trial.recruitment_status_normalized)
+		result = self.organizer.organize_trials([trial])
+		self.assertNotIn(trial, result["featured_trials"])
+		self.assertIn(trial, result["regular_trials"])
+
+	# ── content_stats.recruiting_trials only counts genuinely recruiting ────
+
+	def test_content_stats_recruiting_count_excludes_misclassified(self):
+		recruiting = self._make_trial("Recruiting Trial", "Recruiting")
+		not_recruiting = self._make_trial("Not Recruiting Trial 2", "Not Recruiting")
+		not_yet = self._make_trial("Not Yet Trial", "NOT_YET_RECRUITING")
+
+		organized_trials = self.organizer.organize_trials(
+			[recruiting, not_recruiting, not_yet]
+		)
+		content_stats = self.organizer.get_content_statistics(
+			{
+				"total_count": 0,
+				"high_confidence_count": 0,
+				"featured_articles": [],
+				"regular_articles": [],
+			},
+			organized_trials,
+		)
+		self.assertEqual(content_stats["recruiting_trials"], 1)

--- a/django/subscriptions/tests/test_email_payload_limits.py
+++ b/django/subscriptions/tests/test_email_payload_limits.py
@@ -282,6 +282,50 @@ class RenderWithinLimitTest(TestCase):
 		self.assertEqual(used_articles, [])
 		self.assertEqual(used_trials, [])
 
+	def test_latest_research_none_keeps_three_tuple_contract(self):
+		"""Omitting latest_research must not change behavior for callers that
+		don't have a Latest Research section (admin_summary, trial_notification)."""
+
+		def render(articles, trials):
+			return "ok", articles, trials
+
+		result = render_within_limit(render, [1, 2], ["a"])
+
+		self.assertEqual(result, ("ok", [1, 2], ["a"]))
+
+	def test_latest_research_shrinks_alongside_articles_and_trials(self):
+		call_sizes = []
+
+		def render(articles, trials, latest_research):
+			total = len(articles) + len(trials) + len(latest_research)
+			call_sizes.append(total)
+			if total > 6:
+				html = "x" * (SAFE_BODY_CHARS + 1)
+			else:
+				html = "ok"
+			return html, articles, trials, latest_research
+
+		html, used_articles, used_trials, used_lr = render_within_limit(
+			render, [1, 2], ["a", "b"], ["x", "y", "z", "w"]
+		)
+
+		self.assertEqual(html, "ok")
+		# [1, 2] halves to 1; ["a", "b"] halves to 1; the 4-item Latest
+		# Research list halves to 2 — total 4, fitting under the threshold
+		# on the second attempt.
+		self.assertEqual(len(used_articles), 1)
+		self.assertEqual(len(used_trials), 1)
+		self.assertEqual(len(used_lr), 2)
+		self.assertEqual(call_sizes, [8, 4])
+
+	def test_latest_research_gives_up_returns_four_empty(self):
+		def render(articles, trials, latest_research):
+			return "x" * (SAFE_BODY_CHARS + 1), articles, trials, latest_research
+
+		result = render_within_limit(render, [1, 2], [1, 2], [1, 2])
+
+		self.assertEqual(result, (None, [], [], []))
+
 
 class SendTrialsNotificationLimitTest(BaseSubscriptionCommandTestCase):
 	def setUp(self):

--- a/django/subscriptions/tests/test_latest_research_delta.py
+++ b/django/subscriptions/tests/test_latest_research_delta.py
@@ -1,0 +1,373 @@
+"""
+Tests for P1 finding 3: Latest Research must implement its own definition —
+new articles since the subscriber's last email for that list, grouped by
+category, deduplicated against the main section, tracked through the same
+`SentArticleNotification` table as the main content (not a fixed 30-day
+standing digest built from a query the size-shrink loop can't see).
+
+Regression coverage for `send_weekly_summary` and
+`EmailRenderingPipeline.prepare_optimized_context`. Trials are deliberately out
+of scope for this section (a documented decision, not an oversight — see
+docs/subscriptions.md).
+"""
+
+import os
+from datetime import timedelta
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+
+import django
+
+django.setup()
+
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from gregory.models import (
+	Articles,
+	ArticleOrgContent,
+	Subject,
+	Team,
+	TeamCategory,
+	Trials,
+)
+from organizations.models import Organization
+from sitesettings.models import CustomSetting
+from subscriptions.models import Lists, SentArticleNotification, Subscribers
+from templates.emails.components.content_organizer import EmailRenderingPipeline
+
+
+def _mock_ok_result():
+	result = MagicMock(status_code=200)
+	result.json.return_value = {"ErrorCode": 0, "Message": "OK"}
+	return result
+
+
+class LatestResearchDeltaTestCase(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(name="LR Org", slug="lr-org")
+		self.team = Team.objects.create(
+			name="LR Team", organization=self.org, slug="lr-team"
+		)
+		self.subject = Subject.objects.create(
+			subject_name="LR Subject", team=self.team, subject_slug="lr-subject"
+		)
+		self.category = TeamCategory.objects.create(
+			team=self.team, category_name="LR Category", category_slug="lr-category"
+		)
+		self.site = Site.objects.get_or_create(
+			id=1, defaults={"domain": "testserver", "name": "Test Site"}
+		)[0]
+		self.custom_settings = CustomSetting.objects.get_or_create(
+			site=self.site,
+			defaults={
+				"title": "Test Site",
+				"postmark_api_token": "test-token",
+				"postmark_api_url": "https://api.postmarkapp.com/email",
+			},
+		)[0]
+		self.subscriber = Subscribers.objects.create(
+			first_name="LR",
+			last_name="Tester",
+			email="lr@example.com",
+			active=True,
+		)
+		self.digest_list = Lists.objects.create(
+			list_name="LR Digest",
+			weekly_digest=True,
+			team=self.team,
+			list_email_subject="LR Weekly",
+			article_sort_order="date",
+		)
+		self.digest_list.subjects.add(self.subject)
+		self.digest_list.latest_research_categories.add(self.category)
+		self.subscriber.subscriptions.add(self.digest_list)
+
+	def _make_category_article(self, title, days_ago=1, doi=None):
+		article = Articles.objects.create(
+			title=title,
+			link=f"https://example.com/articles/{title.replace(' ', '-').lower()}",
+			doi=doi or f"10.7777/{title.replace(' ', '-').lower()}",
+		)
+		Articles.objects.filter(pk=article.pk).update(
+			discovery_date=timezone.now() - timedelta(days=days_ago)
+		)
+		article.refresh_from_db()
+		article.team_categories.add(self.category)
+		return article
+
+	def _make_main_article(self, title, days_ago=1):
+		"""An article matched by list subjects, not by category — lands in the
+		main section, not Latest Research."""
+		article = Articles.objects.create(
+			title=title,
+			link=f"https://example.com/articles/{title.replace(' ', '-').lower()}",
+			doi=f"10.7777/{title.replace(' ', '-').lower()}",
+		)
+		Articles.objects.filter(pk=article.pk).update(
+			discovery_date=timezone.now() - timedelta(days=days_ago)
+		)
+		article.refresh_from_db()
+		article.subjects.add(self.subject)
+		return article
+
+	def _run_and_capture_context(self, **command_kwargs):
+		captured = {}
+		real_get_template = __import__(
+			"django.template.loader", fromlist=["get_template"]
+		).get_template
+
+		def fake_get_template(template_name, using=None):
+			tmpl = real_get_template(template_name, using=using)
+			original_render = tmpl.render
+
+			def capturing_render(context=None, request=None):
+				if isinstance(context, dict):
+					captured.update(context)
+				return original_render(context, request)
+
+			tmpl.render = capturing_render
+			return tmpl
+
+		with (
+			patch(
+				"subscriptions.management.commands.send_weekly_summary.send_email",
+				return_value=_mock_ok_result(),
+			),
+			patch(
+				"subscriptions.management.commands.send_weekly_summary.get_template",
+				side_effect=fake_get_template,
+			),
+		):
+			out = StringIO()
+			call_command("send_weekly_summary", stdout=out, **command_kwargs)
+
+		return captured
+
+	def _run_and_capture_html(self, **command_kwargs):
+		"""Like _run_and_capture_context, but also captures the exact HTML
+		string passed to send_email — needed to measure real render sizes for
+		the shrink test rather than guessing at SAFE_BODY_CHARS."""
+		captured_html = {}
+
+		def _send_email_side_effect(**kwargs):
+			captured_html["html"] = kwargs.get("html")
+			return _mock_ok_result()
+
+		with patch(
+			"subscriptions.management.commands.send_weekly_summary.send_email",
+			side_effect=_send_email_side_effect,
+		):
+			out = StringIO()
+			call_command("send_weekly_summary", stdout=out, **command_kwargs)
+
+		return captured_html.get("html", "")
+
+	def _lr_articles_in_context(self, ctx):
+		flat = []
+		for category_data in ctx.get("latest_research", {}).get("categories", []):
+			flat.extend(category_data.get("articles", []))
+		return flat
+
+
+class SentRecordExclusionTest(LatestResearchDeltaTestCase):
+	def test_already_sent_article_excluded_from_latest_research(self):
+		"""Regression: an article already recorded as sent to this subscriber
+		for this list must not appear in Latest Research. Must fail against
+		current code, which never checks SentArticleNotification at all."""
+		already_sent = self._make_category_article("Already Sent Article")
+		SentArticleNotification.objects.create(
+			article=already_sent, list=self.digest_list, subscriber=self.subscriber
+		)
+		fresh = self._make_category_article("Fresh Article")
+
+		ctx = self._run_and_capture_context()
+		lr_articles = self._lr_articles_in_context(ctx)
+
+		self.assertNotIn(already_sent, lr_articles)
+		self.assertIn(fresh, lr_articles)
+
+	def test_latest_research_article_recorded_as_sent_and_absent_next_run(self):
+		article = self._make_category_article("Recorded Article")
+
+		ctx1 = self._run_and_capture_context()
+		self.assertIn(article, self._lr_articles_in_context(ctx1))
+		self.assertTrue(
+			SentArticleNotification.objects.filter(
+				article=article, list=self.digest_list, subscriber=self.subscriber
+			).exists()
+		)
+
+		# Second run: the same article must not reappear.
+		ctx2 = self._run_and_capture_context()
+		self.assertNotIn(article, self._lr_articles_in_context(ctx2))
+
+
+class CategoryTrialsOnlyTest(LatestResearchDeltaTestCase):
+	def test_category_with_only_trials_contributes_nothing(self):
+		"""TeamCategory.trials is a real relation but Latest Research is
+		articles-only by decision — a category whose only new content is
+		trials must contribute nothing, and the section must be omitted."""
+		# A qualifying main-list trial so the send isn't skipped outright —
+		# without it, zero main content and zero LR candidates would make
+		# this test pass vacuously (the whole list gets skipped).
+		main_trial = Trials.objects.create(
+			title="Main List Trial", link="https://example.com/trials/main-list-trial"
+		)
+		Trials.objects.filter(pk=main_trial.pk).update(
+			discovery_date=timezone.now() - timedelta(days=1)
+		)
+		main_trial.refresh_from_db()
+		main_trial.subjects.add(self.subject)
+
+		# A trial linked to the Latest Research category via team_categories —
+		# category.articles (what Latest Research reads) stays empty even
+		# though the category has fresh content through this other relation.
+		category_trial = Trials.objects.create(
+			title="Category-Linked Trial",
+			link="https://example.com/trials/category-linked-trial",
+		)
+		Trials.objects.filter(pk=category_trial.pk).update(
+			discovery_date=timezone.now() - timedelta(days=1)
+		)
+		category_trial.refresh_from_db()
+		category_trial.team_categories.add(self.category)
+
+		ctx = self._run_and_capture_context()
+
+		self.assertEqual(self._lr_articles_in_context(ctx), [])
+		latest_research = ctx.get("latest_research", {})
+		self.assertFalse(latest_research.get("has_latest_research", False))
+
+
+class DedupAgainstMainSectionTest(LatestResearchDeltaTestCase):
+	def test_article_in_both_main_and_category_renders_once_in_main(self):
+		"""An article matched by both the list's subjects (main section) and a
+		Latest Research category must render once, in the main section."""
+		shared = Articles.objects.create(
+			title="Shared Article",
+			link="https://example.com/articles/shared-article",
+			doi="10.7777/shared-article",
+		)
+		Articles.objects.filter(pk=shared.pk).update(
+			discovery_date=timezone.now() - timedelta(days=1)
+		)
+		shared.refresh_from_db()
+		shared.subjects.add(self.subject)
+		shared.team_categories.add(self.category)
+
+		ctx = self._run_and_capture_context()
+
+		main_articles = list(ctx.get("articles", [])) + list(
+			ctx.get("additional_articles", [])
+		)
+		self.assertIn(shared, main_articles)
+		self.assertNotIn(shared, self._lr_articles_in_context(ctx))
+
+
+class LookbackDaysTest(LatestResearchDeltaTestCase):
+	def test_honours_list_lookback_days_not_fixed_30(self):
+		self.digest_list.lookback_days = 8
+		self.digest_list.save()
+
+		old_article = self._make_category_article("Old Category Article", days_ago=20)
+		recent_article = self._make_category_article(
+			"Recent Category Article", days_ago=3
+		)
+
+		ctx = self._run_and_capture_context()
+		lr_articles = self._lr_articles_in_context(ctx)
+
+		self.assertNotIn(old_article, lr_articles)
+		self.assertIn(recent_article, lr_articles)
+
+
+class ShrinkOnOversizeTest(LatestResearchDeltaTestCase):
+	def test_oversized_latest_research_is_shrunk_not_failed(self):
+		"""A Latest Research section large enough to blow past SAFE_BODY_CHARS
+		must be shrunk by render_within_limit, not left to fail the send on the
+		give-up path.
+
+		Titles are DB-bounded (a generated unaccented-title column caps at
+		varchar(2000)), so overflow is manufactured by patching
+		SAFE_BODY_CHARS down to a threshold calibrated from one real render,
+		rather than by using huge titles.
+		"""
+		calibration_article = self._make_category_article(
+			"Calibration Article", days_ago=1
+		)
+		baseline_html = self._run_and_capture_html()
+		baseline_len = len(baseline_html)
+		self.assertGreater(baseline_len, 0)
+		# The calibration send counts as sent — clear it so it's eligible
+		# again below, alongside the rest of the batch.
+		SentArticleNotification.objects.all().delete()
+
+		# 30 more articles of the same shape: the full set overflows a
+		# threshold set just above one article's worth of content; shrunk by
+		# half repeatedly, some prefix of them fits.
+		articles = [calibration_article] + [
+			self._make_category_article(f"Category Article {i}", days_ago=1)
+			for i in range(30)
+		]
+		test_limit = baseline_len + 3_000
+
+		with patch("subscriptions.utils.email_limits.SAFE_BODY_CHARS", test_limit):
+			ctx = self._run_and_capture_context()
+
+		lr_articles = self._lr_articles_in_context(ctx)
+		self.assertGreater(len(lr_articles), 0)
+		self.assertLess(len(lr_articles), len(articles))
+
+		sent_count = SentArticleNotification.objects.filter(
+			list=self.digest_list, subscriber=self.subscriber
+		).count()
+		self.assertEqual(sent_count, len(lr_articles))
+
+
+class OrgContentMapCoverageTest(TestCase):
+	"""Unit-level: prepare_optimized_context must build org_content_map
+	entries for Latest Research articles, not just the main section."""
+
+	def setUp(self):
+		self.org = Organization.objects.create(name="LR Map Org", slug="lr-map-org")
+		self.team = Team.objects.create(
+			name="LR Map Team", organization=self.org, slug="lr-map-team"
+		)
+		self.category = TeamCategory.objects.create(
+			team=self.team,
+			category_name="LR Map Category",
+			category_slug="lr-map-category",
+		)
+		self.site = Site.objects.create(
+			domain="lrmaporg.example.com", name="LR Map Org"
+		)
+		self.article = Articles.objects.create(
+			title="LR Map Article",
+			link="https://example.com/article/lr-map",
+		)
+		self.article.team_categories.add(self.category)
+		ArticleOrgContent.objects.create(
+			article=self.article,
+			organization=self.org,
+			takeaways="LR takeaway",
+		)
+
+	def test_org_content_map_covers_latest_research_articles(self):
+		pipeline = EmailRenderingPipeline()
+		context = pipeline.prepare_optimized_context(
+			email_type="weekly_summary",
+			articles=Articles.objects.none(),
+			organization=self.org,
+			site=self.site,
+			latest_research_category_map={self.category: [self.article]},
+		)
+		self.assertIn(self.article.article_id, context["org_content_map"])
+		self.assertEqual(
+			context["org_content_map"][self.article.article_id].takeaways,
+			"LR takeaway",
+		)

--- a/django/subscriptions/tests/test_latest_research_delta.py
+++ b/django/subscriptions/tests/test_latest_research_delta.py
@@ -371,3 +371,67 @@ class OrgContentMapCoverageTest(TestCase):
 			context["org_content_map"][self.article.article_id].takeaways,
 			"LR takeaway",
 		)
+
+
+class SentRecordLookbackWindowTest(LatestResearchDeltaTestCase):
+	"""The sent-record exclusion window must be at least as wide as the
+	content lookback window, or an article sent between 30 days ago and
+	lookback_days ago gets treated as unsent and resent (audit finding 11).
+	This applies to both the main section and Latest Research, since they
+	share the same SentArticleNotification exclusion set."""
+
+	def test_article_sent_beyond_30_days_still_excluded_when_lookback_is_wider(self):
+		self.digest_list.lookback_days = 60
+		self.digest_list.save()
+
+		# A fresh main article keeps the send from being skipped outright
+		# (without it, the old article being correctly excluded would leave
+		# zero unsent content and the whole send would skip, making the
+		# assertion below pass vacuously rather than for the right reason).
+		fresh = self._make_main_article("Fresh Main Article", days_ago=1)
+
+		main_article = self._make_main_article("Old Sent Main Article", days_ago=50)
+		notification = SentArticleNotification.objects.create(
+			article=main_article, list=self.digest_list, subscriber=self.subscriber
+		)
+		# sent_at is auto_now_add — backdate it past the old fixed 30-day
+		# exclusion window but still inside the list's 60-day lookback.
+		SentArticleNotification.objects.filter(pk=notification.pk).update(
+			sent_at=timezone.now() - timedelta(days=40)
+		)
+
+		ctx = self._run_and_capture_context()
+
+		rendered_main = list(ctx.get("articles", [])) + list(
+			ctx.get("additional_articles", [])
+		)
+		self.assertIn(fresh, rendered_main)
+		self.assertNotIn(main_article, rendered_main)
+
+	def test_category_article_sent_beyond_30_days_still_excluded_from_latest_research(
+		self,
+	):
+		self.digest_list.lookback_days = 60
+		self.digest_list.save()
+
+		# A fresh category article keeps the send from being skipped outright
+		# (without it, the old article being correctly excluded would leave
+		# zero content and the whole send would skip, making the assertion
+		# below pass vacuously rather than for the right reason).
+		fresh = self._make_category_article("Fresh Category Article", days_ago=1)
+
+		category_article = self._make_category_article(
+			"Old Sent Category Article", days_ago=50
+		)
+		notification = SentArticleNotification.objects.create(
+			article=category_article, list=self.digest_list, subscriber=self.subscriber
+		)
+		SentArticleNotification.objects.filter(pk=notification.pk).update(
+			sent_at=timezone.now() - timedelta(days=40)
+		)
+
+		ctx = self._run_and_capture_context()
+
+		lr_articles = self._lr_articles_in_context(ctx)
+		self.assertIn(fresh, lr_articles)
+		self.assertNotIn(category_article, lr_articles)

--- a/django/subscriptions/tests/test_render_error_handling.py
+++ b/django/subscriptions/tests/test_render_error_handling.py
@@ -1,0 +1,269 @@
+"""
+Tests for P1 finding 2: a blanket `except Exception` in
+`EmailRenderingPipeline.prepare_optimized_context` used to catch any bug and
+silently return an empty fallback context, which both send commands would then
+mail out as an empty digest.
+
+The fix:
+- `prepare_optimized_context` no longer swallows exceptions; they propagate to
+  the caller (the management command).
+- `send_weekly_summary` and `send_admin_summary` now wrap the render call in
+  their own try/except, recording a `FailedNotification` and skipping the send
+  rather than crashing the whole run or mailing nothing.
+- Both commands also gained a post-render guard: if the organized content is
+  empty (both articles and trials), the send is skipped and a
+  `FailedNotification` is recorded — a backstop distinct from the pre-existing
+  early skip that fires before any content is fetched for the subscriber.
+"""
+
+import os
+from datetime import timedelta
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+
+import django
+
+django.setup()
+
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from gregory.models import Articles, Subject, Team
+from organizations.models import Organization
+from sitesettings.models import CustomSetting
+from subscriptions.models import (
+	FailedNotification,
+	Lists,
+	SentArticleNotification,
+	Subscribers,
+)
+from templates.emails.components.content_organizer import (
+	get_optimized_email_context as real_get_optimized_email_context,
+)
+
+
+def _mock_ok_result():
+	result = MagicMock(status_code=200)
+	result.json.return_value = {"ErrorCode": 0, "Message": "OK"}
+	return result
+
+
+class BaseRenderErrorTestCase(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(
+			name="Render Error Org", slug="render-error-org"
+		)
+		self.team = Team.objects.create(
+			name="Render Error Team", organization=self.org, slug="render-error-team"
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Render Error Subject",
+			team=self.team,
+			subject_slug="render-error-subject",
+		)
+		self.site = Site.objects.get_or_create(
+			id=1, defaults={"domain": "testserver", "name": "Test Site"}
+		)[0]
+		self.custom_settings = CustomSetting.objects.get_or_create(
+			site=self.site,
+			defaults={
+				"title": "Test Site",
+				"postmark_api_token": "test-token",
+				"postmark_api_url": "https://api.postmarkapp.com/email",
+			},
+		)[0]
+		self.subscriber = Subscribers.objects.create(
+			first_name="Render",
+			last_name="Tester",
+			email="render-error@example.com",
+			active=True,
+		)
+
+	def _make_article(self, title, days_ago=1):
+		article = Articles.objects.create(
+			title=title,
+			link=f"https://example.com/articles/{title.replace(' ', '-').lower()}",
+			doi=f"10.9999/{title.replace(' ', '-').lower()}",
+		)
+		Articles.objects.filter(pk=article.pk).update(
+			discovery_date=timezone.now() - timedelta(days=days_ago)
+		)
+		article.refresh_from_db()
+		article.subjects.add(self.subject)
+		return article
+
+
+class WeeklySummaryRenderErrorTest(BaseRenderErrorTestCase):
+	def setUp(self):
+		super().setUp()
+		self.digest_list = Lists.objects.create(
+			list_name="Render Error Digest",
+			weekly_digest=True,
+			team=self.team,
+			list_email_subject="Render Error Weekly",
+			# Date mode bypasses ML-consensus filtering so a plain article
+			# (no ML predictions, no manual review) is still included.
+			article_sort_order="date",
+		)
+		self.digest_list.subjects.add(self.subject)
+		self.subscriber.subscriptions.add(self.digest_list)
+
+	def test_render_exception_skips_send_and_records_failure(self):
+		self._make_article("Boom Article")
+
+		with (
+			patch(
+				"subscriptions.management.commands.send_weekly_summary.get_optimized_email_context",
+				side_effect=RuntimeError("boom"),
+			),
+			patch(
+				"subscriptions.management.commands.send_weekly_summary.send_email"
+			) as mock_send,
+		):
+			call_command("send_weekly_summary", stdout=StringIO())
+
+		mock_send.assert_not_called()
+		self.assertTrue(
+			FailedNotification.objects.filter(
+				subscriber=self.subscriber, list=self.digest_list
+			).exists()
+		)
+		self.assertFalse(
+			SentArticleNotification.objects.filter(
+				subscriber=self.subscriber, list=self.digest_list
+			).exists()
+		)
+
+	def test_context_organized_to_zero_content_skips_send(self):
+		"""A context that legitimately organizes to zero articles and zero
+		trials must not produce a send, even though unsent content existed
+		going into the render (simulating a downstream organizer bug)."""
+		self._make_article("Would-Be Article")
+
+		def _empty_context(*args, **kwargs):
+			ctx = real_get_optimized_email_context(*args, **kwargs)
+			ctx["articles"] = []
+			ctx["additional_articles"] = []
+			ctx["trials"] = []
+			ctx["additional_trials"] = []
+			return ctx
+
+		with (
+			patch(
+				"subscriptions.management.commands.send_weekly_summary.get_optimized_email_context",
+				side_effect=_empty_context,
+			),
+			patch(
+				"subscriptions.management.commands.send_weekly_summary.send_email"
+			) as mock_send,
+		):
+			call_command("send_weekly_summary", stdout=StringIO())
+
+		mock_send.assert_not_called()
+		self.assertTrue(
+			FailedNotification.objects.filter(
+				subscriber=self.subscriber, list=self.digest_list
+			).exists()
+		)
+
+	def test_no_unsent_content_early_skip_is_not_a_failure(self):
+		"""The pre-existing early skip (no unsent articles/trials at all)
+		fires before render is ever attempted and must not itself write a
+		FailedNotification — that would conflate 'nothing new to send' with
+		an actual rendering failure."""
+		with patch(
+			"subscriptions.management.commands.send_weekly_summary.send_email"
+		) as mock_send:
+			call_command("send_weekly_summary", stdout=StringIO())
+
+		mock_send.assert_not_called()
+		self.assertFalse(
+			FailedNotification.objects.filter(
+				subscriber=self.subscriber, list=self.digest_list
+			).exists()
+		)
+
+
+class AdminSummaryRenderErrorTest(BaseRenderErrorTestCase):
+	def setUp(self):
+		super().setUp()
+		self.admin_list = Lists.objects.create(
+			list_name="Render Error Admin",
+			admin_summary=True,
+			team=self.team,
+			list_email_subject="Render Error Admin Summary",
+		)
+		self.admin_list.subjects.add(self.subject)
+		self.subscriber.subscriptions.add(self.admin_list)
+
+	def test_render_exception_skips_send_and_records_failure(self):
+		self._make_article("Admin Boom Article")
+
+		with (
+			patch(
+				"subscriptions.management.commands.send_admin_summary.get_optimized_email_context",
+				side_effect=RuntimeError("boom"),
+			),
+			patch(
+				"subscriptions.management.commands.send_admin_summary.send_email"
+			) as mock_send,
+		):
+			call_command("send_admin_summary", stdout=StringIO())
+
+		mock_send.assert_not_called()
+		self.assertTrue(
+			FailedNotification.objects.filter(
+				subscriber=self.subscriber, list=self.admin_list
+			).exists()
+		)
+		self.assertFalse(
+			SentArticleNotification.objects.filter(
+				subscriber=self.subscriber, list=self.admin_list
+			).exists()
+		)
+
+	def test_context_organized_to_zero_content_skips_send(self):
+		self._make_article("Admin Would-Be Article")
+
+		def _empty_context(*args, **kwargs):
+			ctx = real_get_optimized_email_context(*args, **kwargs)
+			ctx["articles"] = []
+			ctx["additional_articles"] = []
+			ctx["trials"] = []
+			ctx["additional_trials"] = []
+			return ctx
+
+		with (
+			patch(
+				"subscriptions.management.commands.send_admin_summary.get_optimized_email_context",
+				side_effect=_empty_context,
+			),
+			patch(
+				"subscriptions.management.commands.send_admin_summary.send_email"
+			) as mock_send,
+		):
+			call_command("send_admin_summary", stdout=StringIO())
+
+		mock_send.assert_not_called()
+		self.assertTrue(
+			FailedNotification.objects.filter(
+				subscriber=self.subscriber, list=self.admin_list
+			).exists()
+		)
+
+	def test_no_unsent_content_early_skip_is_not_a_failure(self):
+		with patch(
+			"subscriptions.management.commands.send_admin_summary.send_email"
+		) as mock_send:
+			call_command("send_admin_summary", stdout=StringIO())
+
+		mock_send.assert_not_called()
+		self.assertFalse(
+			FailedNotification.objects.filter(
+				subscriber=self.subscriber, list=self.admin_list
+			).exists()
+		)

--- a/django/subscriptions/tests/test_send_weekly_summary_manual_relevance.py
+++ b/django/subscriptions/tests/test_send_weekly_summary_manual_relevance.py
@@ -355,4 +355,4 @@ class TestManualRelevanceFilteringEdgeCases(TestCase):
 		output = out.getvalue()
 
 		# Should handle gracefully
-		self.assertIn("No articles or trials found", output)
+		self.assertIn("No articles, trials, or Latest Research content found", output)

--- a/django/subscriptions/tests/test_weekly_summary_date_sort.py
+++ b/django/subscriptions/tests/test_weekly_summary_date_sort.py
@@ -320,11 +320,14 @@ class TestEmailContentOrganizerDateMode(TestCase):
 		self.assertEqual(regular[0].pk, new.pk)
 		self.assertEqual(regular[1].pk, old.pk)
 
-	def test_relevancy_mode_uses_featured_regular_split(self):
-		"""Relevancy mode still splits articles into featured/regular buckets."""
+	def test_relevancy_mode_has_no_featured_regular_split(self):
+		"""Relevancy mode returns a single flat list, same as date mode — the
+		featured/regular split was removed (docs/subscriptions.md): neither
+		template drew any visual distinction between the two buckets, so it
+		only reordered articles at the cost of a per-article ML/manual query."""
 		list_obj = self._make_list("relevancy")
 		article = self._make_article("Any Article", days_ago=1)
-		# Mark as manually relevant so it lands in featured
+		# Manual relevance no longer affects bucketing (there is no bucket).
 		ArticleSubjectRelevance.objects.create(
 			article=article, subject=self.subject, is_relevant=True
 		)
@@ -332,5 +335,6 @@ class TestEmailContentOrganizerDateMode(TestCase):
 		organizer = EmailContentOrganizer(email_type="weekly_summary")
 		result = organizer.organize_articles([article], list_obj=list_obj)
 
-		# featured_articles should be non-empty for a manually-relevant article
-		self.assertGreater(len(result["featured_articles"]), 0)
+		self.assertEqual(result["featured_articles"], [])
+		self.assertEqual(result["high_confidence_count"], 0)
+		self.assertIn(article, result["regular_articles"])

--- a/django/subscriptions/utils/email_limits.py
+++ b/django/subscriptions/utils/email_limits.py
@@ -26,7 +26,9 @@ def resolve_limits(list_obj):
 	return article_limit, trial_limit
 
 
-def render_within_limit(render, articles, trials, *, max_attempts=5):
+def render_within_limit(
+	render, articles, trials, latest_research=None, *, max_attempts=5
+):
 	"""
 	Render an email, shrinking its content until the HTML fits SAFE_BODY_CHARS.
 
@@ -36,19 +38,48 @@ def render_within_limit(render, articles, trials, *, max_attempts=5):
 
 	Returns (html, used_articles, used_trials), or (None, [], []) when even a
 	single article and a single trial will not fit.
+
+	`latest_research`, when not None, is a third shrinkable list (opaque to
+	this function — the weekly digest passes (category, article) pairs so its
+	own render callback can regroup by category after a shrink). Passing it
+	switches `render` to the 4-arg form `render(articles, trials,
+	latest_research)` returning `(html, used_articles, used_trials,
+	used_latest_research)`, and the same 4-tuple shape is returned here
+	(all-empty on total failure). Omitting it keeps the original 3-tuple
+	contract for callers that don't have a Latest Research section.
 	"""
 	current_articles = list(articles)
 	current_trials = list(trials)
+	track_latest_research = latest_research is not None
+	current_latest_research = list(latest_research) if track_latest_research else []
 
 	for _ in range(max_attempts):
-		html, used_articles, used_trials = render(current_articles, current_trials)
+		if track_latest_research:
+			html, used_articles, used_trials, used_latest_research = render(
+				current_articles, current_trials, current_latest_research
+			)
+		else:
+			html, used_articles, used_trials = render(current_articles, current_trials)
+
 		if len(html) <= SAFE_BODY_CHARS:
+			if track_latest_research:
+				return html, used_articles, used_trials, used_latest_research
 			return html, used_articles, used_trials
 
-		if len(current_articles) <= 1 and len(current_trials) <= 1:
+		if (
+			len(current_articles) <= 1
+			and len(current_trials) <= 1
+			and (not track_latest_research or len(current_latest_research) <= 1)
+		):
 			break
 
 		current_articles = current_articles[: max(1, len(current_articles) // 2)]
 		current_trials = current_trials[: max(1, len(current_trials) // 2)]
+		if track_latest_research:
+			current_latest_research = current_latest_research[
+				: max(1, len(current_latest_research) // 2)
+			]
 
+	if track_latest_research:
+		return None, [], [], []
 	return None, [], []

--- a/django/subscriptions/utils/email_limits.py
+++ b/django/subscriptions/utils/email_limits.py
@@ -37,7 +37,8 @@ def render_within_limit(
 	the content organizer actually placed in the template.
 
 	Returns (html, used_articles, used_trials), or (None, [], []) when even a
-	single article and a single trial will not fit.
+	single article and a single trial will not fit — but see below: passing
+	`latest_research` changes this to a 4-tuple.
 
 	`latest_research`, when not None, is a third shrinkable list (opaque to
 	this function — the weekly digest passes (category, article) pairs so its

--- a/django/templates/emails/admin_summary.html
+++ b/django/templates/emails/admin_summary.html
@@ -28,15 +28,21 @@
         
         <!-- High-Confidence Articles (Featured) -->
         {% if articles %}
+            <h3 class="content-subtitle" style="color: #15803d; font-size: 16px; margin: 0 0 15px 0;">
+                ✅ High-Confidence ({{ content_stats.high_confidence_articles }})
+            </h3>
             {% for article in articles %}
                 {% with email_type='admin_summary' show_admin_links=True show_discovery_date=True show_ml_predictions=True %}
                     {% include 'emails/components/article_card.html' %}
                 {% endwith %}
             {% endfor %}
         {% endif %}
-        
+
         <!-- Articles Needing Review (Additional) -->
         {% if additional_articles %}
+            <h3 class="content-subtitle" style="color: #b45309; font-size: 16px; margin: 30px 0 15px 0;">
+                🔍 Needs Review ({{ additional_articles|length }})
+            </h3>
             {% for article in additional_articles %}
                 {% with email_type='admin_summary' show_admin_links=True show_discovery_date=True show_ml_predictions=True %}
                     {% include 'emails/components/article_card.html' %}

--- a/django/templates/emails/components/content_organizer.py
+++ b/django/templates/emails/components/content_organizer.py
@@ -98,17 +98,19 @@ class EmailContentOrganizer:
 				trials, key=lambda x: x.discovery_date, reverse=True
 			)
 
-		# Split into categories
+		# Split on the normalized status. A NULL normalized status means the
+		# normalizer did not recognise the raw value; treat that as not-recruiting
+		# rather than falling back to a substring match on the raw string, which is
+		# what produced the original bug (e.g. matching "Not Recruiting").
 		recruiting_trials = [
 			t
 			for t in organized_trials
-			if t.recruitment_status and "recruit" in str(t.recruitment_status).lower()
+			if t.recruitment_status_normalized == "recruiting"
 		]
 		other_trials = [
 			t
 			for t in organized_trials
-			if not t.recruitment_status
-			or "recruit" not in str(t.recruitment_status).lower()
+			if t.recruitment_status_normalized != "recruiting"
 		]
 
 		# Include ALL trials - don't limit content for subscribers
@@ -123,70 +125,35 @@ class EmailContentOrganizer:
 		}
 
 	def _organize_weekly_articles(self, articles, subscriber, list_obj):
-		"""Organize articles for weekly summary emails."""
-		# Date mode: flat list ordered by discovery_date, no featured/regular split.
-		if getattr(list_obj, "article_sort_order", "relevancy") == "date":
-			if hasattr(articles, "order_by"):
-				sorted_list = list(articles.order_by("-discovery_date"))
-			else:
-				sorted_list = sorted(
-					articles, key=lambda x: x.discovery_date, reverse=True
-				)
-			return {
-				"featured_articles": [],
-				"regular_articles": sorted_list,
-				"total_count": len(sorted_list),
-				"high_confidence_count": 0,
-			}
+		"""Organize articles for weekly summary emails: a single flat list,
+		no featured/regular split.
 
-		# Relevancy mode: split into high-confidence (featured) and regular.
-		# Get high-confidence articles first
-		high_confidence_articles = self._filter_high_confidence(articles)
-
-		# Handle both QuerySet and list cases for exclusion
-		if hasattr(articles, "exclude"):
-			# QuerySet case - use exclude
-			regular_articles = articles.exclude(
-				pk__in=[a.pk for a in high_confidence_articles]
-			)
+		Neither `weekly_summary.html` nor the `additional_articles` loop it
+		shares with `articles` draws any visual distinction between the two
+		buckets the split used to produce — the split existed only to
+		reorder articles, at the cost of a per-article manual-review/ML query
+		(see docs/subscriptions.md). Selection (which articles qualify at
+		all) already happened before this method runs; the command's own
+		priority ranking (manual review + ML consensus, `send_weekly_summary`)
+		decides order when `article_limit` truncation applies. Absent
+		truncation, sort by discovery date — the same behavior 'date' sort
+		order already had.
+		"""
+		if hasattr(articles, "order_by"):
+			sorted_list = list(articles.order_by("-discovery_date"))
 		else:
-			# List case - filter manually
-			high_confidence_pks = [a.pk for a in high_confidence_articles]
-			regular_articles = [a for a in articles if a.pk not in high_confidence_pks]
+			sorted_list = sorted(articles, key=lambda x: x.discovery_date, reverse=True)
 
-		# Sort by discovery date for user-friendly experience
-		high_confidence_sorted = sorted(
-			high_confidence_articles, key=lambda x: x.discovery_date, reverse=True
-		)
-
-		# Handle both QuerySet and list cases for ordering
-		if hasattr(regular_articles, "order_by"):
-			# QuerySet case
-			regular_sorted = list(regular_articles.order_by("-discovery_date"))
-		else:
-			# List case - sort manually
-			regular_sorted = sorted(
-				regular_articles, key=lambda x: x.discovery_date, reverse=True
-			)
-
-		# Apply subscriber preferences if available
 		if subscriber and list_obj:
-			high_confidence_sorted = self._apply_subscriber_preferences(
-				high_confidence_sorted, subscriber, list_obj
+			sorted_list = self._apply_subscriber_preferences(
+				sorted_list, subscriber, list_obj
 			)
-			regular_sorted = self._apply_subscriber_preferences(
-				regular_sorted, subscriber, list_obj
-			)
-
-		# Include ALL articles - don't limit content for subscribers
-		featured_articles = high_confidence_sorted  # All high-confidence articles
-		regular_articles = regular_sorted  # All regular articles
 
 		return {
-			"featured_articles": featured_articles,
-			"regular_articles": regular_articles,
-			"total_count": len(high_confidence_sorted) + len(regular_sorted),
-			"high_confidence_count": len(high_confidence_sorted),
+			"featured_articles": [],
+			"regular_articles": sorted_list,
+			"total_count": len(sorted_list),
+			"high_confidence_count": 0,
 		}
 
 	def _organize_admin_articles(self, articles, subscriber):
@@ -435,6 +402,7 @@ class EmailRenderingPipeline:
 		confidence_threshold=None,
 		utm_params=None,
 		organization=None,
+		latest_research_category_map=None,
 	):
 		"""
 		Prepare optimized context with content organization and performance enhancements.
@@ -449,233 +417,75 @@ class EmailRenderingPipeline:
 		    custom_settings: CustomSetting object
 		    confidence_threshold: Custom ML prediction confidence threshold to use
 		    utm_params: Dictionary of UTM parameters for link tracking
+		    latest_research_category_map: dict of {TeamCategory: [Articles]} for the
+		        weekly digest's Latest Research section, already filtered by the
+		        caller (sent-record exclusion, lookback window, dedup against the
+		        main article list). This method only formats it — see
+		        send_weekly_summary for the filtering logic.
 
 		Returns:
 		    dict: Optimized context for template rendering
 		"""
-		try:
-			# Initialize organizer for this email type
-			self.organizer.email_type = email_type
+		# Initialize organizer for this email type
+		self.organizer.email_type = email_type
 
-			# Set custom confidence threshold if provided
-			if confidence_threshold is not None:
-				self.organizer.confidence_threshold = confidence_threshold
+		# Set custom confidence threshold if provided
+		if confidence_threshold is not None:
+			self.organizer.confidence_threshold = confidence_threshold
 
-			# Optimize database queries with prefetch_related
-			if articles is not None and hasattr(articles, "prefetch_related"):
-				# Only apply prefetch if it's not already a sliced QuerySet
-				try:
-					articles = articles.prefetch_related(
-						"authors", "ml_predictions__subject"
-					)
-				except Exception:  # noqa: S110
-					# If prefetch fails (e.g., already sliced), continue with original
-					pass
-
-			if trials is not None and hasattr(trials, "select_related"):
-				# Only apply select_related if it's not already a sliced QuerySet
-				try:
-					trials = trials.select_related()
-				except Exception:  # noqa: S110
-					# If select_related fails (e.g., already sliced), continue with original
-					pass
-
-			# Organize content
-			organized_articles = self.organizer.organize_articles(
-				articles or Articles.objects.none(), subscriber, list_obj
-			)
-
-			organized_trials = self.organizer.organize_trials(
-				trials or Trials.objects.none(), subscriber, list_obj
-			)
-
-			# Generate content statistics
-			content_stats = self.organizer.get_content_statistics(
-				organized_articles, organized_trials
-			)
-
-			# Build optimized context
-			# Derive site domain for URL fallbacks from the site linked to the list.
-			# Strip whitespace to guard against accidental spaces in Site.domain.
-			_site_domain = site.domain.strip() if site and site.domain else ""
-			_site_scheme = (
-				"http" if _site_domain in ("localhost", "127.0.0.1") else "https"
-			)
-			_site_url_base = f"{_site_scheme}://{_site_domain}" if _site_domain else ""
-
-			context = {
-				"email_type": email_type,
-				"current_date": timezone.now(),
-				"subscriber": subscriber,
-				"site": site,
-				"custom_settings": custom_settings,
-				"customsettings": custom_settings,  # Template compatibility
-				# Site domain for URL construction
-				"site_domain": _site_domain,
-				# UTM parameters for link tracking
-				"utm_params": utm_params or {},
-				# Footer context from CustomSetting, falling back to site domain when not set.
-				# This ensures footer links always reflect the domain the list is linked to.
-				"website_url": getattr(custom_settings, "website_url", "")
-				or _site_url_base,
-				"support_url": getattr(custom_settings, "support_url", ""),
-				"about_url": getattr(custom_settings, "about_url", ""),
-				"contact_url": getattr(custom_settings, "contact_url", ""),
-				"bluesky_url": getattr(custom_settings, "bluesky_url", ""),
-				"github_url": getattr(custom_settings, "github_url", ""),
-				"mastodon_url": getattr(custom_settings, "mastodon_url", ""),
-				"privacy_policy_url": getattr(
-					custom_settings, "privacy_policy_url", ""
-				),
-				"terms_url": getattr(custom_settings, "terms_url", ""),
-				# Organized content
-				"articles": organized_articles.get("featured_articles", []),
-				"additional_articles": organized_articles.get("regular_articles", []),
-				"trials": organized_trials.get("featured_trials", []),
-				"additional_trials": organized_trials.get("regular_trials", []),
-				# Content statistics for smart template logic
-				"content_stats": content_stats,
-				"has_high_confidence_articles": content_stats[
-					"high_confidence_articles"
-				]
-				> 0,
-				"has_recruiting_trials": content_stats["recruiting_trials"] > 0,
-				# Performance metadata
-				"render_timestamp": timezone.now(),
-				"optimization_enabled": True,
-			}
-
-			# Add email-type specific context
-			if email_type == "weekly_summary":
-				# Add latest research by category if the list has any latest research categories
-				latest_research = {}
-				if list_obj and hasattr(list_obj, "latest_research_categories"):
-					from subscriptions.management.commands.utils.subscription import (
-						get_latest_research_by_category,
-					)
-
-					category_articles = get_latest_research_by_category(list_obj)
-					latest_research = (
-						self.organizer.organize_latest_research_by_category(
-							category_articles
-						)
-					)
-
-				context.update(
-					{
-						"greeting_time": self._get_greeting_time(),
-						"user": subscriber,
-						"list": list_obj,
-						"title": getattr(custom_settings, "title", "Gregory AI"),
-						"latest_research": latest_research,
-					}
+		# Optimize database queries with prefetch_related
+		if articles is not None and hasattr(articles, "prefetch_related"):
+			# Only apply prefetch if it's not already a sliced QuerySet
+			try:
+				articles = articles.prefetch_related(
+					"authors", "ml_predictions__subject"
 				)
+			except Exception:  # noqa: S110
+				# If prefetch fails (e.g., already sliced), continue with original
+				pass
 
-			elif email_type == "admin_summary":
-				# Handle both dict and object types for subscriber
-				if isinstance(subscriber, dict):
-					admin_email = subscriber.get("email", "admin@example.com")
-				else:
-					admin_email = getattr(subscriber, "email", "admin@example.com")
+		if trials is not None and hasattr(trials, "select_related"):
+			# Only apply select_related if it's not already a sliced QuerySet
+			try:
+				trials = trials.select_related()
+			except Exception:  # noqa: S110
+				# If select_related fails (e.g., already sliced), continue with original
+				pass
 
-				context.update(
-					{
-						"admin": admin_email,
-						"now": timezone.now(),
-						"list": list_obj,
-						"title": getattr(custom_settings, "title", "Gregory AI"),
-						"show_ml_predictions": True,
-						"show_admin_links": True,
-					}
-				)
+		# Organize content
+		organized_articles = self.organizer.organize_articles(
+			articles or Articles.objects.none(), subscriber, list_obj
+		)
 
-			elif email_type == "trial_notification":
-				context.update(
-					{
-						"now": timezone.now(),
-						"title": getattr(custom_settings, "title", "Gregory AI"),
-						"notification_type": "trial_update",
-					}
-				)
+		organized_trials = self.organizer.organize_trials(
+			trials or Trials.objects.none(), subscriber, list_obj
+		)
 
-			logger.info(
-				f"Optimized context prepared for {email_type}: "
-				f"{content_stats['total_articles']} articles, "
-				f"{content_stats['total_trials']} trials"
-			)
+		# Generate content statistics
+		content_stats = self.organizer.get_content_statistics(
+			organized_articles, organized_trials
+		)
 
-			# Build per-org content map for email templates
-			if organization is not None:
-				from gregory.models import ArticleOrgContent
-
-				all_email_articles = list(context.get("articles", [])) + list(
-					context.get("additional_articles", [])
-				)
-				article_ids = [
-					a.article_id for a in all_email_articles if hasattr(a, "article_id")
-				]
-				org_contents = {
-					oc.article_id: oc
-					for oc in ArticleOrgContent.objects.filter(
-						article_id__in=article_ids,
-						organization=organization,
-					)
-				}
-				context["org_content_map"] = org_contents
-			else:
-				_ORG_EXPECTED_TYPES = {"weekly_summary", "admin_summary"}
-				if email_type in _ORG_EXPECTED_TYPES:
-					logger.warning(
-						"prepare_optimized_context called without organization for email_type=%s; "
-						"org_content_map will be empty. Pass organization= for team-owned emails.",
-						email_type,
-					)
-				context["org_content_map"] = {}
-
-			return context
-
-		except Exception as e:
-			logger.error(
-				f"Error preparing optimized context for {email_type}: {str(e)}"
-			)
-			# Fallback to basic context
-			return self._get_fallback_context(
-				email_type, subscriber, site, custom_settings
-			)
-
-	def _get_greeting_time(self):
-		"""Get appropriate greeting based on current time."""
-		current_hour = timezone.now().hour
-		if current_hour < 12:
-			return "morning"
-		elif current_hour < 17:
-			return "afternoon"
-		else:
-			return "evening"
-
-	def _get_fallback_context(self, email_type, subscriber, site, custom_settings):
-		"""Provide fallback context if optimization fails."""
+		# Build optimized context
+		# Derive site domain for URL fallbacks from the site linked to the list.
 		# Strip whitespace to guard against accidental spaces in Site.domain.
 		_site_domain = site.domain.strip() if site and site.domain else ""
 		_site_scheme = "http" if _site_domain in ("localhost", "127.0.0.1") else "https"
 		_site_url_base = f"{_site_scheme}://{_site_domain}" if _site_domain else ""
-		base_context = {
+
+		context = {
 			"email_type": email_type,
 			"current_date": timezone.now(),
 			"subscriber": subscriber,
 			"site": site,
-			"customsettings": custom_settings,
-			"articles": [],
-			"trials": [],
-			"content_stats": {
-				"total_articles": 0,
-				"total_trials": 0,
-				"high_confidence_articles": 0,
-				"recruiting_trials": 0,
-			},
-			"optimization_enabled": False,
-			"error_mode": True,
-			"title": getattr(custom_settings, "title", "Gregory AI"),
+			"custom_settings": custom_settings,
+			"customsettings": custom_settings,  # Template compatibility
+			# Site domain for URL construction
+			"site_domain": _site_domain,
+			# UTM parameters for link tracking
+			"utm_params": utm_params or {},
+			# Footer context from CustomSetting, falling back to site domain when not set.
+			# This ensures footer links always reflect the domain the list is linked to.
 			"website_url": getattr(custom_settings, "website_url", "")
 			or _site_url_base,
 			"support_url": getattr(custom_settings, "support_url", ""),
@@ -686,14 +496,39 @@ class EmailRenderingPipeline:
 			"mastodon_url": getattr(custom_settings, "mastodon_url", ""),
 			"privacy_policy_url": getattr(custom_settings, "privacy_policy_url", ""),
 			"terms_url": getattr(custom_settings, "terms_url", ""),
+			# Organized content
+			"articles": organized_articles.get("featured_articles", []),
+			"additional_articles": organized_articles.get("regular_articles", []),
+			"trials": organized_trials.get("featured_trials", []),
+			"additional_trials": organized_trials.get("regular_trials", []),
+			# Content statistics for smart template logic
+			"content_stats": content_stats,
+			"has_high_confidence_articles": content_stats["high_confidence_articles"]
+			> 0,
+			"has_recruiting_trials": content_stats["recruiting_trials"] > 0,
+			# Performance metadata
+			"render_timestamp": timezone.now(),
+			"optimization_enabled": True,
 		}
 
-		# Add email-type specific context for fallback
+		# Add email-type specific context
 		if email_type == "weekly_summary":
-			base_context.update(
+			# Latest Research formatting only — the caller (send_weekly_summary)
+			# owns the filtering: sent-record exclusion, lookback window, and
+			# dedup against the main article list.
+			latest_research = {}
+			if latest_research_category_map:
+				latest_research = self.organizer.organize_latest_research_by_category(
+					latest_research_category_map
+				)
+
+			context.update(
 				{
-					"greeting_time": "morning",
+					"greeting_time": self._get_greeting_time(),
 					"user": subscriber,
+					"list": list_obj,
+					"title": getattr(custom_settings, "title", "Gregory AI"),
+					"latest_research": latest_research,
 				}
 			)
 
@@ -704,21 +539,75 @@ class EmailRenderingPipeline:
 			else:
 				admin_email = getattr(subscriber, "email", "admin@example.com")
 
-			base_context.update(
+			context.update(
 				{
 					"admin": admin_email,
 					"now": timezone.now(),
+					"list": list_obj,
+					"title": getattr(custom_settings, "title", "Gregory AI"),
 					"show_ml_predictions": True,
 					"show_admin_links": True,
 				}
 			)
 
 		elif email_type == "trial_notification":
-			base_context.update(
-				{"now": timezone.now(), "notification_type": "trial_update"}
+			context.update(
+				{
+					"now": timezone.now(),
+					"title": getattr(custom_settings, "title", "Gregory AI"),
+					"notification_type": "trial_update",
+				}
 			)
 
-		return base_context
+		logger.info(
+			f"Optimized context prepared for {email_type}: "
+			f"{content_stats['total_articles']} articles, "
+			f"{content_stats['total_trials']} trials"
+		)
+
+		# Build per-org content map for email templates
+		if organization is not None:
+			from gregory.models import ArticleOrgContent
+
+			all_email_articles = list(context.get("articles", [])) + list(
+				context.get("additional_articles", [])
+			)
+			for category_data in context.get("latest_research", {}).get(
+				"categories", []
+			):
+				all_email_articles.extend(category_data.get("articles", []))
+			article_ids = [
+				a.article_id for a in all_email_articles if hasattr(a, "article_id")
+			]
+			org_contents = {
+				oc.article_id: oc
+				for oc in ArticleOrgContent.objects.filter(
+					article_id__in=article_ids,
+					organization=organization,
+				)
+			}
+			context["org_content_map"] = org_contents
+		else:
+			_ORG_EXPECTED_TYPES = {"weekly_summary", "admin_summary"}
+			if email_type in _ORG_EXPECTED_TYPES:
+				logger.warning(
+					"prepare_optimized_context called without organization for email_type=%s; "
+					"org_content_map will be empty. Pass organization= for team-owned emails.",
+					email_type,
+				)
+			context["org_content_map"] = {}
+
+		return context
+
+	def _get_greeting_time(self):
+		"""Get appropriate greeting based on current time."""
+		current_hour = timezone.now().hour
+		if current_hour < 12:
+			return "morning"
+		elif current_hour < 17:
+			return "afternoon"
+		else:
+			return "evening"
 
 
 # Convenience functions for easy import by management commands

--- a/docs/subscriptions-audit-2026-07.md
+++ b/docs/subscriptions-audit-2026-07.md
@@ -270,6 +270,15 @@ above 30 and articles in the overlap are re-sent on every run indefinitely.
 Currently masked — all lists are at `lookback_days = 30` — so this is a
 configuration landmine rather than a live bug.
 
+**Status: closed 2026-07-28, as a side effect of the Latest Research fix
+(finding 8).** Flagged by PR review on the Latest Research change: reusing
+the same 30-day-capped sent-record exclusion for Latest Research made this
+landmine reachable through a second path. `send_weekly_summary`'s
+`threshold_date` is now `max(30, days_to_look_back)`, so the sent-record
+lookback is always at least as wide as the content lookback window, for both
+the main section and Latest Research. See
+`subscriptions/tests/test_latest_research_delta.py::SentRecordLookbackWindowTest`.
+
 ### 12. Announcements send synchronously inside the admin request
 
 `admin.py:1913`. Two problems:

--- a/docs/subscriptions-audit-2026-07.md
+++ b/docs/subscriptions-audit-2026-07.md
@@ -138,6 +138,14 @@ ordering, `content_stats.recruiting_trials` and `has_recruiting_trials`.
 templates already key off it — the organizer was never updated when the field
 landed. The fix is `recruitment_status_normalized == "recruiting"`.
 
+**Status: fixed 2026-07-28.** `organize_trials` now splits on
+`recruitment_status_normalized == "recruiting"`; a `NULL` normalized status
+(the normalizer didn't recognise the raw value) is treated as not-recruiting
+rather than guessed from the raw string. See
+[subscriptions.md](subscriptions.md#content-limits-and-staleness-filtering)
+and `subscriptions/tests/test_content_organizer_trials.py` (9 regression
+cases covering every misclassified raw string above).
+
 ### 5. Per-list `ml_threshold` is ignored by the organizer
 
 `prepare_optimized_context` accepts a `confidence_threshold` argument
@@ -147,6 +155,17 @@ The featured/regular split therefore always uses the hardcoded `0.8` from
 
 Article *selection* honours the list's `ml_threshold`; article *presentation*
 does not. A list configured at 0.6 or 0.9 silently gets 0.8 ordering.
+
+**Status: closed 2026-07-28, two different ways per email type** — see the
+design decision recorded in
+[subscriptions.md](subscriptions.md#featuredregular-article-split-design-decision-2026-07-28).
+The weekly digest's featured/regular split was invisible in the template (no
+heading or styling distinguished the two loops), so it was **deleted**
+outright rather than fixed: `_organize_weekly_articles` now always returns a
+single flat list, and `confidence_threshold` is moot for that email type. The
+admin summary's split drives real triage, so it was **fixed**:
+`send_admin_summary` now passes `confidence_threshold=admin_list.ml_threshold`.
+See `subscriptions/tests/test_admin_summary_relevance_scoping.py`.
 
 ### 6. Relevance checks are not scoped to the list's subjects
 
@@ -162,6 +181,19 @@ Confirmed against the dev DB: only 1 article is currently affected, because just
 two subjects have `auto_predict=True` and both belong to the same team. The blast
 radius grows with every subject that enables auto-prediction.
 
+**Status: partially closed 2026-07-28.** The two organizer methods are moot
+for the weekly digest (deleted along with the split, finding 5). For the
+admin summary, `_get_max_ml_score` was already correctly scoped —
+`send_admin_summary` prefetches `ml_predictions_detail` filtered to
+`subject__in=list_subjects` into `filtered_ml_predictions`, which the method
+prefers when present — confirmed by regression test rather than changed.
+**`Articles.is_ml_relevant_any_subject` (`send_weekly_summary.py:318`) is
+unchanged and still scans every `auto_predict` subject on the article, not
+just the list's own** — this bullet was not part of the P1 fix plan's scoped
+Task 5 (organizer methods only) and remains open. It affects weekly digest
+*selection* (which articles qualify), not presentation, so it survives the
+split's removal.
+
 ### 7. A blanket `except` turns any bug into a silently empty email
 
 `content_organizer.py:637` wraps the whole of `prepare_optimized_context`. On any
@@ -170,6 +202,16 @@ exception it returns `_get_fallback_context`, which has `articles: []` and no
 
 - The weekly digest then renders the "No New Content This Week" block (`weekly_summary.html:91`) and sends it.
 - `send_admin_summary.py:197` records every article in `new_articles` as sent regardless of what actually rendered, so one transient error permanently suppresses those articles for that subscriber.
+
+**Status: fixed 2026-07-28.** The blanket `except`/`_get_fallback_context` was
+deleted; `prepare_optimized_context` now lets exceptions propagate.
+`send_weekly_summary` and `send_admin_summary` each wrap their render call in
+their own `try/except`, recording a `FailedNotification` and skipping the
+send rather than mailing an empty digest or crashing the whole run. Both
+commands also gained a post-render guard: organizing to zero articles, zero
+trials (and, for the weekly digest, zero Latest Research items) skips the
+send with a logged `FailedNotification` instead of delivering nothing. See
+`subscriptions/tests/test_render_error_handling.py`.
 
 ### 8. The Latest Research section sits outside all the bookkeeping
 
@@ -182,6 +224,19 @@ articles per category, ignoring `lookback_days`. Those articles:
 - are excluded from `org_content_map` (built at `content_organizer.py:611` from the main lists only)
 - are excluded from `content_stats`
 - add unbounded weight to the payload, feeding finding 1
+
+**Status: fixed 2026-07-28.** Latest Research now implements the definition
+recorded in
+[subscriptions.md](subscriptions.md#latest-research-section-weekly-digest):
+new articles since the subscriber's last email, grouped by category, tracked
+through the same `SentArticleNotification` table as the main content. The
+section is built in `send_weekly_summary` (not inside the organizer, which
+now only formats a pre-filtered `{TeamCategory: [Articles]}` map), honours
+`lookback_days` as a floor, deduplicates against the main section per render
+attempt, flows through `render_within_limit`'s shrink loop, and is included in
+`org_content_map`. `content_stats` was deliberately left alone — no template
+displays a Latest Research count. See
+`subscriptions/tests/test_latest_research_delta.py`.
 
 ---
 

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -190,6 +190,82 @@ trial notification callers). The weekly digest passes its own resolved
 default, so `lookback_days` is now honoured for both articles and trials in
 that email — previously it only governed the articles query.
 
+**Featuring trials by recruitment status:** `EmailContentOrganizer.organize_trials`
+splits trials into `featured_trials` (recruiting) and `regular_trials`
+(everything else) by checking `Trials.recruitment_status_normalized ==
+"recruiting"`. It does not fall back to a substring match on the raw
+`recruitment_status` string, and does not guess when the normalized field is
+`NULL` (the normalizer didn't recognise the raw value) — a `NULL` normalized
+status is always treated as not-recruiting. This mirrors how `trial_card.html`
+and `trial_card_simple.html` already key their status colours off the same
+field. See [`docs/trials-field-normalization.md`](trials-field-normalization.md)
+for how raw registry strings map onto `recruitment_status_normalized`.
+
+---
+
+## Featured/Regular Article Split (Design Decision, 2026-07-28)
+
+Both `weekly_summary.html` and `admin_summary.html` used to receive articles
+pre-split into `articles` ("featured", high-confidence) and
+`additional_articles` ("regular", needs review), each rendered through the
+same component with the same parameters. In the weekly digest, that split had
+**no visual effect** — no heading, no styling difference distinguished the two
+loops — so it existed only to reorder articles, at the cost of a per-article
+manual-review/ML query (`EmailContentOrganizer._filter_high_confidence` /
+`_get_max_ml_score`) with N+1 characteristics.
+
+The two emails were resolved differently, because they serve different
+purposes:
+
+- **Weekly digest — split removed.** `EmailContentOrganizer._organize_weekly_articles`
+  now always returns a single flat list (`featured_articles` is always
+  empty), ordered by discovery date, matching what `article_sort_order='date'`
+  already did. Selection (which articles qualify) still happens in
+  `send_weekly_summary` before the organizer runs; its own priority ranking
+  (manual review + ML consensus, then date) still decides order when
+  `article_limit` truncation applies. This is a reading list, where the split
+  was invisible and the ordering barely mattered — subscribers see no change.
+- **Admin summary — split kept, made visible and correct.** The admin summary
+  exists so a human can triage, and "already high-confidence" versus "needs
+  review" is exactly the distinction that email is for. `admin_summary.html`
+  now renders separate "High-Confidence" and "Needs Review" section headings
+  so the split is no longer silent, and the ML threshold + subject-scoping
+  bugs below were fixed since the split is now load-bearing.
+
+---
+
+## Latest Research Section (Weekly Digest)
+
+Latest Research is **new articles since the subscriber's last email for that
+list, grouped by team category** — a delta, not a standing digest, and
+deliberately **articles-only**.
+
+- It shares the exact same bookkeeping as the main article section:
+  `SentArticleNotification` keyed on `(article, list, subscriber)`. An article
+  shown in either section is suppressed from both on the next run — the two
+  sections compete for the same items rather than drawing independently.
+- The candidate pool for a category is `TeamCategory.articles` (populated by
+  `rebuild_categories`), bounded by a lookback floor of the list's
+  `lookback_days` (or the `--days` CLI override), not a fixed 30 days.
+- Within a single email, an article that also matches the list's subjects
+  renders once, in the main section — the main section is selected first and
+  Latest Research is deduplicated against it.
+- The section is built in `send_weekly_summary`, not inside
+  `EmailContentOrganizer`: `organize_latest_research_by_category` is pure
+  formatting over a `{TeamCategory: [Articles]}` map the command hands it
+  (via `prepare_optimized_context(..., latest_research_category_map=...)`),
+  so it flows through `render_within_limit`'s shrink loop like the main
+  articles and trials, and its articles are included in `org_content_map`.
+- A digest list with no `latest_research_categories` configured, or a
+  category with no qualifying articles, simply omits the section
+  (`has_latest_research=False`).
+
+**Trials are excluded from this section by decision, not oversight.**
+`TeamCategory.trials` (`Trials.team_categories`, `related_name="trials"`) is a
+real, populated relation, and a future reader will notice it is unused here —
+that is intentional. A category whose only new content is trials contributes
+nothing to Latest Research.
+
 ---
 
 ## Bounce and Suppression Handling


### PR DESCRIPTION
## Summary

Closes P1 findings 4-8 from `docs/subscriptions-audit-2026-07.md`, following the plan in `subscriptions-p0-fix-plan.md`'s successor. Builds on the P0 fixes already merged (`f8cc70b4`).

- **Trial recruiting split (finding 4)**: `EmailContentOrganizer.organize_trials` now splits on `Trials.recruitment_status_normalized == "recruiting"` instead of a substring match on the raw string, which misclassified 58/99 trials currently reaching an email (e.g. `"Not Recruiting"` matched `"recruit"`). A `NULL` normalized status (unrecognised raw value) is treated as not-recruiting rather than guessed.
- **Blanket `except` (finding 7)**: removed the `except Exception` wrapping `prepare_optimized_context`, which silently mailed empty digests on any bug and let `send_admin_summary` mark unsent articles as sent. Both `send_weekly_summary` and `send_admin_summary` now catch render errors at the call site, record a `FailedNotification`, and skip the send; both also gained a post-render guard against organizing to zero content (backstop, not the primary path — the existing pre-render "nothing to send" skip still short-circuits first).
- **Latest Research delta (finding 8)**: now implements its intended definition — new articles since the subscriber's last email, grouped by category, tracked through the same `SentArticleNotification` table as the main content, honouring the list's `lookback_days`, deduplicated against the main section, and shrinkable by `render_within_limit` (extended to an optional 4-arg contract for this). Trials remain out of scope for this section by decision, not oversight.
- **Featured/regular split (findings 5 & 6)**: resolved differently per email, per the recorded design decision — **deleted** for the weekly digest (no visual effect in the template; existed only to reorder articles at the cost of a per-article ML/manual-review query) and **kept + fixed** for the admin summary, which drives real triage (`ml_threshold` is now threaded through instead of a hardcoded `0.8`; visible "High-Confidence"/"Needs Review" headings added).

## Out of scope (flagged as follow-up)

`Articles.is_ml_relevant_any_subject` still isn't scoped to a digest list's own subjects — part of the original finding 6, but explicitly outside the P1 plan's scoped fix (organizer methods only). Tracked separately.

## Test plan

- [x] `pytest subscriptions` — 311 passed (was 284 baseline before this branch's work)
- [x] Full `pytest` — 2799 passed
- [x] Every new regression test verified to fail against the pre-fix code before confirming it passes now
- [x] `ruff check django/` and `ruff format --check django/` clean on all touched files
- [x] `docs/subscriptions.md` records the split decision and the Latest Research definition
- [x] `docs/subscriptions-audit-2026-07.md` findings 4-8 annotated with fix status

🤖 Generated with [Claude Code](https://claude.com/claude-code)