### PR TITLE
ci: add database-aware Django system checks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,14 +47,31 @@ jobs:
         working-directory: django
         run: pip install --quiet -r requirements.txt
 
+      - name: Generate ephemeral keys
+        # Generated per-run so no secrets live in the repo; they only need to
+        # be valid for the CI process. Exported to $GITHUB_ENV so every
+        # subsequent step in this job shares them.
+        run: |
+          echo "SECRET_KEY=$(python -c 'import secrets; print(secrets.token_urlsafe(50))')" >> "$GITHUB_ENV"
+          echo "FERNET_SECRET_KEY=$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')" >> "$GITHUB_ENV"
+
       - name: Run pytest
         working-directory: django
-        # SECRET_KEY / FERNET_SECRET_KEY are generated per-run so no secrets
-        # live in the repo; they only need to be valid for the test process.
-        run: |
-          export SECRET_KEY="$(python -c 'import secrets; print(secrets.token_urlsafe(50))')"
-          export FERNET_SECRET_KEY="$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')"
-          pytest -p no:cacheprovider
+        run: pytest -p no:cacheprovider
+
+      - name: Django system checks (database-aware)
+        working-directory: django
+        # `manage.py check` alone skips database-dependent model checks, which
+        # is how models.E034 reached production on 2026-07-30 — an index name
+        # over Django's 30-character limit. The flag is what makes those checks
+        # run. No database connection is required, only a configured one.
+        run: python manage.py check --database default
+
+      - name: No missing migrations
+        working-directory: django
+        # Fails if a model changed without a matching migration, which would
+        # drift the production schema from model state.
+        run: python manage.py makemigrations --check --dry-run
 
   # Static gate for "hollow" error handling: bare `except:` and `except: pass`
   # (the empty catch block). Runs on a bare runner — no ML image needed — so it

--- a/docs/01-install.md
+++ b/docs/01-install.md
@@ -130,9 +130,10 @@ To run a specific test file:
 docker exec gregory python manage.py test gregory.tests.test_filename
 ```
 
-CI also runs two database-aware Django system checks that `manage.py test`
-does not cover (the test suite runs with `--nomigrations`, so it never
-exercises these). Reproduce them locally before pushing:
+CI also runs two database-aware Django system checks that the test suite
+does not cover. CI runs tests with `pytest`, not `manage.py test`, and
+`pytest.ini` sets `--nomigrations`, so `migrate` (and these checks) never
+run as part of testing. Reproduce them locally before pushing:
 
 ```bash
 docker exec gregory python manage.py check --database default

--- a/docs/01-install.md
+++ b/docs/01-install.md
@@ -130,6 +130,19 @@ To run a specific test file:
 docker exec gregory python manage.py test gregory.tests.test_filename
 ```
 
+CI also runs two database-aware Django system checks that `manage.py test`
+does not cover (the test suite runs with `--nomigrations`, so it never
+exercises these). Reproduce them locally before pushing:
+
+```bash
+docker exec gregory python manage.py check --database default
+docker exec gregory python manage.py makemigrations --check --dry-run
+```
+
+The first catches model state that's only invalid once a database backend is
+configured — e.g. an index name over the backend's length limit. The second
+catches a model change that's missing its migration.
+
 ---
 
 ## Scheduled tasks


### PR DESCRIPTION
## Summary
- Adds two CI gates to the `pytest` job in `.github/workflows/tests.yaml`: `manage.py check --database default` and `manage.py makemigrations --check --dry-run`, run after pytest so a check failure doesn't swallow test results.
- Hoists `SECRET_KEY`/`FERNET_SECRET_KEY` generation into their own step exporting to `$GITHUB_ENV`, since both new steps need them too.
- Documents the two commands in `docs/01-install.md` as the local equivalent of the CI gates.

## Why
`manage.py check` silently skips database-dependent model checks unless `--database` is passed, and `pytest` runs with `--nomigrations` so it never calls `migrate`. Neither existing gate could have caught `models.E034` (index name over Django's 30-char limit), which passed CI clean and then broke `migrate` on production during the 2026-07-30 deploy ([PR #811](https://github.com/brunoamaral/gregory-ai/pull/811)). These two gates close that hole for the same class of deploy-blocking error.

Both gates only need a database *configured* (backend/settings), not *reachable* — no changes to the `postgres` service or job structure were needed.

## Test plan
- [x] Verified both gates pass on current `main`-equivalent code using a throwaway `docker run` mounting this worktree (not the long-running `gregory` container, which tracks `main`), with `DB_HOST` pointed at a nonexistent host to confirm no live connection is required.
- [x] Renamed the `SuppressionEvent` index back to `idx_suppression_event_email_changed` (35 chars) and confirmed `check --database default` fails with `models.E034`, exit code 1 — then reverted.
- [x] Added a throwaway field to `CustomSetting` without a migration and confirmed `makemigrations --check --dry-run` fails, exit code 1 — then reverted.
- [ ] Confirm the new steps pass in the actual GitHub Actions run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)