### PR TITLE
fix: reject GET on subscribe_view and add non-identifying failure diagnostics

### DIFF
--- a/django/subscriptions/tests/test_views.py
+++ b/django/subscriptions/tests/test_views.py
@@ -1,4 +1,6 @@
 import os
+from unittest import mock
+
 import django
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
@@ -113,6 +115,67 @@ class SubscribeViewTest(TestCase):
 		self.assertEqual(response.status_code, 302)
 		self.assertIn("/error/", response["Location"])
 		self.assertFalse(Subscribers.objects.filter(email="dave@example.com").exists())
+
+	def test_get_returns_405(self):
+		"""subscribe_view is POST-only; a GET must get 405, not the /error/ redirect."""
+		request = self.factory.get("/subscribe/")
+		response = subscribe_view(request)
+		self.assertEqual(response.status_code, 405)
+		self.assertEqual(response["Allow"], "POST")
+
+	def test_get_does_not_log_error(self):
+		"""A GET must be rejected by @require_POST before the view body — and
+		therefore before the logging branch — ever runs, so it must not emit
+		an ERROR-level log line the way the pre-fix 'no list IDs submitted'
+		path did for every crawler/bot hit."""
+		request = self.factory.get("/subscribe/")
+		with self.assertNoLogs("subscriptions.views", level="ERROR"):
+			subscribe_view(request)
+
+	def test_save_failure_logs_traceback(self):
+		"""An exception during save must log with a traceback (exc_info), not
+		just str(e) — the single path most likely to hide a real server-side
+		bug previously had the least diagnostic information."""
+		data = {
+			"first_name": "Erin",
+			"last_name": "Grey",
+			"email": "erin@example.com",
+			"profile": "patient",
+			"list": [str(self.lst.pk)],
+		}
+		request = self.factory.post("/subscribe/", data)
+		with mock.patch(
+			"subscriptions.views.Subscribers.objects.get_or_create",
+			side_effect=RuntimeError("boom"),
+		):
+			with self.assertLogs("subscriptions.views", level="ERROR") as log:
+				response = subscribe_view(request)
+		self.assertEqual(response.status_code, 302)
+		self.assertIn("/error/", response["Location"])
+		self.assertEqual(len(log.records), 1)
+		self.assertIsNotNone(log.records[0].exc_info)
+
+	def test_invalid_form_logs_field_names_not_values(self):
+		"""Privacy regression test — the log for an invalid form must name the
+		failed *field*, never echo the submitted value. This is the mechanism
+		that keeps email addresses out of application logs; it must fail if
+		someone later logs form.errors or form.data directly."""
+		submitted_email = "not-a-real-email"
+		data = {
+			"first_name": "Frank",
+			"last_name": "Stone",
+			"email": submitted_email,
+			"profile": "patient",
+			"list": [str(self.lst.pk)],
+		}
+		request = self.factory.post("/subscribe/", data)
+		with self.assertLogs("subscriptions.views", level="ERROR") as log:
+			response = subscribe_view(request)
+		self.assertEqual(response.status_code, 302)
+		self.assertIn("/error/", response["Location"])
+		joined_output = "\n".join(log.output)
+		self.assertIn("email", joined_output)
+		self.assertNotIn(submitted_email, joined_output)
 
 
 # ---------------------------------------------------------------------------

--- a/django/subscriptions/views.py
+++ b/django/subscriptions/views.py
@@ -176,11 +176,22 @@ def _resolve_site_from_request(request):
 
 
 @csrf_exempt
+@require_POST
 def subscribe_view(request):
 	# ``request.POST`` may contain multiple ``list`` values when the user
 	# checks more than one subscription option.
 	list_ids = request.POST.getlist("list")
 	subscription_lists = list(Lists.objects.filter(pk__in=list_ids)) if list_ids else []
+
+	# Non-identifying context echoed on every failure-path log line below —
+	# resolved list IDs, origin host, target site. Enough to tell "our own
+	# form is posting bad list IDs" apart from "a scraper is hitting the
+	# endpoint" without ever recording who submitted the form (no email, no
+	# name, no other field value — see the GDPR note in the module plan).
+	origin_header = request.META.get("HTTP_ORIGIN") or request.META.get(
+		"HTTP_REFERER", ""
+	)
+	origin_host = urlparse(origin_header).hostname if origin_header else None  # IPv6-safe, no port
 
 	# Derive the target site from the submitted lists so that origin validation
 	# and redirect-base calculation use the correct site's allowed_domains in
@@ -198,6 +209,12 @@ def subscribe_view(request):
 			)
 		target_site = Site.objects.get_current()
 
+	log_context = "list_ids=%s origin_host=%s target_site=%s" % (
+		list_ids,
+		origin_host,
+		target_site.domain,
+	)
+
 	# Determine redirect base before processing the form so we can redirect
 	# to the correct domain even when the form is invalid.
 	redirect_base = _get_redirect_base(request, target_site)
@@ -209,15 +226,17 @@ def subscribe_view(request):
 		if missing_ids:
 			logger.error(
 				"subscribe_view: requested list IDs %s do not exist in the database. "
-				"Check that the form is posting correct list IDs.",
+				"Check that the form is posting correct list IDs. (%s)",
 				missing_ids,
+				log_context,
 			)
 			return HttpResponseRedirect(f"{redirect_base}/error/")
 	else:
 		# No list selected at all — nothing to subscribe to.
 		logger.error(
 			"subscribe_view: no list IDs submitted. "
-			"The form must include at least one 'list' field value.",
+			"The form must include at least one 'list' field value. (%s)",
+			log_context,
 		)
 		return HttpResponseRedirect(f"{redirect_base}/error/")
 
@@ -225,16 +244,12 @@ def subscribe_view(request):
 	# target site's CustomSetting.allowed_domains (or the site's own domain).
 	# If no Origin/Referer header is present (e.g. server-side or API usage)
 	# the request is allowed through with a warning.
-	origin_header = request.META.get("HTTP_ORIGIN") or request.META.get(
-		"HTTP_REFERER", ""
-	)
 	if origin_header:
-		parsed_origin = urlparse(origin_header)
-		origin_host = parsed_origin.hostname  # IPv6-safe, no port
 		if origin_host and not _check_origin_allowed(origin_host, target_site):
 			logger.warning(
-				"subscribe_view: request from unauthorized origin '%s' rejected.",
+				"subscribe_view: request from unauthorized origin '%s' rejected. (%s)",
 				origin_host,
+				log_context,
 			)
 			accept_header = request.META.get("HTTP_ACCEPT", "")
 			is_ajax = request.META.get("HTTP_X_REQUESTED_WITH") == "XMLHttpRequest"
@@ -244,7 +259,8 @@ def subscribe_view(request):
 	else:
 		logger.warning(
 			"subscribe_view: no Origin or Referer header present; "
-			"site attribution may be inaccurate."
+			"site attribution may be inaccurate. (%s)",
+			log_context,
 		)
 
 	subscriber_form = SubscribersForm(request.POST)
@@ -312,12 +328,30 @@ def subscribe_view(request):
 			return HttpResponseRedirect(f"{redirect_base}/thank-you/")
 
 		except Exception as e:
-			logger.error(f"Subscription error: {e}")
+			# exc_info=True is what makes this actionable: the message alone
+			# (e.g. "duplicate key value violates ...") rarely says where in
+			# the save path it happened. Compare the API's catch-all at
+			# django/api/views.py:875, which also emits a full traceback.
+			logger.error(
+				"Subscription error: %s (%s)",
+				e,
+				log_context,
+				exc_info=True,
+			)
 			return HttpResponseRedirect(f"{redirect_base}/error/")
 
 	else:
-		logger.error("Form is invalid.")
-		logger.error(subscriber_form.errors)
+		# One emission, not two: under concurrent traffic, a separate
+		# "Form is invalid." line and a separate form.errors line interleave
+		# with other requests' log output and can't be reliably paired back
+		# together. Log only the failed *field names* — never
+		# subscriber_form.errors' values or subscriber_form.data, which would
+		# put submitted PII (e.g. the attempted email) into the log.
+		logger.error(
+			"subscribe_view: form invalid, failed fields=%s (%s)",
+			sorted(subscriber_form.errors.keys()),
+			log_context,
+		)
 		return HttpResponseRedirect(f"{redirect_base}/error/")
 
 

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -192,7 +192,7 @@ GET /articles/?team_id=1&subjects=1,3&published_date_after=2022-06-01&format=csv
 | RSS feeds | `GET /feed/author/{orcid}/` | `orcid` (path) | |
 | RSS feeds | `GET /feed/trials/subject/{subject_slug}/` | `subject_slug` (path) | |
 | Stats | `GET /stats/` | `team`, `organization` (alias `org`), `include_public` | See [Stats endpoint](#stats-endpoint) below |
-| Subscriptions | `POST /subscriptions/new/` | `first_name`, `last_name`, `email`, `profile`, `list` | |
+| Subscriptions | `POST /subscriptions/new/` | `first_name`, `last_name`, `email`, `profile`, `list` | POST-only; `GET` returns `405` with `Allow: POST` |
 
 ### Search endpoints
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -67,6 +67,8 @@ Embed an HTML form that POSTs to `/subscriptions/new/`:
 
 On success the user is redirected to `/thank-you/` on your domain. For this to work, add your domain to the **Allowed Domains** field of the target list in the Django admin (**Subscriptions → Lists**).
 
+The endpoint is POST-only — opening the action URL in a browser returns `405 Method Not Allowed` with an `Allow: POST` header. That is expected, not a misconfiguration: test the form by submitting it, not by visiting the URL.
+
 Reference: [subscriptions.md](subscriptions.md), [03-api-and-rss-feeds.md](03-api-and-rss-feeds.md)
 
 ---

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -80,7 +80,10 @@ Unique together: `(subscriber, site)`.
 
 ### `POST /subscriptions/new/`
 
-Subscribes a visitor to one or more lists.
+Subscribes a visitor to one or more lists. POST-only — a `GET` (crawler, link
+preview fetcher, someone pasting the URL into a browser) gets `405 Method Not
+Allowed` with an `Allow: POST` header rather than reaching the form-handling
+code.
 
 **Request body** (`application/x-www-form-urlencoded`):
 


### PR DESCRIPTION
`subscriptions/new/` was routed to `subscribe_view` with no method restriction. On a GET, `request.POST` is empty, so it fell into the "no list IDs submitted" branch, logged at **ERROR**, and redirected to `/error/`. Every crawler, link-preview fetcher, or pasted URL produced an ERROR-level log line.

The cost was not the GET itself — it was that genuine broken form submissions logged at the same level as bot traffic, burying the real signal.

## Fix 2 — reject GET

Added `@require_POST`. A GET now gets `405 Method Not Allowed` with `Allow: POST` and never reaches the logging branch.

`@csrf_exempt` stays outermost so `CsrfViewMiddleware` still sees the flag on the final callable.

This aligns the implementation with the **already-documented** contract — `docs/03-api-and-rss-feeds.md`, `docs/subscriptions.md` and `docs/cookbook.md` all already described it as POST-only with `<form method="POST">`. All three are now updated to state the 405 and `Allow: POST` explicitly.

## Fix 4 — diagnostics on every failure path

Failed subscriptions were close to undiagnosable:

- **The `except Exception` handler had no traceback** — it logged `str(e)` only. The path most likely to hide a real server-side bug had the least diagnostic information. Now logs with `exc_info=True`.
- **"Form is invalid." was two separate emissions** — the message and `form.errors` interleaved with other requests under concurrent traffic and could not be reliably paired. Now one emission carrying `sorted(form.errors.keys())`.
- **No request context anywhere.** Every failure path now carries resolved list IDs, origin host, and target site — enough to tell "our own form is posting bad list IDs" apart from "a scraper is hitting the endpoint".

## Deliberately not included: who failed to subscribe

Recovering the identity of failed signups was **considered and rejected**. It would mean holding an email address for someone whose signup never completed — either in application logs (looser access control, no deletion path) or in a new model needing its own retention policy and purge job.

This app is explicitly GDPR-conscious: `consent_ip`, `consent_source_site` and `consent_method` are documented as consent data. Diagnostics answer the operational question — *is the form broken, and how often* — without storing personal data for people who did not consent.

**No log statement records an email, name, or any submitted field value.** Field *names* only.

## Tests

Four new tests. `test_invalid_form_logs_field_names_not_values` is a **privacy regression test**, not a formatting one — it captures the submitted string and asserts it is absent from log output, so it fails if anyone later logs `form.errors` or `form.data` directly. With identity recovery off the table, that test is the mechanism keeping emails out of the logs as this view is edited over time. Please don't let it be relaxed into an assertion about log wording.

`test_no_list_submitted_redirects_to_error` still passes: a POST with no lists still redirects to `/error/` and still logs at ERROR. That path is a genuine form misconfiguration and stays at ERROR.

## Test results

Full `subscriptions` suite: **402 tests, OK.**

## Reviewer note

One change goes slightly beyond pure logging: `origin_header`/`origin_host` are now computed once at the top of the function so the log context and the origin-validation check share one parse, removing the `parsed_origin` local rather than duplicating the parse. `OriginValidationTest` passes in full, but this is the one edit here that touches security-relevant control flow rather than logging — worth a careful look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

