### PR TITLE
fix: shorten SuppressionEvent index name under Django's 30-char limit (unblocks prod migrate)

### DIFF
--- a/django/subscriptions/migrations/0036_suppression_event_email_index.py
+++ b/django/subscriptions/migrations/0036_suppression_event_email_index.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
 			model_name="suppressionevent",
 			index=models.Index(
 				fields=["email", "-changed_at"],
-				name="idx_suppression_event_email_changed",
+				name="idx_supp_event_email_changed",
 			),
 		),
 	]

--- a/django/subscriptions/models.py
+++ b/django/subscriptions/models.py
@@ -546,9 +546,13 @@ class SuppressionEvent(models.Model):
 			# (ordering check, original-suppression lookup) — the unique
 			# constraint above is keyed on record_type first, so it doesn't
 			# serve an email-only query efficiently as this table grows.
+			# Name kept under 30 characters: Django enforces that limit on index
+			# names for cross-database portability (models.E034), and the check
+			# only runs when a database is involved — `manage.py check` alone
+			# passes, `migrate` does not.
 			models.Index(
 				fields=["email", "-changed_at"],
-				name="idx_suppression_event_email_changed",
+				name="idx_supp_event_email_changed",
 			),
 		]
 		ordering = ["-changed_at"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,8 @@ walkthrough (read in order); everything else is reference or design material.
 | [subscriptions-p2-fix-plan.md](subscriptions-p2-fix-plan.md) | Execution plan for the P2 findings — robustness, mainly announcement sending. |
 | [subscriptions-p3-fix-plan.md](subscriptions-p3-fix-plan.md) | Execution plan for the P3 findings — performance, plus the announcement confirm-count fix. |
 | [subscriptions-remaining-work.md](subscriptions-remaining-work.md) | What was deliberately left out of P0–P3 — latent traps and known gaps, with the decisions each needs. |
+| [subscriptions-cleanup-plan.md](subscriptions-cleanup-plan.md) | Ready-to-go cleanup items from the remaining-work list — no open decisions. |
+| [subscriptions-bounce-webhook-plan.md](subscriptions-bounce-webhook-plan.md) | Plan for the Postmark webhook — proactive suppression and reactivation. |
 | [merge-authors-command.md](merge-authors-command.md) | The author-merge management command. |
 | [lint-triage.md](lint-triage.md) | Ruff lint-gate worklist. |
 

--- a/docs/subscriptions-bounce-webhook-plan.md
+++ b/docs/subscriptions-bounce-webhook-plan.md
@@ -1,0 +1,309 @@
+# Plan: Postmark webhook for suppression and reactivation
+
+Task 8 of [subscriptions-remaining-work.md](subscriptions-remaining-work.md).
+Replaces the current reactive-only suppression handling, which learns about a
+bounce by attempting a send and failing.
+
+This is the largest remaining item and the only one adding new public surface
+area. Configuration and reactivation policy are both settled — there are no open
+decisions. Start with the `SuppressionEvent` model; nothing about reactivation
+works until suppression records what it changed.
+
+## Preconditions
+
+- Branch off `main` before touching anything — CI deploys everything merged there.
+- Tests from `django/`: `pytest subscriptions`. Baseline is 2,836 across the full suite.
+- Lint and format on the host: `uvx ruff check django/` and `uvx ruff format django/`.
+
+---
+
+## Confirmed configuration
+
+Both pre-flight questions are settled (Bruno, 2026-07-29):
+
+- the webhook is configured on the **broadcast** stream, which is what `send_email` sends on
+- it posts to `https://api.brain-regeneration.com/webhooks/`
+- there are no transactional emails yet, so broadcast is the only stream in use — `MessageStream` becomes a sanity check to record and assert, not a routing decision
+
+Routing: the project has a single `ROOT_URLCONF` (`admin.urls`) serving every
+domain, so `path("webhooks/", ...)` there is reachable at that URL with no
+per-domain configuration.
+
+Two things to verify while wiring it up:
+
+- the api vhost must pass the `Authorization` header through to Django. Nginx normally does, but if it is stripped, basic auth silently never arrives and every request looks unauthenticated.
+- the path is `/webhooks/`, not `/webhooks/postmark/`. It is provider-agnostic, so if anything else ever posts webhooks here it will collide. Dispatch on `RecordType` and reject payloads that do not look like Postmark's.
+
+### Authentication: basic auth, and no signature
+
+Postmark **does not support HMAC webhook signatures**. Their documentation says
+so explicitly, while also carrying a TypeScript sample that calls
+`verifyPostmarkWebhook(rawBody, signature)` against an `x-postmark-signature`
+header. That sample is wrong — there is no such header to verify. Do not
+implement signature checking.
+
+The supported protections are HTTP basic auth, with credentials embedded in the
+webhook URL Postmark posts to:
+
+```
+https://<username>:<password>@api.brain-regeneration.com/webhooks/
+```
+
+and optionally allowlisting Postmark's published webhook IP ranges at the
+firewall. The origin IP changes per attempt, so the allowlist is a range, not a
+host.
+
+Put the credential in the environment, never in the repo. The endpoint changes
+subscription state — an unauthenticated one lets anyone unsubscribe arbitrary
+addresses.
+
+**Reject with 403, not 401.** Postmark stops retrying on 403 and retries on
+everything else. A wrong credential should fail once and loudly, not generate
+hours of retries against an endpoint that will never accept them.
+
+---
+
+## What Postmark is configured to send
+
+Enabled: Delivery, Bounce, Open (first open only), Subscription Change.
+Not enabled: Spam Complaint, Link Click.
+
+**Build on Subscription Change.** It is the superset event for suppression
+state, and it fires in both directions:
+
+| Field | Use |
+|:------|:----|
+| `Recipient` | the email address — maps to `Subscribers.email` |
+| `SuppressSending` | `true` = suppress, `false` = the reactivation signal |
+| `SuppressionReason` | `HardBounce`, `SpamComplaint`, or `ManualSuppression` |
+| `Origin` | who initiated it — `Recipient` or `Customer` |
+| `ChangedAt` | event time, needed for ordering |
+| `MessageStream` | must match what we send on — see check 1 |
+| `MessageID` | for idempotency |
+
+Note that spam complaints still reach us through `SuppressionReason:
+"SpamComplaint"` even though the Spam Complaint event type is disabled. Enabling
+it would add detail, not coverage — it is optional.
+
+Bounce events are useful supplementary detail (hard versus soft; a soft bounce
+does not suppress). Delivery and Open are irrelevant to suppression. The
+endpoint must still accept and ignore them with a 200, or Postmark will record
+delivery failures and retry.
+
+---
+
+## The blocker: reactivation has nothing to restore
+
+`subscriptions/utils/suppression.deactivate_subscribers` deactivates **every**
+list subscription a person holds, in one bulk `queryset.update()`. It records
+nothing about what it changed.
+
+Simple-history does not help. `ListSubscription` declares
+`history = HistoricalRecords()`, but simple-history hooks `save()` and
+`post_save`, and every deactivation path in this app uses `queryset.update()` —
+both `deactivate_subscribers` and `views._unsubscribe_confirm`. Measured on the
+current data: **169 deactivated `ListSubscription` rows, 31 historical rows
+recording a deactivation.** Roughly 82% of deactivations left no reconstructable
+trace.
+
+So when an unsuppress event arrives, there is no way to know which subscriptions
+the suppression turned off versus which the person had already opted out of
+themselves. Restoring everything would re-subscribe people to lists they left
+deliberately.
+
+**This must be fixed before reactivation can work at all.** Record what each
+suppression changed, at suppression time:
+
+- add a model — `SuppressionEvent` or similar — holding the subscriber, the Postmark `MessageID`, `ChangedAt`, reason, origin, stream, raw payload, and **the list of `ListSubscription` IDs it deactivated**
+- have `deactivate_subscribers` write it, and return it
+- reactivation then restores exactly that set, and nothing else
+
+The same record doubles as the audit trail for the endpoint, and gives the
+admin somewhere to show suppression state.
+
+---
+
+## Reactivation policy — decided
+
+Settled by Bruno, 2026-07-30.
+
+| `SuppressionReason` | On `SuppressSending: false` |
+|:--------------------|:----------------------------|
+| `HardBounce` | auto-restore |
+| `ManualSuppression` | auto-restore |
+| `SpamComplaint` | **never** — sticky, see below |
+| anything else, or fields missing | record only, flag for review |
+
+In every auto-restore case the 12-month staleness cap applies as well — see
+below.
+
+**Restore means both** the `Subscribers.active` flag and the exact
+`ListSubscription` rows the suppression deactivated. Restoring only the global
+flag is a no-op in practice — the subscriber holds no active subscriptions, so
+they still receive nothing. This is why the `SuppressionEvent` record described
+above is a prerequisite and not a nicety.
+
+**Spam complaints are sticky.** A complaint is a recorded objection to
+processing, and it outranks a later unsuppress — including one performed by your
+own team in the Postmark UI. Never auto-restore. A human override in Django
+admin may remain possible, but it must be an explicit, recorded action by a
+named user, not a side effect of an incoming webhook.
+
+### Fail safe on unexpected field combinations
+
+The semantics of `Origin` on an *unsuppress* event are not established by the
+documentation we have. On the suppress sample it reads as "what caused the
+suppression" — `HardBounce` paired with `Origin: Recipient`, i.e. their mail
+server. If that holds, `ManualSuppression` implies `Origin: Customer` and the
+rule above needs no `Origin` qualifier at all. But on an unsuppress, `Origin`
+may instead mean "who lifted it", and `SuppressionReason` may be absent
+entirely.
+
+Do not guess. Auto-restore only on a positive match against a known-good
+combination; treat anything unrecognised — missing reason, unexpected origin,
+new enum value — as record-only and surface it. Capture a real unsuppress
+payload before relying on either field, and write down what it actually
+contains.
+
+### Staleness cap — decided
+
+Consent decays. An unsuppress arriving long after the suppression would restore
+subscriptions nobody has confirmed in a long time.
+
+Confirmed by Bruno, 2026-07-30: **auto-restore only within 12 months** of the
+original suppression. Beyond that, record and flag for review rather than
+restoring.
+
+So the full auto-restore condition is: reason is `HardBounce` or
+`ManualSuppression`, **and** the original suppression is less than 12 months
+old. Anything else is record-only.
+
+Implementation notes:
+
+- the cap is measured from the original suppression, not from the unsuppress event, so it depends on `SuppressionEvent` having recorded that timestamp. Another reason that model comes first.
+- put the window in a named module constant (e.g. `REACTIVATION_MAX_AGE = timedelta(days=365)`) rather than a Django setting. It is a policy constant, not per-deployment configuration, and a settings key invites it being changed without the reasoning being revisited.
+- **when no matching `SuppressionEvent` exists, fail safe and do not restore.** This is not a hypothetical: every suppression predating the model has no record — the three from 2026-07-28 and the handful already suppressed before that. Their age is unknowable, so they fall outside the cap by default and get flagged for a human.
+
+That last point means reactivation will do nothing at all for existing
+suppressions. That is the correct outcome — restoring a subscription whose age
+and prior state are both unknown is exactly what the cap exists to prevent — but
+say so in the admin surface so it does not read as a bug.
+
+---
+
+## The endpoint
+
+Put it in `subscriptions/` — it changes subscription state, and
+`subscriptions/views.py` already has the `csrf_exempt` import and pattern.
+
+- POST only, `csrf_exempt`, authenticated per check 2
+- Respond 200 quickly. Postmark retries on non-2xx, and slow responses cause duplicate deliveries. Do the work inline only while it stays fast; if it grows, record the payload and process out of band.
+- Parse defensively: an unrecognised `RecordType` is a 200 and a log line, not an error.
+
+### Retry behaviour, and why it constrains the design
+
+Postmark retries any non-200, and gives up on 403. The schedules differ sharply
+by event type:
+
+| Events | Retry schedule |
+|:-------|:---------------|
+| Bounce, Inbound | 1min, 5min, 10min ×3, 15min, 30min, 1hr, 2hr, 6hr — ~10 hours |
+| Delivery, Open, Click, **Subscription Change** | 1min, 5min, 15min — **~21 minutes** |
+
+Subscription Change is the event this whole feature depends on, and it is in the
+short bucket. More than about 20 minutes of downtime and those events are gone
+permanently — Postmark will not replay them later.
+
+Two consequences:
+
+- respond 200 as fast as possible and do the work after acknowledging, rather than processing inline and risking a timeout that costs the event
+- the reactive 406 handling **must stay**. It is the only thing that catches a suppression whose webhook was lost, and losing one is a normal operational event here, not a rare failure.
+
+### Idempotency, and why not on `MessageID` alone
+
+Postmark's own guidance is to dedupe on `MessageID`. That is wrong for this
+event type. The Subscription Change sample payload carries
+`"MessageID": "00000000-0000-0000-0000-000000000000"` — an all-zero placeholder,
+because a suppression change is not always tied to a specific message. A manual
+suppression in the Postmark UI has no originating message at all.
+
+Deduping on `MessageID` alone would collapse every such event into one and
+silently drop all but the first.
+
+Use `(RecordType, Recipient, ChangedAt)` as the uniqueness key, and record
+`MessageID` as data rather than identity. A duplicate is a 200, not an error.
+Confirm the all-zero behaviour against a real payload once the endpoint is
+live — if `MessageID` turns out to be populated and unique in practice, it can
+be added to the key, but do not assume it.
+
+### Ordering
+
+Events can arrive out of order; a suppress and a later unsuppress could land
+reversed, leaving someone suppressed who should not be. Compare `ChangedAt`
+against the most recent applied event for that recipient and ignore anything
+older.
+
+### Unknown recipients
+
+`Recipient` may not match any `Subscribers` row — a test send, an old address, a
+different system on the same server. Record the event, do not error, do not
+create a subscriber.
+
+---
+
+## Tags
+
+Postmark allows **one** tag per message, set with the `Tag` field on the API
+payload (or the `X-PM-Tag` SMTP header). `send_email` currently sends no tag.
+
+Tags are not required for suppression — `Recipient` already identifies the
+subscriber — but they make Postmark-side statistics and debugging much better,
+and the webhook echoes the tag back.
+
+Recommendation: tag by email type, which is low cardinality and matches how the
+sends are already structured: `weekly_summary`, `admin_summary`,
+`trial_notification`, `announcement`. Pass it through `send_email` as a
+parameter with a sensible default. Do not tag by list id — Postmark's tag
+reporting is designed for a small set, and list attribution is better derived
+from our own records.
+
+---
+
+## Tests
+
+- a valid Subscription Change with `SuppressSending: true` deactivates the subscriber and writes a suppression record naming the affected `ListSubscription` IDs
+- `SpamComplaint` never auto-restores, including when the unsuppress originates from `Customer`
+- `HardBounce` and `ManualSuppression` do auto-restore, and restore both the `active` flag and the recorded `ListSubscription` set
+- an unsuppress with a missing or unrecognised `SuppressionReason` is recorded and flagged, not acted on
+- a `HardBounce` unsuppress whose original suppression is 13 months old is recorded and flagged, not restored — the staleness cap
+- an unsuppress for a subscriber with no `SuppressionEvent` record at all is recorded and flagged, not restored
+- a replayed event is a no-op returning 200
+- **two distinct suppressions both carrying the all-zero `MessageID` are both recorded** — the regression against deduping on `MessageID` alone
+- an out-of-order event older than the last applied one for that recipient is ignored
+- an unknown `Recipient` is recorded without error and creates no subscriber
+- `Delivery`, `Open` and `Bounce` payloads return 200 and change no subscription state
+- an unauthenticated POST is rejected **with 403**, so Postmark stops retrying
+- a `MessageStream` other than `broadcast` is recorded but not acted on
+- reactivation restores exactly the subscriptions the suppression deactivated, and not ones the subscriber had already opted out of — the regression for the blocker above
+
+Postmark suggests testing with `curl` against the endpoint, or pointing the
+webhook at RequestBin first to capture real payload shapes. Capturing one real
+Subscription Change before finalising the dedup key is worth the detour, given
+the `MessageID` uncertainty above.
+
+---
+
+## Docs
+
+- `docs/subscriptions.md` — the webhook, the events consumed, the reactivation policy, and the suppression record
+- `docs/02.1-database-tables-and-fields.md` — the new model
+- `docs/01-install.md` or the deployment runbook — the webhook URL and its credential as a required setup step, since a fresh install would otherwise silently lack suppression handling
+
+---
+
+## Out of scope
+
+- Delivery and Open analytics. The endpoint accepts and ignores them; building on them is separate work.
+- Enabling the Spam Complaint or Link Click event types.
+- Retiring the existing reactive 406 handling. It stays as a backstop, and not merely for misconfiguration: Subscription Change events are retried only three times over ~21 minutes, so a short outage loses them for good. The reactive path is what catches those. Both must converge on the same `deactivate_subscribers` helper so they cannot drift.
+- Signature verification. Postmark does not offer it, whatever their sample code implies.

--- a/docs/subscriptions-cleanup-plan.md
+++ b/docs/subscriptions-cleanup-plan.md
@@ -1,0 +1,252 @@
+# Plan: subscriptions cleanup — the ready-to-go items
+
+Seven items from [subscriptions-remaining-work.md](subscriptions-remaining-work.md)
+that need no further decisions. Independent of each other; ship them separately
+or together, but keep tasks 1 and 6 in their own commits — task 1 changes what
+recipients see, task 6 changes what they receive.
+
+Not in scope: the bounce webhook and the P3 selection loop stay parked.
+
+## Preconditions
+
+- Branch off `main` before touching anything — CI deploys everything merged there.
+- Tests from `django/`: `pytest subscriptions`. Baseline is 2,836 across the full suite.
+- Lint and format on the host: `uvx ruff check django/` and `uvx ruff format django/`.
+
+---
+
+## Task 1 — one unsubscribe link per list in announcements
+
+### The problem
+
+`subscriptions/utils/announcement_send.py` deduplicates recipients by email and
+keeps the first list encountered (`all_subscribers[email] = (sub, lst)`), so the
+footer renders a single "Unsubscribe from this list" link pointing at whichever
+list happened to come first. For an announcement sent to several lists, "this
+list" is ambiguous — the recipient cannot tell which subscription they are
+leaving.
+
+Decided by Bruno on 2026-07-29: render one link per list, so there is nothing to
+guess.
+
+### Current shape of the data
+
+Every announcement sent so far targeted exactly one list — Project News or TEST
+— so the ambiguity has not bitten yet. It would immediately: of the 6 active TEST
+subscribers, 5 are also on Project News, so a two-list announcement gives those
+5 an unlabelled link covering one of their two subscriptions.
+
+### The change
+
+1. Collect every list a subscriber matched, not just the first. Keep the deduplication — a subscriber on three of the announcement's lists must still receive one email, not three.
+
+2. Pass those lists into the render context for the footer. `AnnouncementRecipient.list` stays a single FK recording which list they were attributed to; no migration is needed. The link set is a render concern, not a storage one.
+
+3. Extend `templates/emails/components/footer.html` without breaking the digests. The footer is shared by every email type, and the three digest commands pass a single `list_id`. Add an optional `unsubscribe_lists` context variable holding `(list_id, list_name)` pairs:
+	- when `unsubscribe_lists` is present, render one "Unsubscribe from <list name>" link per entry
+	- otherwise fall back to the existing single-`list_id` behaviour unchanged
+
+	Naming the list in the link text is the point of the change — "Unsubscribe from this list" repeated three times would be worse than one ambiguous link.
+
+4. Leave the site-scope and global links exactly as they are. They already work and cover the "get me off everything" case.
+
+### Tests
+
+- an announcement to two lists renders two named unsubscribe links for a subscriber on both, and one for a subscriber on only one
+- a subscriber on several of the announcement's lists still receives exactly one email
+- a weekly digest, admin summary and trial notification render unchanged — one link, existing wording. This is the regression guard for the shared footer.
+- each rendered link resolves to the right `list_id`
+
+### Docs
+
+- `docs/subscriptions.md` — note that announcement footers list every relevant subscription, unlike digests which are single-list by nature.
+
+---
+
+## Task 2 — pass `organization` in trial notifications
+
+`send_trials_notification.py` calls `get_optimized_email_context` without
+`organization=`, unlike the other two send commands, so `org_content_map` is
+always empty. The missing-organization warning in `content_organizer.py` only
+covers `weekly_summary` and `admin_summary`, so nothing reports it.
+
+Decided by Bruno on 2026-07-29: trial notifications do not need Key Takeaways,
+but pass the organization anyway so all three send paths resolve
+organisation-scoped context identically, and a future template addition does not
+silently render nothing.
+
+- pass `organization=team.organization` — already in scope, used for `get_postmark_credentials` in the same block
+- add `trial_notification` to `_ORG_EXPECTED_TYPES` so the warning covers all three
+
+Tests: a trial notification context carries a populated `org_content_map`; the
+warning fires when `organization` is omitted for a trial notification.
+
+---
+
+## Task 3 — restore the announcement footer's legal links
+
+`announcement_send.py` hardcodes `privacy_policy_url` and `terms_url` to `""`,
+so those two footer links disappear for announcements only. Every other email
+type populates them from `CustomSetting`, and every neighbouring key in the same
+dict already reads from `custom_settings`.
+
+This reads as an oversight rather than a decision. Populate them the same way as
+the surrounding keys. If there turns out to be a reason they were blanked,
+write it down instead of restoring them.
+
+Tests: an announcement rendered with a `CustomSetting` carrying both URLs
+includes both links.
+
+---
+
+## Task 4 — make the staff preview resemble what gets sent
+
+`templates/emails/views.py` builds preview context without `organization`, and
+ignores `article_sort_order` — it takes the newest N by date regardless of the
+list's configuration. A relevancy-mode digest therefore previews as something no
+recipient will ever receive, which defeats the point of a preview.
+
+Bring it in line with `send_weekly_summary`: pass `organization`, honour
+`article_sort_order`, and apply the same `lookback_days`, limits, and staleness
+filter the command uses.
+
+The selection logic is now duplicated between the command and the preview, and
+this drift is the direct result. Extract it into a shared helper rather than
+copying the command's logic a second time — a third copy will drift again. If
+extraction turns out to be large, say so and do the smaller fix, but do not
+duplicate.
+
+Tests: a preview for a relevancy-mode list returns the same article set the
+command would select for the same list and window.
+
+---
+
+## Task 5 — make `mark_all_as_sent` safe or delete it
+
+`management/commands/mark_all_as_sent.py` iterates
+`subscribers × lists × every article and trial` with individual `get_or_create`
+calls — against 49,533 articles that is millions of queries. It also iterates
+`subscriber.subscriptions.all()`, which includes lists the subscriber has opted
+out of, so it writes suppression records for lists they will never be mailed
+from. There is no `--dry-run`, no confirmation, and no way to undo it.
+
+Check first whether anything still calls it. The P0 work made its original use
+case — writing off a backlog — obsolete, since content now rolls over instead of
+failing the send.
+
+If it stays:
+
+- scope it with a required `--list`, so "suppress everything for everyone" stops being the default mode
+- filter to `list_subscriptions__is_active=True`
+- replace the per-row `get_or_create` with `bulk_create(..., ignore_conflicts=True)` in batches
+- add `--dry-run` reporting counts, and require confirmation otherwise
+
+If nothing calls it, delete it — that is the better outcome.
+
+Tests: `--dry-run` writes nothing; `--list` scopes correctly; opted-out lists are
+skipped.
+
+---
+
+## Task 6 — article staleness guard
+
+### Why
+
+`Articles.discovery_date` is `auto_now_add` — it records when the feedreaders
+first saw the row, not when the paper was published. A bulk import stamps every
+row with the same day, and the whole historical set becomes eligible for the
+next digest. This is the exact mechanism behind the 2026-07-06 trial flood,
+which P0 fixed for trials with `Lists.trial_max_age_days`; articles have no
+equivalent guard.
+
+It would be quieter than the trial version, and therefore worse: `article_limit`
+now caps payloads, so nothing would error. Subscribers would simply receive
+digests of decade-old papers with no signal that anything was wrong.
+
+### Decided
+
+`Lists.article_max_age_days`, default **90**, compared against
+`published_date`, nulls kept, blank disables. Confirmed by Bruno 2026-07-29.
+
+### The evidence behind the threshold
+
+In normal operation `discovery_date` and `published_date` are effectively the
+same day. Measured over 6,768 articles across 120 days, excluding bulk-import
+days: median lag 0 days, p90 1 day, p95 3 days, p99 21 days.
+
+The guard is therefore a no-op on normal days and only bites during an import.
+Threshold choice barely matters for legitimate content — 30 days would drop
+0.89% of normal-operation articles, 90 days 0.65%, 365 days 0.61%. There is a
+floor of ~0.6% that is genuinely old whatever the threshold. 90 was chosen for
+headroom over the p99 of 21 days and for consistency with the trials guard, not
+because 30 would fail.
+
+Validated retroactively against the real imports in the database:
+
+| Import | Articles | Would pass a 90-day guard |
+|:-------|:---------|:--------------------------|
+| 2022-05-31 | 1,746 | 47 (2.7%) |
+| 2022-06-09 | 1,531 | 21 (1.4%) |
+| 2026-06-30 | 182 | 182 (100%) |
+
+It blocks ~98% of both historical dumps while letting a legitimate 182-article
+burst through untouched.
+
+### The change
+
+Mirror the trials implementation — see Task B0 of
+[subscriptions-p0-fix-plan.md](subscriptions-p0-fix-plan.md) for the shape.
+
+1. Add `Lists.article_max_age_days` (PositiveIntegerField, default 90, null/blank allowed, validators 1–3650) with help text explaining that age is measured on the article's own `published_date`, not `discovery_date`. Generate the migration; do not edit an existing one.
+
+2. Apply it in **every** place articles are selected. This is the part to get right — the equivalent trials fix shipped incomplete because `send_weekly_summary` built its own query and was missed, costing a follow-up round. The four sites:
+	- `send_weekly_summary`, all-articles mode
+	- `send_weekly_summary`, date-sort mode
+	- `send_weekly_summary`, relevancy mode
+	- `get_articles_for_list` (admin summary)
+	- and the Latest Research query in `get_latest_research_by_category`
+
+	That is five, not four — confirm the list by grepping for the article
+	querysets rather than trusting this one, and prefer applying the filter in
+	one shared helper over five call sites.
+
+3. Keep articles whose `published_date` is NULL — 46 of 49,533, and dropping unknown-age articles silently would hide genuinely new ones. `article_limit` bounds them regardless.
+
+4. Add the field to the "Content Settings" fieldset in `ListsAdmin` and update the fieldset description.
+
+### Tests
+
+- an article published 200 days ago but discovered yesterday is excluded from every one of the selection paths above — parametrise across them rather than testing one
+- an article published last week and discovered yesterday is included
+- an article with `published_date` NULL is included
+- `article_max_age_days` set to `None` disables the check
+- regression reproducing the incident shape: 1,000 articles sharing today's `discovery_date` with publication dates spread over 20 years reduce to the handful inside the window
+
+### Docs
+
+- `docs/02.1-database-tables-and-fields.md` — add the column
+- `docs/subscriptions.md` — document it alongside `trial_max_age_days`, including why age is measured on the article's own date
+
+---
+
+## Task 7 — annotate audit finding 13
+
+Finding 13 (`lookback_days` only half-works) shipped in P2 but never got a status
+annotation, so
+[subscriptions-audit-2026-07.md](subscriptions-audit-2026-07.md) still reads as
+though it is open. Add one in the same style as the others, recording that
+`lookback_days` now applies to all three email types and that the sent-record
+window was widened with it to keep audit finding 11 closed.
+
+Docs only.
+
+---
+
+## Definition of done
+
+- `pytest subscriptions` passes; each new test fails when its fix is reverted
+- `pytest` full suite passes
+- `uvx ruff check django/` passes, and `uvx ruff format --check django/` reports nothing that was not already failing
+- the shared-footer regression test in task 1 covers all three digest types, not just announcements
+- `docs/subscriptions.md` covers the announcement footer change
+- audit findings 13 and the "Smaller items" entries for tasks 2 to 5 carry status annotations

--- a/docs/subscriptions-remaining-work.md
+++ b/docs/subscriptions-remaining-work.md
@@ -138,17 +138,11 @@ The count caps mean it would no longer break a send — the failure would be
 quieter than the trial one was, which arguably makes it worse: subscribers get a
 digest of decade-old papers and nothing errors.
 
-### Decision required
-
-Articles have `published_date` and `discovery_date`, and the meaningful "how old
-is this" field is `published_date`. Confirm that before building on it, and pick
-a default threshold. Trials landed on 90 days, chosen because slow registries
-lag; journal publication dates behave differently and may want a different
-number.
-
-Mirror the trial implementation: an `Lists.article_max_age_days` field, applied
-in the article selection queries, nulls kept, blank disables. See Task B0 of
-[subscriptions-p0-fix-plan.md](subscriptions-p0-fix-plan.md) for the shape.
+**Decided and moved.** `Lists.article_max_age_days`, default 90, on
+`published_date`, nulls kept, blank disables — confirmed by Bruno 2026-07-29,
+with the measurements behind the threshold. Now Task 6 of
+[subscriptions-cleanup-plan.md](subscriptions-cleanup-plan.md); nothing
+outstanding here.
 
 ---
 
@@ -188,10 +182,8 @@ in three places — this loop, `api.filters._get_ml_relevant_articles_query`, an
 
 ## Also open, tracked elsewhere
 
-- The incident record's open items —
-  [incidents/2026-07-28-site-scope-unsubscribe-not-honoured.md](incidents/2026-07-28-site-scope-unsubscribe-not-honoured.md).
-  Run `scripts/incident-2026-07-28-scope-check.sh` on production. The access-log
-  item expires as logs rotate, so it is the only thing here with a deadline.
+- The incident record is closed as of 2026-07-29 — nothing outstanding.
+  [incidents/2026-07-28-site-scope-unsubscribe-not-honoured.md](incidents/2026-07-28-site-scope-unsubscribe-not-honoured.md)
 - Audit finding 13 shipped in P2 but never got a status annotation, so it still
   reads as open. One-line docs fix.
 - Postmark batch send, noted in the P2 plan as worth measuring inside


### PR DESCRIPTION
## What

`SuppressionEvent`'s index was named `idx_suppression_event_email_changed` — 35 characters. Django caps index names at 30 for cross-database portability, so `models.E034` fires:

```
subscriptions.SuppressionEvent: (models.E034) The index name
'idx_suppression_event_email_changed' cannot be longer than 30 characters.
```

Renamed to `idx_supp_event_email_changed` (28 chars).

## Why it matters

System checks run **before** migrations, and E034 is an error rather than a warning. That aborts every management command that touches a database — including `migrate`, which is what broke the production deploy.

## Why migration 0036 is edited in place

Normally applied migrations are never rewritten. This one has never applied anywhere and could not have:

- the system check aborts `migrate` before any migration runs, so production never got past it
- confirmed unapplied in dev (`showmigrations`), with no matching index in `pg_indexes`

A `RenameIndex` migration would have been actively wrong here — it would fail on production looking for an index that does not exist.

## Why CI did not catch this

Worth knowing, because this class of error is invisible to both existing gates:

- `manage.py check` **passes** — Django skips database-dependent model checks unless `--database` is passed
- the test suite runs with `--nomigrations`, so it never invokes `migrate` either

This reproduces it in a second:

```bash
docker exec gregory python manage.py check --database default
```

Adding that to CI would have caught this before merge. Not included here to keep the fix minimal — worth a follow-up.

## Verification

- `manage.py check --database default` — clean
- `makemigrations --check --dry-run` — no drift
- migration applies; index present as `idx_supp_event_email_changed`
- `pytest subscriptions` — 395 passed
- `uvx ruff check` / `ruff format --check` — clean
- scanned all of `django/` for other over-length index names — this was the only one

## Note for the reviewer

The second commit (`docs:`) is unrelated planning documentation that had accumulated uncommitted. It is separated so the fix can be reviewed on its own. If you want the fix merged quickly, `88a1c361` is the only commit that matters — the docs commit can be dropped or split out without affecting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)