### PR TITLE
Scope ML relevance check to digest list's own subjects

### DIFF
--- a/django/gregory/models.py
+++ b/django/gregory/models.py
@@ -778,17 +778,32 @@ class Articles(models.Model):
 			# Default to 'any' if unknown consensus type
 			return total_predictions >= 1
 
-	def is_ml_relevant_any_subject(self, threshold=0.8):
+	def is_ml_relevant_any_subject(self, threshold=0.8, subjects=None):
 		"""
 		Check if this article is ML-relevant for any of its associated subjects.
 
 		Args:
 			threshold: Minimum probability score required (default: 0.8)
+			subjects: Optional iterable/queryset of Subject instances to restrict
+				the check to. Callers evaluating relevance for a specific digest
+				list must pass that list's own subjects here -- otherwise an
+				article tagged with both the list's subject and an unrelated
+				team's auto_predict subject would be credited as relevant on the
+				strength of the unrelated subject's ML prediction. Defaults to
+				all of the article's auto_predict subjects when omitted.
 
 		Returns:
 			bool: True if article meets ML consensus criteria for at least one subject
 		"""
-		for subject in self.subjects.filter(auto_predict=True):
+		candidate_subjects = self.subjects.filter(auto_predict=True)
+		if subjects is not None:
+			subject_ids = (
+				subjects.values_list("pk", flat=True)
+				if hasattr(subjects, "values_list")
+				else [s.pk for s in subjects]
+			)
+			candidate_subjects = candidate_subjects.filter(pk__in=subject_ids)
+		for subject in candidate_subjects:
 			if self.is_ml_relevant_for_subject(subject, threshold):
 				return True
 		return False

--- a/django/gregory/tests/test_is_ml_relevant_any_subject_scoping.py
+++ b/django/gregory/tests/test_is_ml_relevant_any_subject_scoping.py
@@ -1,0 +1,97 @@
+"""Regression tests for Articles.is_ml_relevant_any_subject subject scoping.
+
+Without a `subjects` argument, is_ml_relevant_any_subject checks every
+auto_predict subject the article belongs to, regardless of which team owns
+it. A digest list must only be able to credit an article as ML-relevant on
+the strength of predictions for its *own* subjects -- an unrelated team's
+auto_predict subject should not leak relevance into a list that has nothing
+to do with it.
+"""
+
+from django.test import TestCase
+from organizations.models import Organization
+
+from gregory.models import Articles, MLPredictions, Subject, Team
+
+
+class IsMlRelevantAnySubjectScopingTestCase(TestCase):
+	def setUp(self):
+		org = Organization.objects.create(name="Scoping Test Org")
+		self.team_a = Team.objects.create(
+			organization=org, name="Team A", slug="scoping-team-a"
+		)
+		self.team_b = Team.objects.create(
+			organization=org, name="Team B", slug="scoping-team-b"
+		)
+		self.subject_a = Subject.objects.create(
+			subject_name="Subject A",
+			subject_slug="scoping-subject-a",
+			team=self.team_a,
+			auto_predict=True,
+			ml_consensus_type="any",
+		)
+		self.subject_b = Subject.objects.create(
+			subject_name="Subject B",
+			subject_slug="scoping-subject-b",
+			team=self.team_b,
+			auto_predict=True,
+			ml_consensus_type="any",
+		)
+
+	def test_unrelated_subject_prediction_excluded_when_scoped(self):
+		"""Article belongs to both subject_a and subject_b. Only subject_b has
+		a high-confidence ML prediction. A caller scoped to subject_a's own
+		list must not see this article as ML-relevant."""
+		article = Articles.objects.create(
+			title="Cross-team leak", link="https://example.com/scoping-1"
+		)
+		article.subjects.add(self.subject_a, self.subject_b)
+		MLPredictions.objects.create(
+			article=article,
+			subject=self.subject_b,
+			algorithm="pubmed_bert",
+			model_version="v1",
+			probability_score=0.95,
+			predicted_relevant=True,
+		)
+
+		# Scoped to subject_a only (e.g. a digest list owned by team A):
+		# subject_b's prediction must not leak in.
+		self.assertFalse(
+			article.is_ml_relevant_any_subject(threshold=0.8, subjects=[self.subject_a])
+		)
+
+		# Scoped to subject_b: the prediction is in scope, so it counts.
+		self.assertTrue(
+			article.is_ml_relevant_any_subject(threshold=0.8, subjects=[self.subject_b])
+		)
+
+		# Unscoped (default/back-compat behaviour): checks every auto_predict
+		# subject the article belongs to, so it's still relevant.
+		self.assertTrue(article.is_ml_relevant_any_subject(threshold=0.8))
+
+	def test_scoping_accepts_queryset(self):
+		"""subjects may be passed as a queryset (e.g. digest_list.subjects.all()),
+		not just a list of instances."""
+		article = Articles.objects.create(
+			title="Queryset scoping", link="https://example.com/scoping-2"
+		)
+		article.subjects.add(self.subject_a, self.subject_b)
+		MLPredictions.objects.create(
+			article=article,
+			subject=self.subject_b,
+			algorithm="pubmed_bert",
+			model_version="v1",
+			probability_score=0.95,
+			predicted_relevant=True,
+		)
+
+		team_a_subjects = Subject.objects.filter(team=self.team_a)
+		self.assertFalse(
+			article.is_ml_relevant_any_subject(threshold=0.8, subjects=team_a_subjects)
+		)
+
+		team_b_subjects = Subject.objects.filter(team=self.team_b)
+		self.assertTrue(
+			article.is_ml_relevant_any_subject(threshold=0.8, subjects=team_b_subjects)
+		)

--- a/django/subscriptions/management/commands/send_weekly_summary.py
+++ b/django/subscriptions/management/commands/send_weekly_summary.py
@@ -292,9 +292,10 @@ class Command(BaseCommand):
 							f"RELEVANCY SORT MODE: Using ML consensus logic with threshold={threshold}"
 						)
 					)
+				list_subjects = digest_list.subjects.all()
 				base_subject_articles = (
 					Articles.objects.filter(
-						subjects__in=digest_list.subjects.all(),
+						subjects__in=list_subjects,
 						discovery_date__gte=now() - timedelta(days=days_to_look_back),
 					)
 					.order_by("-discovery_date")
@@ -312,8 +313,8 @@ class Command(BaseCommand):
 
 				# Then, get manually reviewed articles (only those tagged as relevant for at least one subject)
 				manual_reviewed = Articles.objects.filter(
-					subjects__in=digest_list.subjects.all(),
-					article_subject_relevances__subject__in=digest_list.subjects.all(),
+					subjects__in=list_subjects,
+					article_subject_relevances__subject__in=list_subjects,
 					article_subject_relevances__is_relevant=True,
 					discovery_date__gte=now() - timedelta(days=days_to_look_back),
 				).distinct()
@@ -323,11 +324,10 @@ class Command(BaseCommand):
 					)
 				)
 
-				# Get articles that are ML-relevant based on new consensus logic
+				# Get articles that are ML-relevant based on new consensus logic.
 				# Scoped to this list's own subjects so an article tagged with an
 				# unrelated team's auto_predict subject can't ride in on that
 				# subject's ML prediction.
-				list_subjects = digest_list.subjects.all()
 				ml_relevant_articles = []
 				for article in subject_articles:
 					if article.is_ml_relevant_any_subject(

--- a/django/subscriptions/management/commands/send_weekly_summary.py
+++ b/django/subscriptions/management/commands/send_weekly_summary.py
@@ -324,9 +324,15 @@ class Command(BaseCommand):
 				)
 
 				# Get articles that are ML-relevant based on new consensus logic
+				# Scoped to this list's own subjects so an article tagged with an
+				# unrelated team's auto_predict subject can't ride in on that
+				# subject's ML prediction.
+				list_subjects = digest_list.subjects.all()
 				ml_relevant_articles = []
 				for article in subject_articles:
-					if article.is_ml_relevant_any_subject(threshold=threshold):
+					if article.is_ml_relevant_any_subject(
+						threshold=threshold, subjects=list_subjects
+					):
 						ml_relevant_articles.append(article.article_id)
 
 				ml_predicted = Articles.objects.filter(pk__in=ml_relevant_articles)


### PR DESCRIPTION
## Summary
- `Articles.is_ml_relevant_any_subject()` iterated *every* `auto_predict` subject an article belonged to, with no scoping to the caller's own subjects. In `send_weekly_summary`'s RELEVANCY SORT MODE, this meant an article tagged with both a digest list's own subject and an unrelated team's `auto_predict` subject could be marked "relevant" purely on the strength of the unrelated subject's ML prediction.
- Documented as finding 6 in `docs/subscriptions-audit-2026-07.md`; the earlier P1 fix scoped `content_organizer.py`'s `_filter_high_confidence`/`_get_max_ml_score` but explicitly left this model method untouched.
- Adds an optional `subjects` parameter to `is_ml_relevant_any_subject` (defaults to `None` → old unscoped behavior, so no other callers break) and updates `send_weekly_summary.py` to pass `digest_list.subjects.all()`.
- Only two subjects have `auto_predict=True` today and both belong to the same team, so there's no live leak yet — but the blast radius grows with every new auto-predict subject, so this closes the gap before it bites.

## Test plan
- [x] Added `django/gregory/tests/test_is_ml_relevant_any_subject_scoping.py` — regression test proving an article whose only qualifying ML prediction is for a subject outside the scoped set is excluded, while remaining relevant when unscoped (back-compat) or scoped to the correct subject; also covers passing a queryset.
- [x] Ran full `gregory` + `subscriptions` test suites (1521 tests) against this worktree in a throwaway container — all passing, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)