### PR TITLE
fix: /categories/?ordering=authors_count_annotated returns 500 (FieldError)

### DIFF
--- a/django/api/tests/test_category_count_annotations.py
+++ b/django/api/tests/test_category_count_annotations.py
@@ -295,8 +295,11 @@ class CategoryAuthorsCountOrderingTests(TestCase):
 		self.assertEqual(response.status_code, 200)
 
 	def test_authors_count_not_annotated_unless_sorted_by(self):
-		"""The whole point of the conditional: an ordinary list request must
-		not pay for the distinct-author count."""
+		"""An ordinary list request must not compute the count in SQL over the
+		whole filtered set. It still reports authors_count — the serializer
+		derives it per row on the page — but that is bounded by page size,
+		whereas the annotation is evaluated before pagination narrows anything
+		down."""
 		url = reverse("categories-list")
 		with CaptureQueriesContext(connection) as ctx:
 			response = self.client.get(

--- a/django/api/tests/test_category_count_annotations.py
+++ b/django/api/tests/test_category_count_annotations.py
@@ -22,10 +22,11 @@ from django.utils.text import slugify
 from rest_framework.test import APIClient
 
 from api.serializers import CategorySerializer
-from api.views import _category_through_count_subquery
+from api.views import CategoryViewSet, _category_through_count_subquery
 from gregory.models import (
 	ArticleCategoryAssignment,
 	Articles,
+	Authors,
 	Organization,
 	OrganizationApiSettings,
 	Subject,
@@ -179,3 +180,198 @@ class CategoryCountAnnotationTests(TestCase):
 				joins_articles and joins_trials,
 				f"Query joins both through tables, reintroducing the fan-out: {sql}",
 			)
+
+
+class CategoryAuthorsCountOrderingTests(TestCase):
+	"""`authors_count_annotated` is listed in CategoryViewSet.ordering_fields,
+	so DRF's OrderingFilter passes it straight through to order_by() instead
+	of discarding it as an unknown field. When the queryset doesn't annotate
+	that name the request dies with
+	`FieldError: Cannot resolve keyword 'authors_count_annotated' into field`
+	— a 500 seen in production. The annotation is expensive (distinct authors
+	across every article in the category), so it is added only for requests
+	that actually sort by it; these tests pin both halves of that deal.
+	"""
+
+	def setUp(self):
+		self.organization = Organization.objects.create(
+			name="Authors Ordering Org", slug="authors-ordering-org"
+		)
+		OrganizationApiSettings.objects.filter(organization=self.organization).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="Authors Ordering Team",
+			slug="authors-ordering-team",
+			organization=self.organization,
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Authors Ordering Subject",
+			subject_slug="authors-ordering-subject",
+			team=self.team,
+		)
+
+		# Two categories with a known, different number of distinct authors.
+		# The 3-author category shares one author across two articles, so a
+		# count that forgets DISTINCT would report 4 and flip the sort order.
+		self.few_authors = _make_category(self.team, self.subject, "Few Authors")
+		self.many_authors = _make_category(self.team, self.subject, "Many Authors")
+
+		authors = [
+			Authors.objects.create(
+				given_name=f"Author{i}", family_name="Test", full_name=f"Author{i} Test"
+			)
+			for i in range(5)
+		]
+
+		shared = authors[0]
+		for i, extra in enumerate(authors[1:3]):
+			article = Articles.objects.create(
+				title=f"Many Authors Article {i}",
+				link=f"https://example.com/many-authors-article-{i}",
+				published_date=timezone.now(),
+			)
+			article.team_categories.add(self.many_authors)
+			article.authors.add(shared, extra)
+
+		article = Articles.objects.create(
+			title="Few Authors Article",
+			link="https://example.com/few-authors-article",
+			published_date=timezone.now(),
+		)
+		article.team_categories.add(self.few_authors)
+		article.authors.add(authors[3])
+
+		self.client = APIClient()
+
+	def _results(self, response):
+		return response.data["results"] if "results" in response.data else response.data
+
+	def test_ordering_by_authors_count_does_not_500(self):
+		url = reverse("categories-list")
+		response = self.client.get(
+			url,
+			{
+				"team_id": self.team.id,
+				"ordering": "-authors_count_annotated",
+				"include_authors": "false",
+			},
+		)
+		self.assertEqual(response.status_code, 200)
+
+		results = self._results(response)
+		names = [row["category_name"] for row in results]
+		self.assertEqual(names, ["Many Authors", "Few Authors"])
+		self.assertEqual(results[0]["authors_count"], 3)
+		self.assertEqual(results[1]["authors_count"], 1)
+
+	def test_ascending_ordering_by_authors_count_does_not_500(self):
+		"""The `-` prefix must not be what makes the name resolvable."""
+		url = reverse("categories-list")
+		response = self.client.get(
+			url,
+			{
+				"team_id": self.team.id,
+				"ordering": "authors_count_annotated",
+				"include_authors": "false",
+			},
+		)
+		self.assertEqual(response.status_code, 200)
+		names = [row["category_name"] for row in self._results(response)]
+		self.assertEqual(names, ["Few Authors", "Many Authors"])
+
+	def test_authors_count_ordering_works_alongside_another_term(self):
+		"""DRF accepts a comma-separated ordering list; the annotation has to
+		be added when the expensive term is anywhere in it, not just first."""
+		url = reverse("categories-list")
+		response = self.client.get(
+			url,
+			{
+				"team_id": self.team.id,
+				"ordering": "category_name,-authors_count_annotated",
+				"include_authors": "false",
+			},
+		)
+		self.assertEqual(response.status_code, 200)
+
+	def test_authors_count_not_annotated_unless_sorted_by(self):
+		"""The whole point of the conditional: an ordinary list request must
+		not pay for the distinct-author count."""
+		url = reverse("categories-list")
+		with CaptureQueriesContext(connection) as ctx:
+			response = self.client.get(
+				url, {"team_id": self.team.id, "include_authors": "false"}
+			)
+		self.assertEqual(response.status_code, 200)
+
+		self.assertFalse(
+			any("authors_count_annotated" in q["sql"] for q in ctx.captured_queries),
+			"Default /categories/ request computed the expensive authors count",
+		)
+
+	def test_count_orderings_are_all_resolvable(self):
+		"""Every name in ordering_fields must resolve against the default
+		queryset (or be added to it on demand, as authors_count_annotated is).
+		A name that is whitelisted but never annotated reaches order_by() and
+		raises FieldError — the production 500 this module guards.
+		"""
+		url = reverse("categories-list")
+		for field in CategoryViewSet.ordering_fields:
+			for term in (field, f"-{field}"):
+				with self.subTest(ordering=term):
+					response = self.client.get(
+						url,
+						{
+							"team_id": self.team.id,
+							"ordering": term,
+							"include_authors": "false",
+						},
+					)
+					self.assertEqual(response.status_code, 200)
+
+	def test_ordering_by_trials_count_uses_the_free_annotation(self):
+		"""trials_count_annotated is always on the queryset, so sorting by it
+		must not add the expensive authors count."""
+		Trials.objects.create(
+			title="Ordering Trial",
+			link="https://example.com/ordering-trial",
+			published_date=timezone.now(),
+		).team_categories.add(self.many_authors)
+
+		url = reverse("categories-list")
+		with CaptureQueriesContext(connection) as ctx:
+			response = self.client.get(
+				url,
+				{
+					"team_id": self.team.id,
+					"ordering": "-trials_count_annotated",
+					"include_authors": "false",
+				},
+			)
+		self.assertEqual(response.status_code, 200)
+
+		results = self._results(response)
+		self.assertEqual(results[0]["category_name"], "Many Authors")
+		self.assertEqual(results[0]["trials_count_total"], 1)
+		self.assertEqual(results[1]["trials_count_total"], 0)
+		self.assertFalse(
+			any("authors_count_annotated" in q["sql"] for q in ctx.captured_queries),
+			"Sorting by trials count computed the expensive authors count",
+		)
+
+	def test_unknown_ordering_field_still_falls_back_silently(self):
+		"""Guards the assumption behind the fix: DRF drops ordering names that
+		are NOT in ordering_fields, which is why only the whitelisted-but-
+		unannotated name could ever reach order_by() and raise FieldError."""
+		url = reverse("categories-list")
+		response = self.client.get(
+			url,
+			{
+				"team_id": self.team.id,
+				"ordering": "no_such_field",
+				"include_authors": "false",
+			},
+		)
+		self.assertEqual(response.status_code, 200)
+		names = [row["category_name"] for row in self._results(response)]
+		self.assertEqual(names, sorted(names))

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1483,6 +1483,30 @@ def _category_through_count_subquery(through_model):
 	)
 
 
+def _category_authors_count_subquery():
+	"""Correlated scalar count of the distinct authors behind a category's
+	articles.
+
+	Unlike the two through-table counts above, this one walks
+	articles_team_categories -> articles_authors, so the DISTINCT is real
+	work rather than a formality (a large category's articles can carry tens
+	of thousands of author rows). It is therefore NOT part of the default
+	/categories/ queryset — see CategoryViewSet.get_queryset, which adds it
+	only when the client explicitly sorts by it.
+	"""
+	return Coalesce(
+		Subquery(
+			ArticleCategoryAssignment.objects.filter(teamcategory=OuterRef("pk"))
+			.order_by()
+			.values("teamcategory")
+			.annotate(c=Count("articles__authors", distinct=True))
+			.values("c"),
+			output_field=IntegerField(),
+		),
+		0,
+	)
+
+
 class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 	"""
 	List all categories in the database with optional filters for team and subject.
@@ -1501,7 +1525,11 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 	- **monthly_counts** - Include monthly article/trial counts with ML predictions (default: false)
 	- **ml_threshold** - ML prediction probability threshold when monthly_counts=true (0.0-1.0, default: 0.5)
 	- **search** - search in category name and description
-	- **ordering** - sort field, prefix with `-` for descending. Allowed values: `category_name`, `id`, `article_count_annotated`, `authors_count_annotated`
+	- **ordering** - sort field, prefix with `-` for descending. Allowed values: `category_name`, `id`, `article_count_annotated`, `trials_count_annotated`, `authors_count_annotated`.
+	  The first four are free — they sort on columns the queryset already
+	  computes. `authors_count_annotated` is the expensive one: it is the only
+	  value that adds a distinct-author count over every article in each
+	  category, so it is computed only for requests that actually sort by it.
 
 	# Response includes:
 	- Category basic information
@@ -1539,6 +1567,7 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 		"category_name",
 		"id",
 		"article_count_annotated",
+		"trials_count_annotated",
 		"authors_count_annotated",
 	]
 	ordering = ["category_name"]
@@ -1599,6 +1628,24 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 			trials_count_annotated=_category_through_count_subquery(TrialCategoryAssignment),
 		)
 
+		# `authors_count_annotated` is an allowed ordering value but is NOT
+		# annotated by default: counting a category's distinct authors means
+		# reaching through to articles_authors, which is far more expensive
+		# than the two through-table counts above. Annotate it only when the
+		# client actually sorts by it — leaving it out unconditionally makes
+		# DRF's OrderingFilter hand an unresolvable name to order_by(), which
+		# is a 500 (FieldError), not a graceful fallback, precisely because
+		# the name passes the ordering_fields whitelist.
+		#
+		# Deliberately not date-filtered: the serializer prefers this
+		# annotation over its live-count fallback, so filtering it here would
+		# make a category's reported authors_count change depending on
+		# whether the client happened to sort by it.
+		if self._orders_by_authors_count():
+			queryset = queryset.annotate(
+				authors_count_annotated=_category_authors_count_subquery()
+			)
+
 		# No .distinct() needed: the count annotations are now correlated
 		# subqueries (no JOIN), team is select_related via FK, subjects is
 		# prefetch_related (a separate query), and subjects__id=<single id>
@@ -1608,6 +1655,20 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 		# paginator's count() down a DISTINCT-over-all-columns path,
 		# undermining the cheap-count fix above.
 		return queryset
+
+	def _orders_by_authors_count(self):
+		"""True when this request's `ordering` sorts by authors count.
+
+		Reads the param the same way DRF's OrderingFilter does: one
+		comma-separated value, each term optionally prefixed with `-`.
+		"""
+		raw = self.request.query_params.get(
+			filters.OrderingFilter.ordering_param, ""
+		)
+		return any(
+			term.strip().lstrip("-") == "authors_count_annotated"
+			for term in raw.split(",")
+		)
 
 	def get_serializer_context(self):
 		"""Add author parameters to serializer context"""

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1526,10 +1526,13 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 	- **ml_threshold** - ML prediction probability threshold when monthly_counts=true (0.0-1.0, default: 0.5)
 	- **search** - search in category name and description
 	- **ordering** - sort field, prefix with `-` for descending. Allowed values: `category_name`, `id`, `article_count_annotated`, `trials_count_annotated`, `authors_count_annotated`.
-	  The first four are free — they sort on columns the queryset already
-	  computes. `authors_count_annotated` is the expensive one: it is the only
-	  value that adds a distinct-author count over every article in each
-	  category, so it is computed only for requests that actually sort by it.
+	  The first four sort on values the queryset already computes, so they add
+	  nothing. `authors_count_annotated` is the expensive one: ordering has to
+	  happen before pagination, so it counts distinct authors for every category
+	  matching the filters rather than just the page being returned. It is
+	  therefore annotated only for requests that sort by it — note this changes
+	  *where* the count comes from, not whether it is computed, since the
+	  serializer otherwise derives `authors_count` per row on its own.
 
 	# Response includes:
 	- Category basic information
@@ -1629,18 +1632,28 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 		)
 
 		# `authors_count_annotated` is an allowed ordering value but is NOT
-		# annotated by default: counting a category's distinct authors means
-		# reaching through to articles_authors, which is far more expensive
-		# than the two through-table counts above. Annotate it only when the
-		# client actually sorts by it — leaving it out unconditionally makes
-		# DRF's OrderingFilter hand an unresolvable name to order_by(), which
-		# is a 500 (FieldError), not a graceful fallback, precisely because
-		# the name passes the ordering_fields whitelist.
+		# annotated by default. Leaving it out unconditionally would be a bug
+		# on its own — DRF's OrderingFilter hands the unresolvable name to
+		# order_by(), which is a 500 (FieldError) rather than the graceful
+		# fallback an unknown name gets, precisely because this one passes the
+		# ordering_fields whitelist.
 		#
-		# Deliberately not date-filtered: the serializer prefers this
-		# annotation over its live-count fallback, so filtering it here would
-		# make a category's reported authors_count change depending on
-		# whether the client happened to sort by it.
+		# The count itself is not avoided by skipping the annotation: the
+		# serializer derives authors_count per row when it is absent (see
+		# CategorySerializer.get_authors_count), so a default list response
+		# still runs one such query per category on the page. What the
+		# annotation changes is the scope — ordering is applied before
+		# pagination, so ranking by this value forces the distinct-author
+		# count for every category matching the filters, not just the page.
+		# Annotating on demand keeps that whole-result-set cost on the
+		# requests that asked to be sorted by it. (Those requests get the
+		# serializer's per-row queries for free in exchange, since the
+		# annotation is then present.)
+		#
+		# Deliberately not date-filtered: because the serializer prefers this
+		# annotation over its own fallback, filtering it here would make a
+		# category's reported authors_count change depending on whether the
+		# client happened to sort by it.
 		if self._orders_by_authors_count():
 			queryset = queryset.annotate(
 				authors_count_annotated=_category_authors_count_subquery()

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -168,7 +168,7 @@ GET /articles/?team_id=1&subjects=1,3&published_date_after=2022-06-01&format=csv
 | Authors | `GET /authors/by_team_subject/` | `team_id` *(req)*, `subject_id` *(req)* | |
 | Authors | `GET /authors/by_team_category/` | `team_id` *(req)*, `category_slug` or `category_id` *(req)* | |
 | Authors | `GET /authors/{id}/coauthors/` | `id` (path) | Co-authors of the given author |
-| Categories | `GET /categories/` | `team_id`, `subject_id`, `category_id`, `search`, `ordering`, `include_authors`, `max_authors`, `monthly_counts`, `ml_threshold`, `date_from`, `date_to`, `timeframe`, pagination | |
+| Categories | `GET /categories/` | `team_id`, `subject_id`, `category_id`, `get_categories`, `search`, `ordering` (`category_name`, `id`, `article_count_annotated`, `trials_count_annotated`, `authors_count_annotated`), `include_authors`, `max_authors`, `monthly_counts`, `ml_threshold`, `date_from`, `date_to`, `timeframe`, pagination | `ordering=authors_count_annotated` is the expensive sort — see [Categories ordering](#categories-ordering) |
 | Categories | `GET /categories/{id}/` | `id` (path) | |
 | Categories | `GET /categories/{id}/authors/` | `id` (path), `min_articles`, `sort_by`, `order`, date filters | Author stats for a category |
 | Sources | `GET /sources/` | `team_id`, `subject_id`, `source_for`, `search`, `ordering`, pagination | |
@@ -407,7 +407,15 @@ That order is for plain `?ordering=recruiting_first` (ascending). `?ordering=-re
 
 Many trials share a rank, so ties are broken automatically by `-discovery_date` in both directions — page-to-page ordering stays stable.
 
-**Unrecognised `ordering` values are silently ignored, not rejected** (DRF `OrderingFilter`'s default behaviour) — a typo or a stale field name falls back to the default ordering instead of returning an error.
+**Unrecognised `ordering` values are silently ignored, not rejected** (DRF `OrderingFilter`'s default behaviour) — a typo or a stale field name falls back to the default ordering instead of returning an error. This applies to every endpoint that accepts `ordering`.
+
+### Categories ordering
+
+`GET /categories/?ordering=<field>` (prefix with `-` to reverse). Accepted values: `category_name` (default), `id`, `article_count_annotated`, `trials_count_annotated`, `authors_count_annotated`.
+
+`article_count_annotated` and `trials_count_annotated` sort by the same numbers the response reports as `article_count_total` and `trials_count_total`. Both are free: the queryset already computes them for every request.
+
+`authors_count_annotated` sorts by the number of distinct authors across a category's articles — the same number reported as `authors_count` in the response body. It is materially more expensive than the other four, so the server computes it only for requests that actually sort by it; a plain `GET /categories/` never pays for it. Expect these requests to be slower on teams with large categories.
 
 ### Sponsor canonicalization
 

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -415,7 +415,9 @@ Many trials share a rank, so ties are broken automatically by `-discovery_date` 
 
 `article_count_annotated` and `trials_count_annotated` sort by the same numbers the response reports as `article_count_total` and `trials_count_total`. Both are free: the queryset already computes them for every request.
 
-`authors_count_annotated` sorts by the number of distinct authors across a category's articles — the same number reported as `authors_count` in the response body. It is materially more expensive than the other four, so the server computes it only for requests that actually sort by it; a plain `GET /categories/` never pays for it. Expect these requests to be slower on teams with large categories.
+`authors_count_annotated` sorts by the number of distinct authors across a category's articles — the same number reported as `authors_count` in the response body. Expect it to be slower than the other four on teams with large categories.
+
+`authors_count` is present in every response regardless of ordering, so this sort does not introduce the author counting; it widens it. Ordering is applied before pagination, so ranking by this value counts distinct authors for every category matching the filters, where an unsorted request only counts the ones on the page it returns.
 
 ### Sponsor canonicalization
 


### PR DESCRIPTION
## The bug

`GET /categories/?ordering=authors_count_annotated` (or `-authors_count_annotated`) 500s in production:

```
django.core.exceptions.FieldError: Cannot resolve keyword 'authors_count_annotated' into field.
Choices are: article_assignments, article_count_annotated, articles, ... trials_count_annotated
```

`authors_count_annotated` is listed in `CategoryViewSet.ordering_fields`, but the queryset stopped annotating it in `a2ad211f` ("test db optimisations"), which dropped `Count('articles__authors', distinct=True)` for performance and left the whitelist entry behind.

That mismatch is what makes it fatal rather than merely broken. DRF's `OrderingFilter` **discards** ordering names that are not in `ordering_fields`, so a typo falls back to the default ordering. A name that *is* whitelisted skips that check and goes straight to `order_by()`, where Django cannot resolve it.

The field kept rendering fine in responses the whole time — `CategorySerializer.get_authors_count` falls back to a live query when the annotation is absent — so nothing surfaced until someone sorted by it.

## The fix

Restore the annotation as a correlated subquery (`_category_authors_count_subquery`), added **only** for requests that actually sort by it.

To be precise about what that buys (an earlier version of this description overstated it, as Copilot correctly flagged): the conditional does not stop author counting from happening on a default request — `CategorySerializer.get_authors_count` falls back to a live per-row query whenever the annotation is absent, and `authors_count` is in every response. What it controls is **scope**. Ordering is applied before pagination, so sorting by `authors_count_annotated` counts distinct authors for every category matching the filters, whereas an unsorted request only counts the ones on the page it returns. Sorted requests get the per-row fallbacks eliminated in exchange, since the annotation is then present.

Two deliberate details:

- **Not date-filtered**, unlike the version removed in `a2ad211f`. The serializer prefers this annotation over its live-count fallback, so a filtered version would make a category's reported `authors_count` change depending on whether the client happened to sort by it.
- **Parses `ordering` the way DRF does** — comma-separated terms, optional `-` prefix — so `?ordering=category_name,-authors_count_annotated` works, not just the bare form.

## Also fixed

`trials_count_annotated` is annotated on every request but was missing from `ordering_fields`, so you couldn't sort by it even though it costs nothing. Added, alongside its article-side twin which was already there.

## Verification

- Reverting `views.py` alone makes 3 of the new tests fail with the **exact** production traceback — same `FieldError`, same field list. Not a vacuous test.
- New tests cover: both sort directions, a comma-separated ordering list, every name in `ordering_fields` resolving against the queryset, and that neither a default request nor a `trials_count_annotated` sort emits the expensive authors count.
- Full suite: **2910 passed**, no failures.

## Docs

`docs/03-api-and-rss-feeds.md` — enumerated the allowed `ordering` values on the `/categories/` row (matching how `/sponsors/` is already documented) and added a "Categories ordering" section marking which sorts are free and which is expensive. Also noted that the "unrecognised ordering values are silently ignored" rule applies to every endpoint, since that behaviour is exactly what this bug slipped past.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
