### PR TITLE
fix: pipeline predictions never updated ml_score/relevant (bulk_create bypasses signal)

### DIFF
--- a/django/gregory/management/commands/backfill_ml_scores.py
+++ b/django/gregory/management/commands/backfill_ml_scores.py
@@ -1,33 +1,24 @@
 from django.core.management.base import BaseCommand
-from django.db import connection
+
+from gregory.relevance import recompute_article_ml_scores
 
 
 class Command(BaseCommand):
 	help = "Backfill ml_score on all articles from their latest ML predictions."
 
-	def handle(self, *args, **options):
-		self.stdout.write("Computing ml_score from predictions (single-pass update)...")
-		with connection.cursor() as cursor:
-			# Single statement: sets ml_score to the average of the most recent
-			# prediction per (algorithm, subject) pair, or NULL when there are none.
-			cursor.execute(
-				"""
-				UPDATE articles
-				SET ml_score = (
-					SELECT AVG(p.probability_score)
-					FROM (
-						SELECT DISTINCT ON (algorithm, subject_id)
-							probability_score
-						FROM gregory_mlpredictions mp
-						WHERE mp.article_id = articles.article_id
-						  AND mp.probability_score IS NOT NULL
-						ORDER BY algorithm, subject_id, created_date DESC
-					) p
-				)
-				"""
-			)
-			updated = cursor.rowcount
+	def add_arguments(self, parser):
+		parser.add_argument(
+			"--article-ids",
+			nargs="+",
+			type=int,
+			default=None,
+			help="Limit the recompute to these article IDs (default: all articles).",
+		)
 
+	def handle(self, *args, **options):
+		article_ids = options.get("article_ids")
+		self.stdout.write("Recomputing Articles.ml_score...")
+		changed = recompute_article_ml_scores(article_ids=article_ids)
 		self.stdout.write(
-			self.style.SUCCESS(f"Done. ml_score updated for {updated} articles.")
+			self.style.SUCCESS(f"Done. ml_score updated for {changed} articles.")
 		)

--- a/django/gregory/management/commands/predict_articles.py
+++ b/django/gregory/management/commands/predict_articles.py
@@ -18,6 +18,7 @@ from django.db.models import Q, Exists, OuterRef
 from django.utils import timezone
 
 from gregory.models import Team, Articles, MLPredictions, PredictionRunLog
+from gregory.relevance import recompute_article_ml_scores, recompute_article_relevance
 from gregory.utils.text_utils import cleanHTML, cleanText, MIN_WORD_COUNT
 
 # Base path for models
@@ -474,6 +475,12 @@ class Command(BaseCommand):
 					prediction_instances, ignore_conflicts=True
 				)
 				stats["new_predictions"] = len(prediction_instances) - conflicts
+
+				# bulk_create bypasses post_save, so the denormalized ml_score
+				# and relevant fields need an explicit recompute for this batch.
+				batch_article_ids = [p.article_id for p in prediction_instances]
+				recompute_article_ml_scores(article_ids=batch_article_ids)
+				recompute_article_relevance(article_ids=batch_article_ids)
 			elif prediction_instances:
 				# For dry run, we just count would-be creations
 				stats["new_predictions"] = len(prediction_instances)

--- a/django/gregory/relevance.py
+++ b/django/gregory/relevance.py
@@ -80,37 +80,52 @@ def compute_ml_drift(threshold=0.8):
 	  unexpected_relevant: the reverse — should always be 0; non-zero here means
 	    the stored flag is relevant for an article nothing currently justifies,
 	    a different failure mode than staleness
+
+	Each count is a single SQL COUNT — no article IDs are materialized into
+	Python, so this stays cheap to call on every admin summary send even as
+	the articles table grows.
 	"""
+	from django.db.models import Q
+
 	from api.filters import ml_relevant_articles_q
 	from gregory.models import Articles
 
+	# .values("article_id") keeps the DISTINCT (needed because the reverse-FK
+	# joins below can multiply rows) scoped to a single column instead of
+	# every field on Articles — cheaper, and avoids a wide SELECT the count()
+	# wrapper never needed in the first place.
 	stale_ml_score = (
 		Articles.objects.filter(
 			ml_predictions_detail__isnull=False, ml_score__isnull=True
 		)
+		.values("article_id")
 		.distinct()
 		.count()
 	)
 
-	flagged = set(
-		Articles.objects.filter(relevant=True).values_list("article_id", flat=True)
+	should_be_relevant_q = Q(article_subject_relevances__is_relevant=True) | (
+		ml_relevant_articles_q(threshold)
 	)
-	manual = set(
-		Articles.objects.filter(
-			article_subject_relevances__is_relevant=True
-		).values_list("article_id", flat=True)
+
+	missing_relevant = (
+		Articles.objects.filter(should_be_relevant_q)
+		.exclude(relevant=True)
+		.values("article_id")
+		.distinct()
+		.count()
 	)
-	ml = set(
-		Articles.objects.filter(ml_relevant_articles_q(threshold)).values_list(
-			"article_id", flat=True
-		)
+	unexpected_relevant = (
+		Articles.objects.filter(relevant=True)
+		.exclude(should_be_relevant_q)
+		.values("article_id")
+		.distinct()
+		.count()
 	)
-	should_be_relevant = manual | ml
 
 	return {
 		"stale_ml_score": stale_ml_score,
-		"missing_relevant": len(should_be_relevant - flagged),
-		"unexpected_relevant": len(flagged - should_be_relevant),
+		"missing_relevant": missing_relevant,
+		"unexpected_relevant": unexpected_relevant,
 	}
 
 

--- a/django/gregory/relevance.py
+++ b/django/gregory/relevance.py
@@ -62,3 +62,91 @@ def recompute_article_relevance(article_ids=None, threshold=0.8):
 	with connection.cursor() as c:
 		c.execute(sql, params)
 		return c.rowcount
+
+
+def compute_ml_drift(threshold=0.8):
+	"""Live, read-only measurement of denormalized-field drift.
+
+	Reports whether recompute_article_ml_scores / recompute_article_relevance
+	would find anything to change, without writing anything — used by the
+	admin summary email health line. See docs/ml-prediction-signal-bypass-plan.md
+	for why this exists: bulk_create pipeline writes used to bypass the signals
+	that keep these fields in sync.
+
+	Returns a dict:
+	  stale_ml_score: articles with predictions but a NULL ml_score
+	  missing_relevant: articles a live consensus/manual check says should be
+	    relevant, but Articles.relevant disagrees
+	  unexpected_relevant: the reverse — should always be 0; non-zero here means
+	    the stored flag is relevant for an article nothing currently justifies,
+	    a different failure mode than staleness
+	"""
+	from api.filters import ml_relevant_articles_q
+	from gregory.models import Articles
+
+	stale_ml_score = (
+		Articles.objects.filter(
+			ml_predictions_detail__isnull=False, ml_score__isnull=True
+		)
+		.distinct()
+		.count()
+	)
+
+	flagged = set(
+		Articles.objects.filter(relevant=True).values_list("article_id", flat=True)
+	)
+	manual = set(
+		Articles.objects.filter(
+			article_subject_relevances__is_relevant=True
+		).values_list("article_id", flat=True)
+	)
+	ml = set(
+		Articles.objects.filter(ml_relevant_articles_q(threshold)).values_list(
+			"article_id", flat=True
+		)
+	)
+	should_be_relevant = manual | ml
+
+	return {
+		"stale_ml_score": stale_ml_score,
+		"missing_relevant": len(should_be_relevant - flagged),
+		"unexpected_relevant": len(flagged - should_be_relevant),
+	}
+
+
+def recompute_article_ml_scores(article_ids=None):
+	"""Sync articles.ml_score with the average of each article's latest
+	prediction per (algorithm, subject) pair.
+
+	Full pass when article_ids is None. Returns number of rows changed."""
+	scope, params = "", []
+	if article_ids is not None:
+		if not article_ids:
+			return 0
+		scope = "WHERE a2.article_id = ANY(%s)"
+		params.append(list(article_ids))
+	sql = f"""
+	UPDATE articles a
+	SET ml_score = computed.new_ml_score
+	FROM (
+		SELECT a2.article_id,
+			(
+				SELECT AVG(p.probability_score)
+				FROM (
+					SELECT DISTINCT ON (algorithm, subject_id)
+						probability_score
+					FROM gregory_mlpredictions mp
+					WHERE mp.article_id = a2.article_id
+					  AND mp.probability_score IS NOT NULL
+					ORDER BY algorithm, subject_id, created_date DESC
+				) p
+			) AS new_ml_score
+		FROM articles a2
+		{scope}
+	) computed
+	WHERE a.article_id = computed.article_id
+	  AND a.ml_score IS DISTINCT FROM computed.new_ml_score
+	"""
+	with connection.cursor() as c:
+		c.execute(sql, params)
+		return c.rowcount

--- a/django/gregory/signals.py
+++ b/django/gregory/signals.py
@@ -64,24 +64,12 @@ def create_organization_api_settings(sender, instance, created, **kwargs):
 def _recompute_article_ml_score(article_id):
 	"""Recompute and persist ml_score for the given article.
 
-	Averages the most recent probability_score per (algorithm, subject) pair.
-	Uses .update() to avoid bumping Articles.last_updated.
-	distinct(fields) + aggregate() is unsupported by the Django ORM, so scores
-	are materialised and averaged in Python — the list is tiny (≤ algorithms × subjects).
+	Thin wrapper around the scoped recompute in gregory.relevance so the
+	per-article signal path and the bulk pipeline path can't drift apart.
 	"""
-	from gregory.models import Articles, MLPredictions
+	from gregory.relevance import recompute_article_ml_scores
 
-	scores = list(
-		MLPredictions.objects.filter(
-			article_id=article_id,
-			probability_score__isnull=False,
-		)
-		.order_by("algorithm", "subject_id", "-created_date")
-		.distinct("algorithm", "subject_id")
-		.values_list("probability_score", flat=True)
-	)
-	score = sum(scores) / len(scores) if scores else None
-	Articles.objects.filter(article_id=article_id).update(ml_score=score)
+	recompute_article_ml_scores(article_ids=[article_id])
 
 
 @receiver(post_save, sender="gregory.MLPredictions")

--- a/django/gregory/tests/management/test_predict_articles.py
+++ b/django/gregory/tests/management/test_predict_articles.py
@@ -619,6 +619,95 @@ class TestRunPredictionsFor(TestCase):
 		self.assertEqual(stats["processed"], 2)
 		self.assertEqual(stats["new_predictions"], 1)
 
+	def test_bulk_create_updates_ml_score_and_relevant(
+		self,
+		mock_prepare_text,
+		mock_load_model,
+		mock_resolve_version,
+		mock_get_articles,
+	):
+		"""MLPredictions.objects.bulk_create bypasses post_save, so this is the
+		test that catches the pipeline never updating the denormalized fields.
+		A test using .save() would pass on the signal and prove nothing about
+		what the command actually does."""
+		mock_get_articles.return_value = [self.article1, self.article2]
+		mock_resolve_version.return_value = "v1.0"
+		mock_model = MagicMock()
+		# article1 predicted relevant at 0.9 (>= default 0.8 threshold);
+		# article2 predicted not relevant at 0.3.
+		mock_model.predict.return_value = ([1, 0], [0.9, 0.3])
+		mock_load_model.return_value = mock_model
+		mock_prepare_text.side_effect = ["prepared text 1", "prepared text 2"]
+
+		self.command.run_predictions_for(
+			self.subject, "pubmed_bert", "v1.0", 90, 0.8, dry_run=False, verbose=1
+		)
+
+		self.article1.refresh_from_db()
+		self.article2.refresh_from_db()
+		self.assertAlmostEqual(self.article1.ml_score, 0.9, places=5)
+		self.assertTrue(self.article1.relevant)
+		self.assertAlmostEqual(self.article2.ml_score, 0.3, places=5)
+		self.assertFalse(self.article2.relevant)
+
+	def test_relevant_clears_when_pipeline_retrain_drops_below_threshold(
+		self,
+		mock_prepare_text,
+		mock_load_model,
+		mock_resolve_version,
+		mock_get_articles,
+	):
+		"""A later pipeline run with a retrained model_version can clear
+		relevant, not just set it."""
+		mock_get_articles.return_value = [self.article1]
+		mock_resolve_version.return_value = "v1.0"
+		mock_model = MagicMock()
+		mock_model.predict.return_value = ([1], [0.9])
+		mock_load_model.return_value = mock_model
+		mock_prepare_text.side_effect = ["prepared text 1"]
+
+		self.command.run_predictions_for(
+			self.subject, "pubmed_bert", "v1.0", 90, 0.8, dry_run=False, verbose=1
+		)
+		self.article1.refresh_from_db()
+		self.assertTrue(self.article1.relevant)
+
+		mock_resolve_version.return_value = "v2.0"
+		mock_model.predict.return_value = ([0], [0.1])
+		mock_prepare_text.side_effect = ["prepared text 1"]
+
+		self.command.run_predictions_for(
+			self.subject, "pubmed_bert", "v2.0", 90, 0.8, dry_run=False, verbose=1
+		)
+		self.article1.refresh_from_db()
+		self.assertAlmostEqual(self.article1.ml_score, 0.1, places=5)
+		self.assertFalse(self.article1.relevant)
+
+	def test_dry_run_writes_neither_ml_score_nor_relevant(
+		self,
+		mock_prepare_text,
+		mock_load_model,
+		mock_resolve_version,
+		mock_get_articles,
+	):
+		mock_get_articles.return_value = [self.article1, self.article2]
+		mock_resolve_version.return_value = "v1.0"
+		mock_model = MagicMock()
+		mock_model.predict.return_value = ([1, 0], [0.9, 0.3])
+		mock_load_model.return_value = mock_model
+		mock_prepare_text.side_effect = ["prepared text 1", "prepared text 2"]
+
+		self.command.run_predictions_for(
+			self.subject, "pubmed_bert", "v1.0", 90, 0.8, dry_run=True, verbose=1
+		)
+
+		self.article1.refresh_from_db()
+		self.article2.refresh_from_db()
+		self.assertIsNone(self.article1.ml_score)
+		self.assertFalse(self.article1.relevant)
+		self.assertIsNone(self.article2.ml_score)
+		self.assertFalse(self.article2.relevant)
+
 
 class TestSummaryTableFormatting(TestCase):
 	def setUp(self):

--- a/django/gregory/tests/test_article_relevance.py
+++ b/django/gregory/tests/test_article_relevance.py
@@ -13,7 +13,7 @@ from gregory.models import (
 	Subject,
 	Team,
 )
-from gregory.relevance import recompute_article_relevance
+from gregory.relevance import compute_ml_drift, recompute_article_relevance
 
 
 class RecomputeArticleRelevanceTestCase(TestCase):
@@ -447,3 +447,89 @@ class RecomputeArticleRelevanceLatestPredictionTestCase(TestCase):
 		recompute_article_relevance()
 		article.refresh_from_db()
 		self.assertTrue(article.relevant)
+
+
+class ComputeMlDriftTestCase(TestCase):
+	"""compute_ml_drift is the read-only measurement behind the admin summary's
+	health line and the weekly cron backfills' expected zero result."""
+
+	@classmethod
+	def setUpTestData(cls):
+		org = Organization.objects.create(name="Drift Org")
+		cls.team = Team.objects.create(
+			organization=org, name="Drift Team", slug="drift-team"
+		)
+		cls.subject = Subject.objects.create(
+			subject_name="Drift Subject",
+			subject_slug="drift-subject",
+			team=cls.team,
+			auto_predict=True,
+			ml_consensus_type="any",
+		)
+
+	def _make_article(self, title, link):
+		return Articles.objects.create(title=title, link=link)
+
+	def test_healthy_state_is_all_zero(self):
+		article = self._make_article("Healthy", "https://example.com/drift1")
+		article.subjects.add(self.subject)
+		MLPredictions.objects.create(
+			article=article,
+			subject=self.subject,
+			algorithm="pubmed_bert",
+			model_version="v1",
+			probability_score=0.9,
+			predicted_relevant=True,
+		)
+		drift = compute_ml_drift()
+		self.assertEqual(drift["stale_ml_score"], 0)
+		self.assertEqual(drift["missing_relevant"], 0)
+		self.assertEqual(drift["unexpected_relevant"], 0)
+
+	def test_stale_ml_score_counted(self):
+		article = self._make_article("Stale score", "https://example.com/drift2")
+		article.subjects.add(self.subject)
+		MLPredictions.objects.create(
+			article=article,
+			subject=self.subject,
+			algorithm="pubmed_bert",
+			model_version="v1",
+			probability_score=0.9,
+			predicted_relevant=True,
+		)
+		# Signal already set ml_score; force it back to NULL to simulate a
+		# bulk_create write that skipped the recompute.
+		Articles.objects.filter(pk=article.pk).update(ml_score=None)
+
+		drift = compute_ml_drift()
+		self.assertEqual(drift["stale_ml_score"], 1)
+
+	def test_missing_relevant_counted(self):
+		article = self._make_article("Missing relevant", "https://example.com/drift3")
+		article.subjects.add(self.subject)
+		ArticleSubjectRelevance.objects.create(
+			article=article, subject=self.subject, is_relevant=True
+		)
+		Articles.objects.filter(pk=article.pk).update(relevant=False)
+
+		drift = compute_ml_drift()
+		self.assertEqual(drift["missing_relevant"], 1)
+		self.assertEqual(drift["unexpected_relevant"], 0)
+
+	def test_unexpected_relevant_counted(self):
+		"""Reverse direction: flag is True but nothing currently justifies it.
+		This is a different failure mode than staleness (see docstring)."""
+		article = self._make_article(
+			"Unexpected relevant", "https://example.com/drift4"
+		)
+		article.subjects.add(self.subject)
+		Articles.objects.filter(pk=article.pk).update(relevant=True)
+
+		drift = compute_ml_drift()
+		self.assertEqual(drift["missing_relevant"], 0)
+		self.assertEqual(drift["unexpected_relevant"], 1)
+
+	def test_article_with_no_predictions_does_not_count_as_stale(self):
+		self._make_article("No predictions", "https://example.com/drift5")
+		drift = compute_ml_drift()
+		self.assertEqual(drift["stale_ml_score"], 0)

--- a/django/gregory/tests/test_bulk_create_recompute.py
+++ b/django/gregory/tests/test_bulk_create_recompute.py
@@ -1,0 +1,201 @@
+"""Tests for the pipeline's bulk_create path: MLPredictions.objects.bulk_create
+bypasses post_save, so ml_score and relevant only update when the caller
+explicitly recomputes. This is the failure mode predict_articles hit in
+production — see docs/ml-prediction-signal-bypass-plan.md."""
+
+from django.test import TestCase
+from organizations.models import Organization
+
+from gregory.models import Articles, MLPredictions, Subject, Team
+from gregory.relevance import recompute_article_ml_scores, recompute_article_relevance
+from gregory.signals import _recompute_article_ml_score
+
+
+class BulkCreateDoesNotTriggerSignalsTestCase(TestCase):
+	"""Documents the bug: bulk_create leaves both denormalized fields stale
+	until something explicitly recomputes them."""
+
+	@classmethod
+	def setUpTestData(cls):
+		org = Organization.objects.create(name="Bulk Create Org")
+		cls.team = Team.objects.create(organization=org, slug="bulk-create-team")
+		cls.subject = Subject.objects.create(
+			subject_name="Bulk Subject",
+			subject_slug="bulk-subject",
+			team=cls.team,
+			auto_predict=True,
+			ml_consensus_type="any",
+		)
+		cls.article = Articles.objects.create(
+			title="Bulk create article",
+			link="https://example.com/bulk1",
+		)
+		cls.article.subjects.add(cls.subject)
+
+	def test_bulk_create_alone_leaves_fields_stale(self):
+		MLPredictions.objects.bulk_create(
+			[
+				MLPredictions(
+					article=self.article,
+					subject=self.subject,
+					algorithm="pubmed_bert",
+					model_version="v1",
+					probability_score=0.9,
+					predicted_relevant=True,
+				)
+			]
+		)
+		self.article.refresh_from_db()
+		self.assertIsNone(self.article.ml_score, "bulk_create must not fire post_save")
+		self.assertFalse(self.article.relevant, "bulk_create must not fire post_save")
+
+	def test_recompute_after_bulk_create_updates_both_fields(self):
+		"""The fix: an explicit recompute call after bulk_create brings both
+		denormalized fields in line with what the signal would have produced."""
+		MLPredictions.objects.bulk_create(
+			[
+				MLPredictions(
+					article=self.article,
+					subject=self.subject,
+					algorithm="pubmed_bert",
+					model_version="v1",
+					probability_score=0.9,
+					predicted_relevant=True,
+				)
+			]
+		)
+		recompute_article_ml_scores(article_ids=[self.article.article_id])
+		recompute_article_relevance(article_ids=[self.article.article_id])
+
+		self.article.refresh_from_db()
+		self.assertAlmostEqual(self.article.ml_score, 0.9, places=5)
+		self.assertTrue(self.article.relevant)
+
+	def test_relevant_clears_when_bulk_created_latest_drops_below_threshold(self):
+		"""A retrained model_version's bulk-created prediction can move the flag
+		in either direction, not just set it."""
+		MLPredictions.objects.bulk_create(
+			[
+				MLPredictions(
+					article=self.article,
+					subject=self.subject,
+					algorithm="pubmed_bert",
+					model_version="v1",
+					probability_score=0.9,
+					predicted_relevant=True,
+				)
+			]
+		)
+		recompute_article_ml_scores(article_ids=[self.article.article_id])
+		recompute_article_relevance(article_ids=[self.article.article_id])
+		self.article.refresh_from_db()
+		self.assertTrue(self.article.relevant)
+
+		MLPredictions.objects.bulk_create(
+			[
+				MLPredictions(
+					article=self.article,
+					subject=self.subject,
+					algorithm="pubmed_bert",
+					model_version="v2",
+					probability_score=0.2,
+					predicted_relevant=False,
+				)
+			]
+		)
+		recompute_article_ml_scores(article_ids=[self.article.article_id])
+		recompute_article_relevance(article_ids=[self.article.article_id])
+		self.article.refresh_from_db()
+		self.assertAlmostEqual(self.article.ml_score, 0.2, places=5)
+		self.assertFalse(
+			self.article.relevant,
+			"a superseded high score must not keep the flag set after recompute",
+		)
+
+
+class RecomputeArticleMlScoresScopingTestCase(TestCase):
+	"""Scoped vs. unscoped recompute_article_ml_scores must agree, and the
+	single-article signal path must not drift from the bulk path."""
+
+	@classmethod
+	def setUpTestData(cls):
+		org = Organization.objects.create(name="Scoping Org")
+		cls.team = Team.objects.create(organization=org, slug="scoping-team")
+		cls.subject = Subject.objects.create(
+			subject_name="Scoping Subject",
+			subject_slug="scoping-subject",
+			team=cls.team,
+		)
+		cls.article_a = Articles.objects.create(
+			title="Scoped ml_score A", link="https://example.com/scoped-a"
+		)
+		cls.article_b = Articles.objects.create(
+			title="Scoped ml_score B", link="https://example.com/scoped-b"
+		)
+		MLPredictions.objects.bulk_create(
+			[
+				MLPredictions(
+					article=cls.article_a,
+					subject=cls.subject,
+					algorithm="pubmed_bert",
+					model_version="v1",
+					probability_score=0.7,
+					predicted_relevant=False,
+				),
+				MLPredictions(
+					article=cls.article_b,
+					subject=cls.subject,
+					algorithm="pubmed_bert",
+					model_version="v1",
+					probability_score=0.4,
+					predicted_relevant=False,
+				),
+			]
+		)
+
+	def test_scoped_recompute_only_touches_requested_articles(self):
+		changed = recompute_article_ml_scores(article_ids=[self.article_a.article_id])
+		self.assertEqual(changed, 1)
+		self.article_a.refresh_from_db()
+		self.article_b.refresh_from_db()
+		self.assertAlmostEqual(self.article_a.ml_score, 0.7, places=5)
+		self.assertIsNone(
+			self.article_b.ml_score, "unscoped article must not be touched"
+		)
+
+	def test_scoped_and_unscoped_agree_for_same_article_set(self):
+		recompute_article_ml_scores(
+			article_ids=[self.article_a.article_id, self.article_b.article_id]
+		)
+		self.article_a.refresh_from_db()
+		self.article_b.refresh_from_db()
+		scoped_a, scoped_b = self.article_a.ml_score, self.article_b.ml_score
+
+		Articles.objects.filter(
+			article_id__in=[self.article_a.article_id, self.article_b.article_id]
+		).update(ml_score=None)
+
+		recompute_article_ml_scores()
+		self.article_a.refresh_from_db()
+		self.article_b.refresh_from_db()
+		self.assertAlmostEqual(self.article_a.ml_score, scoped_a, places=5)
+		self.assertAlmostEqual(self.article_b.ml_score, scoped_b, places=5)
+
+	def test_empty_article_ids_list_is_a_noop(self):
+		changed = recompute_article_ml_scores(article_ids=[])
+		self.assertEqual(changed, 0)
+
+	def test_signal_path_matches_bulk_path(self):
+		"""_recompute_article_ml_score (used by the post_save signal) must
+		produce the same result as calling recompute_article_ml_scores directly,
+		so the per-article and batch paths can never drift apart."""
+		_recompute_article_ml_score(self.article_a.article_id)
+		self.article_a.refresh_from_db()
+		signal_score = self.article_a.ml_score
+
+		Articles.objects.filter(article_id=self.article_a.article_id).update(
+			ml_score=None
+		)
+		recompute_article_ml_scores(article_ids=[self.article_a.article_id])
+		self.article_a.refresh_from_db()
+		self.assertAlmostEqual(self.article_a.ml_score, signal_score, places=5)

--- a/django/subscriptions/management/commands/send_admin_summary.py
+++ b/django/subscriptions/management/commands/send_admin_summary.py
@@ -4,6 +4,7 @@ from django.core.management.base import BaseCommand
 from django.template.loader import get_template
 from django.utils.html import strip_tags
 from gregory.models import MLPredictions
+from gregory.relevance import compute_ml_drift
 from subscriptions.management.commands.utils.get_credentials import (
 	build_unsubscribe_base_url,
 	get_postmark_credentials,
@@ -48,6 +49,10 @@ class Command(BaseCommand):
 				self.style.WARNING("No lists marked as admin summary found.")
 			)
 			return
+
+		# Global, not scoped to a list — computed once and reused across every
+		# list/subscriber send below. See docs/ml-prediction-signal-bypass-plan.md.
+		ml_drift = compute_ml_drift()
 
 		for admin_list in admin_summary_lists:
 			# Sent-record exclusion window must be at least as wide as the
@@ -197,6 +202,7 @@ class Command(BaseCommand):
 					summary_context["show_header_tagline"] = (
 						_admin_list.show_header_tagline
 					)
+					summary_context["ml_drift"] = ml_drift
 
 					html = get_template("emails/admin_summary.html").render(
 						summary_context

--- a/django/subscriptions/tests/test_admin_summary_ml_drift.py
+++ b/django/subscriptions/tests/test_admin_summary_ml_drift.py
@@ -1,0 +1,180 @@
+"""Tests for the admin summary's ML field health line: send_admin_summary
+computes live drift on Articles.ml_score/relevant (see
+docs/ml-prediction-signal-bypass-plan.md) and renders it on every send."""
+
+import os
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+
+import django
+
+django.setup()
+
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+from django.test import TestCase
+
+from gregory.models import (
+	Articles,
+	ArticleSubjectRelevance,
+	MLPredictions,
+	Subject,
+	Team,
+)
+from organizations.models import Organization
+from sitesettings.models import CustomSetting
+from subscriptions.models import Lists, Subscribers
+
+
+def _mock_ok_result():
+	result = MagicMock(status_code=200)
+	result.json.return_value = {"ErrorCode": 0, "Message": "OK"}
+	return result
+
+
+class AdminSummaryMlDriftTestCase(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(name="ML Drift Org", slug="ml-drift-org")
+		self.team = Team.objects.create(
+			name="ML Drift Team", organization=self.org, slug="ml-drift-team"
+		)
+		self.subject = Subject.objects.create(
+			subject_name="ML Drift Subject",
+			team=self.team,
+			subject_slug="ml-drift-subject",
+			auto_predict=True,
+			ml_consensus_type="any",
+		)
+		self.site = Site.objects.get_or_create(
+			id=1, defaults={"domain": "testserver", "name": "Test Site"}
+		)[0]
+		self.custom_settings = CustomSetting.objects.get_or_create(
+			site=self.site,
+			defaults={
+				"title": "Test Site",
+				"postmark_api_token": "test-token",
+				"postmark_api_url": "https://api.postmarkapp.com/email",
+			},
+		)[0]
+		self.subscriber = Subscribers.objects.create(
+			first_name="Admin",
+			last_name="Tester",
+			email="ml-drift-admin@example.com",
+			active=True,
+		)
+		self.admin_list = Lists.objects.create(
+			list_name="ML Drift Admin List",
+			admin_summary=True,
+			team=self.team,
+			list_email_subject="Admin Summary",
+		)
+		self.admin_list.subjects.add(self.subject)
+		self.subscriber.subscriptions.add(self.admin_list)
+
+	def _make_article(self, title):
+		return Articles.objects.create(
+			title=title,
+			link=f"https://example.com/articles/{title.replace(' ', '-').lower()}",
+			doi=f"10.6666/{title.replace(' ', '-').lower()}",
+		)
+
+	def _run_and_capture(self, **command_kwargs):
+		"""Run send_admin_summary, capturing both the render context and the
+		rendered HTML for the admin_summary template."""
+		captured = {"context": None, "html": None}
+		real_get_template = __import__(
+			"django.template.loader", fromlist=["get_template"]
+		).get_template
+
+		def fake_get_template(template_name, using=None):
+			tmpl = real_get_template(template_name, using=using)
+			original_render = tmpl.render
+
+			def capturing_render(context=None, request=None):
+				html = original_render(context, request)
+				if template_name == "emails/admin_summary.html" and isinstance(
+					context, dict
+				):
+					captured["context"] = context
+					captured["html"] = html
+				return html
+
+			tmpl.render = capturing_render
+			return tmpl
+
+		with (
+			patch(
+				"subscriptions.management.commands.send_admin_summary.send_email",
+				return_value=_mock_ok_result(),
+			),
+			patch(
+				"subscriptions.management.commands.send_admin_summary.get_template",
+				side_effect=fake_get_template,
+			),
+		):
+			out = StringIO()
+			call_command("send_admin_summary", stdout=out, **command_kwargs)
+
+		return captured
+
+	def _seed_reviewable_content(self):
+		"""send_admin_summary skips sends entirely with nothing to review, so
+		every test needs at least one fresh article to trigger a send."""
+		article = self._make_article("Reviewable Article")
+		article.subjects.add(self.subject)
+		return article
+
+	def test_zero_drift_renders_health_line_at_zero(self):
+		self._seed_reviewable_content()
+
+		ctx = self._run_and_capture()
+
+		self.assertIsNotNone(ctx["context"], "template must have been rendered")
+		drift = ctx["context"]["ml_drift"]
+		self.assertEqual(drift["stale_ml_score"], 0)
+		self.assertEqual(drift["missing_relevant"], 0)
+		self.assertEqual(drift["unexpected_relevant"], 0)
+		self.assertIn("0 drifted", ctx["html"])
+
+	def test_seeded_stale_ml_score_is_reflected_in_context_and_html(self):
+		self._seed_reviewable_content()
+
+		stale_article = self._make_article("Stale Score Article")
+		MLPredictions.objects.create(
+			article=stale_article,
+			subject=self.subject,
+			algorithm="pubmed_bert",
+			model_version="v1",
+			probability_score=0.5,
+			predicted_relevant=False,
+		)
+		# The MLPredictions signal already set ml_score; force it back to NULL
+		# to simulate a bulk_create write that bypassed the recompute.
+		Articles.objects.filter(pk=stale_article.pk).update(ml_score=None)
+
+		ctx = self._run_and_capture()
+
+		drift = ctx["context"]["ml_drift"]
+		self.assertEqual(drift["stale_ml_score"], 1)
+		self.assertIn("1 drifted", ctx["html"])
+
+	def test_seeded_missing_relevant_is_reflected_in_context_and_html(self):
+		self._seed_reviewable_content()
+
+		should_be_relevant = self._make_article("Should Be Relevant Article")
+		should_be_relevant.subjects.add(self.subject)
+		ArticleSubjectRelevance.objects.create(
+			article=should_be_relevant, subject=self.subject, is_relevant=True
+		)
+		# The signal already synced relevant=True; force it back out of sync
+		# to simulate a write path that bypassed the recompute.
+		Articles.objects.filter(pk=should_be_relevant.pk).update(relevant=False)
+
+		ctx = self._run_and_capture()
+
+		drift = ctx["context"]["ml_drift"]
+		self.assertEqual(drift["missing_relevant"], 1)
+		self.assertEqual(drift["unexpected_relevant"], 0)
+		self.assertIn("1 drifted", ctx["html"])

--- a/django/templates/emails/admin_summary.html
+++ b/django/templates/emails/admin_summary.html
@@ -108,7 +108,7 @@
         <p class="ml-drift-text" style="color: {% if ml_drift_total %}#991b1b{% else %}#166534{% endif %}; font-size: 13px; margin: 0;">
             {{ ml_drift.stale_ml_score }} article{{ ml_drift.stale_ml_score|pluralize }} with predictions but no ml_score,
             {{ ml_drift.missing_relevant }} article{{ ml_drift.missing_relevant|pluralize }} that should be flagged relevant but aren't,
-            {{ ml_drift.unexpected_relevant }} flagged relevant that shouldn't be.
+            {{ ml_drift.unexpected_relevant }} article{{ ml_drift.unexpected_relevant|pluralize }} flagged relevant that shouldn't be.
             {% if ml_drift_total %}Non-zero means a write path is bypassing the denormalized-field recompute — see docs/ml-prediction-signal-bypass-plan.md.{% endif %}
         </p>
     </div>

--- a/django/templates/emails/admin_summary.html
+++ b/django/templates/emails/admin_summary.html
@@ -93,11 +93,28 @@
     <div class="admin-action-box" style="margin-top: 40px; padding: 20px; background-color: #fef3c7; border: 1px solid #fbbf24; border-radius: 8px;">
         <h3 class="admin-action-title" style="color: #92400e; font-size: 16px; margin: 0 0 10px 0;">📋 Admin Actions</h3>
         <p class="admin-action-text" style="color: #92400e; font-size: 14px; margin: 0;">
-            Review the articles above and mark them as relevant using the EDIT ARTICLE buttons. 
+            Review the articles above and mark them as relevant using the EDIT ARTICLE buttons.
             This helps improve our machine learning accuracy for future recommendations.
         </p>
     </div>
-    
+
+    <!-- ML Field Health Check -->
+    {% if ml_drift %}
+    {% with ml_drift_total=ml_drift.stale_ml_score|add:ml_drift.missing_relevant|add:ml_drift.unexpected_relevant %}
+    <div class="ml-drift-box" style="margin-top: 20px; padding: 16px 20px; background-color: {% if ml_drift_total %}#fee2e2{% else %}#f0fdf4{% endif %}; border: 1px solid {% if ml_drift_total %}#fca5a5{% else %}#86efac{% endif %}; border-radius: 8px;">
+        <h3 class="ml-drift-title" style="color: {% if ml_drift_total %}#991b1b{% else %}#166534{% endif %}; font-size: 14px; margin: 0 0 6px 0;">
+            {% if ml_drift_total %}⚠️{% else %}✅{% endif %} ML field health: {{ ml_drift_total }} drifted
+        </h3>
+        <p class="ml-drift-text" style="color: {% if ml_drift_total %}#991b1b{% else %}#166534{% endif %}; font-size: 13px; margin: 0;">
+            {{ ml_drift.stale_ml_score }} article{{ ml_drift.stale_ml_score|pluralize }} with predictions but no ml_score,
+            {{ ml_drift.missing_relevant }} article{{ ml_drift.missing_relevant|pluralize }} that should be flagged relevant but aren't,
+            {{ ml_drift.unexpected_relevant }} flagged relevant that shouldn't be.
+            {% if ml_drift_total %}Non-zero means a write path is bypassing the denormalized-field recompute — see docs/ml-prediction-signal-bypass-plan.md.{% endif %}
+        </p>
+    </div>
+    {% endwith %}
+    {% endif %}
+
     <!-- Additional Resources -->
     <div style="margin-top: 40px; padding-top: 30px; border-top: 1px solid #e5e7eb;">
         <p class="content-text" style="text-align: center;">

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -186,6 +186,44 @@ Reference: [ml-consensus.md](ml-consensus.md)
 
 ---
 
+## How do I check whether the denormalized ML fields are still in sync?
+
+`Articles.ml_score` and `Articles.relevant` are maintained at write time by
+`predict_articles` (see [ml-prediction-signal-bypass-plan.md](ml-prediction-signal-bypass-plan.md)
+for why that wasn't always true). Two commands re-derive both fields from the
+underlying predictions and relevance data, and are safe to re-run at any time:
+
+```bash
+docker exec gregory python manage.py backfill_ml_scores
+docker exec gregory python manage.py refresh_article_relevance
+```
+
+Both report a **changed-row count**. Run as a weekly cron health check — not
+nightly, since a frequent sweep would paper over exactly the kind of bug this
+was:
+
+```cron
+# Weekly health check on the denormalized ML fields. These are maintained at
+# write time by predict_articles; this sweep should normally change 0 rows.
+# A non-zero count means some write path is bypassing the recompute — see
+# docs/ml-prediction-signal-bypass-plan.md.
+30 4 * * 0 docker exec gregory python manage.py backfill_ml_scores
+40 4 * * 0 docker exec gregory python manage.py refresh_article_relevance
+```
+
+**0 rows changed is the passing result** — it means the write-time path is
+working and nothing is stale. **Any non-zero count is a bug report, not a
+status update**: it means some code path is writing `MLPredictions` or
+`ArticleSubjectRelevance` without going through the recompute (e.g. a new
+`bulk_create` site), and the next person to see it should treat it as a
+regression to find, not a routine number to file away.
+
+The same drift is also surfaced passively in the admin summary email — see
+[ml-prediction-signal-bypass-plan.md](ml-prediction-signal-bypass-plan.md) for
+what those two numbers mean.
+
+---
+
 ## How do I choose a sort order for a weekly digest list?
 
 Each digest list has an **Article Sort Order** setting with two options:

--- a/docs/ml-prediction-signal-bypass-plan.md
+++ b/docs/ml-prediction-signal-bypass-plan.md
@@ -1,0 +1,83 @@
+# Predictions written by the pipeline never updated the denormalized fields
+
+`Articles.relevant` and `Articles.ml_score` are both maintained by a `post_save`
+signal on `MLPredictions`. The ML pipeline creates predictions with
+`bulk_create`, which does not fire `post_save`. Neither field was updated
+by a pipeline run since the feature shipped — only by manual backfills.
+
+Found 2026-07-30 while checking whether three implementations of the ML
+consensus rule agree. They do. The denormalized columns they feed did not.
+
+## Root cause
+
+`gregory/management/commands/predict_articles.py` writes predictions with:
+
+```python
+MLPredictions.objects.bulk_create(prediction_instances, ignore_conflicts=True)
+```
+
+`bulk_create` bypasses `save()` and therefore `post_save`. The receiver at
+`gregory/signals.py` — which calls both the ml_score recompute and
+`recompute_article_relevance` — never ran for pipeline output.
+
+The signal does fire for individual `.save()` calls, which is what admin edits
+and the test suite do. That is why this looked correct everywhere except
+production.
+
+## The fix
+
+- [gregory/relevance.py](../django/gregory/relevance.py) now has a scoped
+  `recompute_article_ml_scores(article_ids=None)`, alongside
+  `recompute_article_relevance`, both backed by a single SQL `UPDATE` guarded
+  with `IS DISTINCT FROM` so the reported changed-row count is real and a
+  full-table pass is cheap when nothing changed.
+- [gregory/management/commands/backfill_ml_scores.py](../django/gregory/management/commands/backfill_ml_scores.py)
+  is a thin wrapper over `recompute_article_ml_scores`, mirroring how
+  `refresh_article_relevance` wraps `recompute_article_relevance`.
+- [gregory/signals.py](../django/gregory/signals.py)'s `_recompute_article_ml_score`
+  (the per-article signal path) now calls the same scoped function with a
+  single-element list, so the per-article and bulk paths cannot drift apart.
+- [gregory/management/commands/predict_articles.py](../django/gregory/management/commands/predict_articles.py)
+  calls both recomputes for the batch's article IDs immediately after
+  `bulk_create`, guarded by `not dry_run`.
+
+## Ongoing health check
+
+With the write-time fix in place, drift should not recur. Two things watch
+for it anyway, on the assumption that some future write path will bypass the
+recompute the same way `predict_articles` did:
+
+1. **Weekly cron** — `backfill_ml_scores` and `refresh_article_relevance` run
+   every Sunday at 04:30/04:40 and report a changed-row count. See
+   [cookbook.md](cookbook.md#how-do-i-check-whether-the-denormalized-ml-fields-are-still-in-sync).
+   Weekly rather than nightly is deliberate: a frequent sweep would mask this
+   exact class of bug as a few hours of staleness instead of surfacing it.
+   Zero rows changed is the passing result; non-zero is a bug report.
+
+2. **Admin summary email** — computes the same drift live (not from the last
+   cron run) and renders it as a line near the "Admin Actions" box on every
+   send:
+   - articles with predictions but a NULL `ml_score`
+   - articles the live consensus query says are relevant but whose `relevant`
+     flag disagrees, in both directions (the reverse direction should always
+     be zero — a non-zero there means something different: a wrong rule, not
+     staleness)
+
+   These numbers are global, not scoped to a particular digest list; with more
+   than one `admin_summary` list configured, the same figures would appear in
+   each send.
+
+   The email only sends when there are articles or trials to review, so this
+   is a slow-moving signal, not a guaranteed heartbeat — acceptable given the
+   weekly cron already covers that case.
+
+## Out of scope
+
+- The test binding the three consensus implementations together
+  (`Articles.is_ml_relevant_for_subject`, `api.filters.ml_relevant_articles_q`,
+  `gregory.relevance.recompute_article_relevance`). They agree today and
+  were not the cause of this bug — see
+  [subscriptions-remaining-work.md](subscriptions-remaining-work.md) Task 8.
+- Any change to the consensus rule itself.
+- The `ml_score` NULL-sorting behaviour in the API (`nulls_last`). It was
+  correct; it was just being fed stale data.


### PR DESCRIPTION
## Summary

`Articles.ml_score` and `Articles.relevant` are maintained by a `post_save` signal on `MLPredictions`. `predict_articles` writes predictions with `MLPredictions.objects.bulk_create(...)`, which never fires `post_save` — so neither denormalized field had been updated by a pipeline run since the feature shipped, only by manual backfills. In production as of 2026-07-30: 1,439 articles with a NULL `ml_score`, 12 with a stale `relevant` flag.

- Extracted a scoped `recompute_article_ml_scores(article_ids=None)` into `gregory/relevance.py`, mirroring the existing `recompute_article_relevance` — single `UPDATE`, `IS DISTINCT FROM`-guarded so the changed-row count is real (the old `backfill_ml_scores` reported the full table size every run, regardless of what changed).
- `backfill_ml_scores` is now a thin wrapper over the new function; `signals.py`'s `_recompute_article_ml_score` calls the same function so the per-article (signal) and bulk (pipeline) paths can't drift apart.
- `predict_articles` calls both recomputes for the batch's article IDs immediately after `bulk_create`, guarded by `--dry-run`.
- Added `compute_ml_drift()` (live, read-only) and surfaced it as a health line in the admin summary email, rendered on every send whether zero or non-zero, plus a weekly (not nightly — a frequent sweep would mask this exact bug) cron health check documented in `docs/cookbook.md`.
- Full writeup in `docs/ml-prediction-signal-bypass-plan.md`.

## Why this shape

The bug looked fine everywhere except production because `.save()` (admin edits, most of the test suite) fires the signal; only the pipeline's `bulk_create` bypassed it. The critical test is `test_bulk_create_updates_ml_score_and_relevant` in `test_predict_articles.py` — I verified it fails when the recompute calls are reverted, then confirmed the fix again.

## Test plan

- [x] Full `pytest` suite passes (2903 tests) in a throwaway container against this worktree
- [x] `uvx ruff check django/` and `ruff format --check` clean on all touched/new files
- [x] Manually reverted the `predict_articles.py` fix and confirmed `test_bulk_create_updates_ml_score_and_relevant` / `test_relevant_clears_when_pipeline_retrain_drops_below_threshold` fail, then restored and re-verified green
- [ ] After deploy, run on production and re-check drift is zero:
  ```bash
  docker exec gregory python manage.py backfill_ml_scores
  docker exec gregory python manage.py refresh_article_relevance
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)