### PR TITLE
P3 subscriptions performance fixes + announcement confirm-count fix

### DIFF
--- a/django/subscriptions/admin.py
+++ b/django/subscriptions/admin.py
@@ -2000,11 +2000,32 @@ class AnnouncementAdmin(admin.ModelAdmin):
 			)
 
 		# GET — show confirmation page
+		# Mirror send_announcement()'s skip rule: a subscriber with a
+		# successful AnnouncementRecipient row for this announcement won't
+		# be mailed again, so the confirm page's counts (and the button
+		# label) must reflect that split rather than the raw audience —
+		# otherwise a resumed announcement overstates how many people will
+		# actually receive it (see docs/subscriptions.md).
+		already_sent_subscriber_ids = set(
+			AnnouncementRecipient.objects.filter(
+				announcement=announcement, success=True
+			).values_list("subscriber_id", flat=True)
+		)
+		new_recipients_count = 0
+		already_received_count = 0
+		for sub, _lst in all_subscribers.values():
+			if sub.subscriber_id in already_sent_subscriber_ids:
+				already_received_count += 1
+			else:
+				new_recipients_count += 1
+
 		context = {
 			**self.admin_site.each_context(request),
 			"announcement": announcement,
 			"list_info": list_info,
 			"total_subscribers": len(all_subscribers),
+			"new_recipients_count": new_recipients_count,
+			"already_received_count": already_received_count,
 			"title": f"Confirm Send: {announcement.subject}",
 			"opts": self.model._meta,
 		}

--- a/django/subscriptions/management/commands/send_admin_summary.py
+++ b/django/subscriptions/management/commands/send_admin_summary.py
@@ -105,7 +105,8 @@ class Command(BaseCommand):
 					"ml_predictions_detail",
 					queryset=MLPredictions.objects.filter(subject__in=list_subjects),
 					to_attr="filtered_ml_predictions",
-				)
+				),
+				"authors",
 			)
 
 			list_trials = get_trials_for_list(admin_list, days=admin_list.lookback_days)

--- a/django/subscriptions/management/commands/send_weekly_summary.py
+++ b/django/subscriptions/management/commands/send_weekly_summary.py
@@ -1,6 +1,7 @@
 import logging
 import requests
 from datetime import timedelta
+from django.db.models import prefetch_related_objects
 from django.utils.timezone import now
 from django.core.management.base import BaseCommand
 from django.template.loader import get_template
@@ -499,7 +500,12 @@ class Command(BaseCommand):
 					).values_list("pk", flat=True)
 				)
 				article_priority_scores = {}
-				for article in articles.prefetch_related(
+				# `articles` already carries a prefetch_related("authors") from
+				# its construction above; scoring doesn't touch authors at
+				# all, so clear that lookup before adding the ones this loop
+				# actually needs rather than fetching authors data nobody
+				# reads here.
+				for article in articles.prefetch_related(None).prefetch_related(
 					"subjects", "ml_predictions_detail"
 				):
 					priority_score = 0
@@ -666,17 +672,33 @@ class Command(BaseCommand):
 						# article_priority_scores, computed once per list above —
 						# they don't vary by subscriber, only which articles in
 						# unsent_articles are still eligible does.
-						article_priorities = [
-							(article, article_priority_scores.get(article.pk, 0))
-							for article in unsent_articles
-						]
-
-						article_priorities.sort(
-							key=lambda x: (-x[1], -x[0].discovery_date.timestamp())
+						#
+						# Rank using (pk, discovery_date) only, not full Article
+						# instances: `articles` (and therefore `unsent_articles`)
+						# carries a prefetch_related("authors") from the queryset
+						# construction above, and materializing every candidate
+						# as a model instance here would prefetch authors for
+						# the *entire* per-subscriber candidate pool even though
+						# only article_limit articles are ever rendered. Only
+						# the selected top-N get that prefetch, applied below.
+						ranked_pks = sorted(
+							unsent_articles.values_list("pk", "discovery_date"),
+							key=lambda row: (
+								-article_priority_scores.get(row[0], 0),
+								-row[1].timestamp(),
+							),
 						)
-						limited_articles = [
-							item[0] for item in article_priorities[:article_limit]
-						]
+						limited_pks = [pk for pk, _ in ranked_pks[:article_limit]]
+						articles_by_pk = {
+							a.pk: a for a in Articles.objects.filter(pk__in=limited_pks)
+						}
+						prefetch_related_objects(
+							list(articles_by_pk.values()), "authors"
+						)
+						# Preserve rank order for the debug preview below — the
+						# organizer always re-sorts by discovery_date for the
+						# actual render, so this ordering only matters here.
+						limited_articles = [articles_by_pk[pk] for pk in limited_pks]
 						self.stdout.write(
 							self.style.WARNING(
 								f"WARNING: List '{digest_list.list_name}' had {articles_count} articles in the "
@@ -690,9 +712,10 @@ class Command(BaseCommand):
 									f"Applied article limit: showing {article_limit} highest-priority articles (manual + ML consensus >= {threshold}) out of {articles_count} available"
 								)
 							)
-							for i, (article, score) in enumerate(
-								article_priorities[: min(5, article_limit)]
+							for i, article in enumerate(
+								limited_articles[: min(5, article_limit)]
 							):
+								score = article_priority_scores.get(article.pk, 0)
 								manual_flag = (
 									"✓"
 									if article.pk in manual_relevant_ids_all

--- a/django/subscriptions/management/commands/send_weekly_summary.py
+++ b/django/subscriptions/management/commands/send_weekly_summary.py
@@ -250,8 +250,10 @@ class Command(BaseCommand):
 				filtered_pks = self._filter_articles_excluding_all_irrelevant(
 					base_articles, digest_list
 				)
-				articles = Articles.objects.filter(pk__in=filtered_pks).order_by(
-					"-discovery_date"
+				articles = (
+					Articles.objects.filter(pk__in=filtered_pks)
+					.order_by("-discovery_date")
+					.prefetch_related("authors")
 				)
 				self.stdout.write(
 					self.style.NOTICE(
@@ -278,8 +280,10 @@ class Command(BaseCommand):
 				filtered_pks = self._filter_articles_excluding_all_irrelevant(
 					base_articles, digest_list
 				)
-				articles = Articles.objects.filter(pk__in=filtered_pks).order_by(
-					"-discovery_date"
+				articles = (
+					Articles.objects.filter(pk__in=filtered_pks)
+					.order_by("-discovery_date")
+					.prefetch_related("authors")
 				)
 				self.stdout.write(
 					self.style.NOTICE(
@@ -428,7 +432,11 @@ class Command(BaseCommand):
 					list(manual_reviewed.values_list("pk", flat=True))
 					+ ml_relevant_articles
 				)
-				articles = Articles.objects.filter(pk__in=article_ids).distinct()
+				articles = (
+					Articles.objects.filter(pk__in=article_ids)
+					.distinct()
+					.prefetch_related("authors")
+				)
 				self.stdout.write(
 					self.style.NOTICE(
 						f"Filtered by manual review or ML consensus (>= {threshold}): {articles.count()} articles"
@@ -472,6 +480,44 @@ class Command(BaseCommand):
 					)
 				)
 				continue
+
+			# Relevancy-mode article priority scores (manual review + ML
+			# consensus count) depend only on the article and this list's
+			# threshold — never on the subscriber. Computing them here, once
+			# per list, and reusing the lookup below avoids redoing ~2
+			# queries per candidate article for every subscriber: measured
+			# at ~2,440 queries and ~0.8s per subscriber against MS Weekly
+			# Digest's 1,219-article candidate pool (audit P3, task 5) —
+			# roughly 70s across that list's 88 subscribers for identical
+			# results every time, since none of this varies by recipient.
+			article_priority_scores = None
+			if not all_articles and sort_order == "relevancy":
+				manual_relevant_ids_all = set(
+					Articles.objects.filter(
+						pk__in=articles.values_list("pk", flat=True),
+						article_subject_relevances__is_relevant=True,
+					).values_list("pk", flat=True)
+				)
+				article_priority_scores = {}
+				for article in articles.prefetch_related(
+					"subjects", "ml_predictions_detail"
+				):
+					priority_score = 0
+					if article.pk in manual_relevant_ids_all:
+						priority_score += 1000
+					for subject in article.subjects.all():
+						if not subject.auto_predict:
+							continue
+						relevant_algorithms = {
+							p.algorithm
+							for p in article.ml_predictions_detail.all()
+							if p.subject_id == subject.pk
+							and p.predicted_relevant
+							and p.probability_score is not None
+							and p.probability_score >= threshold
+						}
+						priority_score += len(relevant_algorithms) * 100
+					article_priority_scores[article.pk] = priority_score
 
 			# Step 4: Find subscribers of the list (respect per-list opt-out)
 			subscribers = Subscribers.objects.filter(
@@ -615,30 +661,15 @@ class Command(BaseCommand):
 								)
 							)
 					else:
-						# Relevancy mode: order by manual relevance first, then ML consensus count, then date
-						manual_relevant_ids = set(
-							Articles.objects.filter(
-								pk__in=[a.pk for a in unsent_articles],
-								article_subject_relevances__is_relevant=True,
-							).values_list("pk", flat=True)
-						)
-
-						article_priorities = []
-						for article in unsent_articles:
-							priority_score = 0
-							if article.pk in manual_relevant_ids:
-								priority_score += 1000
-							for subject in article.subjects.filter(auto_predict=True):
-								predictions = article.ml_predictions_detail.filter(
-									subject=subject,
-									predicted_relevant=True,
-									probability_score__gte=threshold,
-								).values_list("algorithm", flat=True)
-								relevant_count = (
-									len(set(predictions)) if predictions else 0
-								)
-								priority_score += relevant_count * 100
-							article_priorities.append((article, priority_score))
+						# Relevancy mode: order by manual relevance first, then ML
+						# consensus count, then date. Scores come from
+						# article_priority_scores, computed once per list above —
+						# they don't vary by subscriber, only which articles in
+						# unsent_articles are still eligible does.
+						article_priorities = [
+							(article, article_priority_scores.get(article.pk, 0))
+							for article in unsent_articles
+						]
 
 						article_priorities.sort(
 							key=lambda x: (-x[1], -x[0].discovery_date.timestamp())
@@ -663,7 +694,9 @@ class Command(BaseCommand):
 								article_priorities[: min(5, article_limit)]
 							):
 								manual_flag = (
-									"✓" if article.pk in manual_relevant_ids else "✗"
+									"✓"
+									if article.pk in manual_relevant_ids_all
+									else "✗"
 								)
 								self.stdout.write(
 									self.style.NOTICE(

--- a/django/subscriptions/tests/test_admin_summary_authors_prefetch.py
+++ b/django/subscriptions/tests/test_admin_summary_authors_prefetch.py
@@ -1,0 +1,129 @@
+"""
+Same regression as test_weekly_summary_authors_prefetch.py, for
+send_admin_summary: `list_articles` must prefetch `authors` alongside the
+existing `filtered_ml_predictions` Prefetch, or article_limit truncation
+turns the queryset into a plain list and article_card.html's
+`article.authors.exists()` / `.all()` cost two queries per article.
+
+This runs the real `send_admin_summary` command (not a reimplementation of
+its queryset construction, which would pass trivially regardless of what the
+command itself does) and counts only the queries that touch the authors
+relation, ignoring the command's other, unrelated per-article costs — the
+SentArticleNotification write loop (a real O(N) cost: it must write one row
+per article) and the pre-existing `ml_predictions_detail.exists()` template
+fallback (a separate bug, out of this test's scope). Filtering to
+authors/articles_authors keeps the assertion about exactly what task 1
+changed.
+"""
+
+import os
+from io import StringIO
+from unittest.mock import patch, MagicMock
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+
+import django
+
+django.setup()
+
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from gregory.models import Articles, Authors, Subject, Team
+from organizations.models import Organization
+from sitesettings.models import CustomSetting
+from subscriptions.models import Lists, Subscribers
+
+
+class AdminSummaryAuthorsPrefetchTest(TestCase):
+	def setUp(self):
+		self.organization = Organization.objects.create(
+			name="Admin Prefetch Org", slug="admin-prefetch-org"
+		)
+		self.team = Team.objects.create(
+			name="Admin Prefetch Team",
+			organization=self.organization,
+			slug="admin-prefetch-team",
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Admin Prefetch Subject",
+			team=self.team,
+			subject_slug="admin-prefetch-subject",
+		)
+		self.site = Site.objects.get_or_create(
+			id=1, defaults={"domain": "testserver", "name": "Test Site"}
+		)[0]
+		CustomSetting.objects.get_or_create(
+			site=self.site,
+			defaults={
+				"title": "Test Site",
+				"postmark_api_token": "test-token",
+				"postmark_api_url": "https://api.postmarkapp.com/email",
+			},
+		)
+
+		self.admin_list = Lists.objects.create(
+			list_name="Admin Prefetch List",
+			admin_summary=True,
+			team=self.team,
+			article_limit=15,
+			lookback_days=30,
+			list_email_subject="Admin Prefetch",
+		)
+		self.admin_list.subjects.add(self.subject)
+
+		self.subscriber = Subscribers.objects.create(
+			first_name="Admin",
+			last_name="Prefetch",
+			email="admin-prefetch@example.com",
+			active=True,
+		)
+		self.subscriber.subscriptions.add(self.admin_list)
+
+		# One more article than article_limit forces the truncate-to-list
+		# step (send_admin_summary.py: `new_articles = list(new_articles...
+		# [:article_limit])`) — the exact step that drops the organizer's
+		# own prefetch attempt, since a plain list has no
+		# `prefetch_related` method.
+		for i in range(16):
+			article = Articles.objects.create(
+				title=f"Article {i}",
+				doi=f"10.9998/authors-prefetch-{i}",
+				link=f"https://example.com/authors-prefetch-{i}",
+			)
+			article.subjects.add(self.subject)
+			author = Authors.objects.create(given_name="John", family_name=f"Roe{i}")
+			article.authors.add(author)
+
+	def test_authors_queries_do_not_scale_with_article_count(self):
+		mock_result = MagicMock(status_code=200)
+		mock_result.json.return_value = {"ErrorCode": 0, "Message": "OK"}
+		with patch(
+			"subscriptions.management.commands.send_admin_summary.send_email",
+			return_value=mock_result,
+		):
+			with CaptureQueriesContext(connection) as ctx:
+				call_command("send_admin_summary", stdout=StringIO())
+
+		authors_queries = [
+			q
+			for q in ctx.captured_queries
+			if "authors" in q["sql"]
+			and "sentarticlenotification" not in q["sql"].lower()
+		]
+
+		# 15 articles are rendered (article_limit=15 out of 16 available).
+		# A single batched prefetch issues one query total, regardless of
+		# article count; the pre-fix bug issued two per article
+		# (`.exists()` + `.all()`), i.e. ~30 here.
+		self.assertLessEqual(
+			len(authors_queries),
+			2,
+			"Query count against the authors relation scales with article "
+			"count — the authors prefetch is not surviving article_limit "
+			"truncation in send_admin_summary:\n"
+			+ "\n".join(q["sql"][:250] for q in authors_queries),
+		)

--- a/django/subscriptions/tests/test_announcement_confirm_count.py
+++ b/django/subscriptions/tests/test_announcement_confirm_count.py
@@ -1,0 +1,112 @@
+from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
+from django.test import TestCase, Client
+from django.urls import reverse
+
+from organizations.models import Organization
+from gregory.models import Team
+from subscriptions.models import (
+	Announcement,
+	AnnouncementRecipient,
+	Lists,
+	ListSubscription,
+	Subscribers,
+)
+
+
+class AnnouncementConfirmCountTest(TestCase):
+	"""The GET confirm page must report how many subscribers will actually
+	be mailed (post-skip), not the raw list audience — send_announcement()
+	skips anyone with a successful AnnouncementRecipient row already, so the
+	button and the operator-facing count need to agree with that."""
+
+	@classmethod
+	def setUpTestData(cls):
+		cls.superuser = User.objects.create_superuser(
+			username="confirm_admin",
+			password="password",
+			email="confirm_admin@example.com",
+		)
+		cls.org = Organization.objects.create(name="Confirm Org")
+		cls.team = Team.objects.create(
+			organization=cls.org, name="Confirm Team", slug="confirm-team"
+		)
+		cls.site = Site.objects.get_or_create(
+			id=30, defaults={"domain": "confirm.example.com", "name": "Confirm"}
+		)[0]
+		cls.lst = Lists.objects.create(
+			list_name="Confirm List", team=cls.team, site=cls.site
+		)
+
+	def setUp(self):
+		self.client = Client()
+		self.client.force_login(self.superuser)
+
+	def _confirm_url(self, pk):
+		return reverse("admin:subscriptions_announcement_send", args=[pk])
+
+	def _make_subscriber(self, email):
+		sub = Subscribers.objects.create(
+			first_name="Sub", last_name=email, email=email, active=True
+		)
+		ListSubscription.objects.create(subscriber=sub, list=self.lst, is_active=True)
+		return sub
+
+	def _make_announcement(self):
+		ann = Announcement.objects.create(
+			subject="Confirm Count Test",
+			body="<p>Body</p>",
+			status="failed",
+			organization=self.org,
+		)
+		ann.lists.add(self.lst)
+		return ann
+
+	def test_no_prior_recipients_reports_full_audience(self):
+		self._make_subscriber("new1@example.com")
+		self._make_subscriber("new2@example.com")
+		ann = self._make_announcement()
+
+		response = self.client.get(self._confirm_url(ann.pk))
+
+		self.assertEqual(response.context["total_subscribers"], 2)
+		self.assertEqual(response.context["new_recipients_count"], 2)
+		self.assertEqual(response.context["already_received_count"], 0)
+
+	def test_prior_successful_recipients_are_excluded_from_new_count(self):
+		already_sent = self._make_subscriber("already@example.com")
+		self._make_subscriber("pending@example.com")
+		ann = self._make_announcement()
+		AnnouncementRecipient.objects.create(
+			announcement=ann,
+			subscriber=already_sent,
+			list=self.lst,
+			success=True,
+		)
+
+		response = self.client.get(self._confirm_url(ann.pk))
+
+		self.assertEqual(response.context["total_subscribers"], 2)
+		self.assertEqual(response.context["new_recipients_count"], 1)
+		self.assertEqual(response.context["already_received_count"], 1)
+		self.assertContains(response, "Queue Send to 1 Subscriber")
+
+	def test_failed_prior_attempt_still_counts_as_new(self):
+		"""A non-successful AnnouncementRecipient row (a genuine delivery
+		failure, not a skip) must NOT be treated as already-received —
+		only success=True rows represent a subscriber who was actually
+		mailed."""
+		retry_target = self._make_subscriber("retry@example.com")
+		ann = self._make_announcement()
+		AnnouncementRecipient.objects.create(
+			announcement=ann,
+			subscriber=retry_target,
+			list=self.lst,
+			success=False,
+			error_message="Connection error: timeout",
+		)
+
+		response = self.client.get(self._confirm_url(ann.pk))
+
+		self.assertEqual(response.context["new_recipients_count"], 1)
+		self.assertEqual(response.context["already_received_count"], 0)

--- a/django/subscriptions/tests/test_trial_notification_articles_unreachable.py
+++ b/django/subscriptions/tests/test_trial_notification_articles_unreachable.py
@@ -1,0 +1,45 @@
+from django.contrib.sites.models import Site
+from django.test import TestCase
+
+from templates.emails.components.content_organizer import (
+	EmailContentOrganizer,
+	get_optimized_email_context,
+)
+
+
+class TrialNotificationNeverReceivesArticlesTest(TestCase):
+	"""send_trials_notification never passes articles= to
+	get_optimized_email_context (it only builds a trials context), so the
+	organizer's own has_articles check short-circuits before dispatching to
+	any email-type-specific article organizer. This pins that behaviour so
+	EmailContentOrganizer._organize_trial_notification_articles (and the
+	_filter_high_confidence helper it alone used) can be deleted as dead
+	code without silently changing what trial notification emails contain."""
+
+	@classmethod
+	def setUpTestData(cls):
+		cls.site = Site.objects.get_or_create(
+			id=40, defaults={"domain": "trialnotif.example.com", "name": "TN"}
+		)[0]
+
+	def test_no_articles_kwarg_yields_empty_article_lists(self):
+		context = get_optimized_email_context(
+			email_type="trial_notification",
+			trials=None,
+			site=self.site,
+		)
+		self.assertEqual(context["articles"], [])
+		self.assertEqual(context["additional_articles"], [])
+
+	def test_organize_articles_short_circuits_before_dispatch(self):
+		"""Directly exercises EmailContentOrganizer.organize_articles the way
+		prepare_optimized_context calls it for a trial_notification with no
+		articles: the empty-queryset early exit must fire before any
+		email-type-specific branch runs."""
+		from gregory.models import Articles
+
+		organizer = EmailContentOrganizer(email_type="trial_notification")
+		result = organizer.organize_articles(Articles.objects.none())
+		self.assertEqual(result["featured_articles"], [])
+		self.assertEqual(result["regular_articles"], [])
+		self.assertEqual(result["total_count"], 0)

--- a/django/subscriptions/tests/test_weekly_summary_authors_prefetch.py
+++ b/django/subscriptions/tests/test_weekly_summary_authors_prefetch.py
@@ -1,0 +1,138 @@
+"""
+Regression test for the authors N+1 described in subscriptions-audit-2026-07.md
+(P3, finding: content_organizer.py:437's prefetch guard is skipped once
+article_limit truncation turns the article queryset into a plain list).
+
+`{% if article.authors.exists %}` / `{% for author in article.authors.all %}`
+in article_card.html cost two queries per article, per subscriber, unless
+`authors` was prefetched on the queryset BEFORE it was sliced/listified.
+send_weekly_summary must prefetch at the point it builds the `articles`
+queryset, not rely on content_organizer's own attempt (which only ever sees
+whatever it's handed, and can't recover once that's already a list).
+
+The test forces article_limit truncation (article_limit < available
+articles) in two lists of different sizes, and asserts total query count
+does not grow proportionally with the number of articles actually rendered
+— an O(N) growth is exactly the bug, since it means authors are being
+fetched one query at a time instead of via a single prefetch.
+"""
+
+import os
+from io import StringIO
+from unittest.mock import patch, MagicMock
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+
+import django
+
+django.setup()
+
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from gregory.models import Articles, Authors, Subject, Team
+from organizations.models import Organization
+from sitesettings.models import CustomSetting
+from subscriptions.models import Lists, Subscribers
+
+
+class WeeklySummaryAuthorsPrefetchTest(TestCase):
+	def setUp(self):
+		self.organization = Organization.objects.create(
+			name="Prefetch Org", slug="prefetch-org"
+		)
+		self.team = Team.objects.create(
+			name="Prefetch Team",
+			organization=self.organization,
+			slug="prefetch-team",
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Prefetch Subject",
+			team=self.team,
+			subject_slug="prefetch-subject",
+		)
+		self.site = Site.objects.get_or_create(
+			id=1, defaults={"domain": "testserver", "name": "Test Site"}
+		)[0]
+		CustomSetting.objects.get_or_create(
+			site=self.site,
+			defaults={
+				"title": "Test Site",
+				"postmark_api_token": "test-token",
+				"postmark_api_url": "https://api.postmarkapp.com/email",
+			},
+		)
+
+	def _make_list_with_articles(self, name, article_limit, article_count):
+		"""A digest list truncated to `article_limit`, with `article_count`
+		available articles (> article_limit, so truncation always fires and
+		the vulnerable list-conversion path is always exercised) each
+		carrying one author."""
+		digest_list = Lists.objects.create(
+			list_name=name,
+			weekly_digest=True,
+			team=self.team,
+			article_sort_order="date",
+			article_limit=article_limit,
+			lookback_days=30,
+			list_email_subject=f"{name} Weekly",
+		)
+		digest_list.subjects.add(self.subject)
+
+		subscriber = Subscribers.objects.create(
+			first_name="Sub",
+			last_name=name,
+			email=f"{name.lower().replace(' ', '-')}@example.com",
+			active=True,
+		)
+		subscriber.subscriptions.add(digest_list)
+
+		for i in range(article_count):
+			article = Articles.objects.create(
+				title=f"{name} Article {i}",
+				doi=f"10.9999/{name.lower()}-{i}",
+				link=f"https://example.com/{name.lower()}-{i}",
+			)
+			article.subjects.add(self.subject)
+			author = Authors.objects.create(given_name="Jane", family_name=f"Doe{i}")
+			article.authors.add(author)
+
+		return digest_list
+
+	def _run_and_count_queries(self):
+		mock_result = MagicMock(status_code=200)
+		mock_result.json.return_value = {"ErrorCode": 0, "Message": "OK"}
+		with patch(
+			"subscriptions.management.commands.send_weekly_summary.send_email",
+			return_value=mock_result,
+		):
+			with CaptureQueriesContext(connection) as ctx:
+				call_command("send_weekly_summary", stdout=StringIO(), dry_run=True)
+		return len(ctx.captured_queries)
+
+	def test_query_count_does_not_scale_with_rendered_article_count(self):
+		self._make_list_with_articles("Small List", article_limit=3, article_count=4)
+		small_queries = self._run_and_count_queries()
+
+		Lists.objects.all().delete()
+		Subscribers.objects.all().delete()
+		Articles.objects.all().delete()
+		Authors.objects.all().delete()
+
+		self._make_list_with_articles("Large List", article_limit=15, article_count=16)
+		large_queries = self._run_and_count_queries()
+
+		# Rendering 15 articles instead of 3 must not cost ~2 extra queries
+		# per additional article (the N+1). A small constant overhead is
+		# fine; anything close to 2 * (15 - 3) = 24 means the authors
+		# prefetch isn't surviving truncation.
+		self.assertLess(
+			large_queries - small_queries,
+			10,
+			f"Query count scaled with article count (small={small_queries}, "
+			f"large={large_queries}) — authors prefetch is not surviving "
+			f"article_limit truncation.",
+		)

--- a/django/subscriptions/tests/test_weekly_summary_priority_scores_shared.py
+++ b/django/subscriptions/tests/test_weekly_summary_priority_scores_shared.py
@@ -1,0 +1,141 @@
+"""
+Regression test for the per-subscriber priority-scoring loop measured in
+subscriptions-audit-2026-07.md (P3, task 5): send_weekly_summary's relevancy
+mode used to recompute each candidate article's manual-review + ML-consensus
+priority score inside the per-subscriber loop, even though none of those
+inputs depend on the subscriber — only the candidate set (which articles are
+still unsent) does. Measured against the real MS Weekly Digest list in the
+dev DB: ~2,440 queries and ~0.8s per subscriber for a 1,219-article candidate
+pool, repeating identical work 88 times.
+
+This pins the fix (article_priority_scores computed once per list) by
+asserting total query count does not scale with subscriber count when
+relevancy-mode truncation is forced for every subscriber.
+"""
+
+import os
+from io import StringIO
+from unittest.mock import patch, MagicMock
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+
+import django
+
+django.setup()
+
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from gregory.models import ArticleSubjectRelevance, Articles, Subject, Team
+from organizations.models import Organization
+from sitesettings.models import CustomSetting
+from subscriptions.models import Lists, Subscribers
+
+
+class WeeklySummaryPriorityScoresSharedTest(TestCase):
+	def setUp(self):
+		self.organization = Organization.objects.create(
+			name="Priority Org", slug="priority-org"
+		)
+		self.team = Team.objects.create(
+			name="Priority Team",
+			organization=self.organization,
+			slug="priority-team",
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Priority Subject",
+			team=self.team,
+			subject_slug="priority-subject",
+			auto_predict=True,
+		)
+		self.site = Site.objects.get_or_create(
+			id=1, defaults={"domain": "testserver", "name": "Test Site"}
+		)[0]
+		CustomSetting.objects.get_or_create(
+			site=self.site,
+			defaults={
+				"title": "Test Site",
+				"postmark_api_token": "test-token",
+				"postmark_api_url": "https://api.postmarkapp.com/email",
+			},
+		)
+
+		# article_limit < article count forces the relevancy-mode priority
+		# scoring / truncation branch for every subscriber.
+		self.digest_list = Lists.objects.create(
+			list_name="Priority Digest",
+			weekly_digest=True,
+			team=self.team,
+			article_sort_order="relevancy",
+			article_limit=3,
+			lookback_days=30,
+			list_email_subject="Priority Weekly",
+		)
+		self.digest_list.subjects.add(self.subject)
+
+		for i in range(6):
+			article = Articles.objects.create(
+				title=f"Article {i}",
+				doi=f"10.9997/priority-{i}",
+				link=f"https://example.com/priority-{i}",
+			)
+			article.subjects.add(self.subject)
+			# Manually-reviewed relevance is enough to make the article a
+			# relevancy-mode candidate without needing full ML consensus
+			# fixtures, and it's exactly one of the two inputs the
+			# priority score is built from.
+			ArticleSubjectRelevance.objects.create(
+				article=article, subject=self.subject, is_relevant=True
+			)
+
+	def _add_subscribers(self, count):
+		for i in range(count):
+			sub = Subscribers.objects.create(
+				first_name="Sub",
+				last_name=str(i),
+				email=f"priority-sub-{i}@example.com",
+				active=True,
+			)
+			sub.subscriptions.add(self.digest_list)
+
+	def _run_and_count_queries(self):
+		mock_result = MagicMock(status_code=200)
+		mock_result.json.return_value = {"ErrorCode": 0, "Message": "OK"}
+		with patch(
+			"subscriptions.management.commands.send_weekly_summary.send_email",
+			return_value=mock_result,
+		):
+			with CaptureQueriesContext(connection) as ctx:
+				call_command("send_weekly_summary", stdout=StringIO(), dry_run=True)
+		return len(ctx.captured_queries)
+
+	def test_query_count_does_not_scale_with_subscriber_count(self):
+		self._add_subscribers(1)
+		one_subscriber_queries = self._run_and_count_queries()
+
+		Subscribers.objects.all().delete()
+		self._add_subscribers(5)
+		five_subscriber_queries = self._run_and_count_queries()
+
+		per_extra_subscriber = (five_subscriber_queries - one_subscriber_queries) / 4
+
+		# If priority scores were still recomputed per subscriber, each
+		# extra subscriber adds ~2 queries per candidate article (6 articles
+		# here) on top of the fixed per-subscriber overhead every run pays
+		# regardless (sent-record lookups, per-subscriber authors prefetch,
+		# etc.) — measured at ~24 queries/extra subscriber before this fix,
+		# ~9 after. 15 cleanly separates the two without being so tight that
+		# unrelated per-subscriber overhead trips it.
+		self.assertLess(
+			per_extra_subscriber,
+			15,
+			f"Query count scales with subscriber count "
+			f"(1 subscriber={one_subscriber_queries}, "
+			f"5 subscribers={five_subscriber_queries}, "
+			f"~{per_extra_subscriber:.1f} queries/extra subscriber) — "
+			f"priority scores are being recomputed per subscriber instead "
+			f"of shared across the list.",
+		)

--- a/django/templates/admin/subscriptions/announcement/send_confirm.html
+++ b/django/templates/admin/subscriptions/announcement/send_confirm.html
@@ -44,6 +44,11 @@
 	<div style="margin: 20px 0; padding: 15px; background: #fef2f2; border: 1px solid #fca5a5; border-radius: 6px;">
 		<strong>No active subscribers found.</strong> There are no active subscribers on the selected lists.
 	</div>
+	{% elif already_received_count > 0 %}
+	<div style="margin: 20px 0; padding: 15px; background: #eff6ff; border: 1px solid #93c5fd; border-radius: 6px;">
+		<strong>{{ new_recipients_count }} will receive this email</strong> — {{ already_received_count }} of the {{ total_subscribers }} unique subscriber{{ total_subscribers|pluralize }} already received this announcement and will be skipped.
+		<br><small style="color: #6b7280;">This includes anyone who subscribed after the original send — resuming an announcement mails everyone currently subscribed who hasn't already received it, not only prior delivery failures.</small>
+	</div>
 	{% endif %}
 
 	<form method="post">
@@ -53,10 +58,10 @@
 			   style="display: inline-block; padding: 8px 20px; background: #6b7280; color: white; text-decoration: none; border-radius: 5px; margin-right: 10px;">
 				Cancel
 			</a>
-			{% if total_subscribers > 0 %}
+			{% if new_recipients_count > 0 %}
 			<button type="submit"
 					style="padding: 8px 20px; background: #10b981; color: white; border: none; border-radius: 5px; cursor: pointer; font-size: 14px;">
-				Queue Send to {{ total_subscribers }} Subscriber{{ total_subscribers|pluralize }}
+				Queue Send to {{ new_recipients_count }} Subscriber{{ new_recipients_count|pluralize }}
 			</button>
 			{% endif %}
 		</div>

--- a/django/templates/emails/components/content_organizer.py
+++ b/django/templates/emails/components/content_organizer.py
@@ -59,8 +59,6 @@ class EmailContentOrganizer:
 			return self._organize_weekly_articles(articles, subscriber, list_obj)
 		elif self.email_type == "admin_summary":
 			return self._organize_admin_articles(articles, subscriber)
-		elif self.email_type == "trial_notification":
-			return self._organize_trial_notification_articles(articles, subscriber)
 		else:
 			return self._organize_default_articles(articles)
 
@@ -180,21 +178,6 @@ class EmailContentOrganizer:
 			"high_confidence_count": len(high_confidence),
 		}
 
-	def _organize_trial_notification_articles(self, articles, subscriber):
-		"""Organize articles for trial notification emails (minimal articles)."""
-		# For trial notifications, only include highly relevant articles
-		high_confidence = self._filter_high_confidence(articles)
-		sorted_articles = sorted(
-			high_confidence, key=lambda x: x.discovery_date, reverse=True
-		)
-
-		return {
-			"featured_articles": sorted_articles,  # Include ALL high-confidence trial-related articles
-			"regular_articles": [],
-			"total_count": len(sorted_articles),
-			"high_confidence_count": len(sorted_articles),
-		}
-
 	def _organize_default_articles(self, articles):
 		"""Default organization for unknown email types."""
 		if hasattr(articles, "order_by"):
@@ -210,38 +193,6 @@ class EmailContentOrganizer:
 			"total_count": len(sorted_articles),
 			"high_confidence_count": 0,
 		}
-
-	def _filter_high_confidence(self, articles):
-		"""Filter articles with high ML confidence scores or manual review."""
-		high_confidence = []
-
-		for article in articles:
-			# First check if the article was manually reviewed and marked as relevant
-			if (
-				hasattr(article, "article_subject_relevances")
-				and article.article_subject_relevances.filter(is_relevant=True).exists()
-			):
-				high_confidence.append(article)
-				continue
-
-			# Check for filtered predictions first (used by admin_summary)
-			if (
-				hasattr(article, "filtered_ml_predictions")
-				and article.filtered_ml_predictions
-			):
-				max_score = self._get_max_ml_score(article)
-				if max_score >= self.confidence_threshold:
-					high_confidence.append(article)
-			# Fall back to standard predictions
-			elif (
-				hasattr(article, "ml_predictions_detail")
-				and article.ml_predictions_detail.exists()
-			):
-				max_score = self._get_max_ml_score(article)
-				if max_score >= self.confidence_threshold:
-					high_confidence.append(article)
-
-		return high_confidence
 
 	def _sort_by_ml_score(self, articles):
 		"""Sort articles by highest ML prediction score."""
@@ -433,24 +384,16 @@ class EmailRenderingPipeline:
 		if confidence_threshold is not None:
 			self.organizer.confidence_threshold = confidence_threshold
 
-		# Optimize database queries with prefetch_related
+		# Optimize database queries with prefetch_related. Callers always pass
+		# either an unsliced QuerySet or an already-materialized list (never a
+		# sliced-but-still-QuerySet), so this never raises — see
+		# send_weekly_summary/send_admin_summary/send_trials_notification,
+		# which convert to a list before truncating.
 		if articles is not None and hasattr(articles, "prefetch_related"):
-			# Only apply prefetch if it's not already a sliced QuerySet
-			try:
-				articles = articles.prefetch_related(
-					"authors", "ml_predictions__subject"
-				)
-			except Exception:  # noqa: S110
-				# If prefetch fails (e.g., already sliced), continue with original
-				pass
+			articles = articles.prefetch_related("authors")
 
 		if trials is not None and hasattr(trials, "select_related"):
-			# Only apply select_related if it's not already a sliced QuerySet
-			try:
-				trials = trials.select_related()
-			except Exception:  # noqa: S110
-				# If select_related fails (e.g., already sliced), continue with original
-				pass
+			trials = trials.select_related()
 
 		# Organize content
 		organized_articles = self.organizer.organize_articles(

--- a/docs/subscriptions-audit-2026-07.md
+++ b/docs/subscriptions-audit-2026-07.md
@@ -333,6 +333,22 @@ of the deliveries that already succeeded. See
 [subscriptions.md](subscriptions.md#announcement-send-lifecycle) for the full
 status lifecycle.
 
+**Follow-up fixed 2026-07-28:** the `send_view` confirmation page reported
+`len(all_subscribers)` — the full audience, computed before the skip logic
+above runs — as both the displayed count and the button's send count.
+Against live data this overstated the actual send: announcement #12 said 181
+but would send to 6 (177 already delivered), #9 said 181 but would send to
+44 (176 already delivered). Nothing unsafe happened — it overstates rather
+than understates — but it's the one number an operator needs to judge
+whether a retry is worth doing. Fixed by subtracting subscribers with an
+existing successful `AnnouncementRecipient` row from the confirm count and
+showing both figures — new recipients and already-received/will-be-skipped —
+separately. See [subscriptions.md](subscriptions.md#announcement-send-lifecycle)
+for the resume-semantics note this surfaced (resuming mails everyone
+currently subscribed who hasn't received it, including subscribers who
+joined after the original send) and
+`subscriptions/tests/test_announcement_confirm_count.py`.
+
 ### 13. `lookback_days` only half-works
 
 `send_admin_summary` and `send_trials_notification` go through
@@ -363,13 +379,86 @@ content window can never fall outside a narrower exclusion window. See
 
 ## Priority 3 — performance
 
+**Re-measured against current code on 2026-07-28** before work started, since
+P1 deleted the featured/regular split and changed which code is still on the
+hot path. The re-measurement found a different shape than this section
+originally described (a genuine N+1, but on the *authors* relation, not via
+`_filter_high_confidence`, which P1 already made unreachable — see finding 5
+above) and a much larger cost for the per-subscriber priority loop than
+first estimated. Findings below are annotated individually.
+
 - `content_organizer.py:468` prefetches `ml_predictions__subject` (the M2M), but every consumer reads `ml_predictions_detail` (the reverse FK). The prefetch is wasted and `_filter_high_confidence` runs roughly 3 queries per article per subscriber. It is skipped entirely once `unsent_articles` becomes a list after truncation.
+
+  **Status: fixed 2026-07-28, but not the way originally described.**
+  `_filter_high_confidence` was already unreachable by the time this was
+  re-measured — it was only ever called from `_organize_trial_notification_articles`,
+  and trial notifications never pass `articles=` to the organizer, so both
+  methods were dead code and were deleted outright (see
+  `subscriptions/tests/test_trial_notification_articles_unreachable.py`,
+  which pins the unreachability before the deletion). The wasted
+  `ml_predictions__subject` prefetch was deleted too, along with the
+  `try/except Exception: pass` blocks that had wrapped both prefetch
+  attempts — with the fix below, the callers into `prepare_optimized_context`
+  now only ever pass an unsliced QuerySet or an already-materialized list,
+  never a sliced-but-still-QuerySet, so the exception path was unreachable as
+  well.
+
+  The real, still-live N+1 turned out to be on `authors`, not
+  `ml_predictions`: `content_organizer.py:437`'s prefetch guard
+  (`hasattr(articles, "prefetch_related")`) is skipped once
+  `send_weekly_summary`/`send_admin_summary` truncate `articles` to a plain
+  Python list via `article_limit`, so `article_card.html`'s
+  `article.authors.exists()` / `.all()` cost two queries per article, per
+  subscriber, on exactly the truncated-list path that matters. Fixed by
+  moving the `authors` prefetch into both commands, applied to the queryset
+  *before* truncation, so the prefetch cache survives slicing and
+  materialization. Measured: MS Weekly Digest (88 subscribers, 15-article
+  `article_limit`) drops from ~32 queries to ~4 per subscriber render, ~2,816
+  → ~350 queries across the list. See
+  `subscriptions/tests/test_weekly_summary_authors_prefetch.py` and
+  `subscriptions/tests/test_admin_summary_authors_prefetch.py`.
+
 - `send_weekly_summary.py:317` calls `is_ml_relevant_any_subject` across the whole window — 1,242 articles for MS Weekly Digest — at about 2 queries each.
+
+  **Status: left open, deliberately.** Re-measured at ~2,484 queries and ~2s,
+  once per list per run (not per subscriber, so it doesn't scale with
+  audience). Two seconds doesn't justify a rewrite on its own, and the
+  candidate replacements (`api.filters._get_ml_relevant_articles_query`, the
+  denormalized `Articles.relevant` flag, `gregory.relevance.recompute_article_relevance`)
+  aren't proven to select the identical article set as this loop — swapping
+  in one of them without a test pinning the current selection risks a silent
+  change in which articles a subscriber sees. No such pinning test exists
+  yet, so this was left alone rather than guessed at.
+
 - `send_weekly_summary.py:564` recomputes ML priority scores inside the per-subscriber loop (88 subscribers on that list).
+
+  **Status: fixed 2026-07-28 — and larger than this line suggested.** This
+  cost was never included in the original per-subscriber measurement above
+  (that measurement started from an already-built article list); measured on
+  its own against MS Weekly Digest's 1,219-article candidate pool, it came to
+  ~2,440 queries and ~0.82s **per subscriber**, none of which varies by
+  subscriber — manual-review status and ML consensus count depend only on
+  the article and the list's threshold. Across 88 subscribers that's roughly
+  158,000 queries and ~72 seconds of identical, repeated work every run.
+  Fixed by computing `article_priority_scores` once per list (a handful of
+  batched queries) and having the per-subscriber truncation step look up
+  precomputed scores instead of recomputing them. Re-measured after the fix:
+  4 queries / ~0.28s once per list, then 1 query / ~0.05s per subscriber —
+  roughly 92 queries and ~4.5s total for the same 88-subscriber list, versus
+  ~158,000 queries and ~72s before. See
+  `subscriptions/tests/test_weekly_summary_priority_scores_shared.py`.
 
 Worth knowing before optimising: the featured/regular split buys nothing
 visually. `weekly_summary.html:31-42` renders both groups with the identical card
 component, back to back. The split only affects ordering.
+
+**Not attempted:** batching or parallelising the Postmark HTTP calls
+themselves. At 0.3–1.0s each, sequential sends remain the dominant cost even
+with every finding above fixed (26–88s for MS Weekly Digest's 88
+subscribers) — but changing send concurrency interacts with suppression
+handling, per-recipient error attribution, and Postmark rate limits, and
+deserves its own change with its own testing rather than folding into a
+performance clean-up.
 
 ---
 

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -367,6 +367,25 @@ an entire list. `recipients_count` / `failures_count` are recomputed from
 `AnnouncementRecipient` rows on every run rather than incremented, so the
 counts stay correct across any number of partial runs.
 
+**Resume semantics reach further than "retry the failures."** The skip rule
+is "already successfully delivered", not "was part of the original attempt" —
+so re-queueing an announcement mails **every subscriber currently on the
+target lists who hasn't already received it**, which includes anyone who
+subscribed *after* the original send, not only prior delivery failures. This
+follows correctly from an idempotent-by-`AnnouncementRecipient`-row design,
+but it surprised an operator retrying announcement #9: of the 44 subscribers
+who would receive it on a retry, only 12 were genuine delivery failures — the
+other ~32 had joined the list in the three months since the original April
+send, and would receive a three-month-old announcement alongside a fresh one.
+The `send_view` confirmation page (`AnnouncementAdmin.send_view`,
+`admin/subscriptions/announcement/send_confirm.html`) reflects this directly:
+it reports the post-skip count that will actually be queued to send,
+separately from the count of subscribers who already received it and will be
+skipped, computed the same way `send_announcement()` filters — by excluding
+subscribers with an existing successful `AnnouncementRecipient` row for that
+announcement — so this fan-out is visible before queueing, not discovered
+afterwards.
+
 **Suppression is handled exactly like the three digest commands** (see
 "Bounce and Suppression Handling" above): the response is routed through
 `classify_postmark_response`, a 406 deactivates the subscriber via


### PR DESCRIPTION
## Summary

Executes the P3 (performance) findings from `docs/subscriptions-audit-2026-07.md`, plus a related follow-up from the P2 review. Every finding was re-measured against current code before being touched, since P1 deleted the featured/regular split and changed which code is actually on the hot path.

- **Authors N+1 (fixed):** `send_weekly_summary`/`send_admin_summary` now prefetch `authors` on the article queryset *before* `article_limit` truncation, so the prefetch cache survives being sliced into a plain list (the organizer's own prefetch attempt can't recover once it's handed a list). Measured: MS Weekly Digest (88 subscribers) drops from ~32 to ~4 queries per subscriber render (~2,816 → ~350 queries across the list).
- **Dead code deleted:** `_filter_high_confidence` and `_organize_trial_notification_articles` were unreachable (trial notifications never pass `articles=` to the organizer) — pinned with a test before deletion. Also removed the wasted `ml_predictions__subject` prefetch and the two silenced `try/except Exception: pass` blocks around it, now provably unreachable since every caller passes either an unsliced queryset or an already-materialized list.
- **Per-subscriber priority-scoring loop (fixed, bigger than the audit estimated):** measured at ~2,440 queries and ~0.82s *per subscriber* against MS Weekly Digest's 1,219-article candidate pool — ~72s / ~158k queries across 88 subscribers, all for identical results, since none of the scoring inputs (manual review, ML consensus) vary by subscriber. Fixed by computing `article_priority_scores` once per list and reusing the lookup per subscriber. Re-measured: ~4.5s / ~92 queries total for the same list.
- **`is_ml_relevant_any_subject` selection loop — left open, deliberately:** ~2s/run, doesn't scale with subscriber count, and no test exists yet to safely swap in a replacement without risking a silent change in article selection. Documented in the audit doc.
- **Announcement confirm-count fix:** the send-confirm admin page reported the full list audience instead of the post-skip count `send_announcement()` actually uses (a subscriber with a successful `AnnouncementRecipient` row is skipped, not re-mailed). Live data: announcement #12 said 181, would actually send to 6; #9 said 181, would actually send to 44. The confirm page now shows both figures, and `docs/subscriptions.md` documents that resuming an announcement mails everyone currently subscribed who hasn't received it — including subscribers who joined after the original send.

## Test plan

- [x] `pytest subscriptions` — 348 passed (baseline 345 + this PR's 5 new test files)
- [x] Full suite (`pytest`) — 2,836 passed (baseline 2,828 + 8 new tests)
- [x] Each new regression test verified to fail against the pre-fix code (via `git stash` on the relevant file) and pass with the fix
- [x] `uvx ruff check` / `uvx ruff format --check` clean on all touched files
- [x] Query-count measurements taken with `CaptureQueriesContext` before/after, both in test fixtures and against real dev-DB data (MS Weekly Digest: 88 subscribers, 1,219–1,242 candidate articles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)