### PR TITLE
fix: eliminate redundant Team query on cache-warm /stats/ calls

### DIFF
--- a/django/api/tests/test_visibility_stats.py
+++ b/django/api/tests/test_visibility_stats.py
@@ -441,16 +441,18 @@ class StatsQueryCountTest(StatsVisibilityBase):
 		"""
 		A team-scoped /stats/ call must stay within a small query budget.
 
-		Budget breakdown (cold cache, 8 queries with the test suite's
+		Budget breakdown (cold cache, 7 queries with the test suite's
 		LocMemCache — CACHES in admin.settings_test — which never touches
 		the DB; production's DatabaseCache adds a cache GET/SET pair plus a
 		cull COUNT and SAVEPOINT/RELEASE, hence the generous <=15 ceiling):
 		  1 — VisibleOrgMiddleware: OrganizationApiSettings lookup
-		  1 — team visibility check (Team.objects.filter COUNT)
-		  1 — resolve team_id_list (Team VALUES)
+		  1 — resolve team_id_list (Team VALUES) — doubles as the
+		      team-visibility check when ?organization= is absent, since
+		      that predicate is identical to a standalone visibility query
+		      (see StatsView.get); no separate COUNT is issued
 		  4 — articles, trials, authors, subscribers COUNT DISTINCT
 		  1 — sources VALUES
-		= 8 queries.
+		= 7 queries.
 		"""
 		from django.db import connection
 		from django.test.utils import CaptureQueriesContext
@@ -465,10 +467,23 @@ class StatsQueryCountTest(StatsVisibilityBase):
 
 	def test_cached_call_query_budget(self):
 		"""A cache-warm call must issue far fewer queries than a cold one."""
+		from django.db import connection
+		from django.test.utils import CaptureQueriesContext
+
 		self.client.get("/stats/", {"team": self.pub_team.id})  # warm the cache
-		# 3, not 4: the test suite's LocMemCache backend answers cache GET
-		# in-process, issuing no SQL (unlike production's DatabaseCache).
-		with self.assertNumQueries(
-			3, msg="Cache hit should eliminate the count queries"
-		):
+		with CaptureQueriesContext(connection) as ctx:
 			self.client.get("/stats/", {"team": self.pub_team.id})
+		# <=3, not a pinned exact count: OrganizationApiSettings lookup (1)
+		# + team_id_list resolution, which also serves as the
+		# team-visibility check (1) + cache GET (0 or 1 depending on
+		# backend). LocMemCache (admin.settings_test, what CI's pytest run
+		# uses) answers GET in-process with no SQL, landing at 2;
+		# DatabaseCache backends (production, and admin.settings's default
+		# used when this test is invoked via `manage.py test` instead of
+		# pytest) add one SQL round-trip for the GET, landing at 3. Either
+		# way this must stay far below the cold-cache budget above.
+		self.assertLessEqual(
+			len(ctx.captured_queries),
+			3,
+			msg=f"Cache hit should eliminate the count queries: {len(ctx.captured_queries)} queries",
+		)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -3731,7 +3731,25 @@ class StatsView(APIView):
 			if not set(org_ids).issubset(visible_org_ids):
 				raise Http404
 
-		if team_ids and visible_org_ids is not None:
+		# Team-visibility check against the requested team_ids.
+		#
+		# When ?organization= is NOT given, effective_org_ids below resolves
+		# to exactly visible_org_ids, so a standalone
+		# `Team.objects.filter(id__in=team_ids, organization_id__in=visible_org_ids)`
+		# here would be the identical predicate to the team_id_list query run
+		# a few lines down — i.e. the same SELECT executed twice. We skip it
+		# in that case and instead derive visibility from team_id_list's
+		# length once it's resolved (see below): any requested team missing
+		# from the result was invisible to the caller.
+		#
+		# When ?organization= IS given, effective_org_ids narrows to org_ids
+		# (a subset of visible_org_ids), which is NOT equivalent: a team that
+		# is visible to the caller but simply doesn't belong to the requested
+		# org(s) must yield a zero count, not a 404 (see
+		# OrgAndTeamIntersectionTest.test_team_not_in_org_returns_zero_not_404).
+		# That distinction requires the broader visible_org_ids check to run
+		# as its own query, independent of the org-narrowed scoping query.
+		if team_ids and visible_org_ids is not None and org_ids is not None:
 			visible = Team.objects.filter(
 				id__in=team_ids, organization_id__in=visible_org_ids
 			)
@@ -3760,6 +3778,18 @@ class StatsView(APIView):
 			team_id_list = list(teams_qs.values_list("id", flat=True))
 		else:
 			team_id_list = None
+
+		# Deferred team-visibility check for the common (?organization=
+		# absent) case: team_id_list above already ran the
+		# id__in=team_ids / organization_id__in=visible_org_ids predicate,
+		# so reuse its result instead of re-querying.
+		if (
+			team_ids
+			and visible_org_ids is not None
+			and org_ids is None
+			and len(team_id_list) != len(set(team_ids))
+		):
+			raise Http404
 
 		# --- Cache lookup -----------------------------------------------
 		cache_key = "stats:" + (


### PR DESCRIPTION
`api.tests.test_visibility_stats.StatsQueryCountTest.test_cached_call_query_budget` was failing on `main`: `4 != 3 : 4 queries executed, 3 expected`.

Two separate things turned out to be going on.

## 1. A genuine redundant query (the real bug)

`StatsView.get()` issued **two `Team` queries with an identical predicate** whenever `?team=` was given without `?organization=`:

- a `.count()` visibility check — `id__in=team_ids, organization_id__in=visible_org_ids`
- then a `.values_list("id")` to resolve `team_id_list`, scoped by `effective_org_ids`

When `?organization=` is absent, `effective_org_ids` resolves to exactly `visible_org_ids` — so it was the same SELECT, executed twice, on a cached hot path.

Traced via `git log -S` to `93a80983` ("feat(stats): add org filter, collapse double joins, cache payload"). That commit introduced `effective_org_ids` for the new `?organization=` filter without noticing it had made the pre-existing visibility check redundant in the common case.

**Fix:** skip the standalone `.count()` when `?organization=` is absent and derive visibility from `team_id_list`'s length instead — a requested team missing from the result was invisible to the caller.

When `?organization=` **is** given the standalone check is kept, because the two are then genuinely different: `effective_org_ids` narrows to a subset of `visible_org_ids`, and a team that is visible to the caller but outside the requested org must yield a **zero count, not a 404** (`OrgAndTeamIntersectionTest.test_team_not_in_org_returns_zero_not_404`).

The two branches together cover exactly the original condition, split on `org_ids`. `team_id_list` is guaranteed non-`None` where the deferred check runs (`team_ids` truthy ⇒ not `fully_unscoped`, and `and` short-circuits). Both querysets go through `Team.objects`, so the `is_active` predicate matches. `set(team_ids)` handles duplicate params.

## 2. Why it showed up as a failure at all

The test pins an exact `assertNumQueries`, which is **cache-backend-dependent**: `cache.get()` issues SQL under `DatabaseCache` but none under `LocMemCache`.

- CI runs `pytest` (`.github/workflows/tests.yaml`) → `admin.settings_test` → `LocMemCache` → 3 queries → **passed**
- `manage.py test` → `admin.settings` → `DatabaseCache` → 4 queries → **failed**

So this was never red in CI. The original test comment already acknowledged the split.

## Decision: tolerant ceiling instead of a pinned count

Removing the redundant query drops the budget by one in *both* environments (3→2 pytest, 4→3 `manage.py test`), so **no single exact number satisfies both**. This PR converts the assertion from `assertNumQueries(3)` to `assertLessEqual(..., 3)`, matching the tolerant-ceiling pattern the sibling `test_scoped_call_query_budget` already uses in the same class for the identical reason.

This deliberately loosens the guard, and that trade-off was reviewed and accepted rather than defaulted into. The ceiling still does real work: the cold-cache path is 7 queries and the warm path is now 2–3, so any regression back to 4+ on a cache hit still fails. The alternative considered and rejected was two backend-specific exact assertions — more machinery than a one-query swing warrants, and the sibling test already set the precedent.

## Verification

- `main` baseline: 807 tests, 1 failure (this test)
- This branch (rebased onto `origin/main`): **814 tests, 0 failures**
- `pytest` on `test_visibility_stats.py` (CI's actual path): 28 passed, no regression

No API-surface change — filters, params and response shape are unchanged — so no docs update per CLAUDE.md's rule for pure query optimisations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

