### PR TITLE
Add subject filtering and by_subject breakdown to GET /stats/

### DIFF
--- a/django/api/tests/test_visibility_stats.py
+++ b/django/api/tests/test_visibility_stats.py
@@ -499,6 +499,51 @@ class StatsQueryCountTest(StatsVisibilityBase):
 			msg=f"Cache hit should eliminate the count queries: {len(ctx.captured_queries)} queries",
 		)
 
+	def test_subject_scoped_call_query_budget(self):
+		"""
+		A call whose scope actually contains a subject exercises the
+		by_subject group-bys (skipped, and therefore untested, by
+		test_scoped_call_query_budget above — that fixture has no subjects).
+
+		Budget breakdown (cold cache, both cache layers empty):
+		  11 — the 8 from test_scoped_call_query_budget, plus 3 group-bys
+		       (articles/trials/authors) for the one missing by_subject row
+		       — see StatsView.get's by_subject block.
+		Under LocMemCache (admin.settings_test, what CI's pytest run uses)
+		get_many()/set_many() issue no SQL, so this test's real ceiling there
+		is the same <=18 as the other budget tests, and it holds. But under
+		`manage.py test`'s default DatabaseCache (admin.settings — what this
+		test measures when run outside pytest), every individual set() —
+		including each item set_many() loops over, since DatabaseCache
+		doesn't bulk-optimize writes — is its own transaction: a cull-check
+		COUNT, BEGIN, an existence SELECT, an INSERT/UPDATE, COMMIT (5
+		queries). This call makes two separate writes (the one by_subject
+		row, plus the whole-payload cache.set() at the end), so DatabaseCache
+		adds roughly 2 reads + 2*5 writes = 12 queries on top of the 11 core
+		ones — measured at 23-24. Ceiling set well above that measured
+		number, not derived from it, so a real regression still trips it.
+		"""
+		from django.core.cache import cache as django_cache
+		from django.db import connection
+		from django.test.utils import CaptureQueriesContext
+		from gregory.models import Subject
+
+		subject = Subject.objects.create(
+			team=self.pub_team, subject_name="Budget Subject", subject_slug="budget-subject"
+		)
+		self.art_pub.subjects.add(subject)
+		django_cache.clear()
+
+		with CaptureQueriesContext(connection) as ctx:
+			self.client.get(
+				"/stats/", {"team": self.pub_team.id, "subject": subject.id}
+			)
+		self.assertLessEqual(
+			len(ctx.captured_queries),
+			30,
+			msg=f"StatsView exceeded the query budget: {len(ctx.captured_queries)} queries",
+		)
+
 
 # ---------------------------------------------------------------------------
 # ?subject= filtering and by_subject facet
@@ -846,3 +891,200 @@ class BySubjectFacetTest(StatsVisibilityBase):
 		resp = self.client.get("/stats/", {"team": self.my_team.id})
 		for row in resp.data["by_subject"]:
 			self.assertNotIn("subscribers", row)
+
+
+# ---------------------------------------------------------------------------
+# Correctness regressions: team/subject must pin to the SAME row, not just
+# co-occur somewhere in the caller's data (PR #823 review findings).
+# ---------------------------------------------------------------------------
+
+
+class SubjectCountCorrectnessTest(SubjectStatsBase):
+	"""Chained .filter() calls on a multi-valued relation can silently mix
+	rows from two different related objects. These pin the fix.
+	"""
+
+	def test_authors_count_requires_same_article(self):
+		"""An author must have ONE article satisfying both team and subject.
+
+		Before the fix, chaining .filter(articles__teams__in=...).filter(
+		articles__subjects__in=...) re-joins Authors->Articles per call, so an
+		author with one article in the team and an unrelated article carrying
+		the subject was wrongly counted.
+		"""
+		other_team = _make_team(self.pub_org, "Other Team CC")
+		author = Authors.objects.create(given_name="Same", family_name="Article")
+
+		art_team_only = _make_article(
+			"Team Only", "https://cc.ex/team-only", teams=[self.my_team]
+		)
+		art_team_only.authors.add(author)
+
+		art_subject_only = _make_article(
+			"Subject Only",
+			"https://cc.ex/subject-only",
+			teams=[other_team],
+			subjects=[self.subj_a],
+		)
+		art_subject_only.authors.add(author)
+
+		resp = self.client.get(
+			"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
+		)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data["authors"], 0)
+
+	def test_subscribers_count_requires_same_list(self):
+		"""A subscriber must be on ONE list satisfying both team and subject.
+
+		Before the fix, .filter(subscriptions__team__in=...).filter(
+		subscriptions__subjects__in=...) let a subscriber on List A (this
+		team, no subjects) and List B (a different team, this subject) count
+		— two different lists satisfying one predicate each.
+		"""
+		other_team = _make_team(self.pub_org, "Other Team Sub CC")
+		list_team_only = Lists.objects.create(
+			list_name="Team Only List", team=self.my_team
+		)
+		list_subject_only = Lists.objects.create(
+			list_name="Subject Only List", team=other_team
+		)
+		list_subject_only.subjects.add(self.subj_a)
+
+		cross_subscriber = Subscribers.objects.create(
+			first_name="Cross",
+			last_name="List",
+			email="crosslist-cc@example.com",
+			active=True,
+		)
+		cross_subscriber.subscriptions.add(list_team_only, list_subject_only)
+
+		resp = self.client.get(
+			"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
+		)
+		self.assertEqual(resp.status_code, 200)
+		# sub_a (base fixture, on list_a: team=my_team, subject=subj_a) is the
+		# only subscriber that should count; cross_subscriber satisfies team
+		# and subject via two DIFFERENT lists and must not add a second.
+		self.assertEqual(resp.data["subscribers"], 1)
+
+
+# ---------------------------------------------------------------------------
+# by_subject two-layer cache (PR #823 review, fix 3)
+# ---------------------------------------------------------------------------
+
+
+class BySubjectRowCacheTest(SubjectStatsBase):
+	"""Per-(team scope, subject) row cache, separate from the whole-payload
+	cache: a row computed for one ?subject= combination must be reused by
+	every other combination over the same team scope.
+	"""
+
+	def test_rows_reused_across_subject_filters(self):
+		"""A layer-1 miss must not re-run the by_subject group-by queries
+		when the layer-2 rows for the roster are already warm.
+		"""
+		from django.core.cache import cache as django_cache
+		from django.db import connection
+		from django.test.utils import CaptureQueriesContext
+
+		self.client.get("/stats/", {"team": self.my_team.id})  # warms both layers
+
+		layer1_key = f"stats:{self.my_team.id}:subj:all"
+		django_cache.delete(layer1_key)
+
+		through_table = Articles.subjects.through._meta.db_table
+
+		with CaptureQueriesContext(connection) as ctx:
+			self.client.get(
+				"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
+			)
+
+		group_by_queries = [
+			q
+			for q in ctx.captured_queries
+			if through_table in q["sql"] and "GROUP BY" in q["sql"].upper()
+		]
+		self.assertEqual(
+			group_by_queries,
+			[],
+			msg="by_subject group-by re-ran despite warm layer-2 rows",
+		)
+
+	def test_row_cache_key_differs_by_team_scope(self):
+		"""The same subject under two different team scopes must not share
+		a row — team_part namespaces the layer-2 key.
+		"""
+		from django.core.cache import cache as django_cache
+
+		wide_team = _make_team(self.my_org, "Wide Team CC")
+		_make_article(
+			"Wide Team Art",
+			"https://cc.ex/wide-team-art",
+			teams=[wide_team],
+			subjects=[self.subj_a],
+		)
+
+		self.client.get("/stats/", {"team": self.my_team.id})
+		self.client.get(
+			"/stats/", {"team": f"{self.my_team.id},{wide_team.id}"}
+		)
+
+		narrow_key = f"stats:subjrow:{self.my_team.id}:{self.subj_a.id}"
+		wide_team_part = ",".join(str(i) for i in sorted([self.my_team.id, wide_team.id]))
+		wide_key = f"stats:subjrow:{wide_team_part}:{self.subj_a.id}"
+
+		narrow_row = django_cache.get(narrow_key)
+		wide_row = django_cache.get(wide_key)
+		self.assertIsNotNone(narrow_row)
+		self.assertIsNotNone(wide_row)
+		# my_team alone only has art_mine tagged with subj_a; the wider
+		# scope also picks up the new wide_team article.
+		self.assertEqual(narrow_row["articles"], 1)
+		self.assertEqual(wide_row["articles"], 2)
+
+	def test_renamed_subject_reflected_without_ttl_wait(self):
+		"""subject_name comes from the roster query, not the cached row."""
+		from django.core.cache import cache as django_cache
+
+		self.client.get("/stats/", {"team": self.my_team.id})  # warms layer 2
+
+		self.subj_a.subject_name = "Renamed Subject A"
+		self.subj_a.save(update_fields=["subject_name"])
+
+		django_cache.delete(f"stats:{self.my_team.id}:subj:all")  # layer-1 only
+
+		resp = self.client.get("/stats/", {"team": self.my_team.id})
+		row = next(r for r in resp.data["by_subject"] if r["subject_id"] == self.subj_a.id)
+		self.assertEqual(row["subject_name"], "Renamed Subject A")
+
+	def test_row_cache_survives_layer1_miss(self):
+		"""Documents the staleness contract: a layer-1 miss can pick up a
+		still-warm layer-2 row, so by_subject can lag the top-level totals
+		by up to STATS_CACHE_TTL. Pinned so a future change to this is
+		deliberate, not accidental.
+		"""
+		from django.core.cache import cache as django_cache
+
+		self.client.get(
+			"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
+		)  # warms both layers
+
+		_make_article(
+			"New After Warm",
+			"https://cc.ex/new-after-warm",
+			teams=[self.my_team],
+			subjects=[self.subj_a],
+		)
+
+		django_cache.delete(f"stats:{self.my_team.id}:subj:{self.subj_a.id}")
+
+		resp = self.client.get(
+			"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
+		)
+		row = next(r for r in resp.data["by_subject"] if r["subject_id"] == self.subj_a.id)
+		# Top-level total is fresh (layer-1 miss recomputes it)...
+		self.assertEqual(resp.data["articles"], 2)  # art_mine + the new article
+		# ...but the by_subject row is served from the still-warm layer-2
+		# cache and has not caught up yet — the documented skew.
+		self.assertEqual(row["articles"], 1)

--- a/django/api/tests/test_visibility_stats.py
+++ b/django/api/tests/test_visibility_stats.py
@@ -25,7 +25,8 @@ from organizations.models import Organization, OrganizationUser
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
-from gregory.models import Articles, OrganizationApiSettings, Subject, Team
+from gregory.models import Articles, Authors, OrganizationApiSettings, Sources, Subject, Team
+from subscriptions.models import Lists, Subscribers
 
 User = get_user_model()
 
@@ -56,10 +57,12 @@ def _make_subject(team, name):
 	)
 
 
-def _make_article(title, link, teams=()):
+def _make_article(title, link, teams=(), subjects=()):
 	art = Articles.objects.create(title=title, link=link)
 	for t in teams:
 		art.teams.add(t)
+	for s in subjects:
+		art.subjects.add(s)
 	return art
 
 
@@ -410,8 +413,8 @@ class StatsCacheTest(StatsVisibilityBase):
 		self.client.get("/stats/", {"team": self.pub_team2.id})
 
 		# Both requests must produce distinct, non-None cache entries.
-		key1 = f"stats:{self.pub_team.id}"
-		key2 = f"stats:{self.pub_team2.id}"
+		key1 = f"stats:{self.pub_team.id}:subj:all"
+		key2 = f"stats:{self.pub_team2.id}:subj:all"
 		self.assertIsNotNone(django_cache.get(key1))
 		self.assertIsNotNone(django_cache.get(key2))
 		self.assertNotEqual(key1, key2)
@@ -420,7 +423,7 @@ class StatsCacheTest(StatsVisibilityBase):
 		"""setUp.cache.clear() isolates test runs."""
 		from django.core.cache import cache as django_cache
 
-		self.assertIsNone(django_cache.get("stats:all"))
+		self.assertIsNone(django_cache.get("stats:all:subj:all"))
 
 
 # ---------------------------------------------------------------------------
@@ -441,18 +444,24 @@ class StatsQueryCountTest(StatsVisibilityBase):
 		"""
 		A team-scoped /stats/ call must stay within a small query budget.
 
-		Budget breakdown (cold cache, 7 queries with the test suite's
+		Budget breakdown (cold cache, 8 queries with the test suite's
 		LocMemCache — CACHES in admin.settings_test — which never touches
 		the DB; production's DatabaseCache adds a cache GET/SET pair plus a
-		cull COUNT and SAVEPOINT/RELEASE, hence the generous <=15 ceiling):
+		cull COUNT and SAVEPOINT/RELEASE, hence the generous <=18 ceiling):
 		  1 — VisibleOrgMiddleware: OrganizationApiSettings lookup
 		  1 — resolve team_id_list (Team VALUES) — doubles as the
 		      team-visibility check when ?organization= is absent, since
 		      that predicate is identical to a standalone visibility query
 		      (see StatsView.get); no separate COUNT is issued
+		  1 — resolve visible_subjects (Subject VALUES) — always run, to
+		      build the by_subject roster; here it comes back empty (this
+		      base fixture has no subjects) so the 3 by_subject group-by
+		      queries below are skipped
 		  4 — articles, trials, authors, subscribers COUNT DISTINCT
 		  1 — sources VALUES
-		= 7 queries.
+		= 8 queries. A call whose scope actually contains subjects adds up
+		to 3 more (articles/trials/authors group-bys for by_subject) — see
+		docs/spec-stats-subject-filter.md §4.6.
 		"""
 		from django.db import connection
 		from django.test.utils import CaptureQueriesContext
@@ -461,7 +470,7 @@ class StatsQueryCountTest(StatsVisibilityBase):
 			self.client.get("/stats/", {"team": self.pub_team.id})
 		self.assertLessEqual(
 			len(ctx.captured_queries),
-			15,
+			18,
 			msg=f"StatsView exceeded the query budget: {len(ctx.captured_queries)} queries",
 		)
 
@@ -473,17 +482,367 @@ class StatsQueryCountTest(StatsVisibilityBase):
 		self.client.get("/stats/", {"team": self.pub_team.id})  # warm the cache
 		with CaptureQueriesContext(connection) as ctx:
 			self.client.get("/stats/", {"team": self.pub_team.id})
-		# <=3, not a pinned exact count: OrganizationApiSettings lookup (1)
+		# <=4, not a pinned exact count: OrganizationApiSettings lookup (1)
 		# + team_id_list resolution, which also serves as the
-		# team-visibility check (1) + cache GET (0 or 1 depending on
-		# backend). LocMemCache (admin.settings_test, what CI's pytest run
-		# uses) answers GET in-process with no SQL, landing at 2;
-		# DatabaseCache backends (production, and admin.settings's default
-		# used when this test is invoked via `manage.py test` instead of
-		# pytest) add one SQL round-trip for the GET, landing at 3. Either
-		# way this must stay far below the cold-cache budget above.
+		# team-visibility check (1) + visible_subjects resolution, which
+		# also serves as the ?subject= 404 check and runs before the cache
+		# lookup so a cache hit can't bypass it (1) + cache GET (0 or 1
+		# depending on backend). LocMemCache (admin.settings_test, what
+		# CI's pytest run uses) answers GET in-process with no SQL, landing
+		# at 3; DatabaseCache backends (production, and admin.settings's
+		# default used when this test is invoked via `manage.py test`
+		# instead of pytest) add one SQL round-trip for the GET, landing at
+		# 4. Either way this must stay far below the cold-cache budget above.
 		self.assertLessEqual(
 			len(ctx.captured_queries),
-			3,
+			4,
 			msg=f"Cache hit should eliminate the count queries: {len(ctx.captured_queries)} queries",
 		)
+
+
+# ---------------------------------------------------------------------------
+# ?subject= filtering and by_subject facet
+# ---------------------------------------------------------------------------
+
+
+class SubjectStatsBase(StatsVisibilityBase):
+	"""Shared fixture: subjects, tagged articles/trials, a source, a list."""
+
+	def setUp(self):
+		super().setUp()
+		from django.core.cache import cache
+
+		cache.clear()
+
+		self.user = User.objects.create_user(username="subj-member", password="pw")
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+		self.include_public = {"include_public": "true"}
+
+		self.subj_a = _make_subject(self.my_team, "Subject A")
+		self.subj_b = _make_subject(self.my_team, "Subject B")
+		self.subj_pub = _make_subject(self.pub_team, "Subject Pub")
+		self.subj_priv = _make_subject(self.priv_team, "Subject Priv")
+
+		# art_mine / trial_mine (from the base fixture) get tagged with subj_a.
+		self.art_mine.subjects.add(self.subj_a)
+		self.trial_mine.subjects.add(self.subj_a)
+
+		self.art_mine2 = _make_article(
+			"Mine Art 2", "https://st.ex/subj/a4", teams=[self.my_team], subjects=[self.subj_b]
+		)
+
+		# Article tagged with subj_a but belonging to no team — the §4.4 leak
+		# guard: a ?team=my_team&subject=subj_a call must exclude it.
+		self.art_teamless = _make_article(
+			"Teamless", "https://st.ex/subj/teamless", teams=[], subjects=[self.subj_a]
+		)
+
+		self.source_a = Sources.objects.create(
+			name="Src A",
+			link="https://src-a.example.com/feed",
+			team=self.my_team,
+			subject=self.subj_a,
+			source_for="science paper",
+		)
+		self.source_null = Sources.objects.create(
+			name="Src Null",
+			link="https://src-null.example.com/feed",
+			team=self.my_team,
+			subject=None,
+			source_for="science paper",
+		)
+
+		self.list_a = Lists.objects.create(list_name="List A", team=self.my_team)
+		self.list_a.subjects.add(self.subj_a)
+		self.sub_a = Subscribers.objects.create(
+			first_name="Sub", last_name="A", email="suba-stats@example.com", active=True
+		)
+		self.sub_a.subscriptions.add(self.list_a)
+
+		self.list_none = Lists.objects.create(list_name="List None", team=self.my_team)
+		self.sub_none = Subscribers.objects.create(
+			first_name="Sub", last_name="None", email="subnone-stats@example.com", active=True
+		)
+		self.sub_none.subscriptions.add(self.list_none)
+
+
+class SubjectFilterStatsTest(SubjectStatsBase):
+	"""?subject= scopes every count, unions across IDs, and validates input."""
+
+	def test_subject_filter_scopes_counts(self):
+		resp = self.client.get(
+			"/stats/", {"subject": self.subj_a.id, **self.include_public}
+		)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data["articles"], 1)  # art_mine only
+		self.assertEqual(resp.data["trials"], 1)  # trial_mine only
+		self.assertEqual(resp.data["subscribers"], 1)  # sub_a only
+		self.assertEqual(resp.data["sources"]["total"], 1)  # source_a only
+
+	def test_subject_filter_unions_rather_than_intersects(self):
+		resp = self.client.get(
+			"/stats/",
+			{"subject": f"{self.subj_a.id},{self.subj_b.id}", **self.include_public},
+		)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data["articles"], 2)  # art_mine + art_mine2
+
+	def test_invalid_subject_param_returns_400(self):
+		resp = self.client.get("/stats/", {"subject": "abc"})
+		self.assertEqual(resp.status_code, 400)
+		self.assertIn("Invalid subject parameter", resp.data["error"])
+
+	def test_teamless_article_excluded_by_team_scope(self):
+		"""§4.4 leak guard: team join stays in effect even with ?subject=."""
+		resp = self.client.get(
+			"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
+		)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data["articles"], 1)  # art_mine, not art_teamless
+
+	def test_source_with_null_subject_dropped_when_filtering(self):
+		resp_unfiltered = self.client.get("/stats/", {"team": self.my_team.id})
+		self.assertEqual(resp_unfiltered.data["sources"]["total"], 2)
+
+		resp_filtered = self.client.get(
+			"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
+		)
+		self.assertEqual(resp_filtered.data["sources"]["total"], 1)
+
+	def test_list_without_subjects_contributes_no_subscribers(self):
+		resp = self.client.get(
+			"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
+		)
+		self.assertEqual(resp.data["subscribers"], 1)  # sub_a, not sub_none
+
+
+class SubjectVisibilityStatsTest(SubjectStatsBase):
+	"""A subject in a non-visible org is 404, same as team/organization."""
+
+	def test_hidden_org_subject_404_for_anonymous(self):
+		anon = APIClient()
+		resp = anon.get("/stats/", {"subject": self.subj_priv.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_hidden_org_subject_404_for_api_key(self):
+		scheme = _make_api_scheme(self.my_org, "subj-visibility-key")
+		key_client = APIClient()
+		key_client.credentials(HTTP_AUTHORIZATION=scheme.api_key)
+		resp = key_client.get("/stats/", {"subject": self.subj_priv.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_org_subject_404_without_include_public(self):
+		resp = self.client.get("/stats/", {"subject": self.subj_pub.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_org_subject_200_with_include_public(self):
+		resp = self.client.get(
+			"/stats/", {"subject": self.subj_pub.id, **self.include_public}
+		)
+		self.assertEqual(resp.status_code, 200)
+
+	def test_mixed_visible_hidden_subject_returns_404(self):
+		resp = self.client.get(
+			"/stats/",
+			{"subject": f"{self.subj_a.id},{self.subj_priv.id}", **self.include_public},
+		)
+		self.assertEqual(resp.status_code, 404)
+
+
+class SubjectTeamIntersectionStatsTest(SubjectStatsBase):
+	"""?team= + ?subject= intersection: zero payload, not 404, on mismatch."""
+
+	def test_team_and_subject_of_other_team_returns_zero_not_404(self):
+		resp = self.client.get(
+			"/stats/",
+			{"team": self.pub_team.id, "subject": self.subj_a.id, **self.include_public},
+		)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data["articles"], 0)
+		self.assertEqual(resp.data["trials"], 0)
+		self.assertEqual(resp.data["by_subject"], [])
+
+	def test_team_and_its_own_subject_returns_counts(self):
+		resp = self.client.get(
+			"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
+		)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(resp.data["articles"], 1)
+
+
+class SubjectStatsCacheTest(SubjectStatsBase):
+	"""Subject-filtered payloads must not share a cache entry with others."""
+
+	def test_team_only_and_team_plus_subject_do_not_share_cache(self):
+		from django.core.cache import cache as django_cache
+
+		self.client.get("/stats/", {"team": self.my_team.id})
+		self.client.get(
+			"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
+		)
+		key_unfiltered = f"stats:{self.my_team.id}:subj:all"
+		key_filtered = f"stats:{self.my_team.id}:subj:{self.subj_a.id}"
+		cached_unfiltered = django_cache.get(key_unfiltered)
+		cached_filtered = django_cache.get(key_filtered)
+		self.assertIsNotNone(cached_unfiltered)
+		self.assertIsNotNone(cached_filtered)
+		self.assertNotEqual(cached_unfiltered["articles"], cached_filtered["articles"])
+
+	def test_different_subject_filters_cached_independently(self):
+		from django.core.cache import cache as django_cache
+
+		self.client.get(
+			"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
+		)
+		self.client.get(
+			"/stats/", {"team": self.my_team.id, "subject": self.subj_b.id}
+		)
+		key_a = f"stats:{self.my_team.id}:subj:{self.subj_a.id}"
+		key_b = f"stats:{self.my_team.id}:subj:{self.subj_b.id}"
+		self.assertIsNotNone(django_cache.get(key_a))
+		self.assertIsNotNone(django_cache.get(key_b))
+
+	def test_reordered_subject_list_shares_cache_key(self):
+		from django.core.cache import cache as django_cache
+
+		self.client.get(
+			"/stats/",
+			{"team": self.my_team.id, "subject": f"{self.subj_a.id},{self.subj_b.id}"},
+		)
+		sorted_ids = ",".join(
+			str(i) for i in sorted([self.subj_a.id, self.subj_b.id])
+		)
+		key_sorted = f"stats:{self.my_team.id}:subj:{sorted_ids}"
+		self.assertIsNotNone(django_cache.get(key_sorted))
+
+		resp2 = self.client.get(
+			"/stats/",
+			{"team": self.my_team.id, "subject": f"{self.subj_b.id},{self.subj_a.id}"},
+		)
+		self.assertEqual(django_cache.get(key_sorted), resp2.data)
+
+
+class BySubjectFacetTest(StatsVisibilityBase):
+	"""The by_subject breakdown: roster, ordering, and per-subject counts."""
+
+	def setUp(self):
+		super().setUp()
+		from django.core.cache import cache
+
+		cache.clear()
+
+		self.user = User.objects.create_user(username="facet-member", password="pw")
+		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
+		self.client.force_login(self.user)
+
+		# Zero-count subject (name sorts after "Alpha"/"Beta").
+		self.subj_zeta = _make_subject(self.my_team, "Zeta Subject")
+		self.subj_alpha = _make_subject(self.my_team, "Alpha Subject")
+		self.subj_beta = _make_subject(self.my_team, "Beta Subject")
+		# Belongs to a private org invisible to this caller.
+		self.subj_hidden = _make_subject(self.priv_team, "Hidden Subject")
+
+		self.author1 = Authors.objects.create(given_name="Ann", family_name="One")
+		self.author2 = Authors.objects.create(given_name="Bob", family_name="Two")
+
+		# Tagged with both subj_alpha and the invisible subj_hidden: the
+		# by_subject roster must still drop subj_hidden (leak guard).
+		self.art_alpha1 = _make_article(
+			"Alpha Art 1",
+			"https://facet.ex/a1",
+			teams=[self.my_team],
+			subjects=[self.subj_alpha, self.subj_hidden],
+		)
+		self.art_alpha1.authors.add(self.author1)
+
+		self.art_alpha2 = _make_article(
+			"Alpha Art 2",
+			"https://facet.ex/a2",
+			teams=[self.my_team],
+			subjects=[self.subj_alpha],
+		)
+		self.art_alpha2.authors.add(self.author2)
+
+		# Two feeds, same domain, both under subj_alpha → 1 domain for alpha.
+		Sources.objects.create(
+			name="Alpha Feed 1",
+			link="https://shared-domain.example.com/feed1",
+			team=self.my_team,
+			subject=self.subj_alpha,
+			source_for="science paper",
+		)
+		Sources.objects.create(
+			name="Alpha Feed 2",
+			link="https://shared-domain.example.com/feed2",
+			team=self.my_team,
+			subject=self.subj_alpha,
+			source_for="science paper",
+		)
+		# Same domain again, but under subj_beta → domain appears in both
+		# rows while counting once in the top-level sources.total.
+		Sources.objects.create(
+			name="Beta Feed",
+			link="https://shared-domain.example.com/feed3",
+			team=self.my_team,
+			subject=self.subj_beta,
+			source_for="science paper",
+		)
+		# No subject at all → must not appear in any by_subject row.
+		Sources.objects.create(
+			name="Null Feed",
+			link="https://null-domain.example.com/feed",
+			team=self.my_team,
+			subject=None,
+			source_for="science paper",
+		)
+
+	def _by_subject(self, resp):
+		return {row["subject_id"]: row for row in resp.data["by_subject"]}
+
+	def test_roster_includes_zero_count_subjects(self):
+		resp = self.client.get("/stats/", {"team": self.my_team.id})
+		rows = self._by_subject(resp)
+		self.assertIn(self.subj_zeta.id, rows)
+		self.assertEqual(rows[self.subj_zeta.id]["articles"], 0)
+		self.assertEqual(rows[self.subj_zeta.id]["trials"], 0)
+		self.assertEqual(rows[self.subj_zeta.id]["sources"], 0)
+
+	def test_roster_ordered_by_subject_name(self):
+		resp = self.client.get("/stats/", {"team": self.my_team.id})
+		names = [row["subject_name"] for row in resp.data["by_subject"]]
+		self.assertEqual(names, sorted(names))
+
+	def test_roster_respects_subject_filter(self):
+		resp = self.client.get(
+			"/stats/", {"team": self.my_team.id, "subject": self.subj_alpha.id}
+		)
+		ids = [row["subject_id"] for row in resp.data["by_subject"]]
+		self.assertEqual(ids, [self.subj_alpha.id])
+
+	def test_hidden_org_subject_excluded_despite_visible_article_tag(self):
+		resp = self.client.get("/stats/", {"team": self.my_team.id})
+		ids = {row["subject_id"] for row in resp.data["by_subject"]}
+		self.assertNotIn(self.subj_hidden.id, ids)
+
+	def test_per_subject_authors_counted_once_each(self):
+		resp = self.client.get("/stats/", {"team": self.my_team.id})
+		rows = self._by_subject(resp)
+		self.assertEqual(rows[self.subj_alpha.id]["authors"], 2)
+		self.assertEqual(resp.data["authors"], 2)
+
+	def test_per_subject_sources_counts_distinct_domains(self):
+		resp = self.client.get("/stats/", {"team": self.my_team.id})
+		rows = self._by_subject(resp)
+		# Two feeds, same domain, same subject → still 1.
+		self.assertEqual(rows[self.subj_alpha.id]["sources"], 1)
+		# Domain shared with alpha, different subject → appears here too.
+		self.assertEqual(rows[self.subj_beta.id]["sources"], 1)
+		# Shared domain counted once overall despite feeding two subjects,
+		# plus the null-domain source → 2 total.
+		self.assertEqual(resp.data["sources"]["total"], 2)
+
+	def test_no_subscribers_key_in_by_subject_rows(self):
+		resp = self.client.get("/stats/", {"team": self.my_team.id})
+		for row in resp.data["by_subject"]:
+			self.assertNotIn("subscribers", row)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -3907,13 +3907,17 @@ class StatsView(APIView):
 		apply_subject = effective_subject_ids is not None
 
 		# --- Cache lookup -----------------------------------------------
+		# team_part is also the namespace for the per-subject-row cache
+		# (layer 2, see the by_subject facet below) — reused as-is so a row
+		# computed under one team scope is never served under another.
+		team_part = (
+			"all"
+			if team_id_list is None
+			else ",".join(str(i) for i in sorted(team_id_list))
+		)
 		cache_key = (
 			"stats:"
-			+ (
-				"all"
-				if team_id_list is None
-				else ",".join(str(i) for i in sorted(team_id_list))
-			)
+			+ team_part
 			+ ":subj:"
 			+ (
 				"all"
@@ -3933,10 +3937,13 @@ class StatsView(APIView):
 			subscribers_count = Subscribers.objects.filter(active=True).count()
 			sources_qs = Sources.objects.all()
 		else:
-			# .values(pk).distinct().count() instead of .distinct().count():
+			# .order_by().values(pk).distinct().count() instead of .distinct().count():
 			# the latter runs DISTINCT over every column (incl. Authors.biography,
 			# a free-text field), forcing Postgres to dedupe full rows across the
-			# join instead of just primary keys — ~5x slower at prod scale.
+			# join instead of just primary keys — ~5x slower at prod scale. The
+			# .order_by() clears Meta.ordering (Articles orders by -discovery_date
+			# by default), which would otherwise sneak a second column into the
+			# DISTINCT and defeat the point.
 			#
 			# The team join is kept even when only ?subject= is given: an
 			# article belonging solely to a non-visible team could carry a
@@ -3947,35 +3954,55 @@ class StatsView(APIView):
 				articles_qs = articles_qs.filter(teams__in=team_id_list)
 			if apply_subject:
 				articles_qs = articles_qs.filter(subjects__in=effective_subject_ids)
-			articles_count = articles_qs.values("article_id").distinct().count()
+			articles_count = (
+				articles_qs.order_by().values("article_id").distinct().count()
+			)
 
 			trials_qs = Trials.objects.all()
 			if team_id_list is not None:
 				trials_qs = trials_qs.filter(teams__in=team_id_list)
 			if apply_subject:
 				trials_qs = trials_qs.filter(subjects__in=effective_subject_ids)
-			trials_count = trials_qs.values("trial_id").distinct().count()
+			trials_count = (
+				trials_qs.order_by().values("trial_id").distinct().count()
+			)
 
+			# Exists/OuterRef, not chained .filter() calls: Authors has no direct
+			# team/subject columns, so team and subject can only be pinned to the
+			# SAME article via a correlated subquery. Two chained
+			# .filter(articles__teams__in=...).filter(articles__subjects__in=...)
+			# calls each re-join Authors->Articles independently, so an author
+			# with one article in the team and an unrelated article carrying the
+			# subject would be counted — wrong. This also drops the DISTINCT
+			# entirely (Exists is a boolean per author, not a fan-out join).
 			authors_qs = Authors.objects.all()
-			if team_id_list is not None:
-				authors_qs = authors_qs.filter(articles__teams__in=team_id_list)
-			if apply_subject:
-				authors_qs = authors_qs.filter(
-					articles__subjects__in=effective_subject_ids
-				)
-			authors_count = authors_qs.values("author_id").distinct().count()
+			if team_id_list is not None or apply_subject:
+				article_match = Articles.objects.filter(authors=OuterRef("pk"))
+				if team_id_list is not None:
+					article_match = article_match.filter(teams__in=team_id_list)
+				if apply_subject:
+					article_match = article_match.filter(
+						subjects__in=effective_subject_ids
+					)
+				authors_qs = authors_qs.filter(Exists(article_match))
+			authors_count = authors_qs.count()
 
-			subscribers_qs = Subscribers.objects.filter(active=True)
+			# A single filter() call, not chained ones: Subscribers reaches both
+			# team and subject through the same subscriptions (Lists) relation,
+			# so both predicates must land on one filter() call to force a single
+			# join — a subscriber on List A (team T, no subject) and List B
+			# (other team, this subject) must NOT count for ?team=T&subject=S.
+			sub_filters = {"active": True}
 			if team_id_list is not None:
-				subscribers_qs = subscribers_qs.filter(
-					subscriptions__team__in=team_id_list
-				)
+				sub_filters["subscriptions__team__in"] = team_id_list
 			if apply_subject:
-				subscribers_qs = subscribers_qs.filter(
-					subscriptions__subjects__in=effective_subject_ids
-				)
+				sub_filters["subscriptions__subjects__in"] = effective_subject_ids
 			subscribers_count = (
-				subscribers_qs.values("subscriber_id").distinct().count()
+				Subscribers.objects.filter(**sub_filters)
+				.order_by()
+				.values("subscriber_id")
+				.distinct()
+				.count()
 			)
 
 			# Sources has a direct FK to Team and to Subject — no distinct needed.
@@ -4017,21 +4044,48 @@ class StatsView(APIView):
 		)
 
 		# --- by_subject facet --------------------------------------------
+		# Per-(team scope, subject) row cache (layer 2), separate from the
+		# whole-payload cache (layer 1, keyed by cache_key above): the same
+		# row is identical no matter which OTHER subjects were requested
+		# alongside it, so a warm row is reused across every ?subject=
+		# combination over the same team scope instead of being recomputed
+		# per combination. `sources` and `subject_name` are deliberately
+		# left out of the cached value — both come for free from data this
+		# call already fetched (subject_domains / the roster), so caching
+		# them would only add a staleness surface for no gain.
 		by_subject = []
 		if by_subject_roster:
-			roster_ids = [s["id"] for s in by_subject_roster]
-			subj_articles = self._subject_counts(Articles, roster_ids, team_id_list)
-			subj_trials = self._subject_counts(Trials, roster_ids, team_id_list)
-			subj_authors = self._subject_counts(
-				Articles, roster_ids, team_id_list, count_field="articles__authors"
-			)
+			row_keys = {
+				s["id"]: f"stats:subjrow:{team_part}:{s['id']}"
+				for s in by_subject_roster
+			}
+			cached_rows = cache.get_many(list(row_keys.values()))
+			missing_ids = [
+				sid for sid, key in row_keys.items() if key not in cached_rows
+			]
+
+			if missing_ids:
+				subj_articles = self._subject_counts(Articles, missing_ids, team_id_list)
+				subj_trials = self._subject_counts(Trials, missing_ids, team_id_list)
+				subj_authors = self._subject_counts(
+					Articles, missing_ids, team_id_list, count_field="articles__authors"
+				)
+				fresh_rows = {
+					row_keys[sid]: {
+						"articles": subj_articles.get(sid, 0),
+						"trials": subj_trials.get(sid, 0),
+						"authors": subj_authors.get(sid, 0),
+					}
+					for sid in missing_ids
+				}
+				cache.set_many(fresh_rows, settings.STATS_CACHE_TTL)
+				cached_rows.update(fresh_rows)
+
 			by_subject = [
 				{
 					"subject_id": s["id"],
 					"subject_name": s["subject_name"],
-					"articles": subj_articles.get(s["id"], 0),
-					"trials": subj_trials.get(s["id"], 0),
-					"authors": subj_authors.get(s["id"], 0),
+					**cached_rows[row_keys[s["id"]]],
 					"sources": len(subject_domains.get(s["id"], ())),
 				}
 				for s in by_subject_roster

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -3882,7 +3882,11 @@ class StatsView(APIView):
 			subj_qs.values("id", "subject_name", "team_id").order_by("subject_name")
 		)
 
-		if subject_ids is not None and len(visible_subjects) != len(set(subject_ids)):
+		if (
+			subject_ids is not None
+			and visible_org_ids is not None
+			and len(visible_subjects) != len(set(subject_ids))
+		):
 			raise Http404
 
 		if subject_ids is not None:

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -3724,12 +3724,23 @@ class StatsView(APIView):
 	    Scope to one or more organisations (comma-separated integer IDs).
 	    When combined with ?team=, the effective scope is the intersection:
 	    teams that belong to the requested org(s).
+	?subject=1,2
+	    Scope to one or more subjects (comma-separated integer IDs, OR/union
+	    semantics). Adds a ``by_subject`` breakdown to the payload, listing
+	    every in-scope subject (including zero-count ones) with its own
+	    articles/trials/authors/sources counts. Per-subject subscriber counts
+	    are deliberately omitted — see docs/03-api-and-rss-feeds.md.
 
-	Both params are validated against ``request.visible_org_ids``
-	(set by VisibleOrgMiddleware).  A team or org that is not visible to the
-	caller returns 404 so that existence is not leaked.  When the middleware
-	attribute is absent (management commands, tests bypassing middleware) the
-	visibility check is skipped and the params still narrow the queryset.
+	All three params are validated against ``request.visible_org_ids``
+	(set by VisibleOrgMiddleware). A team, org, or subject that is not visible
+	to the caller returns 404 so that existence is not leaked. When the
+	middleware attribute is absent (management commands, tests bypassing
+	middleware) the visibility check is skipped and the params still narrow
+	the queryset.
+
+	A subject that is visible but outside the requested ``?team=``/``?organization=``
+	scope does not 404 — it returns a well-formed, all-zero payload, matching
+	the existing ``?team=`` + ``?organization=`` intersection behaviour.
 
 	Results are short-lived cached (STATS_CACHE_TTL seconds, default 600) using
 	Django's database cache so all gunicorn workers share the same value.
@@ -3769,6 +3780,22 @@ class StatsView(APIView):
 				return Response(
 					{
 						"error": "Invalid organization parameter. Expected integer or comma-separated integers."
+					},
+					status=status.HTTP_400_BAD_REQUEST,
+				)
+
+		# --- Parse ?subject= ---------------------------------------------
+		subject_param = request.query_params.get("subject")
+		subject_ids = None
+		if subject_param:
+			try:
+				subject_ids = [
+					int(s.strip()) for s in subject_param.split(",") if s.strip()
+				]
+			except ValueError:
+				return Response(
+					{
+						"error": "Invalid subject parameter. Expected integer or comma-separated integers."
 					},
 					status=status.HTTP_400_BAD_REQUEST,
 				)
@@ -3838,18 +3865,64 @@ class StatsView(APIView):
 		):
 			raise Http404
 
+		# --- Resolve subjects (one query: visibility + scope + roster) ---
+		# When ?subject= is absent, this is the in-scope roster used for
+		# by_subject; when present, it's looked up WITHOUT the team narrowing
+		# (applied in Python below), because the team narrowing is what
+		# distinguishes a 404 from an all-zero payload (decision 7 in
+		# docs/spec-stats-subject-filter.md).
+		subj_qs = Subject.objects.all()
+		if visible_org_ids is not None:
+			subj_qs = subj_qs.filter(team__organization_id__in=visible_org_ids)
+		if subject_ids is not None:
+			subj_qs = subj_qs.filter(id__in=subject_ids)
+		elif team_id_list is not None:
+			subj_qs = subj_qs.filter(team_id__in=team_id_list)
+		visible_subjects = list(
+			subj_qs.values("id", "subject_name", "team_id").order_by("subject_name")
+		)
+
+		if subject_ids is not None and len(visible_subjects) != len(set(subject_ids)):
+			raise Http404
+
+		if subject_ids is not None:
+			effective_subject_ids = [
+				s["id"]
+				for s in visible_subjects
+				if team_id_list is None or s["team_id"] in team_id_list
+			]
+			by_subject_roster = [
+				s
+				for s in visible_subjects
+				if team_id_list is None or s["team_id"] in team_id_list
+			]
+		else:
+			effective_subject_ids = None
+			by_subject_roster = visible_subjects
+
+		apply_subject = effective_subject_ids is not None
+
 		# --- Cache lookup -----------------------------------------------
-		cache_key = "stats:" + (
-			"all"
-			if team_id_list is None
-			else ",".join(str(i) for i in sorted(team_id_list))
+		cache_key = (
+			"stats:"
+			+ (
+				"all"
+				if team_id_list is None
+				else ",".join(str(i) for i in sorted(team_id_list))
+			)
+			+ ":subj:"
+			+ (
+				"all"
+				if subject_ids is None
+				else ",".join(str(i) for i in sorted(set(subject_ids)))
+			)
 		)
 		cached = cache.get(cache_key)
 		if cached is not None:
 			return Response(cached)
 
 		# --- Counts (single join per queryset) --------------------------
-		if fully_unscoped:
+		if fully_unscoped and not apply_subject:
 			articles_count = Articles.objects.count()
 			trials_count = Trials.objects.count()
 			authors_count = Authors.objects.count()
@@ -3860,34 +3933,53 @@ class StatsView(APIView):
 			# the latter runs DISTINCT over every column (incl. Authors.biography,
 			# a free-text field), forcing Postgres to dedupe full rows across the
 			# join instead of just primary keys — ~5x slower at prod scale.
-			articles_count = (
-				Articles.objects.filter(teams__in=team_id_list)
-				.values("article_id")
-				.distinct()
-				.count()
-			)
-			trials_count = (
-				Trials.objects.filter(teams__in=team_id_list)
-				.values("trial_id")
-				.distinct()
-				.count()
-			)
-			authors_count = (
-				Authors.objects.filter(articles__teams__in=team_id_list)
-				.values("author_id")
-				.distinct()
-				.count()
-			)
-			subscribers_count = (
-				Subscribers.objects.filter(
-					active=True, subscriptions__team__in=team_id_list
+			#
+			# The team join is kept even when only ?subject= is given: an
+			# article belonging solely to a non-visible team could carry a
+			# subject the caller can see, and filtering on subject alone
+			# would leak it into the count.
+			articles_qs = Articles.objects.all()
+			if team_id_list is not None:
+				articles_qs = articles_qs.filter(teams__in=team_id_list)
+			if apply_subject:
+				articles_qs = articles_qs.filter(subjects__in=effective_subject_ids)
+			articles_count = articles_qs.values("article_id").distinct().count()
+
+			trials_qs = Trials.objects.all()
+			if team_id_list is not None:
+				trials_qs = trials_qs.filter(teams__in=team_id_list)
+			if apply_subject:
+				trials_qs = trials_qs.filter(subjects__in=effective_subject_ids)
+			trials_count = trials_qs.values("trial_id").distinct().count()
+
+			authors_qs = Authors.objects.all()
+			if team_id_list is not None:
+				authors_qs = authors_qs.filter(articles__teams__in=team_id_list)
+			if apply_subject:
+				authors_qs = authors_qs.filter(
+					articles__subjects__in=effective_subject_ids
 				)
-				.values("subscriber_id")
-				.distinct()
-				.count()
+			authors_count = authors_qs.values("author_id").distinct().count()
+
+			subscribers_qs = Subscribers.objects.filter(active=True)
+			if team_id_list is not None:
+				subscribers_qs = subscribers_qs.filter(
+					subscriptions__team__in=team_id_list
+				)
+			if apply_subject:
+				subscribers_qs = subscribers_qs.filter(
+					subscriptions__subjects__in=effective_subject_ids
+				)
+			subscribers_count = (
+				subscribers_qs.values("subscriber_id").distinct().count()
 			)
-			# Sources has a direct FK to Team — no distinct needed.
-			sources_qs = Sources.objects.filter(team_id__in=team_id_list)
+
+			# Sources has a direct FK to Team and to Subject — no distinct needed.
+			sources_qs = Sources.objects.all()
+			if team_id_list is not None:
+				sources_qs = sources_qs.filter(team_id__in=team_id_list)
+			if apply_subject:
+				sources_qs = sources_qs.filter(subject_id__in=effective_subject_ids)
 
 		# --- Sources domain aggregation (single pass) -------------------
 		def extract_domain(url):
@@ -3898,17 +3990,20 @@ class StatsView(APIView):
 			except Exception:
 				return None
 
-		source_data = list(sources_qs.values("link", "source_for"))
+		source_data = list(sources_qs.values("link", "source_for", "subject_id"))
 
 		all_domains = set()
 		type_domains = {}
 		domain_feed_count = {}
+		subject_domains = {}  # subject_id -> set of netlocs, for by_subject sources
 		for s in source_data:
 			d = extract_domain(s["link"])
 			if d:
 				all_domains.add(d)
 				type_domains.setdefault(s["source_for"], set()).add(d)
 				domain_feed_count[d] = domain_feed_count.get(d, 0) + 1
+				if s["subject_id"] is not None:
+					subject_domains.setdefault(s["subject_id"], set()).add(d)
 
 		sources_by_type = {k: len(v) for k, v in type_domains.items()}
 		sources_by_domain = sorted(
@@ -3916,6 +4011,27 @@ class StatsView(APIView):
 			key=lambda x: x["count"],
 			reverse=True,
 		)
+
+		# --- by_subject facet --------------------------------------------
+		by_subject = []
+		if by_subject_roster:
+			roster_ids = [s["id"] for s in by_subject_roster]
+			subj_articles = self._subject_counts(Articles, roster_ids, team_id_list)
+			subj_trials = self._subject_counts(Trials, roster_ids, team_id_list)
+			subj_authors = self._subject_counts(
+				Articles, roster_ids, team_id_list, count_field="articles__authors"
+			)
+			by_subject = [
+				{
+					"subject_id": s["id"],
+					"subject_name": s["subject_name"],
+					"articles": subj_articles.get(s["id"], 0),
+					"trials": subj_trials.get(s["id"], 0),
+					"authors": subj_authors.get(s["id"], 0),
+					"sources": len(subject_domains.get(s["id"], ())),
+				}
+				for s in by_subject_roster
+			]
 
 		payload = {
 			"articles": articles_count,
@@ -3927,6 +4043,24 @@ class StatsView(APIView):
 				"by_type": sources_by_type,
 				"by_domain": sources_by_domain,
 			},
+			"by_subject": by_subject,
 		}
 		cache.set(cache_key, payload, settings.STATS_CACHE_TTL)
 		return Response(payload)
+
+	@staticmethod
+	def _subject_counts(model, subject_ids, team_id_list, count_field=None):
+		"""Per-subject distinct count of ``count_field`` (default: model pk).
+
+		Aggregates off ``model.subjects.through`` so each of articles/trials/
+		authors is one grouped query, regardless of caller-side filtering.
+		"""
+		through = model.subjects.through
+		src = model._meta.model_name  # "articles" / "trials"
+		qs = through.objects.filter(subject_id__in=subject_ids)
+		if team_id_list is not None:
+			qs = qs.filter(**{f"{src}__teams__in": team_id_list})
+		rows = qs.values("subject_id").annotate(
+			count=Count(count_field or f"{src}_id", distinct=True)
+		)
+		return {r["subject_id"]: r["count"] for r in rows}

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -388,6 +388,8 @@ When both `organization` and `team` are given the effective scope is their **int
 
 Results are cached for `STATS_CACHE_TTL` seconds (default 600 s / 10 min) using Django's database cache. All gunicorn workers share the same cached value. The cache key encodes both the resolved set of in-scope team IDs and the requested `subject` IDs, so different filter combinations — including the same team with and without a subject filter — are cached independently.
 
+`by_subject` has a second, finer-grained cache layer underneath the whole-payload one: each subject's `articles`/`trials`/`authors` numbers are cached per `(team scope, subject)`, independently of which *other* subjects were requested alongside it. A `?subject=` combination that's new but overlaps a team scope seen before reuses whatever rows are already warm and only computes the missing ones — so, unlike the totals, `by_subject`'s numbers can be up to `STATS_CACHE_TTL` older than the rest of the payload if the whole-payload entry happens to expire before the per-subject one does. `sources` and `subject_name` are excluded from that layer (recomputed from data the call already fetches for the totals) and are therefore always current.
+
 ### Trials-specific filter parameters
 
 | Parameter | Description |

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -191,7 +191,7 @@ GET /articles/?team_id=1&subjects=1,3&published_date_after=2022-06-01&format=csv
 | Email templates | `GET /emails/context/{template_name}/` | `template_name` (path) | |
 | RSS feeds | `GET /feed/author/{orcid}/` | `orcid` (path) | |
 | RSS feeds | `GET /feed/trials/subject/{subject_slug}/` | `subject_slug` (path) | |
-| Stats | `GET /stats/` | `team`, `organization` (alias `org`), `include_public` | See [Stats endpoint](#stats-endpoint) below |
+| Stats | `GET /stats/` | `team`, `organization` (alias `org`), `subject`, `include_public` | See [Stats endpoint](#stats-endpoint) below |
 | Subscriptions | `POST /subscriptions/new/` | `first_name`, `last_name`, `email`, `profile`, `list` | POST-only; `GET` returns `405` with `Allow: POST` |
 
 ### Search endpoints
@@ -328,9 +328,13 @@ GET /stats/?organization=3,7
 GET /stats/?team=12
 GET /stats/?organization=3&team=12
 GET /stats/?include_public=true
+GET /stats/?subject=4
+GET /stats/?subject=4,9
+GET /stats/?team=12&subject=4
 ```
 
-Response shape (unchanged across all filter combinations):
+Response shape (additive: `by_subject` is only meaningfully populated when the
+in-scope team(s) have subjects, but the key is always present):
 
 ```json
 {
@@ -345,7 +349,11 @@ Response shape (unchanged across all filter combinations):
       { "domain": "pubmed.ncbi.nlm.nih.gov", "count": 12 },
       ...
     ]
-  }
+  },
+  "by_subject": [
+    { "subject_id": 2, "subject_name": "Multiple Sclerosis", "articles": 812, "trials": 30, "authors": 640, "sources": 12 },
+    { "subject_id": 5, "subject_name": "Rare Disease", "articles": 0, "trials": 0, "authors": 0, "sources": 0 }
+  ]
 }
 ```
 
@@ -355,20 +363,30 @@ Response shape (unchanged across all filter combinations):
 |:----------|:-----|:----------|
 | `organization` | int or CSV of ints | Scope counts to one or more organisations. Alias `org` is accepted. |
 | `team` | int or CSV of ints | Scope counts to one or more teams. |
+| `subject` | int or CSV of ints | Scope counts to one or more subjects (union, not intersection — matches `team`/`organization`, not the `subject_id` filter on the list endpoints). Adds/populates `by_subject`. IDs only — subject slugs are not unique across teams, so there is no slug form of this filter here. |
 | `include_public` | bool (`true`/`false`) | Handled by the visibility layer — adds public-org data for identified callers. |
 
-When both `organization` and `team` are given the effective scope is their **intersection**: teams that belong to the requested org(s).
+When both `organization` and `team` are given the effective scope is their **intersection**: teams that belong to the requested org(s). The same applies to `subject` versus `team`/`organization`: a subject the caller can see but that doesn't belong to the requested team/org scope does **not** 404 — it returns a well-formed payload with every count at zero and `by_subject: []`.
+
+#### `by_subject`
+
+- Lists **every subject in scope**, including ones with zero articles and zero trials — this is deliberate (it doubles as the data a subject picker needs) and differs from `/articles/stats/` and `/trials/stats/`, which aggregate off the through table and omit empty subjects.
+- Scope: subjects whose team is in the resolved team scope, further narrowed to `?subject=` when given. Ordered by `subject_name` ascending.
+- Per-subject counts are `articles`, `trials`, `authors`, `sources` — **no per-subject `subscribers`**. With `Lists` as the only path from a subscriber to a subject, that number would describe list-tagging more than the subject itself.
+- `sources` counts distinct **domains** (matching the top-level `sources.total` semantics), not feed rows — two RSS feeds on the same domain count once. A `Sources` row with `subject` unset (`null`) is excluded from every `by_subject` row and, when `?subject=` is applied, from the filtered totals too.
+- Neither `authors` nor `sources` in a `by_subject` row sums to the top-level total, and that's correct: both are *distinct within that subject*. An author publishing under two subjects appears in both rows and once at the top; a domain feeding two subjects likewise.
+- Roughly 42% of trials in this dataset have no subject assigned — a subject-filtered `trials` count is expected to be substantially lower than the team-scoped one; that's coverage, not a bug.
 
 #### Error responses
 
 | Status | Condition |
 |:-------|:----------|
-| `400 Bad Request` | Non-integer value in `team` or `organization`. |
-| `404 Not Found` | Any requested `team` or `organization` is not visible to the caller (hidden org — existence is not leaked). |
+| `400 Bad Request` | Non-integer value in `team`, `organization`, or `subject`. |
+| `404 Not Found` | Any requested `team`, `organization`, or `subject` is not visible to the caller (hidden org — existence is not leaked). Subject visibility is judged against the caller's visible organisations only, independent of `team`/`organization` scoping (see the intersection note above). |
 
 #### Caching
 
-Results are cached for `STATS_CACHE_TTL` seconds (default 600 s / 10 min) using Django's database cache. All gunicorn workers share the same cached value. The cache key encodes the resolved set of in-scope team IDs, so different filter combinations are cached independently.
+Results are cached for `STATS_CACHE_TTL` seconds (default 600 s / 10 min) using Django's database cache. All gunicorn workers share the same cached value. The cache key encodes both the resolved set of in-scope team IDs and the requested `subject` IDs, so different filter combinations — including the same team with and without a subject filter — are cached independently.
 
 ### Trials-specific filter parameters
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ walkthrough (read in order); everything else is reference or design material.
 | [article-doi-dedup.md](article-doi-dedup.md) | Article de-duplication by DOI. |
 | [streaming-csv-response.md](streaming-csv-response.md) | Implementation of streamed CSV responses. |
 | [spec-ml-training.md](spec-ml-training.md) | Specification for the ML training workflow. |
+| [spec-stats-subject-filter.md](spec-stats-subject-filter.md) | Specification for `?subject=` filtering and the `by_subject` breakdown on `GET /stats/`. |
 
 ## Operations & commands
 

--- a/docs/spec-stats-subject-filter.md
+++ b/docs/spec-stats-subject-filter.md
@@ -1,0 +1,396 @@
+# Specification — subject filtering on `GET /stats/`
+
+Status: plan, not implemented. Written 2026-08-04.
+
+Adds a `?subject=` filter and a `by_subject` breakdown to the site-wide stats
+endpoint (`StatsView`, [django/api/views.py:3715](../django/api/views.py)), so a
+client can ask "how much data does team 1 have **for multiple sclerosis**" in one
+call instead of scoping to the team and eyeballing the difference.
+
+## 1 — What exists today
+
+`GET /stats/` is a plain `APIView` (not a DRF filterset). It accepts two params,
+both CSV-of-ints, both validated against `request.visible_org_ids`:
+
+| Param | Behaviour |
+|:------|:----------|
+| `team` | Scope to one or more teams. Invisible team → 404. |
+| `organization` (alias `org`) | Scope to one or more orgs. Invisible org → 404. Combined with `team`, the effective scope is the **intersection**. |
+
+The flow is: parse → validate visibility → resolve a single `team_id_list`
+(one `Team` VALUES query, reused everywhere) → cache lookup on
+`stats:<sorted team ids>` → 4 `COUNT DISTINCT` queries + 1 `Sources` VALUES →
+build payload → `cache.set(..., settings.STATS_CACHE_TTL)` (default 600s).
+
+Cold-cache budget today: **7 queries** under LocMemCache, pinned by
+`StatsQueryCountTest` with a ceiling of 15 (the slack covers production's
+`DatabaseCache` GET/SET/cull overhead).
+
+### 1.1 How each count reaches `Subject`
+
+| Count | Relation | Note |
+|:------|:---------|:-----|
+| articles | `Articles.subjects` M2M (`related_name="articles"`) | independent of `Articles.teams` |
+| trials | `Trials.subjects` M2M (`related_name="trials"`) | independent of `Trials.teams` |
+| authors | `Authors → articles__subjects` | two-hop |
+| subscribers | `Subscribers.subscriptions` → `Lists.subjects` M2M | `Lists` also has a `team` FK |
+| sources | `Sources.subject` | **single, nullable FK** — not M2M |
+
+`Subject.team` is a nullable FK, and `(team, subject_slug)` is unique — slugs are
+**not** globally unique, which is why this filter takes IDs, not slugs.
+
+### 1.2 Coverage on the dev database
+
+Measured 2026-08-04, dev DB:
+
+| | total | without a subject |
+|:--|--:|--:|
+| subjects | 7 | — |
+| articles | 50,183 | 372 (0.7%) |
+| trials | 30,169 | 12,829 (42.5%) |
+| sources | 52 | 1 |
+| lists | 9 | 2 |
+
+The trials figure matters: any subject-filtered trial count drops ~42% relative
+to the team-scoped one, and that is correct, not a bug. Worth a line in the docs
+so nobody files it as one.
+
+## 2 — Decisions taken
+
+Confirmed with Bruno before drafting:
+
+1. **Param shape** — `?subject=1,2`, CSV of ints, **OR** semantics (union), matching
+   this endpoint's existing `?team=` / `?organization=` style rather than the list
+   endpoints' `?subject_id=`. No `subjects_any` / AND variant: on an aggregate
+   endpoint an AND across subjects has no obvious meaning.
+2. **Sources** — filtered on the `subject` FK. Sources with `subject IS NULL` drop
+   out of `sources.total`, `by_type` and `by_domain`.
+3. **Subscribers** — filtered via `subscriptions__subjects__in`. Lists with no
+   subjects tagged contribute nobody.
+4. **`by_subject`** — add it, in the same PR, carrying per-subject `articles`,
+   `trials`, `authors` and `sources`. **Not** per-subject subscribers.
+5. **No slug form of the filter.** `(team, subject_slug)` is unique, not
+   `subject_slug` alone, so a slug filter would only be safe alongside a mandatory
+   `?team=`. IDs only; RSS routes stay the one place slugs are addressable.
+
+Two more that follow from existing precedent, taken without asking:
+
+6. **Invisible subject → 404**, judged against `visible_org_ids` only — same as
+   `team` and `organization` today, so subject existence isn't leaked.
+7. **Visible subject outside the requested team/org scope → zero counts, not 404** —
+   mirrors `OrgAndTeamIntersectionTest.test_team_not_in_org_returns_zero_not_404`.
+   `?team=1&subject=<subject of team 9>` returns a well-formed all-zero payload.
+
+## 3 — Response shape
+
+Additive. Every existing key keeps its meaning; `by_subject` is new.
+
+```json
+{
+  "articles": 8420,
+  "trials": 133,
+  "subscribers": 78,
+  "authors": 11902,
+  "sources": { "total": 42, "by_type": {...}, "by_domain": [...] },
+  "by_subject": [
+    { "subject_id": 2, "subject_name": "Multiple Sclerosis", "articles": 8412, "trials": 133, "authors": 11837, "sources": 12 },
+    { "subject_id": 5, "subject_name": "Rare Disease",       "articles": 0,    "trials": 0,   "authors": 0,     "sources": 0 }
+  ]
+}
+```
+
+- `by_subject` lists **every in-scope subject**, including those with zero
+  articles and zero trials — the payload doubles as the list a UI needs to build
+  a subject picker, so silently dropping empty subjects would be worse than the
+  extra rows. (`/articles/stats/` and `/trials/stats/` aggregate straight off the
+  through table and therefore omit empties; this endpoint deliberately differs.)
+- Scope of the list: subjects whose `team_id` is in `team_id_list`, further
+  narrowed to the requested `?subject=` set when one is given.
+- Ordering: `subject_name` ascending. Stable across calls, which `-count` is not
+  when two subjects tie.
+- Counts inside `by_subject` are `articles`, `trials`, `authors` and `sources`.
+  Per-subject subscribers is deliberately absent (decision 4) — with `Lists` as
+  the only path to `Subject`, the number would say more about how lists are tagged
+  than about the subject.
+- `sources` is a count of **distinct domains**, matching what the top-level
+  `sources.total` means. Not a count of feed rows: two RSS feeds on
+  `pubmed.ncbi.nlm.nih.gov` are one source there and must be one here too.
+- Neither `authors` nor `sources` sums to its top-level total, and that is
+  correct, not a reconciliation bug. Both are distinct counts *within* a subject:
+  an author writing under two subjects appears in both rows and once at the top,
+  and a domain feeding two subjects likewise. Say this explicitly in the API docs
+  — it is the first thing anyone will try to add up.
+
+`docs/03-api-and-rss-feeds.md` currently claims the shape is "unchanged across all
+filter combinations" — that sentence has to go.
+
+## 4 — Implementation
+
+All in `StatsView.get`, [django/api/views.py:3740](../django/api/views.py).
+
+### 4.1 Parse `?subject=` (after the `?organization=` block, ~line 3774)
+
+Same shape as the two existing parsers, same 400 on a non-integer:
+
+```python
+subject_param = request.query_params.get("subject")
+subject_ids = None
+if subject_param:
+    try:
+        subject_ids = [int(s.strip()) for s in subject_param.split(",") if s.strip()]
+    except ValueError:
+        return Response(
+            {"error": "Invalid subject parameter. Expected integer or comma-separated integers."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+```
+
+### 4.2 Resolve subjects — one query, three jobs
+
+Placed **after** `team_id_list` is resolved (~line 3839) and **before** the cache
+lookup. This single query serves visibility validation, count scoping, and the
+`by_subject` enumeration:
+
+```python
+subj_qs = Subject.objects.all()
+if visible_org_ids is not None:
+    subj_qs = subj_qs.filter(team__organization_id__in=visible_org_ids)
+if subject_ids is not None:
+    subj_qs = subj_qs.filter(id__in=subject_ids)
+elif team_id_list is not None:
+    subj_qs = subj_qs.filter(team_id__in=team_id_list)
+visible_subjects = list(subj_qs.values("id", "subject_name", "team_id"))
+```
+
+Then, in order:
+
+1. **404 check** — only when `?subject=` was given and the middleware ran:
+   `len(visible_subjects) != len(set(subject_ids))` → `raise Http404`. Note the
+   predicate is org-visibility only; `team_id` is deliberately *not* in it.
+2. **Effective scope** — `effective_subject_ids = [s["id"] for s in visible_subjects
+   if team_id_list is None or s["team_id"] in team_id_list]`. When `?subject=` was
+   given and this comes out empty, decision 6 applies: return the all-zero payload.
+3. **`by_subject` roster** — the same list, filtered the same way, sorted by
+   `subject_name`.
+
+Note the `elif` in the query above: when `?subject=` is absent the roster is the
+in-scope subjects; when it is present the requested IDs are looked up *without*
+the team narrowing, because the team narrowing is what distinguishes 404 from
+zero and it has to be applied in Python, after the visibility verdict.
+
+### 4.3 Cache key
+
+**Mandatory** — without it, a `?subject=`-filtered payload poisons the unfiltered
+one for `STATS_CACHE_TTL` seconds. Extend line 3842:
+
+```python
+cache_key = (
+    "stats:"
+    + ("all" if team_id_list is None else ",".join(str(i) for i in sorted(team_id_list)))
+    + ":subj:"
+    + ("all" if subject_ids is None else ",".join(str(i) for i in sorted(set(subject_ids))))
+)
+```
+
+Key off the **requested** `subject_ids`, not `effective_subject_ids` — two
+different requests must not share a key just because both resolved to an empty
+effective set.
+
+The new format orphans every existing `stats:*` entry. They expire on their own
+within `STATS_CACHE_TTL`; no manual flush, no migration.
+
+### 4.4 Counts
+
+The current code branches on `fully_unscoped` (no middleware, no `?team=`) to use
+cheap non-distinct `.count()`. Adding an M2M subject join to that branch makes the
+non-distinct count wrong. Rework so the distinct path is taken whenever *either*
+a team scope or a subject scope is active:
+
+```python
+apply_subject = effective_subject_ids is not None
+
+articles_qs = Articles.objects.all()
+if team_id_list is not None:
+    articles_qs = articles_qs.filter(teams__in=team_id_list)
+if apply_subject:
+    articles_qs = articles_qs.filter(subjects__in=effective_subject_ids)
+articles_count = (
+    articles_qs.count()
+    if (team_id_list is None and not apply_subject)
+    else articles_qs.values("article_id").distinct().count()
+)
+```
+
+…and the same for trials (`trial_id`), authors
+(`articles__subjects__in`), subscribers (`subscriptions__subjects__in` alongside
+the existing `subscriptions__team__in`) and sources (`subject_id__in` — plain FK,
+still no distinct needed).
+
+**Keep the team join on every count even when `?subject=` is given.** Dropping it
+is a visibility leak: an article belonging only to a non-visible team can be
+tagged with a subject the caller *can* see, and `filter(subjects__in=[...])` alone
+would count it.
+
+Preserve the `.values(pk).distinct().count()` idiom and its comment (line 3859) —
+`.distinct()` over full rows is ~5x slower at prod scale.
+
+### 4.5 `by_subject`
+
+Three grouped queries over the M2M through tables, following `_by_subject_counts`
+([django/api/views.py:428](../django/api/views.py)). All three anchor on the
+through table and differ only in what they count, so one helper covers them:
+
+```python
+def _subject_counts(model, subject_ids, team_id_list, count_field=None):
+    through = model.subjects.through
+    src = model._meta.model_name  # "articles" / "trials"
+    qs = through.objects.filter(subject_id__in=subject_ids)
+    if team_id_list is not None:
+        qs = qs.filter(**{f"{src}__teams__in": team_id_list})
+    return {
+        r["subject_id"]: r["count"]
+        for r in qs.values("subject_id").annotate(
+            count=Count(count_field or f"{src}_id", distinct=True)
+        )
+    }
+```
+
+- articles — `_subject_counts(Articles, ...)`
+- trials — `_subject_counts(Trials, ...)`
+- authors — `_subject_counts(Articles, ..., count_field="articles__authors")`,
+  which walks `articles_subjects → articles → articles_authors` and counts
+  distinct author IDs per subject.
+
+Per-subject `sources` needs **no query at all**. The existing domain aggregation
+(views.py:3892-3918) already materialises every in-scope source row into Python
+with `sources_qs.values("link", "source_for")`; add `"subject_id"` to that
+`values()` and accumulate a second dict in the same loop:
+
+```python
+source_data = list(sources_qs.values("link", "source_for", "subject_id"))
+subject_domains = {}          # subject_id -> set of netlocs
+for s in source_data:
+    d = extract_domain(s["link"])
+    if d:
+        ...                    # existing all_domains / type_domains / domain_feed_count
+        if s["subject_id"] is not None:
+            subject_domains.setdefault(s["subject_id"], set()).add(d)
+```
+
+`len(subject_domains.get(sid, ()))` is then the per-subject count, distinct by
+domain and therefore consistent with `sources.total` by construction. Sources with
+a NULL subject are skipped here, exactly as decision 2 already skips them from the
+filtered totals.
+
+Zip the four dicts against the roster, defaulting to 0. Skip the three group-by
+queries when the roster is empty.
+
+**Measured on dev** (50,183 articles, 428,022 article-author rows, all teams, all
+7 subjects): articles group-by **0.04s**, authors group-by **0.31s**. The authors
+query is by a wide margin the most expensive thing on this endpoint — acceptable
+only because it sits behind the 600s cache. Re-measure it under `?team=`-scoped
+conditions on prod-sized data before merging, and if it degrades, fall back to a
+correlated subquery in the shape of `author_articles_count_subquery`
+([django/api/views.py:2612](../django/api/views.py)) rather than widening the
+group-by.
+
+### 4.6 Query budget
+
+| | queries |
+|:--|--:|
+| today, cold, LocMemCache | 7 |
+| \+ subject resolution (§4.2) | 1 |
+| \+ `by_subject` group-bys — articles, trials, authors (§4.5) | 3 |
+| \+ `by_subject` sources — folded into the existing Python pass | 0 |
+| **new total** | **11** |
+
+Under the existing ceiling of 15, but that ceiling was sized for production's
+`DatabaseCache` overhead on a 7-query baseline. Raise it to 18 and rewrite the
+breakdown comment in `StatsQueryCountTest.test_scoped_call_query_budget`
+(test_visibility_stats.py:440) — leaving a stale comment there is worse than the
+number itself.
+
+Query *count* is not the concern here — query *cost* is. The authors group-by
+alone is 0.31s on dev (§4.5), roughly as much wall time as the other ten put
+together. `EXPLAIN ANALYZE` it on a prod-sized copy before merging (§6).
+
+## 5 — Files to change
+
+| File | Change |
+|:-----|:-------|
+| `django/api/views.py` | `StatsView.get` — §4.1 to §4.5; extend the class docstring's Filters section with `?subject=` and the 404-vs-zero rule |
+| `django/api/tests/test_visibility_stats.py` | new test classes (§6); raise the query ceiling and fix its breakdown comment |
+| `docs/03-api-and-rss-feeds.md` | endpoint table row (line 194) → add `subject`; Stats section (lines 322-360) → new example URLs, `by_subject` in the sample payload, `subject` row in the filter-parameter table, drop the "unchanged across all filter combinations" claim, note the 42%-of-trials-have-no-subject caveat |
+
+No migration. No model change. No new dependency.
+
+## 6 — Tests
+
+New in `test_visibility_stats.py` (its `_make_subject` / `_make_article` /
+`_make_trial` helpers already exist; `_make_article` needs a `subjects=` kwarg,
+`_make_trial` already takes one).
+
+**`SubjectFilterStatsTest`**
+- `?subject=<id>` scopes articles, trials, authors, subscribers and sources
+- `?subject=1,2` unions rather than intersects
+- `?subject=abc` → 400, message matches the team/org wording
+- an article tagged with the subject but assigned to no team is excluded when
+  `?team=` is given — the §4.4 leak guard
+- a source with `subject IS NULL` drops out of `sources.total` (decision 2)
+- a list with no subjects contributes no subscribers (decision 3)
+
+**`SubjectVisibilityStatsTest`**
+- subject in a hidden org → 404, anonymous and API-key callers
+- subject in a public org → 404 without `include_public`, 200 with it
+- `?subject=<visible>,<hidden>` → 404 (mixed request fails whole, as with orgs)
+
+**`SubjectTeamIntersectionStatsTest`**
+- `?team=1&subject=<subject of team 9>` → 200, all counts zero, `by_subject: []`
+- `?team=1&subject=<subject of team 1>` → the team's numbers
+
+**`SubjectStatsCacheTest`**
+- `/stats/?team=1` and `/stats/?team=1&subject=2` do not share a cache entry —
+  the regression this whole section exists to catch
+- two different `?subject=` values do not share one
+- `?subject=2,1` and `?subject=1,2` **do** share one (sorted key)
+
+**`BySubjectFacetTest`**
+- lists every in-scope subject including zero-count ones
+- ordered by `subject_name`
+- respects `?subject=`
+- excludes subjects of non-visible orgs even when a visible article is tagged with
+  one — the leak `_by_subject_counts` already guards against upstream
+- per-subject `authors` counts each author once per subject: an author with two
+  articles under the same subject counts 1, and an author writing under two
+  subjects appears in both rows while counting once in the top-level `authors`
+- per-subject `sources` counts distinct **domains**: two feeds on one domain under
+  the same subject count 1, and a domain feeding two subjects appears in both rows
+  while counting once in `sources.total`
+- a source with `subject IS NULL` appears in no `by_subject` row
+- no `subscribers` key inside `by_subject` rows (decision 4) — pin it so it
+  doesn't get added by accident
+
+Plus: extend `StatsQueryCountTest` with a `?subject=`-scoped budget case.
+
+Run:
+
+```bash
+docker exec gregory python manage.py test api.tests.test_visibility_stats
+```
+
+Then the full suite before committing, per repo practice on broad changes.
+
+Manual check against prod-sized data, on dev:
+
+```bash
+docker exec gregory python manage.py shell -c "from django.test import Client; c=Client(); print(c.get('/stats/', {'team':1,'subject':1}).json())"
+```
+
+## 7 — Open questions
+
+1. Should `by_subject` be suppressible (`?by_subject=false`) for callers that only
+   want the totals? At 3 queries — one of them the 0.31s authors group-by — this
+   is more defensible than it was at 2. Decide after the prod-scale measurement in
+   §4.5: if the authors query holds under half a second, leave it always-on.
+
+Everything else is settled; §2 has the decisions and their reasons.

--- a/docs/spec-stats-subject-filter.md
+++ b/docs/spec-stats-subject-filter.md
@@ -1,6 +1,6 @@
 # Specification — subject filtering on `GET /stats/`
 
-Status: plan, not implemented. Written 2026-08-04.
+Status: implemented, PR [#823](https://github.com/brunoamaral/gregory-ai/pull/823). Written 2026-08-04.
 
 Adds a `?subject=` filter and a `by_subject` breakdown to the site-wide stats
 endpoint (`StatsView`, [django/api/views.py:3715](../django/api/views.py)), so a

--- a/docs/spec-stats-subject-filter.md
+++ b/docs/spec-stats-subject-filter.md
@@ -394,3 +394,66 @@ docker exec gregory python manage.py shell -c "from django.test import Client; c
    §4.5: if the authors query holds under half a second, leave it always-on.
 
 Everything else is settled; §2 has the decisions and their reasons.
+
+## 8 — Post-review fixes (PR #823)
+
+Copilot's automated review and a follow-up manual review each caught issues after
+the initial implementation landed on the PR branch. All are fixed on the same
+branch, verified against the full test suite, and folded in here.
+
+**Copilot review:**
+- The `?subject=` 404-existence check ran even when `visible_org_ids` is `None`
+  (middleware bypassed — management commands, tests). Gated it on
+  `visible_org_ids is not None`, matching how `?team=`/`?organization=` already
+  behave in that case (§4.2 above already assumed this; the implementation
+  didn't match it).
+
+**Manual review — two correctness bugs, both wrong-number bugs on the primary
+path, neither caught by the original test suite:**
+
+- **Authors count.** Chaining `.filter(articles__teams__in=...)` then
+  `.filter(articles__subjects__in=...)` on `Authors` re-joins `Authors->Articles`
+  per call, so an author with one article in the team and an unrelated article
+  carrying the subject was wrongly counted. Fixed with a correlated `Exists`
+  subquery that pins both predicates to the *same* article — also faster
+  (dev-measured ~1.2s → ~0.1s for the same result, since it drops the
+  `authors ⋈ articles ⋈ ...` fan-out and the `DISTINCT` it required). Regression
+  test: `SubjectCountCorrectnessTest.test_authors_count_requires_same_article`.
+- **Subscribers count.** Same shape of bug, one level removed: two chained
+  `.filter()` calls let the team predicate land on one `Lists` row and the
+  subject predicate on a different one for the same subscriber. Fixed by
+  collapsing both predicates into one `.filter(**kwargs)` call, forcing a single
+  join. Regression test:
+  `SubjectCountCorrectnessTest.test_subscribers_count_requires_same_list`.
+- Articles, trials, and the `by_subject` group-bys were **not** affected — their
+  team and subject predicates already hang off the same `Articles`/`Trials` row
+  or the same through-table row, so a second chained `.filter()` still
+  constrains that one row.
+
+**Caching — `by_subject` gets a second cache layer.** The per-subject
+`articles`/`trials`/`authors` numbers are identical regardless of which *other*
+subjects were requested alongside them, so they're now cached per
+`(team scope, subject)` (key `stats:subjrow:<team part>:<subject id>`, same TTL),
+independent of the whole-payload cache (`stats:<team part>:subj:<requested
+subjects>`). A payload-cache miss reuses whatever subject rows are already warm
+and computes only the missing ones via `cache.get_many()`/`cache.set_many()`.
+`sources` and `subject_name` stay out of the cached row (both come for free from
+data the call already fetches) so they're never stale. The tradeoff: `by_subject`
+can now lag the top-level totals by up to `STATS_CACHE_TTL` if the payload cache
+expires before a warm subject row does — documented in
+`docs/03-api-and-rss-feeds.md`'s caching section, and pinned by
+`BySubjectRowCacheTest.test_row_cache_survives_layer1_miss`.
+
+One measured wrinkle: production's `DatabaseCache` backend doesn't bulk-optimize
+`set_many()` (it loops individual `set()` calls, each its own transaction — cull
+check, `BEGIN`, existence `SELECT`, `INSERT`/`UPDATE`, `COMMIT`), so a cold call
+against a team with many subjects costs more SQL round-trips on `manage.py test`
+than the original `<=18` query-budget ceiling assumed. `StatsQueryCountTest.
+test_subject_scoped_call_query_budget` measures this directly (23-24 queries for
+one missing subject row under `DatabaseCache`; unaffected — still `<=18` — under
+the `LocMemCache` that CI's pytest run uses) and carries its own, higher ceiling
+rather than loosening the original test's.
+
+Verification: `docker exec gregory python manage.py test api.tests.test_visibility_stats`
+(58 tests) and the full suite (2519 tests) both pass, under both `manage.py test`
+and `pytest`.


### PR DESCRIPTION
## Summary
- Adds `?subject=1,2` (CSV of ints, union semantics — matching `?team=`/`?organization=`, not the list endpoints' `subject_id`) to `GET /stats/`
- Adds a `by_subject` facet listing every in-scope subject (including zero-count ones) with its own `articles`/`trials`/`authors`/`sources` counts, so a client can ask "how much data for team X on subject Y" in one call
- Subject visibility judged against `visible_org_ids` only (404 if hidden); a visible subject outside the requested `?team=`/`?organization=` scope returns an all-zero payload, not 404 — mirrors existing team/org intersection behaviour
- Cache key extended with the requested subject IDs so filtered and unfiltered payloads never collide

Full design rationale in [`docs/spec-stats-subject-filter.md`](docs/spec-stats-subject-filter.md).

## Test plan
- [x] `docker exec gregory python manage.py test api.tests.test_visibility_stats` — 51/51 pass, including 5 new test classes (`SubjectFilterStatsTest`, `SubjectVisibilityStatsTest`, `SubjectTeamIntersectionStatsTest`, `SubjectStatsCacheTest`, `BySubjectFacetTest`)
- [x] `docker exec gregory python manage.py test` — full suite, 2512/2512 pass
- [x] Manual check against dev data: `?team=1&subject=1` returns a correctly-scoped `by_subject` row; cold-cache call with `by_subject` populated took ~0.89s (well under the 600s cache TTL)
- [x] `docs/03-api-and-rss-feeds.md` updated in the same PR per repo convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)