### PR TITLE
Add OpenAPI schema generation via drf-spectacular

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,3 +119,4 @@ Always check `django/gregory/models.py` when:
 - Test coverage for new features
 - Follow Django best practices
 - When changing a filter, serializer, view, model, or route, update the docs in the same PR — `docs/03-api-and-rss-feeds.md` (the canonical API reference), the relevant view docstring, and `docs/02.1-database-tables-and-fields.md` for schema changes. See `docs/README.md`.
+- The API also has a generated OpenAPI schema (drf-spectacular) at `/api/schema/` — regenerate it in the same PR (`python manage.py spectacular --file schema.yml --fail-on-warn`) and commit `schema.yml`. New filter fields need `help_text` (see `api/filters.py`); endpoints with no introspectable serializer (manual `APIView`s, `@action`s returning hand-built dicts) need `@extend_schema`/`@extend_schema_view` — see the existing usages in `api/views.py` and `api/schema_serializers.py`.

--- a/django/admin/settings.py
+++ b/django/admin/settings.py
@@ -91,6 +91,7 @@ INSTALLED_APPS = [
 	'rest_framework',
 	'rest_framework_simplejwt',
 	'rest_framework_csv',  # Add CSV renderer support
+	'drf_spectacular',
 	'django_filters',
 	'django.contrib.postgres',
 	'django.contrib.admin',
@@ -265,7 +266,42 @@ REST_FRAMEWORK = {
 		'django_filters.rest_framework.DjangoFilterBackend',
 		'rest_framework.filters.SearchFilter',
 		'rest_framework.filters.OrderingFilter',
-	]
+	],
+	'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}
+
+# drf-spectacular — OpenAPI schema generation. See /api/schema/, /api/schema/swagger-ui/,
+# /api/schema/redoc/ (admin/urls.py). Canonical prose reference is
+# docs/03-api-and-rss-feeds.md; this schema is the machine-checkable counterpart.
+SPECTACULAR_SETTINGS = {
+	'TITLE': 'GregoryAI API',
+	'DESCRIPTION': (
+		'REST API for GregoryAI: articles, clinical trials, authors, sources, '
+		'subjects, categories, sponsors and teams. See docs/03-api-and-rss-feeds.md '
+		'for prose documentation and authentication details.'
+	),
+	'VERSION': '1.0.0',
+	'SERVE_INCLUDE_SCHEMA': False,
+	# ApiKeyMiddleware (api/middleware.py) reads a raw API key straight off the
+	# Authorization header (no "Bearer"/"Basic" prefix, no DRF authentication
+	# class) — drf-spectacular can't discover it automatically, so it's declared
+	# by hand here and referenced via `security=` on the views that use it.
+	'APPEND_COMPONENTS': {
+		'securitySchemes': {
+			'apiKeyAuth': {
+				'type': 'apiKey',
+				'in': 'header',
+				'name': 'Authorization',
+				'description': (
+					'Raw API key (no "Bearer"/"Basic" prefix) issued per '
+					'organisation. Required for write endpoints '
+					'(articles/post, articles/edit, trials/edit); optional '
+					'on read endpoints, where it scopes org-visibility and '
+					'unlocks per-org fields (takeaways, summary_plain_english).'
+				),
+			},
+		},
+	},
 }
 
 # Email Settings

--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -19,6 +19,11 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import include, path, re_path
 from rest_framework import routers
+from drf_spectacular.views import (
+	SpectacularAPIView,
+	SpectacularSwaggerView,
+	SpectacularRedocView,
+)
 
 from api.views import (
 	ArticleViewSet,
@@ -83,6 +88,18 @@ urlpatterns = (
 		# API auth route
 		path("api-auth/", include("rest_framework.urls")),
 		path("api/token/", LoginView.as_view(), name="token_obtain_pair"),
+		# OpenAPI schema (see docs/03-api-and-rss-feeds.md)
+		path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+		path(
+			"api/schema/swagger-ui/",
+			SpectacularSwaggerView.as_view(url_name="schema"),
+			name="swagger-ui",
+		),
+		path(
+			"api/schema/redoc/",
+			SpectacularRedocView.as_view(url_name="schema"),
+			name="redoc",
+		),
 		# API routes
 		path("articles/post/", post_article),
 		path("articles/edit/", edit_article),

--- a/django/api/filters.py
+++ b/django/api/filters.py
@@ -118,7 +118,7 @@ class SubjectFilterMixin:
 	``subjects_any`` — OR:  returns objects tagged with *any* of the listed IDs.
 	"""
 
-	def filter_subjects_any(self, queryset, name, value):
+	def filter_subjects_any(self, queryset, name, value: list[str]):
 		if not value:
 			return queryset
 		ids = set()
@@ -164,72 +164,175 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 	category, journal, team, subject, and special article types.
 	"""
 
-	title = filters.CharFilter(method="filter_title", label="Title")
-	summary = filters.CharFilter(method="filter_summary", label="Summary")
-	search = filters.CharFilter(method="filter_search", label="Search")
-	author_id = filters.NumberFilter(
-		field_name="authors__author_id", lookup_expr="exact", label="Author ID"
+	title = filters.CharFilter(
+		method="filter_title",
+		label="Title",
+		help_text="Case-insensitive substring match against the title only.",
 	)
-	doi = filters.CharFilter(method="filter_doi", label="DOI")
+	summary = filters.CharFilter(
+		method="filter_summary",
+		label="Summary",
+		help_text="Case-insensitive substring match against the summary/abstract only.",
+	)
+	search = filters.CharFilter(
+		method="filter_search",
+		label="Search",
+		help_text=(
+			"Boolean search across title and summary. Bare terms are AND-ed; "
+			'uppercase OR/NOT and "quoted phrases" are supported, e.g. '
+			"?search=stem OR cells. Not combinable with title/summary-only search."
+		),
+	)
+	author_id = filters.NumberFilter(
+		field_name="authors__author_id",
+		lookup_expr="exact",
+		label="Author ID",
+		help_text="Filter by author ID (see /authors/).",
+	)
+	doi = filters.CharFilter(
+		method="filter_doi",
+		label="DOI",
+		help_text=(
+			"Filter by DOI, case-insensitive. Accepts a single value or a "
+			"comma-separated list, e.g. ?doi=10.1/a,10.2/b."
+		),
+	)
 	category_slug = filters.CharFilter(
 		field_name="team_categories__category_slug",
 		lookup_expr="exact",
 		label="Category Slug",
+		help_text="Filter by category slug (see /categories/).",
 	)
 	category_id = filters.NumberFilter(
-		field_name="team_categories__id", lookup_expr="exact", label="Category ID"
+		field_name="team_categories__id",
+		lookup_expr="exact",
+		label="Category ID",
+		help_text="Filter by category ID (see /categories/).",
 	)
 	category_modality = filters.ChoiceFilter(
 		field_name="team_categories__modality",
 		choices=CategoryModality.choices,
 		distinct=True,
 		label="Intervention modality of the article's categories",
+		help_text=(
+			"Filter by the intervention modality of the article's categories; "
+			"one of the CategoryModality values."
+		),
 	)
-	journal_slug = filters.CharFilter(method="filter_journal", label="Journal")
+	journal_slug = filters.CharFilter(
+		method="filter_journal",
+		label="Journal",
+		help_text="Filter by journal name (convert spaces to dashes), case-insensitive exact match.",
+	)
 	team_id = filters.NumberFilter(
-		field_name="teams__id", lookup_expr="exact", label="Team ID"
+		field_name="teams__id",
+		lookup_expr="exact",
+		label="Team ID",
+		help_text="Filter by team ID.",
 	)
-	site_id = filters.NumberFilter(method="filter_site", label="Site ID")
+	site_id = filters.NumberFilter(
+		method="filter_site",
+		label="Site ID",
+		help_text=(
+			"Filter by Django Site ID; returns articles belonging to any team "
+			"attached to that site (see Team.site)."
+		),
+	)
 	subject_id = filters.NumberFilter(
-		field_name="subjects__id", lookup_expr="exact", label="Subject ID"
+		field_name="subjects__id",
+		lookup_expr="exact",
+		label="Subject ID",
+		help_text="Filter by subject ID (see /subjects/). Commonly combined with team_id.",
 	)
 	subjects = filters.BaseInFilter(
 		method="filter_subjects_all",
 		label="All subject IDs (comma-separated, AND match)",
+		help_text=(
+			"Comma-separated list of subject IDs with AND semantics — returns "
+			"only articles tagged with *all* listed subjects, e.g. ?subjects=1,2."
+		),
 	)
 	subjects_any = filters.BaseInFilter(
 		method="filter_subjects_any",
 		label="Any subject IDs (comma-separated, OR match)",
+		help_text=(
+			"Comma-separated list of subject IDs with OR semantics — returns "
+			"articles tagged with *any* of the listed subjects, e.g. "
+			"?subjects_any=1,2."
+		),
 	)
 	source_id = filters.NumberFilter(
-		field_name="sources__source_id", lookup_expr="exact", label="Source ID"
+		field_name="sources__source_id",
+		lookup_expr="exact",
+		label="Source ID",
+		help_text="Filter by source ID (see /sources/).",
 	)
 
 	# New parameters for special article types
-	relevant = filters.BooleanFilter(method="filter_relevant", label="Relevant")
+	relevant = filters.BooleanFilter(
+		method="filter_relevant",
+		label="Relevant",
+		help_text=(
+			"Filter for relevant articles (true/false). When combined with "
+			"subject_id, relevance is scoped to that specific subject — only "
+			"articles relevant *for that subject* (via ML predictions or manual "
+			"marking) are returned. Without subject_id, relevance is checked "
+			"across all subjects."
+		),
+	)
 	ml_threshold = filters.NumberFilter(
 		method="filter_ml_threshold",
 		label="ML Threshold (0.0-1.0)",
+		help_text=(
+			"Minimum ML prediction confidence (0.0-1.0, e.g. 0.75). Also scoped "
+			"to subject_id when provided. Defaults to 0.8 when relevant=true and "
+			"this is omitted."
+		),
 		widget=forms.NumberInput(attrs={"step": "0.01", "min": "0.0", "max": "1.0"}),
 	)
 	open_access = filters.BooleanFilter(
-		method="filter_open_access", label="Open Access"
+		method="filter_open_access",
+		label="Open Access",
+		help_text="Filter for open access articles (true/false).",
 	)
-	last_days = filters.NumberFilter(method="filter_last_days", label="Last Days")
-	week = filters.NumberFilter(method="filter_week", label="Week")
-	year = filters.NumberFilter(method="filter_year", label="Year")
+	last_days = filters.NumberFilter(
+		method="filter_last_days",
+		label="Last Days",
+		help_text="Filter for articles discovered in the last N days.",
+	)
+	week = filters.NumberFilter(
+		method="filter_week",
+		label="Week",
+		help_text="Filter for a specific ISO week number; requires year to be set too.",
+	)
+	year = filters.NumberFilter(
+		method="filter_year",
+		label="Year",
+		help_text="Year to use together with the week parameter; has no effect on its own.",
+	)
 	has_clinical_trials = filters.BooleanFilter(
-		method="filter_has_clinical_trials", label="Has Clinical Trials"
+		method="filter_has_clinical_trials",
+		label="Has Clinical Trials",
+		help_text="Filter for articles linked to one or more clinical trials (true/false).",
 	)
 	published_date_after = filters.DateFilter(
 		method="filter_published_date_after",
 		input_formats=["%Y-%m-%d"],
 		label="Published date on or after (YYYY-MM-DD)",
+		help_text=(
+			"Articles published on or after this date (YYYY-MM-DD, inclusive). "
+			"Invalid or non-ISO-8601 dates return 400 Bad Request."
+		),
 	)
 	published_date_before = filters.DateFilter(
 		method="filter_published_date_before",
 		input_formats=["%Y-%m-%d"],
 		label="Published date on or before (YYYY-MM-DD)",
+		help_text=(
+			"Articles published on or before this date (YYYY-MM-DD, inclusive — "
+			"the full day is included). Invalid or non-ISO-8601 dates return 400 "
+			"Bad Request."
+		),
 	)
 
 	class Meta:
@@ -523,45 +626,96 @@ class TrialFilter(SubjectFilterMixin, filters.FilterSet):
 	"""
 
 	# Core search filters
-	title = filters.CharFilter(method="filter_title", label="Title")
-	summary = filters.CharFilter(method="filter_summary", label="Summary")
-	search = filters.CharFilter(method="filter_search", label="Search")
+	title = filters.CharFilter(
+		method="filter_title",
+		label="Title",
+		help_text="Case-insensitive substring match against the title only.",
+	)
+	summary = filters.CharFilter(
+		method="filter_summary",
+		label="Summary",
+		help_text="Case-insensitive substring match against the summary only.",
+	)
+	search = filters.CharFilter(
+		method="filter_search",
+		label="Search",
+		help_text=(
+			"Boolean search across title and summary. Bare terms are AND-ed; "
+			'uppercase OR/NOT and "quoted phrases" are supported.'
+		),
+	)
 
 	# ID and relationship filters
 	trial_id = filters.NumberFilter(
-		field_name="trial_id", lookup_expr="exact", label="Trial ID"
+		field_name="trial_id",
+		lookup_expr="exact",
+		label="Trial ID",
+		help_text="Filter by a specific trial ID.",
 	)
 	team_id = filters.NumberFilter(
-		field_name="teams__id", lookup_expr="exact", label="Team ID"
+		field_name="teams__id",
+		lookup_expr="exact",
+		label="Team ID",
+		help_text="Filter by team ID.",
 	)
-	site_id = filters.NumberFilter(method="filter_site", label="Site ID")
+	site_id = filters.NumberFilter(
+		method="filter_site",
+		label="Site ID",
+		help_text=(
+			"Filter by Django Site ID; returns trials belonging to any team "
+			"attached to that site (see Team.site)."
+		),
+	)
 	subject_id = filters.NumberFilter(
-		field_name="subjects__id", lookup_expr="exact", label="Subject ID"
+		field_name="subjects__id",
+		lookup_expr="exact",
+		label="Subject ID",
+		help_text="Filter by subject ID (see /subjects/).",
 	)
 	subjects = filters.BaseInFilter(
 		method="filter_subjects_all",
 		label="All subject IDs (comma-separated, AND match)",
+		help_text=(
+			"Comma-separated list of subject IDs with AND semantics — returns "
+			"only trials tagged with *all* listed subjects, e.g. ?subjects=1,2."
+		),
 	)
 	subjects_any = filters.BaseInFilter(
 		method="filter_subjects_any",
 		label="Any subject IDs (comma-separated, OR match)",
+		help_text=(
+			"Comma-separated list of subject IDs with OR semantics — returns "
+			"trials tagged with *any* of the listed subjects, e.g. "
+			"?subjects_any=1,2."
+		),
 	)
 	category_slug = filters.CharFilter(
 		field_name="team_categories__category_slug",
 		lookup_expr="exact",
 		label="Category Slug",
+		help_text="Filter by category slug (see /categories/).",
 	)
 	category_id = filters.NumberFilter(
-		field_name="team_categories__id", lookup_expr="exact", label="Category ID"
+		field_name="team_categories__id",
+		lookup_expr="exact",
+		label="Category ID",
+		help_text="Filter by category ID (see /categories/).",
 	)
 	category_modality = filters.ChoiceFilter(
 		field_name="team_categories__modality",
 		choices=CategoryModality.choices,
 		distinct=True,
 		label="Intervention modality of the trial's categories",
+		help_text=(
+			"Filter by the intervention modality of the trial's categories; "
+			"one of the CategoryModality values."
+		),
 	)
 	source_id = filters.NumberFilter(
-		field_name="sources__source_id", lookup_expr="exact", label="Source ID"
+		field_name="sources__source_id",
+		lookup_expr="exact",
+		label="Source ID",
+		help_text="Filter by source ID (see /sources/).",
 	)
 
 	# Registry identifier filters
@@ -572,32 +726,69 @@ class TrialFilter(SubjectFilterMixin, filters.FilterSet):
 	identifiers = filters.BaseInFilter(
 		method="filter_identifiers",
 		label="Mixed registry id(s), comma-separated; matches any across NCT/EudraCT/EUCT/EUCTR/CTIS (case-insensitive)",
+		help_text=(
+			"Mixed list of registry identifiers, comma-separated, matched across "
+			"all registry keys at once (NCT/EudraCT/EUCT/EUCTR/CTIS), "
+			"case-insensitive, e.g. ?identifiers=NCT02521311,2020-001234-12. "
+			"Acronyms are excluded (not unique) — use acronym for those."
+		),
 	)
 	nct = filters.BaseInFilter(
 		method="filter_nct",
 		label="NCT ID(s), comma-separated; matches any (case-insensitive)",
+		help_text=(
+			"ClinicalTrials.gov NCT id(s), comma-separated, matches any "
+			"(case-insensitive), e.g. ?nct=NCT02521311,NCT06065670."
+		),
 	)
 	eudract = filters.BaseInFilter(
-		method="filter_eudract", label="EudraCT number(s), comma-separated; matches any"
+		method="filter_eudract",
+		label="EudraCT number(s), comma-separated; matches any",
+		help_text="EudraCT number(s), comma-separated, matches any (case-insensitive).",
 	)
 	euct = filters.BaseInFilter(
 		method="filter_euct",
 		label="EU CT / EUCTR number(s), comma-separated; matches any",
+		help_text=(
+			"EU CT / EUCTR number(s), comma-separated, matches any "
+			"(case-insensitive). Matches either the euct or euctr identifier key."
+		),
 	)
 	ctis = filters.BaseInFilter(
-		method="filter_ctis", label="CTIS number(s), comma-separated; matches any"
+		method="filter_ctis",
+		label="CTIS number(s), comma-separated; matches any",
+		help_text="CTIS number(s), comma-separated, matches any (case-insensitive).",
 	)
 	acronym = filters.BaseInFilter(
 		method="filter_acronym",
 		label="Trial acronym(s), comma-separated; matches any (case-insensitive)",
+		help_text=(
+			"Trial acronym(s), comma-separated, matches any (case-insensitive), "
+			"e.g. ?acronym=ReCOVER,MODIF-MS."
+		),
 	)
 
 	# Trial-specific filters
 	recruitment_status = filters.CharFilter(
-		field_name="recruitment_status", lookup_expr="iexact"
+		field_name="recruitment_status",
+		lookup_expr="iexact",
+		label="Recruitment status (raw, legacy)",
+		help_text=(
+			"Raw-text case-insensitive exact match against the registry's own "
+			'recruitment-status string (e.g. "Recruiting" matches "RECRUITING" '
+			'but not "Not Recruiting") — free text, so it silently misses '
+			"spelling/format variants across registries. Prefer "
+			"recruitment_status_normalized."
+		),
 	)
 	status = filters.CharFilter(
-		field_name="recruitment_status", lookup_expr="iexact"
+		field_name="recruitment_status",
+		lookup_expr="iexact",
+		label="Recruitment status (legacy alias of recruitment_status)",
+		help_text=(
+			"Legacy alias for recruitment_status — same raw-text, "
+			"case-insensitive exact match. Prefer recruitment_status_normalized."
+		),
 	)  # Legacy alias for backward compatibility
 	recruitment_status_normalized = ChoiceInFilter(
 		field_name="recruitment_status_normalized",
@@ -605,79 +796,201 @@ class TrialFilter(SubjectFilterMixin, filters.FilterSet):
 		choices=TrialRecruitmentStatus.choices,
 		label="One or more canonical recruitment statuses, comma-separated (OR), "
 		"e.g. ?recruitment_status_normalized=recruiting,active_not_recruiting",
+		help_text=(
+			"Exact match against the canonical recruitment status; accepts one "
+			"or more comma-separated values (OR semantics). One of: "
+			"not_yet_recruiting, recruiting, enrolling_by_invitation, "
+			"active_not_recruiting, not_recruiting, suspended, completed, "
+			"terminated, withdrawn, unknown, other."
+		),
 	)
 	internal_number = filters.CharFilter(
-		field_name="internal_number", lookup_expr="icontains"
+		field_name="internal_number",
+		lookup_expr="icontains",
+		label="Internal number",
+		help_text="Filter by WHO internal number (case-insensitive substring).",
 	)
-	phase = filters.CharFilter(field_name="phase", lookup_expr="icontains")
+	phase = filters.CharFilter(
+		field_name="phase",
+		lookup_expr="icontains",
+		label="Phase (raw, legacy)",
+		help_text=(
+			"Raw-text contains filter on the registry's own phase string "
+			'(Phase I, II, III, etc.) — free text, so it silently misses '
+			'spelling/format variants (e.g. "Phase III" vs "Phase 3"). Prefer '
+			"phase_normalized."
+		),
+	)
 	phase_normalized = ChoiceInFilter(
 		field_name="phase_normalized",
 		lookup_expr="in",
 		choices=TrialPhase.choices,
 		label="One or more canonical phases, comma-separated (OR), "
 		"e.g. ?phase_normalized=phase_2,phase_3",
+		help_text=(
+			"Exact match against the canonical phase; accepts one or more "
+			"comma-separated values (OR semantics). One of: early_phase_1, "
+			"phase_1, phase_1_2, phase_2, phase_2_3, phase_3, phase_3_4, "
+			"phase_4, post_market, not_applicable, other."
+		),
 	)
-	study_type = filters.CharFilter(field_name="study_type", lookup_expr="icontains")
-	study_type_normalized = filters.ChoiceFilter(choices=TrialStudyType.choices)
+	study_type = filters.CharFilter(
+		field_name="study_type",
+		lookup_expr="icontains",
+		label="Study type (raw, legacy)",
+		help_text=(
+			"Legacy free-text case-insensitive substring filter on the raw "
+			"registry study-type string — can both overmatch and undermatch "
+			'across registries (e.g. matches "Interventional clinical trial of '
+			'medicinal product" but misses "Intervention"); prefer '
+			"study_type_normalized."
+		),
+	)
+	study_type_normalized = filters.ChoiceFilter(
+		choices=TrialStudyType.choices,
+		label="Canonical study type",
+		help_text=(
+			"Exact match against the canonical study type; one of: "
+			"interventional, observational, expanded_access, basic_science, "
+			"other."
+		),
+	)
 	primary_sponsor = filters.CharFilter(
-		field_name="primary_sponsor", lookup_expr="icontains"
+		field_name="primary_sponsor",
+		lookup_expr="icontains",
+		label="Primary sponsor (raw, legacy)",
+		help_text=(
+			"Legacy free-text case-insensitive substring filter on the raw "
+			"registry sponsor string — silently misses spelling/duplicate "
+			"variants across registries; prefer sponsor_id/sponsor_slug."
+		),
 	)  # Legacy: free-text on the raw registry string — prefer sponsor_id/sponsor_slug
 	sponsor_id = filters.NumberFilter(
 		field_name="primary_sponsor_normalized_id",
 		lookup_expr="exact",
 		label="Canonical sponsor ID (see /sponsors/)",
+		help_text="Exact match against a canonical sponsor's id (see /sponsors/).",
 	)
 	sponsor_slug = filters.CharFilter(
 		field_name="primary_sponsor_normalized__slug",
 		lookup_expr="exact",
 		label="Canonical sponsor slug (see /sponsors/)",
+		help_text="Exact match against a canonical sponsor's slug (see /sponsors/).",
 	)
 	source_register = filters.CharFilter(
-		field_name="source_register", lookup_expr="icontains"
+		field_name="source_register",
+		lookup_expr="icontains",
+		label="Source registry",
+		help_text="Filter by source registry (case-insensitive substring).",
 	)
-	countries = filters.CharFilter(field_name="countries", lookup_expr="icontains")
+	countries = filters.CharFilter(
+		field_name="countries",
+		lookup_expr="icontains",
+		label="Countries (raw, legacy)",
+		help_text=(
+			"Raw-text case-insensitive substring filter on the registry's own "
+			"countries string — free text, so it silently misses "
+			"spelling/format variants across registries. See country for the "
+			"normalized equivalent."
+		),
+	)
 	country = filters.CharFilter(
 		method="filter_country",
 		label="Normalized country: one or more ISO 3166-1 alpha-2 codes, comma-separated, "
 		"e.g. ?country=DE or ?country=DE,FR (OR semantics)",
+		help_text=(
+			"Match against one or more normalized country codes (ISO 3166-1 "
+			"alpha-2), comma-separated, OR semantics (e.g. ?country=DE or "
+			"?country=DE,FR), derived from every source's raw country data."
+		),
 	)
 	region = filters.ChoiceFilter(
 		method="filter_region",
 		choices=TrialRegion.choices,
 		label="Normalized region, derived from the trial's countries",
+		help_text=(
+			"Exact match against a normalized region derived from the trial's "
+			"countries; one of: africa, asia, europe, north_america, "
+			"south_america, oceania (e.g. ?region=europe)."
+		),
 	)
 
 	# Medical/research filters
-	condition = filters.CharFilter(field_name="condition", lookup_expr="icontains")
+	condition = filters.CharFilter(
+		field_name="condition",
+		lookup_expr="icontains",
+		label="Condition",
+		help_text="Filter by medical condition (case-insensitive substring).",
+	)
 	intervention = filters.CharFilter(
-		field_name="intervention", lookup_expr="icontains"
+		field_name="intervention",
+		lookup_expr="icontains",
+		label="Intervention",
+		help_text="Filter by intervention type (case-insensitive substring).",
 	)
 	therapeutic_areas = filters.CharFilter(
-		field_name="therapeutic_areas", lookup_expr="icontains"
+		field_name="therapeutic_areas",
+		lookup_expr="icontains",
+		label="Therapeutic areas",
+		help_text="Filter by therapeutic areas (case-insensitive substring).",
 	)
 	inclusion_agemin = filters.CharFilter(
-		field_name="inclusion_agemin", lookup_expr="exact"
+		field_name="inclusion_agemin",
+		lookup_expr="exact",
+		label="Inclusion age minimum (raw, legacy)",
+		help_text=(
+			"Exact match against the raw inclusion age-minimum criteria string. "
+			"Prefer age_eligible for a numeric range check."
+		),
 	)
 	inclusion_agemax = filters.CharFilter(
-		field_name="inclusion_agemax", lookup_expr="exact"
+		field_name="inclusion_agemax",
+		lookup_expr="exact",
+		label="Inclusion age maximum (raw, legacy)",
+		help_text=(
+			"Exact match against the raw inclusion age-maximum criteria string. "
+			"Prefer age_eligible for a numeric range check."
+		),
 	)
 	age_eligible = filters.NumberFilter(
 		method="filter_age_eligible",
 		label="Trials whose eligible age range (in years) includes this age, "
 		"e.g. ?age_eligible=40. A null min is treated as no lower bound; a null max as no upper bound.",
+		help_text=(
+			"Trials whose eligible age range (inclusion_age_min_years..."
+			"inclusion_age_max_years, in years) includes this age, e.g. "
+			"?age_eligible=40. A null min is treated as no lower bound; a null "
+			"max as no upper bound."
+		),
 	)
 	# The legacy icontains filter here was removed 2026-07-20 — it returned confidently
 	# wrong results (?inclusion_gender=Female matched "Female, Male", a both-sexes trial),
 	# not merely weak like the other legacy filters. See
 	# INCLUSION-GENDER-NORMALIZATION-PLAN.md and docs/trials-field-normalization.md.
 	inclusion_gender_normalized = filters.ChoiceFilter(
-		choices=TrialSexEligibility.choices
+		choices=TrialSexEligibility.choices,
+		label="Canonical sex eligibility",
+		help_text=(
+			"Exact match against canonical sex eligibility; one of: all, "
+			"female, male. Replaces the removed legacy inclusion_gender "
+			"substring filter, which returned confidently wrong results "
+			'(?inclusion_gender=Female matched "Female, Male", a both-sexes '
+			"trial). **Breaking change (2026-07-20):** ?inclusion_gender=... is "
+			"no longer a recognised parameter and is silently ignored "
+			"(unfiltered results), not rejected — see "
+			"docs/trials-field-normalization.md."
+		),
 	)
 
 	# Results filters
 	has_results = filters.BooleanFilter(
 		method="filter_has_results",
 		label="Has results posted (results_posted flag, results completion date, results link, or results available = Yes)",
+		help_text=(
+			"true/false; a trial counts as having results when any of "
+			"results_posted, results completion date, results link, or "
+			'results-available = "Yes" is set.'
+		),
 	)
 
 	# Date-range filters
@@ -686,12 +999,20 @@ class TrialFilter(SubjectFilterMixin, filters.FilterSet):
 		lookup_expr="gte",
 		input_formats=["%Y-%m-%d"],
 		label="Date registered on or after (YYYY-MM-DD)",
+		help_text=(
+			"Trials registered on or after this date (YYYY-MM-DD, inclusive). "
+			"Invalid or non-ISO-8601 dates return 400 Bad Request."
+		),
 	)
 	date_registration_before = filters.DateFilter(
 		field_name="date_registration",
 		lookup_expr="lte",
 		input_formats=["%Y-%m-%d"],
 		label="Date registered on or before (YYYY-MM-DD)",
+		help_text=(
+			"Trials registered on or before this date (YYYY-MM-DD, inclusive). "
+			"Invalid or non-ISO-8601 dates return 400 Bad Request."
+		),
 	)
 
 	class Meta:
@@ -818,15 +1139,15 @@ class TrialFilter(SubjectFilterMixin, filters.FilterSet):
 			queryset, value, ["nct", "eudract", "euct", "euctr", "ctis"]
 		)
 
-	def filter_nct(self, queryset, name, value):
+	def filter_nct(self, queryset, name, value: list[str]):
 		"""Match ClinicalTrials.gov NCT id(s) against ``identifiers['nct']``."""
 		return self._match_identifier(queryset, value, ["nct"])
 
-	def filter_eudract(self, queryset, name, value):
+	def filter_eudract(self, queryset, name, value: list[str]):
 		"""Match EudraCT number(s) against ``identifiers['eudract']``."""
 		return self._match_identifier(queryset, value, ["eudract"])
 
-	def filter_euct(self, queryset, name, value):
+	def filter_euct(self, queryset, name, value: list[str]):
 		"""Match EU CT number(s) against ``identifiers['euct']`` or ``['euctr']``.
 
 		The two keys are used interchangeably across the ingestion pipeline for
@@ -834,7 +1155,7 @@ class TrialFilter(SubjectFilterMixin, filters.FilterSet):
 		"""
 		return self._match_identifier(queryset, value, ["euct", "euctr"])
 
-	def filter_ctis(self, queryset, name, value):
+	def filter_ctis(self, queryset, name, value: list[str]):
 		"""Match CTIS number(s) against ``identifiers['ctis']``."""
 		return self._match_identifier(queryset, value, ["ctis"])
 
@@ -907,21 +1228,40 @@ class TrialFilter(SubjectFilterMixin, filters.FilterSet):
 class AuthorFilter(filters.FilterSet):
 	"""Filter class for Authors, allowing searching by full name, given name, family name and filtering by author ID."""
 
-	full_name = filters.CharFilter(method="filter_full_name", label="Full Name")
+	full_name = filters.CharFilter(
+		method="filter_full_name",
+		label="Full Name",
+		help_text="Case-insensitive substring match against the author's full name.",
+	)
 	given_name = filters.CharFilter(
-		field_name="given_name", lookup_expr="icontains", label="Given Name"
+		field_name="given_name",
+		lookup_expr="icontains",
+		label="Given Name",
+		help_text="Case-insensitive substring match against the given (first) name.",
 	)
 	family_name = filters.CharFilter(
-		field_name="family_name", lookup_expr="icontains", label="Family Name"
+		field_name="family_name",
+		lookup_expr="icontains",
+		label="Family Name",
+		help_text="Case-insensitive substring match against the family (last) name.",
 	)
 	author_id = filters.NumberFilter(
-		field_name="author_id", lookup_expr="exact", label="Author ID"
+		field_name="author_id",
+		lookup_expr="exact",
+		label="Author ID",
+		help_text="Filter by a specific author ID.",
 	)
 	orcid = filters.CharFilter(
-		field_name="ORCID", lookup_expr="icontains", label="ORCID"
+		field_name="ORCID",
+		lookup_expr="icontains",
+		label="ORCID",
+		help_text="Case-insensitive substring match against the author's ORCID iD.",
 	)
 	country = filters.CharFilter(
-		field_name="country", lookup_expr="exact", label="Country"
+		field_name="country",
+		lookup_expr="exact",
+		label="Country",
+		help_text="Exact match against the author's country code.",
 	)
 
 	class Meta:
@@ -948,19 +1288,40 @@ class SourceFilter(filters.FilterSet):
 	"""
 
 	source_id = filters.NumberFilter(
-		field_name="source_id", lookup_expr="exact", label="Source ID"
+		field_name="source_id",
+		lookup_expr="exact",
+		label="Source ID",
+		help_text="Filter by a specific source ID.",
 	)
 	team_id = filters.NumberFilter(
-		field_name="team__id", lookup_expr="exact", label="Team ID"
+		field_name="team__id",
+		lookup_expr="exact",
+		label="Team ID",
+		help_text="Filter by team ID.",
 	)
 	subject_id = filters.NumberFilter(
-		field_name="subject__id", lookup_expr="exact", label="Subject ID"
+		field_name="subject__id",
+		lookup_expr="exact",
+		label="Subject ID",
+		help_text="Filter by subject ID (see /subjects/).",
 	)
-	active = filters.BooleanFilter(field_name="active", label="Active")
+	active = filters.BooleanFilter(
+		field_name="active",
+		label="Active",
+		help_text="Filter by whether the source is actively polled (true/false).",
+	)
 	source_for = filters.CharFilter(
-		field_name="source_for", lookup_expr="exact", label="Source For"
+		field_name="source_for",
+		lookup_expr="exact",
+		label="Source For",
+		help_text="Exact match against the source's content type (e.g. articles vs trials).",
 	)
-	link = filters.CharFilter(field_name="link", lookup_expr="icontains", label="Link")
+	link = filters.CharFilter(
+		field_name="link",
+		lookup_expr="icontains",
+		label="Link",
+		help_text="Case-insensitive substring match against the source's feed/URL.",
+	)
 
 	class Meta:
 		model = Sources
@@ -972,7 +1333,11 @@ class SponsorFilter(filters.FilterSet):
 	Filter class for Sponsors (see /sponsors/).
 	"""
 
-	sponsor_type = filters.ChoiceFilter(choices=SponsorType.choices)
+	sponsor_type = filters.ChoiceFilter(
+		choices=SponsorType.choices,
+		label="Sponsor type",
+		help_text="Exact match against the canonical sponsor type (see SponsorType values).",
+	)
 
 	class Meta:
 		model = Sponsor
@@ -985,7 +1350,10 @@ class SubjectFilter(filters.FilterSet):
 	"""
 
 	team_id = filters.NumberFilter(
-		field_name="team__id", lookup_expr="exact", label="Team ID"
+		field_name="team__id",
+		lookup_expr="exact",
+		label="Team ID",
+		help_text="Filter by team ID.",
 	)
 
 	class Meta:
@@ -999,16 +1367,27 @@ class CategoryFilter(filters.FilterSet):
 	"""
 
 	category_id = filters.NumberFilter(
-		field_name="id", lookup_expr="exact", label="Category ID"
+		field_name="id",
+		lookup_expr="exact",
+		label="Category ID",
+		help_text="Filter by a specific category ID.",
 	)
 	team_id = filters.NumberFilter(
-		field_name="team__id", lookup_expr="exact", label="Team ID"
+		field_name="team__id",
+		lookup_expr="exact",
+		label="Team ID",
+		help_text="Filter by team ID.",
 	)
 	subject_id = filters.NumberFilter(
-		field_name="subjects__id", lookup_expr="exact", label="Subject ID"
+		field_name="subjects__id",
+		lookup_expr="exact",
+		label="Subject ID",
+		help_text="Filter by subject ID (see /subjects/).",
 	)
 	category_terms = filters.CharFilter(
-		method="filter_category_terms", label="Category Terms"
+		method="filter_category_terms",
+		label="Category Terms",
+		help_text="Case-insensitive substring match against the category's terms.",
 	)
 
 	class Meta:

--- a/django/api/schema_serializers.py
+++ b/django/api/schema_serializers.py
@@ -1,0 +1,203 @@
+"""Plain (non-ModelSerializer) response shapes used only for OpenAPI schema
+generation via drf-spectacular's ``@extend_schema(responses=...)``.
+
+These views build their response dicts by hand (aggregation queries, not a
+queryset of model instances), so DRF/drf-spectacular cannot infer a response
+shape from a ``serializer_class`` the normal way. Declaring the shape here
+keeps /api/schema/ honest about what these endpoints actually return — see
+STAGE-1-OPENAPI-SCHEMA-PLAN.md task 3.
+"""
+
+from django_filters import rest_framework as filters
+from rest_framework import serializers
+
+
+def filterset_request_schema(filterset_class, required=(), extra_description=""):
+	"""Build a raw OpenAPI request-body schema from a django-filter ``FilterSet``.
+
+	Used for the ``POST /*/search/`` endpoints (see
+	``api.views.BodyParamsAsQueryParamsMixin``), which accept every filter
+	field of the corresponding FilterSet in the JSON body instead of (or in
+	addition to) the query string. Deriving the body schema from the same
+	``base_filters`` the GET query parameters come from means the two stay in
+	sync automatically — no hand-maintained duplicate field list to drift.
+
+	List-valued filters (``BaseCSVFilter``/``BaseInFilter``, e.g. ``subjects``,
+	``nct``) accept either a JSON array or a comma-separated string in the
+	body — ``BodyParamsAsQueryParamsMixin`` comma-joins a JSON array before
+	merging it into query_params. The schema advertises the array form since
+	it's the natural JSON shape; the comma-separated string form documented
+	on the equivalent GET query parameter also works.
+	"""
+	properties = {}
+	for name, filter_field in filterset_class.base_filters.items():
+		description = filter_field.extra.get("help_text") or filter_field.label or ""
+		if isinstance(filter_field, filters.BooleanFilter):
+			schema = {"type": "boolean"}
+		elif isinstance(filter_field, filters.NumberFilter):
+			schema = {"type": "number"}
+		elif isinstance(filter_field, filters.DateFilter):
+			schema = {"type": "string", "format": "date"}
+		elif isinstance(filter_field, (filters.BaseCSVFilter, filters.BaseInFilter)):
+			schema = {"type": "array", "items": {"type": "string"}}
+		else:
+			schema = {"type": "string"}
+		if description:
+			schema["description"] = description
+		properties[name] = schema
+	schema = {"type": "object", "properties": properties}
+	if required:
+		schema["required"] = list(required)
+	if extra_description:
+		schema["description"] = extra_description
+	return schema
+
+
+class ErrorResponseSerializer(serializers.Serializer):
+	"""Generic ``{"error": "..."}`` shape used by hand-written error responses."""
+
+	error = serializers.CharField()
+
+
+class SubjectCountSerializer(serializers.Serializer):
+	subject_id = serializers.IntegerField()
+	subject_name = serializers.CharField()
+	count = serializers.IntegerField()
+
+
+class ArticlesByAccessSerializer(serializers.Serializer):
+	open = serializers.IntegerField()
+	restricted = serializers.IntegerField()
+	unknown = serializers.IntegerField()
+
+
+class ArticlesStatsSerializer(serializers.Serializer):
+	"""Response of ``GET /articles/stats/`` — see ArticleViewSet.build_stats_payload."""
+
+	total = serializers.IntegerField(help_text="Distinct articles matching the filtered queryset.")
+	by_access = ArticlesByAccessSerializer()
+	relevant = serializers.IntegerField(
+		help_text="Count matching the same semantics as ?relevant=true on the list endpoint."
+	)
+	retracted = serializers.IntegerField()
+	missing_doi = serializers.IntegerField()
+	by_subject = SubjectCountSerializer(many=True)
+
+
+class TrialsByCountrySerializer(serializers.Serializer):
+	country = serializers.CharField(
+		allow_null=True, help_text="ISO 3166-1 alpha-2 code, or null for trials with no TrialCountry rows."
+	)
+	count = serializers.IntegerField()
+
+
+class TrialsByYearSerializer(serializers.Serializer):
+	year = serializers.IntegerField(allow_null=True, help_text="Registration year, or null for trials with no date_registration.")
+	count = serializers.IntegerField()
+
+
+class TrialsBySponsorSerializer(serializers.Serializer):
+	sponsor_id = serializers.IntegerField()
+	slug = serializers.CharField()
+	name = serializers.CharField()
+	sponsor_type = serializers.CharField(allow_null=True)
+	count = serializers.IntegerField()
+
+
+class TrialsStatsSerializer(serializers.Serializer):
+	"""Response of ``GET /trials/stats/`` — see TrialViewSet.build_stats_payload.
+
+	The recruitment-status bucket keys (``recruiting``, ``completed``, ...) are
+	one key per ``TrialRecruitmentStatus`` value plus ``no_status`` — declared
+	here as a representative subset via ``extra_fields``-style documentation in
+	the field help text rather than one IntegerField per enum member, since the
+	bucket set is derived from the enum at runtime (see
+	docs/03-api-and-rss-feeds.md for the full key list).
+	"""
+
+	total = serializers.IntegerField()
+	no_status = serializers.IntegerField()
+	by_subject = SubjectCountSerializer(many=True)
+	by_phase = serializers.DictField(
+		child=serializers.IntegerField(),
+		help_text="{phase_slug: count, ..., 'no_phase': count} — one key per TrialPhase value.",
+	)
+	by_region = serializers.DictField(
+		child=serializers.IntegerField(),
+		help_text=(
+			"{region_slug: count, ..., 'no_region': count} — one key per TrialRegion value. "
+			"Does not sum to total (a trial can span multiple regions)."
+		),
+	)
+	by_country = TrialsByCountrySerializer(many=True)
+	by_year = TrialsByYearSerializer(many=True)
+	by_sponsor = TrialsBySponsorSerializer(
+		many=True, help_text="Top 25 canonical sponsors by count, excluding unresolved sponsors."
+	)
+	no_sponsor = serializers.IntegerField()
+	by_sponsor_type = serializers.DictField(
+		child=serializers.IntegerField(),
+		help_text="{sponsor_type_slug: count, ..., 'no_type': count} — one key per SponsorType value.",
+	)
+	by_modality = serializers.DictField(
+		child=serializers.IntegerField(),
+		help_text=(
+			"{modality_slug: count, ..., 'no_modality': count} — one key per CategoryModality "
+			"value. Not a partition of total (a trial can carry categories of several modalities)."
+		),
+	)
+	by_study_type = serializers.DictField(
+		child=serializers.IntegerField(),
+		help_text="{study_type_slug: count, ..., 'no_study_type': count} — one key per TrialStudyType value.",
+	)
+	by_sex = serializers.DictField(
+		child=serializers.IntegerField(),
+		help_text="{sex_slug: count, ..., 'no_sex_data': count} — one key per TrialSexEligibility value.",
+	)
+
+
+class TrialSiteRowSerializer(serializers.Serializer):
+	"""Row shape of ``GET /trials/sites/`` — see TrialViewSet.sites."""
+
+	trial_id = serializers.IntegerField()
+	name = serializers.CharField(allow_null=True)
+	city = serializers.CharField(allow_null=True)
+	country = serializers.CharField(allow_null=True)
+	latitude = serializers.FloatField(allow_null=True)
+	longitude = serializers.FloatField(allow_null=True)
+
+
+class GlobalStatsByDomainSerializer(serializers.Serializer):
+	domain = serializers.CharField()
+	count = serializers.IntegerField()
+
+
+class GlobalStatsSourcesSerializer(serializers.Serializer):
+	total = serializers.IntegerField(help_text="Distinct source domains.")
+	by_type = serializers.DictField(
+		child=serializers.IntegerField(), help_text="{source_for: distinct domain count}"
+	)
+	by_domain = GlobalStatsByDomainSerializer(many=True)
+
+
+class GlobalStatsBySubjectSerializer(serializers.Serializer):
+	subject_id = serializers.IntegerField()
+	subject_name = serializers.CharField()
+	articles = serializers.IntegerField()
+	trials = serializers.IntegerField()
+	authors = serializers.IntegerField()
+	sources = serializers.IntegerField()
+
+
+class GlobalStatsSerializer(serializers.Serializer):
+	"""Response of ``GET /stats/`` — see StatsView.get."""
+
+	articles = serializers.IntegerField()
+	trials = serializers.IntegerField()
+	subscribers = serializers.IntegerField()
+	authors = serializers.IntegerField()
+	sources = GlobalStatsSourcesSerializer()
+	by_subject = GlobalStatsBySubjectSerializer(
+		many=True,
+		help_text="Present only when ?subject= is given — every in-scope subject, including zero-count ones.",
+	)

--- a/django/api/schema_serializers.py
+++ b/django/api/schema_serializers.py
@@ -4,8 +4,7 @@ generation via drf-spectacular's ``@extend_schema(responses=...)``.
 These views build their response dicts by hand (aggregation queries, not a
 queryset of model instances), so DRF/drf-spectacular cannot infer a response
 shape from a ``serializer_class`` the normal way. Declaring the shape here
-keeps /api/schema/ honest about what these endpoints actually return — see
-STAGE-1-OPENAPI-SCHEMA-PLAN.md task 3.
+keeps /api/schema/ honest about what these endpoints actually return.
 """
 
 from django_filters import rest_framework as filters

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from rest_framework import serializers
 from gregory.models import (
 	Articles,
@@ -123,10 +125,10 @@ class CategoryTopAuthorSerializer(serializers.ModelSerializer):
 			"articles_count",
 		]
 
-	def get_articles_count(self, obj):
+	def get_articles_count(self, obj) -> int:
 		return getattr(obj, "category_articles_count", 0)
 
-	def get_country(self, obj):
+	def get_country(self, obj) -> Optional[str]:
 		return obj.country.code if obj.country else None
 
 
@@ -153,7 +155,7 @@ class CategorySerializer(serializers.ModelSerializer):
 			"monthly_counts",
 		]
 
-	def get_article_count_total(self, obj):
+	def get_article_count_total(self, obj) -> int:
 		"""Prefer the queryset's Count(..., distinct=True) annotation; fall
 		back to a live count for an un-annotated instance (e.g. built
 		directly in a test)."""
@@ -164,7 +166,7 @@ class CategorySerializer(serializers.ModelSerializer):
 		# Fallback to simple count query (avoid obj.article_count() which may be complex)
 		return obj.articles.count()
 
-	def get_trials_count_total(self, obj):
+	def get_trials_count_total(self, obj) -> int:
 		"""Prefer the queryset's Count(..., distinct=True) annotation; fall
 		back to a live count for an un-annotated instance."""
 		annotated = getattr(obj, "trials_count_annotated", None)
@@ -174,7 +176,7 @@ class CategorySerializer(serializers.ModelSerializer):
 		# Fallback to simple count query
 		return obj.trials.count()
 
-	def get_authors_count(self, obj):
+	def get_authors_count(self, obj) -> int:
 		"""Optimized authors count avoiding complex JOINs"""
 		# Use annotated count if available
 		if hasattr(obj, "authors_count_annotated"):
@@ -189,7 +191,7 @@ class CategorySerializer(serializers.ModelSerializer):
 			Exists(obj.articles.filter(authors=OuterRef("pk")))
 		).count()
 
-	def get_top_authors(self, obj):
+	def get_top_authors(self, obj) -> list:
 		"""Optimized top authors calculation avoiding complex JOINs"""
 		# Get author parameters from serializer context
 		context = self.context
@@ -240,7 +242,7 @@ class CategorySerializer(serializers.ModelSerializer):
 
 		return CategoryTopAuthorSerializer(top_authors, many=True).data
 
-	def get_monthly_counts(self, obj):
+	def get_monthly_counts(self, obj) -> Optional[dict]:
 		"""Get monthly counts of articles and trials when requested"""
 		# Get monthly counts parameters from serializer context
 		context = self.context
@@ -399,11 +401,11 @@ class ArticleAuthorSerializer(serializers.ModelSerializer):
 			"country",
 		]
 
-	def get_country(self, obj):
+	def get_country(self, obj) -> Optional[str]:
 		# Return the country code or name
 		return obj.country.code if obj.country else None
 
-	def get_full_name(self, obj):
+	def get_full_name(self, obj) -> str:
 		return obj.full_name
 
 
@@ -457,7 +459,7 @@ class ArticleSerializer(
 		]
 		read_only_fields = ("discovery_date", "ml_predictions", "ml_score", "clinical_trials")
 
-	def get_clinical_trials(self, obj):
+	def get_clinical_trials(self, obj) -> list:
 		"""Get trials referenced in the article"""
 		references = obj.trial_references.all()
 		trials = [ref.trial for ref in references]
@@ -492,7 +494,7 @@ class ArticleSerializer(
 		self._org_content_cache[key] = content
 		return content
 
-	def get_takeaways(self, obj):
+	def get_takeaways(self, obj) -> Optional[str]:
 		"""Return takeaways from ArticleOrgContent for the caller's org, or None."""
 		org = _resolve_per_org_fields_org(self.context.get("request"))
 		if org is None:
@@ -500,7 +502,7 @@ class ArticleSerializer(
 		content = self._get_org_content(obj, org)
 		return content.takeaways if content else None
 
-	def get_summary_plain_english(self, obj):
+	def get_summary_plain_english(self, obj) -> Optional[str]:
 		"""Return plain-English summary from ArticleOrgContent for the caller's org, or None."""
 		org = _resolve_per_org_fields_org(self.context.get("request"))
 		if org is None:
@@ -525,7 +527,7 @@ class TrialCountrySerializer(serializers.ModelSerializer):
 			"sources",
 		]
 
-	def get_country(self, obj):
+	def get_country(self, obj) -> Optional[str]:
 		return obj.country.code if obj.country else None
 
 
@@ -650,7 +652,7 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 		]
 		read_only_fields = ("discovery_date", "articles")
 
-	def get_articles(self, obj):
+	def get_articles(self, obj) -> list:
 		"""Get articles that reference this trial.
 
 		Uses the prefetched ``article_references`` cache when available (populated
@@ -661,7 +663,7 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 		articles = [ref.article for ref in references]
 		return ArticleReferenceSerializer(articles, many=True).data
 
-	def get_countries_normalized(self, obj):
+	def get_countries_normalized(self, obj) -> Optional[list]:
 		"""Flat, sorted list of normalized country codes (e.g. ["DE", "FR", "US"]) — the
 		codes on trial_countries, without the per-country status/source detail. Uses the
 		same prefetched cache as the `trial_countries` field."""
@@ -695,7 +697,7 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 		self._org_content_cache[key] = content
 		return content
 
-	def get_takeaways(self, obj):
+	def get_takeaways(self, obj) -> Optional[str]:
 		"""Return takeaways from TrialOrgContent for the caller's org, or None."""
 		org = _resolve_per_org_fields_org(self.context.get("request"))
 		if org is None:
@@ -703,7 +705,7 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 		content = self._get_org_content(obj, org)
 		return content.takeaways if content else None
 
-	def get_summary_plain_english(self, obj):
+	def get_summary_plain_english(self, obj) -> Optional[str]:
 		"""Return plain-English summary from TrialOrgContent for the caller's org, or None."""
 		org = _resolve_per_org_fields_org(self.context.get("request"))
 		if org is None:
@@ -737,7 +739,7 @@ class TrialSiteSerializer(serializers.ModelSerializer):
 			"sources",
 		]
 
-	def get_country(self, obj):
+	def get_country(self, obj) -> Optional[str]:
 		return obj.country.code if obj.country else None
 
 
@@ -798,7 +800,7 @@ class AuthorSerializer(serializers.ModelSerializer):
 			"articles_list",
 		]
 
-	def get_articles_count(self, obj):
+	def get_articles_count(self, obj) -> int:
 		# The queryset always annotates a (correctly org-scoped) article_count,
 		# so prefer it and avoid a per-row COUNT query. Only fall back to a
 		# live query if a caller passes in an un-annotated instance directly.
@@ -811,7 +813,7 @@ class AuthorSerializer(serializers.ModelSerializer):
 			return qs.filter(teams__organization_id__in=request.visible_org_ids).distinct().count()
 		return qs.count()
 
-	def get_relevant_articles_count(self, obj):
+	def get_relevant_articles_count(self, obj) -> int:
 		annotated = getattr(obj, "relevant_articles_count", None)
 		if annotated is not None:
 			return annotated
@@ -821,11 +823,11 @@ class AuthorSerializer(serializers.ModelSerializer):
 			qs = qs.filter(teams__organization_id__in=request.visible_org_ids)
 		return qs.distinct().count()
 
-	def get_country(self, obj):
+	def get_country(self, obj) -> Optional[str]:
 		# Return the country code or name
 		return obj.country.code if obj.country else None
 
-	def get_articles_list(self, obj):
+	def get_articles_list(self, obj) -> str:
 		site = get_site()
 		if not site:
 			return ""
@@ -853,7 +855,7 @@ class CoauthorSerializer(serializers.ModelSerializer):
 				  "ORCID", "country", "shared_articles", "articles_count",
 				  "relevant_articles_count"]
 
-	def get_country(self, obj):
+	def get_country(self, obj) -> Optional[str]:
 		return obj.country.code if obj.country else None
 
 

--- a/django/api/tests/test_openapi_schema.py
+++ b/django/api/tests/test_openapi_schema.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+
+from drf_spectacular.drainage import GENERATOR_STATS
+from drf_spectacular.generators import SchemaGenerator
+from drf_spectacular.validation import validate_schema
+
+
+class OpenAPISchemaGenerationTest(TestCase):
+	"""Guards /api/schema/ against silent regressions.
+
+	A view, filter, or serializer change that drf-spectacular can no longer
+	introspect (missing serializer_class, an un-annotated SerializerMethodField,
+	a django-filter field it can't resolve, ...) should fail CI here rather than
+	ship a wrong or incomplete schema. Mirrors what
+	``python manage.py spectacular --fail-on-warn`` checks — see
+	STAGE-1-OPENAPI-SCHEMA-PLAN.md.
+	"""
+
+	def setUp(self):
+		# GENERATOR_STATS is a process-wide singleton that accumulates warnings
+		# across every schema generation in the process; reset so this test
+		# only sees warnings from its own run.
+		GENERATOR_STATS.reset()
+
+	def test_schema_generates_without_warnings_or_errors(self):
+		generator = SchemaGenerator()
+		schema = generator.get_schema(request=None, public=True)
+		self.assertIsNotNone(schema)
+		self.assertFalse(
+			bool(GENERATOR_STATS),
+			"drf-spectacular emitted warnings/errors during schema generation — "
+			"run `python manage.py spectacular --fail-on-warn` locally to see "
+			"them, then annotate the offending view/filter/serializer "
+			"(@extend_schema, @extend_schema_field, help_text, ...).",
+		)
+
+	def test_schema_is_valid_openapi(self):
+		generator = SchemaGenerator()
+		schema = generator.get_schema(request=None, public=True)
+		# Raises on structural violations (bad $refs, malformed parameter
+		# objects, ...).
+		validate_schema(schema)

--- a/django/api/tests/test_openapi_schema.py
+++ b/django/api/tests/test_openapi_schema.py
@@ -12,8 +12,7 @@ class OpenAPISchemaGenerationTest(TestCase):
 	introspect (missing serializer_class, an un-annotated SerializerMethodField,
 	a django-filter field it can't resolve, ...) should fail CI here rather than
 	ship a wrong or incomplete schema. Mirrors what
-	``python manage.py spectacular --fail-on-warn`` checks — see
-	STAGE-1-OPENAPI-SCHEMA-PLAN.md.
+	``python manage.py spectacular --fail-on-warn`` checks.
 	"""
 
 	def setUp(self):

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -113,6 +113,20 @@ from rest_framework.response import Response
 from django.http import Http404, StreamingHttpResponse
 from rest_framework.views import APIView
 from rest_framework_simplejwt.views import TokenObtainPairView
+from drf_spectacular.utils import (
+	extend_schema,
+	extend_schema_view,
+	OpenApiParameter,
+	OpenApiTypes,
+)
+from api.schema_serializers import (
+	ArticlesStatsSerializer,
+	ErrorResponseSerializer,
+	GlobalStatsSerializer,
+	TrialSiteRowSerializer,
+	TrialsStatsSerializer,
+	filterset_request_schema,
+)
 import hashlib
 import json
 import logging
@@ -553,6 +567,29 @@ def generateAccessSchemeLog(
 ###
 
 
+@extend_schema(
+	request=OpenApiTypes.OBJECT,
+	responses={
+		200: OpenApiTypes.OBJECT,
+		201: OpenApiTypes.OBJECT,
+		400: ErrorResponseSerializer,
+		401: ErrorResponseSerializer,
+		403: ErrorResponseSerializer,
+		404: ErrorResponseSerializer,
+		409: ErrorResponseSerializer,
+		500: ErrorResponseSerializer,
+	},
+	auth=[{"apiKeyAuth": []}],
+	description=(
+		"Allows authenticated clients to add new articles or trials to the "
+		"database. The `kind` field in the payload must match the `source_for` "
+		"value of the indicated source. Routing per kind: `science paper` → "
+		"CrossRef enrichment, saved to Articles; `trials` → saved to Trials "
+		"(dedup by identifier then title); `news article` → saved to Articles, "
+		"no CrossRef lookup. Requires an API key (`Authorization` header) "
+		"belonging to an organisation — see docs/03-api-and-rss-feeds.md."
+	),
+)
 @api_view(["POST"])
 def post_article(request):
 	"""
@@ -931,6 +968,29 @@ def post_article(request):
 ###
 
 
+@extend_schema(
+	request=OpenApiTypes.OBJECT,
+	responses={
+		200: OpenApiTypes.OBJECT,
+		400: ErrorResponseSerializer,
+		401: ErrorResponseSerializer,
+		403: ErrorResponseSerializer,
+		404: ErrorResponseSerializer,
+		409: ErrorResponseSerializer,
+		500: ErrorResponseSerializer,
+	},
+	auth=[{"apiKeyAuth": []}],
+	description=(
+		"Edit editorial and metadata fields on an existing article. Lookup is "
+		"by `doi` (required). Raises 404 if not found, 409 if the DOI matches "
+		"multiple articles (data quality issue), and 403 if the article is not "
+		"associated with the API key's organisation. Per-org fields "
+		"(`takeaways`, `summary_plain_english`) are upserted into "
+		"ArticleOrgContent for the key's organisation — empty string clears the "
+		"field (stored as NULL). Per-article fields (`access`, `retracted`, "
+		"`kind`) are written back to the Articles row directly."
+	),
+)
 @api_view(["POST"])
 def edit_article(request):
 	"""
@@ -1120,6 +1180,27 @@ def edit_article(request):
 ###
 
 
+@extend_schema(
+	request=OpenApiTypes.OBJECT,
+	responses={
+		200: OpenApiTypes.OBJECT,
+		400: ErrorResponseSerializer,
+		401: ErrorResponseSerializer,
+		403: ErrorResponseSerializer,
+		404: ErrorResponseSerializer,
+		409: ErrorResponseSerializer,
+		500: ErrorResponseSerializer,
+	},
+	auth=[{"apiKeyAuth": []}],
+	description=(
+		"Edit per-organisation editorial fields on an existing trial. Lookup "
+		"is by `identifiers` dict (required, same format as post_article's "
+		"trial branch: keys `nct`, `euct`, `eudract`). Raises 404 if not "
+		"found, 409 if multiple trials match (dedup issue). Only per-org "
+		"fields (`takeaways`, `summary_plain_english`) are editable — trial "
+		"metadata comes from registries and is not client-editable."
+	),
+)
 @api_view(["POST"])
 def edit_trial(request):
 	"""
@@ -1272,6 +1353,19 @@ def edit_trial(request):
 ###
 # ARTICLES
 ###
+_OPTIONAL_API_KEY_SECURITY = [
+	{},
+	{"basicAuth": []},
+	{"jwtAuth": []},
+	{"cookieAuth": []},
+	{"apiKeyAuth": []},
+]
+
+
+@extend_schema_view(
+	list=extend_schema(auth=_OPTIONAL_API_KEY_SECURITY),
+	retrieve=extend_schema(auth=_OPTIONAL_API_KEY_SECURITY),
+)
 class ArticleViewSet(
 	BulkExportThrottleMixin,
 	CSVStreamingMixin,
@@ -1417,6 +1511,7 @@ class ArticleViewSet(
 
 	stats_cache_prefix = "articles_stats"
 
+	@extend_schema(responses=ArticlesStatsSerializer, auth=_OPTIONAL_API_KEY_SECURITY)
 	@action(detail=False, methods=["get"], url_path="stats")
 	def stats(self, request):
 		"""Aggregate counts over the filtered queryset.
@@ -1927,6 +2022,10 @@ _RECRUITING_RANK = {
 }
 
 
+@extend_schema_view(
+	list=extend_schema(auth=_OPTIONAL_API_KEY_SECURITY),
+	retrieve=extend_schema(auth=_OPTIONAL_API_KEY_SECURITY),
+)
 class TrialViewSet(
 	BulkExportThrottleMixin,
 	CSVStreamingMixin,
@@ -2228,6 +2327,7 @@ class TrialViewSet(
 
 	stats_cache_prefix = "trials_stats"
 
+	@extend_schema(responses=TrialsStatsSerializer, auth=_OPTIONAL_API_KEY_SECURITY)
 	@action(detail=False, methods=["get"], url_path="stats")
 	def stats(self, request):
 		"""Recruitment-status totals (by ``recruitment_status_normalized``) over the
@@ -2241,6 +2341,21 @@ class TrialViewSet(
 		"""
 		return self._stats_response(request)
 
+	@extend_schema(
+		parameters=[
+			OpenApiParameter(
+				"latitude__isnull",
+				OpenApiTypes.BOOL,
+				OpenApiParameter.QUERY,
+				description=(
+					"Narrow to sites without coordinates (true/1/yes) or with a pin "
+					"(false/0/no). Any other value is rejected (400)."
+				),
+			),
+		],
+		responses={200: TrialSiteRowSerializer(many=True), 400: ErrorResponseSerializer},
+		auth=_OPTIONAL_API_KEY_SECURITY,
+	)
 	@action(detail=False, methods=["get"], url_path="sites")
 	def sites(self, request):
 		"""Flat, paginated listing of TrialSite rows across the filtered trial set —
@@ -2631,6 +2746,18 @@ def author_articles_count_subquery(visible_org_ids=None, relevant_only=False):
 	return Coalesce(Subquery(counts, output_field=IntegerField()), Value(0))
 
 
+_AUTHOR_ID_PATH_PARAM = OpenApiParameter(
+	"id",
+	OpenApiTypes.INT,
+	OpenApiParameter.PATH,
+	description="Author ID (Authors.author_id).",
+)
+
+
+@extend_schema_view(
+	retrieve=extend_schema(parameters=[_AUTHOR_ID_PATH_PARAM]),
+	coauthors=extend_schema(parameters=[_AUTHOR_ID_PATH_PARAM]),
+)
 class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 	"""
 	Enhanced Authors API with sorting and filtering capabilities.
@@ -3011,6 +3138,7 @@ class LoginView(TokenObtainPairView):
 class ProtectedEndpointView(APIView):
 	permission_classes = [permissions.IsAuthenticated]
 
+	@extend_schema(responses=OpenApiTypes.OBJECT)
 	def get(self, request):
 		return Response({"message": "You have accessed the protected endpoint!"})
 
@@ -3280,6 +3408,20 @@ class ArticleSearchView(
 			)
 			return Articles.objects.none()
 
+	@extend_schema(
+		request={
+			"application/json": filterset_request_schema(
+				ArticleFilter,
+				required=["team_id", "subject_id"],
+				extra_description=(
+					"Every ArticleFilter field is accepted here (identical semantics "
+					"to the matching GET query parameter — see /articles/). "
+					"team_id and subject_id are required."
+				),
+			),
+		},
+		responses={200: OpenApiTypes.OBJECT, 400: ErrorResponseSerializer, 404: ErrorResponseSerializer},
+	)
 	def post(self, request, *args, **kwargs):
 		# For POST requests, validate required parameters
 		team_id = request.data.get("team_id")
@@ -3491,6 +3633,20 @@ class TrialSearchView(
 
 		return queryset
 
+	@extend_schema(
+		request={
+			"application/json": filterset_request_schema(
+				TrialFilter,
+				required=["team_id", "subject_id"],
+				extra_description=(
+					"Every TrialFilter field is accepted here (identical semantics "
+					"to the matching GET query parameter — see /trials/). "
+					"team_id and subject_id are required."
+				),
+			),
+		},
+		responses={200: OpenApiTypes.OBJECT, 400: ErrorResponseSerializer, 404: ErrorResponseSerializer},
+	)
 	def post(self, request, *args, **kwargs):
 		# For POST requests, validate required parameters
 		team_id = request.data.get("team_id")
@@ -3649,6 +3805,20 @@ class AuthorSearchView(BodyParamsAsQueryParamsMixin, generics.ListAPIView):
 			)
 			return Authors.objects.none()
 
+	@extend_schema(
+		request={
+			"application/json": {
+				"type": "object",
+				"properties": {
+					"team_id": {"type": "integer", "description": "Required. Team ID to scope authors by."},
+					"subject_id": {"type": "integer", "description": "Required. Subject ID to scope authors by."},
+					**filterset_request_schema(AuthorFilter)["properties"],
+				},
+				"required": ["team_id", "subject_id"],
+			},
+		},
+		responses={200: OpenApiTypes.OBJECT, 400: ErrorResponseSerializer, 404: ErrorResponseSerializer},
+	)
 	def post(self, request, *args, **kwargs):
 		# For POST requests, validate required parameters
 		team_id = request.data.get("team_id")
@@ -3748,6 +3918,38 @@ class StatsView(APIView):
 
 	permission_classes = [permissions.AllowAny]
 
+	@extend_schema(
+		parameters=[
+			OpenApiParameter(
+				"team",
+				OpenApiTypes.STR,
+				OpenApiParameter.QUERY,
+				description="Scope to one or more teams (comma-separated integer IDs), e.g. ?team=1,2,3.",
+			),
+			OpenApiParameter(
+				"organization",
+				OpenApiTypes.STR,
+				OpenApiParameter.QUERY,
+				description="Scope to one or more organisations (comma-separated integer IDs). Alias: org.",
+			),
+			OpenApiParameter(
+				"org",
+				OpenApiTypes.STR,
+				OpenApiParameter.QUERY,
+				description="Alias for organization.",
+			),
+			OpenApiParameter(
+				"subject",
+				OpenApiTypes.STR,
+				OpenApiParameter.QUERY,
+				description=(
+					"Scope to one or more subjects (comma-separated integer IDs, OR "
+					"semantics). Adds a by_subject breakdown to the payload."
+				),
+			),
+		],
+		responses={200: GlobalStatsSerializer, 400: ErrorResponseSerializer, 404: ErrorResponseSerializer},
+	)
 	def get(self, request):
 		from urllib.parse import urlparse
 		from subscriptions.models import Subscribers

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -29,6 +29,7 @@ django-simple-history==3.8.0
 djangorestframework==3.17.1
 djangorestframework-csv==3.0.2
 djangorestframework_simplejwt==5.5.0
+drf-spectacular==0.30.0
 feedparser==6.0.11
 filelock==3.18.0
 flatbuffers==25.2.10

--- a/django/schema.yml
+++ b/django/schema.yml
@@ -1,0 +1,6785 @@
+openapi: 3.0.3
+info:
+  title: GregoryAI API
+  version: 1.0.0
+  description: 'REST API for GregoryAI: articles, clinical trials, authors, sources,
+    subjects, categories, sponsors and teams. See docs/03-api-and-rss-feeds.md for
+    prose documentation and authentication details.'
+paths:
+  /api/token/:
+    post:
+      operationId: api_token_create
+      description: |-
+        Takes a set of user credentials and returns an access and refresh JSON web
+        token pair to prove the authentication of those credentials.
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - api
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenObtainPair'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TokenObtainPair'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TokenObtainPair'
+        required: true
+      security:
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenObtainPair'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/TokenObtainPair'
+          description: ''
+  /articles/:
+    get:
+      operationId: articles_list
+      description: |-
+        List all articles in the database with comprehensive filtering options.
+        CSV responses are automatically streamed for better performance with large datasets.
+
+        # Query Parameters:
+        - **team_id** - filter by team ID
+        - **site_id** - filter by Django Site ID; returns articles belonging to any team attached to that site (see Team.site)
+        - **doi** - filter by DOI, case-insensitive; accepts a single value or a comma-separated list (e.g. `?doi=10.1/a,10.2/b`)
+        - **subject_id** - filter by subject ID (used with team_id)
+        - **subjects** - comma-separated list of subject IDs with AND semantics — returns only articles tagged with *all* listed subjects (e.g., `?subjects=1,2`)
+        - **subjects_any** - comma-separated list of subject IDs with OR semantics — returns articles tagged with *any* of the listed subjects (e.g., `?subjects_any=1,2`)
+        - **author_id** - filter by author ID
+        - **category_slug** - filter by category slug
+        - **category_id** - filter by category ID
+        - **journal_slug** - filter by journal (convert spaces to dashes)
+        - **source_id** - filter by source ID
+        - **category_modality** - filter by the intervention modality of the article's categories; one of the `CategoryModality` values
+        - **has_clinical_trials** - filter for articles linked to one or more clinical trials (true/false)
+        - **search** - search in title and summary (supports boolean operators, e.g. `a OR b`)
+        - **title** - search only in the title field (case-insensitive substring)
+        - **summary** - search only in the summary/abstract field (case-insensitive substring)
+        - **ordering** - sort field, prefix with `-` for descending. Allowed values: `discovery_date`, `published_date`, `title`, `article_id`, `ml_score`. Articles without a score always appear last when ordering by `ml_score`.
+        - **page** - page number for pagination
+        - **page_size** - items per page (max 100)
+        - **all_results** - set to 'true' to bypass pagination and get all results (useful for CSV export)
+
+        # Special Article Types:
+        - **relevant** - filter for relevant articles (true/false). When combined with **subject_id**, relevance is scoped to that specific subject — only articles that are relevant *for that subject* (via ML predictions or manual marking) are returned. Without subject_id, relevance is checked across all subjects.
+        - **ml_threshold** - minimum ML prediction confidence (float 0.0-1.0, e.g., 0.75). Also scoped to subject_id when provided.
+        - **open_access** - filter for open access articles (true/false)
+        - **last_days** - filter for articles from last N days (number)
+        - **week** - filter for specific week number (requires year parameter)
+        - **year** - year for week filtering (used with week parameter)
+
+        # Date Range Parameters:
+        Filter by publication date. Both parameters are optional and can be used independently or together.
+        Invalid or non-ISO-8601 dates return **400 Bad Request**.
+        - **published_date_after** - articles published on or after this date (YYYY-MM-DD, inclusive)
+        - **published_date_before** - articles published on or before this date (YYYY-MM-DD, inclusive — the full day is included)
+
+        # Stats Endpoint:
+        `GET /articles/stats/` returns aggregate counts over the filtered queryset: `total`
+        (distinct articles), `by_access` (`{open, restricted, unknown}` — articles without an
+        access value are folded into `unknown`), `relevant`, `retracted`, `missing_doi`, and a
+        `by_subject` breakdown (`[{subject_id, subject_name, count}]`, distinct per article,
+        restricted to subjects visible to the caller). It accepts the same query parameters as
+        the list endpoint, so e.g. `/articles/stats/?team_id=1&relevant=true` scopes the counts
+        exactly like the equivalent list request. The `relevant` count uses the same semantics
+        as the list's `?relevant=true` filter: when `subject_id` is present it counts articles
+        relevant *for that subject* (manual review or ML consensus, honoring `ml_threshold`),
+        not articles merely relevant for some other subject. Results are cached server-side for
+        STATS_CACHE_TTL seconds (default 600).
+
+        # Response Fields:
+        Each article includes a **ml_score** field: the average ML probability score across the most recent
+        prediction per (algorithm, subject) pair. `null` when no predictions exist yet.
+
+        # Examples:
+        - By DOI (single): `/articles/?doi=10.1016/j.procs.2023.01.401`
+        - By DOI (multiple): `/articles/?doi=10.1016/j.procs.2023.01.401,10.1016/j.other.2024.02.001`
+        - Team articles: `/articles/?team_id=1`
+        - Team + subject: `/articles/?team_id=1&subject_id=4`
+        - Multi-subject AND: `/articles/?subjects=1,2`
+        - Multi-subject OR: `/articles/?subjects_any=1,2`
+        - With search: `/articles/?team_id=1&search=stem+cells`
+        - Category by slug: `/articles/?team_id=1&category_slug=natalizumab`
+        - Category by ID: `/articles/?team_id=1&category_id=5`
+        - Relevant articles: `/articles/?relevant=true`
+        - Relevant with ML threshold: `/articles/?relevant=true&ml_threshold=0.75`
+        - Relevant from last 15 days: `/articles/?relevant=true&last_days=15`
+        - Relevant from specific week: `/articles/?relevant=true&week=52&year=2024`
+        - Open access articles: `/articles/?open_access=true`
+        - Published in 2023: `/articles/?published_date_after=2023-01-01&published_date_before=2023-12-31`
+        - Published since a date: `/articles/?published_date_after=2024-01-01`
+        - Date range + subject + CSV: `/articles/?team_id=1&subjects=1,3&published_date_after=2022-06-01&published_date_before=2023-12-31&format=csv&all_results=true`
+        - CSV export all results: `/articles/?format=csv&all_results=true`
+        - Sort by AI relevance: `/articles/?ordering=-ml_score`
+        - Relevant + AI relevance sort: `/articles/?relevant=true&ordering=-ml_score`
+        - Complex filter: `/articles/?team_id=1&subject_id=4&author_id=123&search=regeneration&relevant=true&ml_threshold=0.8&ordering=-ml_score`
+      parameters:
+      - in: query
+        name: author_id
+        schema:
+          type: integer
+        description: Filter by author ID (see /authors/).
+      - in: query
+        name: category_id
+        schema:
+          type: integer
+        description: Filter by category ID (see /categories/).
+      - in: query
+        name: category_modality
+        schema:
+          type: string
+          nullable: true
+          enum:
+          - biologic_antibody
+          - cell_gene_therapy
+          - device_neuromodulation
+          - natural_product
+          - other
+          - rehabilitation
+          - research_topic
+          - small_molecule
+        description: |-
+          Filter by the intervention modality of the article's categories; one of the CategoryModality values.
+
+          * `small_molecule` - Small-molecule drug
+          * `biologic_antibody` - Antibody / biologic
+          * `cell_gene_therapy` - Cell / gene therapy
+          * `rehabilitation` - Rehabilitation / physical
+          * `device_neuromodulation` - Device / neuromodulation
+          * `natural_product` - Natural product / supplement
+          * `research_topic` - Research topic (not an intervention)
+          * `other` - Other
+      - in: query
+        name: category_slug
+        schema:
+          type: string
+        description: Filter by category slug (see /categories/).
+      - in: query
+        name: doi
+        schema:
+          type: string
+        description: Filter by DOI, case-insensitive. Accepts a single value or a
+          comma-separated list, e.g. ?doi=10.1/a,10.2/b.
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: query
+        name: has_clinical_trials
+        schema:
+          type: boolean
+        description: Filter for articles linked to one or more clinical trials (true/false).
+      - in: query
+        name: journal_slug
+        schema:
+          type: string
+        description: Filter by journal name (convert spaces to dashes), case-insensitive
+          exact match.
+      - in: query
+        name: last_days
+        schema:
+          type: number
+        description: Filter for articles discovered in the last N days.
+      - in: query
+        name: ml_threshold
+        schema:
+          type: number
+        description: Minimum ML prediction confidence (0.0-1.0, e.g. 0.75). Also scoped
+          to subject_id when provided. Defaults to 0.8 when relevant=true and this
+          is omitted.
+      - in: query
+        name: open_access
+        schema:
+          type: boolean
+        description: Filter for open access articles (true/false).
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: published_date_after
+        schema:
+          type: string
+          format: date
+        description: Articles published on or after this date (YYYY-MM-DD, inclusive).
+          Invalid or non-ISO-8601 dates return 400 Bad Request.
+      - in: query
+        name: published_date_before
+        schema:
+          type: string
+          format: date
+        description: Articles published on or before this date (YYYY-MM-DD, inclusive
+          — the full day is included). Invalid or non-ISO-8601 dates return 400 Bad
+          Request.
+      - in: query
+        name: relevant
+        schema:
+          type: boolean
+        description: Filter for relevant articles (true/false). When combined with
+          subject_id, relevance is scoped to that specific subject — only articles
+          relevant *for that subject* (via ML predictions or manual marking) are returned.
+          Without subject_id, relevance is checked across all subjects.
+      - in: query
+        name: search
+        schema:
+          type: string
+        description: Boolean search across title and summary. Bare terms are AND-ed;
+          uppercase OR/NOT and "quoted phrases" are supported, e.g. ?search=stem OR
+          cells. Not combinable with title/summary-only search.
+      - in: query
+        name: site_id
+        schema:
+          type: number
+        description: Filter by Django Site ID; returns articles belonging to any team
+          attached to that site (see Team.site).
+      - in: query
+        name: source_id
+        schema:
+          type: integer
+        description: Filter by source ID (see /sources/).
+      - in: query
+        name: subject_id
+        schema:
+          type: integer
+        description: Filter by subject ID (see /subjects/). Commonly combined with
+          team_id.
+      - in: query
+        name: subjects
+        schema:
+          type: array
+          items:
+            type: integer
+        description: Comma-separated list of subject IDs with AND semantics — returns
+          only articles tagged with *all* listed subjects, e.g. ?subjects=1,2.
+        explode: false
+        style: form
+      - in: query
+        name: subjects_any
+        schema:
+          type: array
+          items:
+            type: string
+        description: Comma-separated list of subject IDs with OR semantics — returns
+          articles tagged with *any* of the listed subjects, e.g. ?subjects_any=1,2.
+        explode: false
+        style: form
+      - in: query
+        name: summary
+        schema:
+          type: string
+        description: Case-insensitive substring match against the summary/abstract
+          only.
+      - in: query
+        name: team_id
+        schema:
+          type: integer
+        description: Filter by team ID.
+      - in: query
+        name: title
+        schema:
+          type: string
+        description: Case-insensitive substring match against the title only.
+      - in: query
+        name: week
+        schema:
+          type: number
+        description: Filter for a specific ISO week number; requires year to be set
+          too.
+      - in: query
+        name: year
+        schema:
+          type: number
+        description: Year to use together with the week parameter; has no effect on
+          its own.
+      tags:
+      - articles
+      security:
+      - {}
+      - basicAuth: []
+      - jwtAuth: []
+      - cookieAuth: []
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedArticleList'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/PaginatedArticleList'
+          description: ''
+  /articles/{article_id}/:
+    get:
+      operationId: articles_retrieve
+      description: |-
+        List all articles in the database with comprehensive filtering options.
+        CSV responses are automatically streamed for better performance with large datasets.
+
+        # Query Parameters:
+        - **team_id** - filter by team ID
+        - **site_id** - filter by Django Site ID; returns articles belonging to any team attached to that site (see Team.site)
+        - **doi** - filter by DOI, case-insensitive; accepts a single value or a comma-separated list (e.g. `?doi=10.1/a,10.2/b`)
+        - **subject_id** - filter by subject ID (used with team_id)
+        - **subjects** - comma-separated list of subject IDs with AND semantics — returns only articles tagged with *all* listed subjects (e.g., `?subjects=1,2`)
+        - **subjects_any** - comma-separated list of subject IDs with OR semantics — returns articles tagged with *any* of the listed subjects (e.g., `?subjects_any=1,2`)
+        - **author_id** - filter by author ID
+        - **category_slug** - filter by category slug
+        - **category_id** - filter by category ID
+        - **journal_slug** - filter by journal (convert spaces to dashes)
+        - **source_id** - filter by source ID
+        - **category_modality** - filter by the intervention modality of the article's categories; one of the `CategoryModality` values
+        - **has_clinical_trials** - filter for articles linked to one or more clinical trials (true/false)
+        - **search** - search in title and summary (supports boolean operators, e.g. `a OR b`)
+        - **title** - search only in the title field (case-insensitive substring)
+        - **summary** - search only in the summary/abstract field (case-insensitive substring)
+        - **ordering** - sort field, prefix with `-` for descending. Allowed values: `discovery_date`, `published_date`, `title`, `article_id`, `ml_score`. Articles without a score always appear last when ordering by `ml_score`.
+        - **page** - page number for pagination
+        - **page_size** - items per page (max 100)
+        - **all_results** - set to 'true' to bypass pagination and get all results (useful for CSV export)
+
+        # Special Article Types:
+        - **relevant** - filter for relevant articles (true/false). When combined with **subject_id**, relevance is scoped to that specific subject — only articles that are relevant *for that subject* (via ML predictions or manual marking) are returned. Without subject_id, relevance is checked across all subjects.
+        - **ml_threshold** - minimum ML prediction confidence (float 0.0-1.0, e.g., 0.75). Also scoped to subject_id when provided.
+        - **open_access** - filter for open access articles (true/false)
+        - **last_days** - filter for articles from last N days (number)
+        - **week** - filter for specific week number (requires year parameter)
+        - **year** - year for week filtering (used with week parameter)
+
+        # Date Range Parameters:
+        Filter by publication date. Both parameters are optional and can be used independently or together.
+        Invalid or non-ISO-8601 dates return **400 Bad Request**.
+        - **published_date_after** - articles published on or after this date (YYYY-MM-DD, inclusive)
+        - **published_date_before** - articles published on or before this date (YYYY-MM-DD, inclusive — the full day is included)
+
+        # Stats Endpoint:
+        `GET /articles/stats/` returns aggregate counts over the filtered queryset: `total`
+        (distinct articles), `by_access` (`{open, restricted, unknown}` — articles without an
+        access value are folded into `unknown`), `relevant`, `retracted`, `missing_doi`, and a
+        `by_subject` breakdown (`[{subject_id, subject_name, count}]`, distinct per article,
+        restricted to subjects visible to the caller). It accepts the same query parameters as
+        the list endpoint, so e.g. `/articles/stats/?team_id=1&relevant=true` scopes the counts
+        exactly like the equivalent list request. The `relevant` count uses the same semantics
+        as the list's `?relevant=true` filter: when `subject_id` is present it counts articles
+        relevant *for that subject* (manual review or ML consensus, honoring `ml_threshold`),
+        not articles merely relevant for some other subject. Results are cached server-side for
+        STATS_CACHE_TTL seconds (default 600).
+
+        # Response Fields:
+        Each article includes a **ml_score** field: the average ML probability score across the most recent
+        prediction per (algorithm, subject) pair. `null` when no predictions exist yet.
+
+        # Examples:
+        - By DOI (single): `/articles/?doi=10.1016/j.procs.2023.01.401`
+        - By DOI (multiple): `/articles/?doi=10.1016/j.procs.2023.01.401,10.1016/j.other.2024.02.001`
+        - Team articles: `/articles/?team_id=1`
+        - Team + subject: `/articles/?team_id=1&subject_id=4`
+        - Multi-subject AND: `/articles/?subjects=1,2`
+        - Multi-subject OR: `/articles/?subjects_any=1,2`
+        - With search: `/articles/?team_id=1&search=stem+cells`
+        - Category by slug: `/articles/?team_id=1&category_slug=natalizumab`
+        - Category by ID: `/articles/?team_id=1&category_id=5`
+        - Relevant articles: `/articles/?relevant=true`
+        - Relevant with ML threshold: `/articles/?relevant=true&ml_threshold=0.75`
+        - Relevant from last 15 days: `/articles/?relevant=true&last_days=15`
+        - Relevant from specific week: `/articles/?relevant=true&week=52&year=2024`
+        - Open access articles: `/articles/?open_access=true`
+        - Published in 2023: `/articles/?published_date_after=2023-01-01&published_date_before=2023-12-31`
+        - Published since a date: `/articles/?published_date_after=2024-01-01`
+        - Date range + subject + CSV: `/articles/?team_id=1&subjects=1,3&published_date_after=2022-06-01&published_date_before=2023-12-31&format=csv&all_results=true`
+        - CSV export all results: `/articles/?format=csv&all_results=true`
+        - Sort by AI relevance: `/articles/?ordering=-ml_score`
+        - Relevant + AI relevance sort: `/articles/?relevant=true&ordering=-ml_score`
+        - Complex filter: `/articles/?team_id=1&subject_id=4&author_id=123&search=regeneration&relevant=true&ml_threshold=0.8&ordering=-ml_score`
+      parameters:
+      - in: path
+        name: article_id
+        schema:
+          type: integer
+        description: A unique integer value identifying this articles.
+        required: true
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - articles
+      security:
+      - {}
+      - basicAuth: []
+      - jwtAuth: []
+      - cookieAuth: []
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Article'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/Article'
+          description: ''
+  /articles/edit/:
+    post:
+      operationId: articles_edit_create
+      description: Edit editorial and metadata fields on an existing article. Lookup
+        is by `doi` (required). Raises 404 if not found, 409 if the DOI matches multiple
+        articles (data quality issue), and 403 if the article is not associated with
+        the API key's organisation. Per-org fields (`takeaways`, `summary_plain_english`)
+        are upserted into ArticleOrgContent for the key's organisation — empty string
+        clears the field (stored as NULL). Per-article fields (`access`, `retracted`,
+        `kind`) are written back to the Articles row directly.
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - articles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: {}
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties: {}
+          multipart/form-data:
+            schema:
+              type: object
+              additionalProperties: {}
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+            text/csv:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /articles/post/:
+    post:
+      operationId: articles_post_create
+      description: 'Allows authenticated clients to add new articles or trials to
+        the database. The `kind` field in the payload must match the `source_for`
+        value of the indicated source. Routing per kind: `science paper` → CrossRef
+        enrichment, saved to Articles; `trials` → saved to Trials (dedup by identifier
+        then title); `news article` → saved to Articles, no CrossRef lookup. Requires
+        an API key (`Authorization` header) belonging to an organisation — see docs/03-api-and-rss-feeds.md.'
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - articles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: {}
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties: {}
+          multipart/form-data:
+            schema:
+              type: object
+              additionalProperties: {}
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+            text/csv:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '201':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+            text/csv:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /articles/search/:
+    get:
+      operationId: articles_search_list
+      description: |-
+        Advanced search for articles by title and abstract (summary).
+
+        This endpoint accepts both GET and POST requests with team_id and subject_id
+        parameters, along with optional search parameters. Every filter on
+        ArticleFilter works identically on both verbs — for GET, put them on the
+        query string; for POST, put them in the JSON body. BodyParamsAsQueryParamsMixin
+        merges the body into query_params before filtering, so both paths run
+        through the same DjangoFilterBackend/OrderingFilter code; if the same filter
+        key is set in both places, the query string wins. team_id and subject_id are
+        the exception — they're forced from the body on POST (identity_params),
+        both for get_queryset()'s own validation and for ArticleFilter's identically
+        named fields, so a mismatched query-string team_id/subject_id has no effect
+        at all rather than silently narrowing the filterset against a different
+        team/subject than the one validated.
+
+        Parameters (can be sent as query params for GET or in request body for POST):
+        - title: Search only in title field
+        - summary: Search only in summary/abstract field
+        - search: Search in both title and summary fields
+        - team_id: Required - Team ID to filter articles by (must be provided)
+        - subject_id: Required - Subject ID to filter articles by (must be provided)
+        - page: Page number for pagination (default: 1)
+        - page_size: Number of results per page (default: 10, max: 100)
+        - all_results: Set to 'true' to retrieve all results without pagination (useful for CSV export)
+        - ordering: Order results by field (e.g., -discovery_date, -published_date, title, article_id)
+
+        Every other ArticleFilter field also applies here, e.g.
+        published_date_after / published_date_before, relevant, subjects,
+        open_access:
+        - Published in 2023: /articles/search/?team_id=1&subject_id=1&published_date_after=2023-01-01&published_date_before=2023-12-31
+
+        Prefer GET where practical — it's cacheable and linkable. POST exists for
+        `search` strings with long boolean expressions that would exceed practical
+        URL length limits.
+
+        Results are ordered by discovery date (newest first) by default.
+
+        To download all search results as CSV, add format=csv and all_results=true to the query parameters.
+        Example: /articles/search/?team_id=1&subject_id=1&search=covid&format=csv&all_results=true
+      parameters:
+      - in: query
+        name: author_id
+        schema:
+          type: integer
+        description: Filter by author ID (see /authors/).
+      - in: query
+        name: category_id
+        schema:
+          type: integer
+        description: Filter by category ID (see /categories/).
+      - in: query
+        name: category_modality
+        schema:
+          type: string
+          nullable: true
+          enum:
+          - biologic_antibody
+          - cell_gene_therapy
+          - device_neuromodulation
+          - natural_product
+          - other
+          - rehabilitation
+          - research_topic
+          - small_molecule
+        description: |-
+          Filter by the intervention modality of the article's categories; one of the CategoryModality values.
+
+          * `small_molecule` - Small-molecule drug
+          * `biologic_antibody` - Antibody / biologic
+          * `cell_gene_therapy` - Cell / gene therapy
+          * `rehabilitation` - Rehabilitation / physical
+          * `device_neuromodulation` - Device / neuromodulation
+          * `natural_product` - Natural product / supplement
+          * `research_topic` - Research topic (not an intervention)
+          * `other` - Other
+      - in: query
+        name: category_slug
+        schema:
+          type: string
+        description: Filter by category slug (see /categories/).
+      - in: query
+        name: doi
+        schema:
+          type: string
+        description: Filter by DOI, case-insensitive. Accepts a single value or a
+          comma-separated list, e.g. ?doi=10.1/a,10.2/b.
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: query
+        name: has_clinical_trials
+        schema:
+          type: boolean
+        description: Filter for articles linked to one or more clinical trials (true/false).
+      - in: query
+        name: journal_slug
+        schema:
+          type: string
+        description: Filter by journal name (convert spaces to dashes), case-insensitive
+          exact match.
+      - in: query
+        name: last_days
+        schema:
+          type: number
+        description: Filter for articles discovered in the last N days.
+      - in: query
+        name: ml_threshold
+        schema:
+          type: number
+        description: Minimum ML prediction confidence (0.0-1.0, e.g. 0.75). Also scoped
+          to subject_id when provided. Defaults to 0.8 when relevant=true and this
+          is omitted.
+      - in: query
+        name: open_access
+        schema:
+          type: boolean
+        description: Filter for open access articles (true/false).
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: published_date_after
+        schema:
+          type: string
+          format: date
+        description: Articles published on or after this date (YYYY-MM-DD, inclusive).
+          Invalid or non-ISO-8601 dates return 400 Bad Request.
+      - in: query
+        name: published_date_before
+        schema:
+          type: string
+          format: date
+        description: Articles published on or before this date (YYYY-MM-DD, inclusive
+          — the full day is included). Invalid or non-ISO-8601 dates return 400 Bad
+          Request.
+      - in: query
+        name: relevant
+        schema:
+          type: boolean
+        description: Filter for relevant articles (true/false). When combined with
+          subject_id, relevance is scoped to that specific subject — only articles
+          relevant *for that subject* (via ML predictions or manual marking) are returned.
+          Without subject_id, relevance is checked across all subjects.
+      - in: query
+        name: search
+        schema:
+          type: string
+        description: Boolean search across title and summary. Bare terms are AND-ed;
+          uppercase OR/NOT and "quoted phrases" are supported, e.g. ?search=stem OR
+          cells. Not combinable with title/summary-only search.
+      - in: query
+        name: site_id
+        schema:
+          type: number
+        description: Filter by Django Site ID; returns articles belonging to any team
+          attached to that site (see Team.site).
+      - in: query
+        name: source_id
+        schema:
+          type: integer
+        description: Filter by source ID (see /sources/).
+      - in: query
+        name: subject_id
+        schema:
+          type: integer
+        description: Filter by subject ID (see /subjects/). Commonly combined with
+          team_id.
+      - in: query
+        name: subjects
+        schema:
+          type: array
+          items:
+            type: integer
+        description: Comma-separated list of subject IDs with AND semantics — returns
+          only articles tagged with *all* listed subjects, e.g. ?subjects=1,2.
+        explode: false
+        style: form
+      - in: query
+        name: subjects_any
+        schema:
+          type: array
+          items:
+            type: string
+        description: Comma-separated list of subject IDs with OR semantics — returns
+          articles tagged with *any* of the listed subjects, e.g. ?subjects_any=1,2.
+        explode: false
+        style: form
+      - in: query
+        name: summary
+        schema:
+          type: string
+        description: Case-insensitive substring match against the summary/abstract
+          only.
+      - in: query
+        name: team_id
+        schema:
+          type: integer
+        description: Filter by team ID.
+      - in: query
+        name: title
+        schema:
+          type: string
+        description: Case-insensitive substring match against the title only.
+      - in: query
+        name: week
+        schema:
+          type: number
+        description: Filter for a specific ISO week number; requires year to be set
+          too.
+      - in: query
+        name: year
+        schema:
+          type: number
+        description: Year to use together with the week parameter; has no effect on
+          its own.
+      tags:
+      - articles
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedArticleList'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/PaginatedArticleList'
+          description: ''
+    post:
+      operationId: articles_search_create
+      description: |-
+        Advanced search for articles by title and abstract (summary).
+
+        This endpoint accepts both GET and POST requests with team_id and subject_id
+        parameters, along with optional search parameters. Every filter on
+        ArticleFilter works identically on both verbs — for GET, put them on the
+        query string; for POST, put them in the JSON body. BodyParamsAsQueryParamsMixin
+        merges the body into query_params before filtering, so both paths run
+        through the same DjangoFilterBackend/OrderingFilter code; if the same filter
+        key is set in both places, the query string wins. team_id and subject_id are
+        the exception — they're forced from the body on POST (identity_params),
+        both for get_queryset()'s own validation and for ArticleFilter's identically
+        named fields, so a mismatched query-string team_id/subject_id has no effect
+        at all rather than silently narrowing the filterset against a different
+        team/subject than the one validated.
+
+        Parameters (can be sent as query params for GET or in request body for POST):
+        - title: Search only in title field
+        - summary: Search only in summary/abstract field
+        - search: Search in both title and summary fields
+        - team_id: Required - Team ID to filter articles by (must be provided)
+        - subject_id: Required - Subject ID to filter articles by (must be provided)
+        - page: Page number for pagination (default: 1)
+        - page_size: Number of results per page (default: 10, max: 100)
+        - all_results: Set to 'true' to retrieve all results without pagination (useful for CSV export)
+        - ordering: Order results by field (e.g., -discovery_date, -published_date, title, article_id)
+
+        Every other ArticleFilter field also applies here, e.g.
+        published_date_after / published_date_before, relevant, subjects,
+        open_access:
+        - Published in 2023: /articles/search/?team_id=1&subject_id=1&published_date_after=2023-01-01&published_date_before=2023-12-31
+
+        Prefer GET where practical — it's cacheable and linkable. POST exists for
+        `search` strings with long boolean expressions that would exceed practical
+        URL length limits.
+
+        Results are ordered by discovery date (newest first) by default.
+
+        To download all search results as CSV, add format=csv and all_results=true to the query parameters.
+        Example: /articles/search/?team_id=1&subject_id=1&search=covid&format=csv&all_results=true
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - articles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: Case-insensitive substring match against the title
+                    only.
+                summary:
+                  type: string
+                  description: Case-insensitive substring match against the summary/abstract
+                    only.
+                search:
+                  type: string
+                  description: Boolean search across title and summary. Bare terms
+                    are AND-ed; uppercase OR/NOT and "quoted phrases" are supported,
+                    e.g. ?search=stem OR cells. Not combinable with title/summary-only
+                    search.
+                author_id:
+                  type: number
+                  description: Filter by author ID (see /authors/).
+                doi:
+                  type: string
+                  description: Filter by DOI, case-insensitive. Accepts a single value
+                    or a comma-separated list, e.g. ?doi=10.1/a,10.2/b.
+                category_slug:
+                  type: string
+                  description: Filter by category slug (see /categories/).
+                category_id:
+                  type: number
+                  description: Filter by category ID (see /categories/).
+                category_modality:
+                  type: string
+                  description: Filter by the intervention modality of the article's
+                    categories; one of the CategoryModality values.
+                journal_slug:
+                  type: string
+                  description: Filter by journal name (convert spaces to dashes),
+                    case-insensitive exact match.
+                team_id:
+                  type: number
+                  description: Filter by team ID.
+                site_id:
+                  type: number
+                  description: Filter by Django Site ID; returns articles belonging
+                    to any team attached to that site (see Team.site).
+                subject_id:
+                  type: number
+                  description: Filter by subject ID (see /subjects/). Commonly combined
+                    with team_id.
+                source_id:
+                  type: number
+                  description: Filter by source ID (see /sources/).
+                relevant:
+                  type: boolean
+                  description: Filter for relevant articles (true/false). When combined
+                    with subject_id, relevance is scoped to that specific subject
+                    — only articles relevant *for that subject* (via ML predictions
+                    or manual marking) are returned. Without subject_id, relevance
+                    is checked across all subjects.
+                ml_threshold:
+                  type: number
+                  description: Minimum ML prediction confidence (0.0-1.0, e.g. 0.75).
+                    Also scoped to subject_id when provided. Defaults to 0.8 when
+                    relevant=true and this is omitted.
+                open_access:
+                  type: boolean
+                  description: Filter for open access articles (true/false).
+                last_days:
+                  type: number
+                  description: Filter for articles discovered in the last N days.
+                week:
+                  type: number
+                  description: Filter for a specific ISO week number; requires year
+                    to be set too.
+                year:
+                  type: number
+                  description: Year to use together with the week parameter; has no
+                    effect on its own.
+                has_clinical_trials:
+                  type: boolean
+                  description: Filter for articles linked to one or more clinical
+                    trials (true/false).
+                published_date_after:
+                  type: string
+                  format: date
+                  description: Articles published on or after this date (YYYY-MM-DD,
+                    inclusive). Invalid or non-ISO-8601 dates return 400 Bad Request.
+                published_date_before:
+                  type: string
+                  format: date
+                  description: Articles published on or before this date (YYYY-MM-DD,
+                    inclusive — the full day is included). Invalid or non-ISO-8601
+                    dates return 400 Bad Request.
+                subjects:
+                  type: array
+                  items:
+                    type: string
+                  description: Comma-separated list of subject IDs with AND semantics
+                    — returns only articles tagged with *all* listed subjects, e.g.
+                    ?subjects=1,2.
+                subjects_any:
+                  type: array
+                  items:
+                    type: string
+                  description: Comma-separated list of subject IDs with OR semantics
+                    — returns articles tagged with *any* of the listed subjects, e.g.
+                    ?subjects_any=1,2.
+              required:
+              - team_id
+              - subject_id
+              description: Every ArticleFilter field is accepted here (identical semantics
+                to the matching GET query parameter — see /articles/). team_id and
+                subject_id are required.
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+            text/csv:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /articles/stats/:
+    get:
+      operationId: articles_stats_retrieve
+      description: |-
+        Aggregate counts over the filtered queryset.
+
+        Accepts the same query parameters as the list endpoint (team_id,
+        subject_id, relevant, search, …) and the same org-visibility
+        scoping, so the counts always match what the equivalent list
+        request would return. Cached server-side; see
+        ``CachedStatsActionMixin``.
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - articles
+      security:
+      - {}
+      - basicAuth: []
+      - jwtAuth: []
+      - cookieAuth: []
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArticlesStats'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ArticlesStats'
+          description: ''
+  /authors/:
+    get:
+      operationId: authors_list
+      description: |-
+        Enhanced Authors API with sorting and filtering capabilities.
+
+        # Query Parameters:
+
+        - **author_id** - filter by specific author ID
+        - **full_name** - search by author's full name (case-insensitive)
+        - **given_name** - search by author's given name (case-insensitive)
+        - **family_name** - search by author's family name (case-insensitive)
+        - **orcid** - filter by ORCID identifier (case-insensitive contains search)
+        - **country** - filter by country code (exact match)
+        - **sort_by** - 'article_count' (default: 'author_id')
+        - **order** - 'asc' or 'desc' (default: 'desc' for article_count, 'asc' for others)
+        - **team_id** - filter by team ID
+        - **subject_id** - filter by subject ID
+        - **category_slug** - filter by team category slug
+        - **category_id** - filter by team category ID
+        - **date_from** - filter articles from this date (YYYY-MM-DD)
+        - **date_to** - filter articles to this date (YYYY-MM-DD)
+        - **timeframe** - 'year', 'month', 'week' (relative to current date)
+
+        # Examples:
+
+        - Get specific author: `?author_id=380002`
+        - Search by name: `?full_name=John%20Smith`
+        - Search by given name: `?given_name=John`
+        - Search by family name: `?family_name=Smith`
+        - Filter by ORCID: `?orcid=0000-0000-0000-0001`
+        - Filter by country: `?country=US`
+        - Sort by article count: `?sort_by=article_count&order=desc`
+        - Filter by timeframe: `?sort_by=article_count&timeframe=year`
+        - Team and subject filter: `?team_id=1&subject_id=5&sort_by=article_count`
+        - Count per category: `?team_id=1&category_slug=natalizumab&sort_by=article_count&order=desc`
+        - Category with ID: `?team_id=1&category_id=5&sort_by=article_count&order=desc`
+        - Category with timeframe: `?team_id=1&category_slug=natalizumab&timeframe=year&sort_by=article_count`
+        - Date range: `?date_from=2024-06-01&date_to=2024-12-31&team_id=1&subject_id=1&sort_by=article_count`
+      parameters:
+      - in: query
+        name: author_id
+        schema:
+          type: integer
+        description: Filter by a specific author ID.
+      - in: query
+        name: country
+        schema:
+          type: string
+        description: Exact match against the author's country code.
+      - in: query
+        name: family_name
+        schema:
+          type: string
+        description: Case-insensitive substring match against the family (last) name.
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: query
+        name: full_name
+        schema:
+          type: string
+        description: Case-insensitive substring match against the author's full name.
+      - in: query
+        name: given_name
+        schema:
+          type: string
+        description: Case-insensitive substring match against the given (first) name.
+      - in: query
+        name: orcid
+        schema:
+          type: string
+        description: Case-insensitive substring match against the author's ORCID iD.
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - authors
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedAuthorList'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/PaginatedAuthorList'
+          description: ''
+  /authors/{id}/:
+    get:
+      operationId: authors_retrieve
+      description: |-
+        Enhanced Authors API with sorting and filtering capabilities.
+
+        # Query Parameters:
+
+        - **author_id** - filter by specific author ID
+        - **full_name** - search by author's full name (case-insensitive)
+        - **given_name** - search by author's given name (case-insensitive)
+        - **family_name** - search by author's family name (case-insensitive)
+        - **orcid** - filter by ORCID identifier (case-insensitive contains search)
+        - **country** - filter by country code (exact match)
+        - **sort_by** - 'article_count' (default: 'author_id')
+        - **order** - 'asc' or 'desc' (default: 'desc' for article_count, 'asc' for others)
+        - **team_id** - filter by team ID
+        - **subject_id** - filter by subject ID
+        - **category_slug** - filter by team category slug
+        - **category_id** - filter by team category ID
+        - **date_from** - filter articles from this date (YYYY-MM-DD)
+        - **date_to** - filter articles to this date (YYYY-MM-DD)
+        - **timeframe** - 'year', 'month', 'week' (relative to current date)
+
+        # Examples:
+
+        - Get specific author: `?author_id=380002`
+        - Search by name: `?full_name=John%20Smith`
+        - Search by given name: `?given_name=John`
+        - Search by family name: `?family_name=Smith`
+        - Filter by ORCID: `?orcid=0000-0000-0000-0001`
+        - Filter by country: `?country=US`
+        - Sort by article count: `?sort_by=article_count&order=desc`
+        - Filter by timeframe: `?sort_by=article_count&timeframe=year`
+        - Team and subject filter: `?team_id=1&subject_id=5&sort_by=article_count`
+        - Count per category: `?team_id=1&category_slug=natalizumab&sort_by=article_count&order=desc`
+        - Category with ID: `?team_id=1&category_id=5&sort_by=article_count&order=desc`
+        - Category with timeframe: `?team_id=1&category_slug=natalizumab&timeframe=year&sort_by=article_count`
+        - Date range: `?date_from=2024-06-01&date_to=2024-12-31&team_id=1&subject_id=1&sort_by=article_count`
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: Author ID (Authors.author_id).
+        required: true
+      tags:
+      - authors
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Author'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/Author'
+          description: ''
+  /authors/{id}/coauthors/:
+    get:
+      operationId: authors_coauthors_retrieve
+      description: Co-authors ordered by number of shared articles (desc).
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: Author ID (Authors.author_id).
+        required: true
+      tags:
+      - authors
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Author'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/Author'
+          description: ''
+  /authors/by_team_category/:
+    get:
+      operationId: authors_by_team_category_retrieve
+      description: |-
+        Get authors filtered by team category with article counts
+
+        Parameters:
+        - team_id (required): Team ID
+        - category_slug OR category_id (required): Team category slug or ID
+        - Additional filters from main queryset apply
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - authors
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Author'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/Author'
+          description: ''
+  /authors/by_team_subject/:
+    get:
+      operationId: authors_by_team_subject_retrieve
+      description: |-
+        Get authors filtered by team and subject with article counts
+
+        Parameters:
+        - team_id (required): Team ID
+        - subject_id (required): Subject ID
+        - Additional filters from main queryset apply
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - authors
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Author'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/Author'
+          description: ''
+  /authors/search/:
+    get:
+      operationId: authors_search_list
+      description: |-
+        Advanced search for authors by full name.
+
+        Supports both GET and POST requests with required team_id and subject_id
+        parameters. Filtering by full_name is case-insensitive and allows partial
+        matches. Pagination and CSV export options mirror the article search
+        endpoint.
+      parameters:
+      - in: query
+        name: author_id
+        schema:
+          type: integer
+        description: Filter by a specific author ID.
+      - in: query
+        name: country
+        schema:
+          type: string
+        description: Exact match against the author's country code.
+      - in: query
+        name: family_name
+        schema:
+          type: string
+        description: Case-insensitive substring match against the family (last) name.
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: query
+        name: full_name
+        schema:
+          type: string
+        description: Case-insensitive substring match against the author's full name.
+      - in: query
+        name: given_name
+        schema:
+          type: string
+        description: Case-insensitive substring match against the given (first) name.
+      - in: query
+        name: orcid
+        schema:
+          type: string
+        description: Case-insensitive substring match against the author's ORCID iD.
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - authors
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedAuthorList'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/PaginatedAuthorList'
+          description: ''
+    post:
+      operationId: authors_search_create
+      description: |-
+        Advanced search for authors by full name.
+
+        Supports both GET and POST requests with required team_id and subject_id
+        parameters. Filtering by full_name is case-insensitive and allows partial
+        matches. Pagination and CSV export options mirror the article search
+        endpoint.
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - authors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                team_id:
+                  type: integer
+                  description: Required. Team ID to scope authors by.
+                subject_id:
+                  type: integer
+                  description: Required. Subject ID to scope authors by.
+                full_name:
+                  type: string
+                  description: Case-insensitive substring match against the author's
+                    full name.
+                given_name:
+                  type: string
+                  description: Case-insensitive substring match against the given
+                    (first) name.
+                family_name:
+                  type: string
+                  description: Case-insensitive substring match against the family
+                    (last) name.
+                author_id:
+                  type: number
+                  description: Filter by a specific author ID.
+                orcid:
+                  type: string
+                  description: Case-insensitive substring match against the author's
+                    ORCID iD.
+                country:
+                  type: string
+                  description: Exact match against the author's country code.
+              required:
+              - team_id
+              - subject_id
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+            text/csv:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /categories/:
+    get:
+      operationId: categories_list
+      description: |-
+        List all categories in the database with optional filters for team and subject.
+        Now includes author statistics for each category.
+
+        # Query Parameters:
+        - **team_id** - filter by team ID
+        - **subject_id** - filter by subject ID
+        - **category_id** - filter by specific category ID
+        - **get_categories** - comma-separated list of category IDs (e.g., 1,2,3)
+        - **include_authors** - Include top authors data (default: true)
+        - **max_authors** - Maximum number of top authors to return per category (default: 10, max: 50)
+        - **date_from** - Filter articles from this date (YYYY-MM-DD)
+        - **date_to** - Filter articles to this date (YYYY-MM-DD)
+        - **timeframe** - 'year', 'month', 'week' (relative to current date)
+        - **monthly_counts** - Include monthly article/trial counts with ML predictions (default: false)
+        - **ml_threshold** - ML prediction probability threshold when monthly_counts=true (0.0-1.0, default: 0.5)
+        - **search** - search in category name and description
+        - **ordering** - sort field, prefix with `-` for descending. Allowed values: `category_name`, `id`, `article_count_annotated`, `trials_count_annotated`, `authors_count_annotated`.
+          The first four sort on values the queryset already computes, so they add
+          nothing. `authors_count_annotated` is the expensive one: ordering has to
+          happen before pagination, so it counts distinct authors for every category
+          matching the filters rather than just the page being returned. It is
+          therefore annotated only for requests that sort by it — note this changes
+          *where* the count comes from, not whether it is computed, since the
+          serializer otherwise derives `authors_count` per row on its own.
+
+        # Response includes:
+        - Category basic information
+        - Total article and trial counts
+        - Authors count (unique authors in category)
+        - Top authors with their article counts in this category
+        - Monthly counts (when monthly_counts=true), including monthly_relevant_article_counts:
+          articles whose latest prediction from at least one ML model meets ml_threshold,
+          counted once per month regardless of how many models flagged them
+
+        # Additional Actions:
+        - `/categories/{id}/authors/` - Get detailed author statistics for a specific category
+
+        # Examples:
+        - Basic: `GET /categories/?team_id=1`
+        - With subject: `GET /categories/?team_id=1&subject_id=2`
+        - Date filtered: `GET /categories/?team_id=1&timeframe=year`
+        - More authors: `GET /categories/?team_id=1&max_authors=20`
+        - Without authors: `GET /categories/?team_id=1&include_authors=false`
+        - Monthly counts: `GET /categories/?category_id=6&monthly_counts=true&ml_threshold=0.8`
+        - Single category with monthly counts: `GET /categories/?category_id=6&monthly_counts=true`
+        - Multiple categories by ID: `GET /categories/?get_categories=1,2,3`
+      parameters:
+      - in: query
+        name: category_id
+        schema:
+          type: integer
+        description: Filter by a specific category ID.
+      - in: query
+        name: category_terms
+        schema:
+          type: string
+        description: Case-insensitive substring match against the category's terms.
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: subject_id
+        schema:
+          type: integer
+        description: Filter by subject ID (see /subjects/).
+      - in: query
+        name: team_id
+        schema:
+          type: integer
+        description: Filter by team ID.
+      tags:
+      - categories
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCategoryList'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/PaginatedCategoryList'
+          description: ''
+  /categories/{id}/:
+    get:
+      operationId: categories_retrieve
+      description: |-
+        List all categories in the database with optional filters for team and subject.
+        Now includes author statistics for each category.
+
+        # Query Parameters:
+        - **team_id** - filter by team ID
+        - **subject_id** - filter by subject ID
+        - **category_id** - filter by specific category ID
+        - **get_categories** - comma-separated list of category IDs (e.g., 1,2,3)
+        - **include_authors** - Include top authors data (default: true)
+        - **max_authors** - Maximum number of top authors to return per category (default: 10, max: 50)
+        - **date_from** - Filter articles from this date (YYYY-MM-DD)
+        - **date_to** - Filter articles to this date (YYYY-MM-DD)
+        - **timeframe** - 'year', 'month', 'week' (relative to current date)
+        - **monthly_counts** - Include monthly article/trial counts with ML predictions (default: false)
+        - **ml_threshold** - ML prediction probability threshold when monthly_counts=true (0.0-1.0, default: 0.5)
+        - **search** - search in category name and description
+        - **ordering** - sort field, prefix with `-` for descending. Allowed values: `category_name`, `id`, `article_count_annotated`, `trials_count_annotated`, `authors_count_annotated`.
+          The first four sort on values the queryset already computes, so they add
+          nothing. `authors_count_annotated` is the expensive one: ordering has to
+          happen before pagination, so it counts distinct authors for every category
+          matching the filters rather than just the page being returned. It is
+          therefore annotated only for requests that sort by it — note this changes
+          *where* the count comes from, not whether it is computed, since the
+          serializer otherwise derives `authors_count` per row on its own.
+
+        # Response includes:
+        - Category basic information
+        - Total article and trial counts
+        - Authors count (unique authors in category)
+        - Top authors with their article counts in this category
+        - Monthly counts (when monthly_counts=true), including monthly_relevant_article_counts:
+          articles whose latest prediction from at least one ML model meets ml_threshold,
+          counted once per month regardless of how many models flagged them
+
+        # Additional Actions:
+        - `/categories/{id}/authors/` - Get detailed author statistics for a specific category
+
+        # Examples:
+        - Basic: `GET /categories/?team_id=1`
+        - With subject: `GET /categories/?team_id=1&subject_id=2`
+        - Date filtered: `GET /categories/?team_id=1&timeframe=year`
+        - More authors: `GET /categories/?team_id=1&max_authors=20`
+        - Without authors: `GET /categories/?team_id=1&include_authors=false`
+        - Monthly counts: `GET /categories/?category_id=6&monthly_counts=true&ml_threshold=0.8`
+        - Single category with monthly counts: `GET /categories/?category_id=6&monthly_counts=true`
+        - Multiple categories by ID: `GET /categories/?get_categories=1,2,3`
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this team category.
+        required: true
+      tags:
+      - categories
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Category'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/Category'
+          description: ''
+  /categories/{id}/authors/:
+    get:
+      operationId: categories_authors_retrieve
+      description: |-
+        Get detailed author statistics for a specific category.
+
+        # Query Parameters:
+        - **min_articles** - Minimum articles per author (default: 1)
+        - **sort_by** - 'articles_count', 'author_name' (default: 'articles_count')
+        - **order** - 'asc', 'desc' (default: 'desc')
+        - Date filtering parameters (same as main endpoint)
+
+        **URL:** `/categories/{id}/authors/`
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this team category.
+        required: true
+      tags:
+      - categories
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Category'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/Category'
+          description: ''
+  /protected_endpoint/:
+    get:
+      operationId: protected_endpoint_retrieve
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - protected_endpoint
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+            text/csv:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+  /sources/:
+    get:
+      operationId: sources_list
+      description: |-
+        List all sources of data with optional filters for team and subject.
+
+        # Query Parameters:
+        - **source_id** - filter by specific source ID
+        - **team_id** - filter by team ID
+        - **subject_id** - filter by subject ID
+        - **active** - filter by active status (true/false)
+        - **source_for** - filter by what the source feeds; one of: `science paper`, `trials`, `news article`
+        - **link** - filter by source link (case-insensitive substring)
+        - **search** - search in source name and description
+        - **ordering** - sort field, prefix with `-` for descending. Allowed values: `name`, `source_id`
+      parameters:
+      - in: query
+        name: active
+        schema:
+          type: boolean
+        description: Filter by whether the source is actively polled (true/false).
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: query
+        name: link
+        schema:
+          type: string
+        description: Case-insensitive substring match against the source's feed/URL.
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: source_for
+        schema:
+          type: string
+        description: Exact match against the source's content type (e.g. articles
+          vs trials).
+      - in: query
+        name: source_id
+        schema:
+          type: integer
+        description: Filter by a specific source ID.
+      - in: query
+        name: subject_id
+        schema:
+          type: integer
+        description: Filter by subject ID (see /subjects/).
+      - in: query
+        name: team_id
+        schema:
+          type: integer
+        description: Filter by team ID.
+      tags:
+      - sources
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSourceList'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/PaginatedSourceList'
+          description: ''
+  /sources/{source_id}/:
+    get:
+      operationId: sources_retrieve
+      description: |-
+        List all sources of data with optional filters for team and subject.
+
+        # Query Parameters:
+        - **source_id** - filter by specific source ID
+        - **team_id** - filter by team ID
+        - **subject_id** - filter by subject ID
+        - **active** - filter by active status (true/false)
+        - **source_for** - filter by what the source feeds; one of: `science paper`, `trials`, `news article`
+        - **link** - filter by source link (case-insensitive substring)
+        - **search** - search in source name and description
+        - **ordering** - sort field, prefix with `-` for descending. Allowed values: `name`, `source_id`
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: path
+        name: source_id
+        schema:
+          type: integer
+        description: A unique integer value identifying this sources.
+        required: true
+      tags:
+      - sources
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Source'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/Source'
+          description: ''
+  /sponsors/:
+    get:
+      operationId: sponsors_list
+      description: |-
+        List canonical sponsor entities (deduplicated trial sponsors — see
+        docs/trials-field-normalization.md). Sponsors are global, not org-owned, so
+        unlike most other viewsets this one carries no OrgVisibilityMixin — same
+        reasoning as the by_sponsor/by_sponsor_type facets on /trials/stats/.
+
+        # Query Parameters:
+        - **search** - search by sponsor name
+        - **sponsor_type** - filter by sponsor type; one of: industry,
+          academic_medical, government, nonprofit, other
+        - **ordering** - 'name' (default) or 'trials_count' (add '-' for reverse)
+        - **page_size** - items per page (max 100)
+
+        # Examples:
+        - Filter by type: `/sponsors/?sponsor_type=industry`
+        - Search by name: `/sponsors/?search=novartis`
+        - Most-trials first: `/sponsors/?ordering=-trials_count`
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: sponsor_type
+        schema:
+          type: string
+          nullable: true
+          enum:
+          - academic_medical
+          - government
+          - industry
+          - nonprofit
+          - other
+        description: |-
+          Exact match against the canonical sponsor type (see SponsorType values).
+
+          * `industry` - Industry
+          * `academic_medical` - Academic / medical
+          * `government` - Government
+          * `nonprofit` - Non-profit / patient organisation
+          * `other` - Other
+      tags:
+      - sponsors
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSponsorList'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/PaginatedSponsorList'
+          description: ''
+  /sponsors/{id}/:
+    get:
+      operationId: sponsors_retrieve
+      description: |-
+        List canonical sponsor entities (deduplicated trial sponsors — see
+        docs/trials-field-normalization.md). Sponsors are global, not org-owned, so
+        unlike most other viewsets this one carries no OrgVisibilityMixin — same
+        reasoning as the by_sponsor/by_sponsor_type facets on /trials/stats/.
+
+        # Query Parameters:
+        - **search** - search by sponsor name
+        - **sponsor_type** - filter by sponsor type; one of: industry,
+          academic_medical, government, nonprofit, other
+        - **ordering** - 'name' (default) or 'trials_count' (add '-' for reverse)
+        - **page_size** - items per page (max 100)
+
+        # Examples:
+        - Filter by type: `/sponsors/?sponsor_type=industry`
+        - Search by name: `/sponsors/?search=novartis`
+        - Most-trials first: `/sponsors/?ordering=-trials_count`
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this sponsor.
+        required: true
+      tags:
+      - sponsors
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sponsor'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/Sponsor'
+          description: ''
+  /stats/:
+    get:
+      operationId: stats_retrieve
+      description: |-
+        Returns aggregate statistics about the data in the system.
+
+        Filters
+        -------
+        ?team=1,2,3
+            Scope to one or more teams (comma-separated integer IDs).
+        ?organization=1,2  (alias: ?org=)
+            Scope to one or more organisations (comma-separated integer IDs).
+            When combined with ?team=, the effective scope is the intersection:
+            teams that belong to the requested org(s).
+        ?subject=1,2
+            Scope to one or more subjects (comma-separated integer IDs, OR/union
+            semantics). Adds a ``by_subject`` breakdown to the payload, listing
+            every in-scope subject (including zero-count ones) with its own
+            articles/trials/authors/sources counts. Per-subject subscriber counts
+            are deliberately omitted — see docs/03-api-and-rss-feeds.md.
+
+        All three params are validated against ``request.visible_org_ids``
+        (set by VisibleOrgMiddleware). A team, org, or subject that is not visible
+        to the caller returns 404 so that existence is not leaked. When the
+        middleware attribute is absent (management commands, tests bypassing
+        middleware) the visibility check is skipped and the params still narrow
+        the queryset.
+
+        A subject that is visible but outside the requested ``?team=``/``?organization=``
+        scope does not 404 — it returns a well-formed, all-zero payload, matching
+        the existing ``?team=`` + ``?organization=`` intersection behaviour.
+
+        Results are short-lived cached (STATS_CACHE_TTL seconds, default 600) using
+        Django's database cache so all gunicorn workers share the same value.
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: query
+        name: org
+        schema:
+          type: string
+        description: Alias for organization.
+      - in: query
+        name: organization
+        schema:
+          type: string
+        description: 'Scope to one or more organisations (comma-separated integer
+          IDs). Alias: org.'
+      - in: query
+        name: subject
+        schema:
+          type: string
+        description: Scope to one or more subjects (comma-separated integer IDs, OR
+          semantics). Adds a by_subject breakdown to the payload.
+      - in: query
+        name: team
+        schema:
+          type: string
+        description: Scope to one or more teams (comma-separated integer IDs), e.g.
+          ?team=1,2,3.
+      tags:
+      - stats
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GlobalStats'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/GlobalStats'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /subjects/:
+    get:
+      operationId: subjects_list
+      description: |-
+        ✅ **PREFERRED ENDPOINT**: This is the main subjects endpoint that supports filtering options.
+
+        List all subjects in the database with optional team filtering.
+
+        # Query Parameters:
+        - **team_id** - filter by team ID (replaces /teams/{id}/subjects/)
+        - **search** - search in subject name and description
+        - **ordering** - order by 'id', 'subject_name', 'team' (add '-' for reverse)
+
+        # Examples:
+        - Filter by team: `/subjects/?team_id=1`
+        - Search subjects: `/subjects/?search=multiple`
+        - Team filter with search: `/subjects/?team_id=1&search=sclerosis`
+        - Order by name: `/subjects/?ordering=subject_name`
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: team_id
+        schema:
+          type: integer
+        description: Filter by team ID.
+      tags:
+      - subjects
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSubjectsList'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/PaginatedSubjectsList'
+          description: ''
+  /subjects/{id}/:
+    get:
+      operationId: subjects_retrieve
+      description: |-
+        ✅ **PREFERRED ENDPOINT**: This is the main subjects endpoint that supports filtering options.
+
+        List all subjects in the database with optional team filtering.
+
+        # Query Parameters:
+        - **team_id** - filter by team ID (replaces /teams/{id}/subjects/)
+        - **search** - search in subject name and description
+        - **ordering** - order by 'id', 'subject_name', 'team' (add '-' for reverse)
+
+        # Examples:
+        - Filter by team: `/subjects/?team_id=1`
+        - Search subjects: `/subjects/?search=multiple`
+        - Team filter with search: `/subjects/?team_id=1&search=sclerosis`
+        - Order by name: `/subjects/?ordering=subject_name`
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this subject.
+        required: true
+      tags:
+      - subjects
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subjects'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/Subjects'
+          description: ''
+  /teams/:
+    get:
+      operationId: teams_list
+      description: List all teams
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - teams
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedTeamList'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/PaginatedTeamList'
+          description: ''
+  /teams/{id}/:
+    get:
+      operationId: teams_retrieve
+      description: List all teams
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this team.
+        required: true
+      tags:
+      - teams
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Team'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/Team'
+          description: ''
+  /teams/{team_id}/subjects/{subject_id}/categories/:
+    get:
+      operationId: teams_subjects_categories_list
+      description: List all categories for a specific team and subject combination
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: path
+        name: subject_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: team_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - teams
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCategoryList'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/PaginatedCategoryList'
+          description: ''
+  /trials/:
+    get:
+      operationId: trials_list
+      description: |-
+        List all clinical trials by discovery date with comprehensive filtering options.
+        CSV responses are automatically streamed for better performance with large datasets.
+
+        # Core Query Parameters:
+        - **trial_id** - filter by specific trial ID
+        - **team_id** - filter by team ID
+        - **site_id** - filter by Django Site ID; returns trials belonging to any team attached to that site (see Team.site)
+        - **subject_id** - filter by subject ID
+        - **subjects** - comma-separated list of subject IDs with AND semantics — returns only trials tagged with *all* listed subjects (e.g., `?subjects=1,2`)
+        - **subjects_any** - comma-separated list of subject IDs with OR semantics — returns trials tagged with *any* of the listed subjects (e.g., `?subjects_any=1,2`)
+        - **category_slug** - filter by category slug
+        - **category_id** - filter by category ID
+        - **category_modality** - filter by the intervention modality of the trial's categories; one of the `CategoryModality` values
+        - **source_id** - filter by source ID
+        - **status/recruitment_status** - filter by recruitment status
+        - **search** - search in title and summary (supports boolean operators, e.g. `a OR b`)
+        - **title** - search only in the title field (case-insensitive substring)
+        - **summary** - search only in the summary field (case-insensitive substring)
+        - **page** - page number for pagination
+        - **page_size** - items per page (max 100)
+        - **all_results** - set to 'true' to bypass pagination and get all results (useful for CSV export)
+
+        # Ordering:
+        `?ordering=<field>` (prefix with `-` to reverse). Accepted values:
+        - **discovery_date** - when Gregory first ingested the trial (default: `-discovery_date`, newest first)
+        - **published_date** - registry publication date
+        - **title**
+        - **trial_id**
+        - **last_updated**
+        - **recruiting_first** - recruitment-availability order, NOT alphabetical on
+          `recruitment_status_normalized`: `recruiting` → `enrolling_by_invitation` →
+          `not_yet_recruiting` → `active_not_recruiting` → `suspended` →
+          `not_recruiting` → `unknown` → `other` → `completed` → `terminated` →
+          `withdrawn`, with null status last — that ordering is for plain
+          `?ordering=recruiting_first` (ascending); `?ordering=-recruiting_first`
+          reverses the whole scale, so null-status trials come first there instead.
+          Ties (many trials share a rank) are broken by `-discovery_date`
+          automatically, in both directions.
+
+        Unrecognised `ordering` values are silently ignored (not rejected) — a DRF
+        `OrderingFilter` default — so a typo or stale field name falls back to the
+        default ordering rather than erroring.
+
+        # Sites:
+        Per-site rows (`TrialSite` — name/city/state/country/coordinates, sourced from CTIS
+        retrieve enrichment and/or ClinicalTrials.gov) are **detail-only**: `trial_sites`
+        appears on `GET /trials/{id}/` but never on the list/CSV/search responses (sites fan
+        out, mean ~12/trial, so nesting them on every list row would bloat those responses for
+        a field most callers don't need there). For a flat, filterable, paginated listing
+        across many trials — e.g. to build a site-level pin map — use `GET /trials/sites/`
+        instead, which accepts the same filters as this endpoint (team_id, subject_id,
+        country, recruitment_status_normalized, …) plus `latitude__isnull`, and rejects
+        `all_results=true` (it is not a bulk export). See TRIAL-GEOGRAPHY-PLAN.md PR G2/G3.
+
+        # Stats Endpoint:
+        `GET /trials/stats/` returns `total`, `no_status` (recruitment_status_normalized is
+        null), one key per `TrialRecruitmentStatus` bucket — `not_yet_recruiting`, `recruiting`,
+        `enrolling_by_invitation`, `active_not_recruiting`, `not_recruiting`, `suspended`,
+        `completed`, `terminated`, `withdrawn`, `unknown`, `other` (always present, 0 when
+        empty) — plus five facet breakdowns computed over the filtered queryset:
+        - `by_subject` — `[{subject_id, subject_name, count}]`, distinct per trial,
+          restricted to subjects visible to the caller. Sums to `total`.
+        - `by_phase` — `{phase_slug: count, ...}`, one key per `TrialPhase` value
+          (always present, 0 when empty) plus `no_phase` (raw `phase` was never set).
+          Sums to `total`.
+        - `by_region` — `{region_slug: count, ...}`, one key per `TrialRegion` value
+          (always present, 0 when empty) plus `no_region` (`regions_normalized` is
+          null or empty). Does **not** sum to `total` — a trial spanning several
+          regions counts once per region.
+        - `by_country` — `[{country: alpha2_or_null, count}]`, sorted by `-count`
+          then country code, zero-count countries omitted, a trailing
+          `{"country": null, ...}` entry for trials with no `TrialCountry` rows
+          (omitted when 0). Does **not** sum to `total` — multi-country trials count
+          once per country.
+        - `by_year` — `[{year: int_or_null, count}]`, ascending by year, zero-count
+          years omitted, a trailing `{"year": null, ...}` entry for trials with no
+          `date_registration` (omitted when 0). Derived from `date_registration`
+          only (no `published_date` fallback). Sums to `total`.
+        - `by_sponsor` — `[{sponsor_id, slug, name, sponsor_type, count}]`, top 25 by
+          count then sponsor name, over the canonical `Sponsor` entity a trial's raw
+          `primary_sponsor` resolves to (see docs/trials-field-normalization.md) —
+          excludes trials with no resolved sponsor yet, reported separately as the
+          sibling key `no_sponsor`. Does not sum to `total` once truncated to 25.
+        - `by_sponsor_type` — `{sponsor_type_slug: count, ...}`, one key per
+          `SponsorType` value (always present, 0 when empty) plus `no_type`
+          (resolved sponsor, no sponsor_type derived yet) — excludes the same
+          null-FK group as `no_sponsor`.
+        - `by_modality` — `{modality_slug: count, ...}`, one key per
+          `CategoryModality` value (always present, 0 when empty) plus
+          `no_modality`, over the trial's `team_categories.modality`. **Not** a
+          partition of `total` and **not** safe to sum: this joins an M2M, so a
+          trial carrying two categories of different modalities is counted once
+          *per modality*. `no_modality` also conflates two different things —
+          "trial has no category at all" (most trials; categories are a curated
+          lens over a small subset) and "trial has a category that isn't
+          curated with a modality yet" — deliberately, to avoid the extra query
+          cost of splitting them out as separate keys; use `?category_slug=` when
+          the distinction matters.
+        - `by_study_type` — `{study_type_slug: count, ...}`, one key per
+          `TrialStudyType` value (always present, 0 when empty) plus
+          `no_study_type`. `no_study_type` is large (~13.2k globally) because most
+          of it is legacy rows with no `source_register` at all, not a
+          normalization gap — see docs/trials-field-normalization.md.
+        - `by_sex` — `{sex_slug: count, ...}`, one key per `TrialSexEligibility`
+          value (always present, 0 when empty) plus `no_sex_data`. `no_sex_data`
+          is large (~46% of trials globally) because it includes the legacy
+          `source_register IS NULL` population that also lacks sponsors and
+          countries — same caveat as `no_modality`/`no_sponsor`. See
+          docs/trials-field-normalization.md and
+          INCLUSION-GENDER-NORMALIZATION-PLAN.md.
+
+        Recruitment-status buckets and `by_phase`/`by_region`/`by_country`/`by_study_type`/`by_sex` are counted on the
+        `*_normalized` canonical vocabularies (same as their respective filters), not on the
+        raw registry strings — see docs/trials-field-normalization.md. It accepts the
+        same query parameters as the list endpoint, so e.g.
+        `/trials/stats/?team_id=1&recruitment_status_normalized=recruiting` scopes the totals
+        exactly like the equivalent list request — including composition across facets, e.g.
+        `/trials/stats/?phase_normalized=phase_3` makes `by_country` the phase-3 × country
+        slice of the matrix. Results are cached server-side for
+        STATS_CACHE_TTL seconds (default 600). **Breaking change:** the `stats` block that used
+        to be embedded in every paginated list response has moved here — list responses no
+        longer include it, and clients that relied on `response.data["stats"]` must call
+        `/trials/stats/` instead.
+
+        # Registry Identifier Parameters:
+        Each accepts one or more comma-separated values and returns trials matching *any* of them
+        (case-insensitive). Combine with other filters (team, subject, status) as usual.
+        - **identifiers** - mixed list matched across all registry keys at once (NCT/EudraCT/EUCT/EUCTR/CTIS),
+          e.g. `?identifiers=NCT02521311,2020-001234-12`. Acronyms are excluded (not unique) — use `acronym` for those.
+        - **nct** - ClinicalTrials.gov NCT id(s), e.g. `?nct=NCT02521311,NCT06065670`
+        - **eudract** - EudraCT number(s)
+        - **euct** - EU CT / EUCTR number(s) (matches either `euct` or `euctr` keys)
+        - **ctis** - CTIS number(s)
+        - **acronym** - trial acronym(s), e.g. `?acronym=ReCOVER,MODIF-MS`
+
+        # Trial-Specific Parameters:
+        - **internal_number** - filter by WHO internal number
+        - **phase** - raw-text contains filter on the registry's own phase string (Phase I, II, III, etc.) — free text, so it silently misses spelling/format variants (e.g. "Phase III" vs "Phase 3")
+        - **phase_normalized** - exact match against the canonical phase; one of: early_phase_1, phase_1, phase_1_2, phase_2, phase_2_3, phase_3, phase_3_4, phase_4, post_market, not_applicable, other
+        - **status** / **recruitment_status** - raw-text `iexact` filters against the registry's own recruitment-status string (e.g. "Recruiting", "RECRUITING", "recruiting" all match each other, but "Not Recruiting" does not match "not_yet_recruiting") — free text, so it silently misses spelling/format variants across registries
+        - **recruitment_status_normalized** - exact match against the canonical recruitment status; one of: not_yet_recruiting, recruiting, enrolling_by_invitation, active_not_recruiting, not_recruiting, suspended, completed, terminated, withdrawn, unknown, other
+        - **study_type** - legacy free-text case-insensitive substring (`icontains`) filter on the raw registry study-type string — it can both overmatch and undermatch across registries (e.g. matches "Interventional clinical trial of medicinal product" but misses "Intervention"); prefer **study_type_normalized** below
+        - **study_type_normalized** - exact match against the canonical study type; one of: interventional, observational, expanded_access, basic_science, other
+        - **primary_sponsor** - legacy free-text `icontains` filter on the raw registry sponsor string — silently misses spelling/duplicate variants across registries; prefer **sponsor_id**/**sponsor_slug** below (same legacy treatment as `phase` vs `phase_normalized`)
+        - **sponsor_id** - exact match against a canonical sponsor's id (see `/sponsors/`)
+        - **sponsor_slug** - exact match against a canonical sponsor's slug (see `/sponsors/`)
+        - **source_register** - filter by source registry
+        - **countries** - raw-text `icontains` filter on the registry's own countries string — free text, so it silently misses spelling/format variants across registries (see **country** below for the normalized equivalent)
+        - **country** - match against one or more normalized country codes (ISO 3166-1 alpha-2), comma-separated, OR semantics (e.g. `?country=DE` or `?country=DE,FR`), derived from every source's raw country data — see docs/trials-field-normalization.md
+        - **region** - exact match against a normalized region derived from the trial's countries; one of: africa, asia, europe, north_america, south_america, oceania (e.g. `?region=europe`)
+
+        # Medical/Research Parameters:
+        - **condition** - filter by medical condition
+        - **intervention** - filter by intervention type
+        - **therapeutic_areas** - filter by therapeutic areas
+        - **inclusion_agemin/agemax** - filter by age inclusion criteria
+        - **inclusion_gender_normalized** - exact match against canonical sex eligibility; one of: all, female, male. Replaces the removed legacy `inclusion_gender` substring filter, which returned confidently wrong results (`?inclusion_gender=Female` matched "Female, Male", a both-sexes trial) — see docs/trials-field-normalization.md. **Breaking change (2026-07-20):** `?inclusion_gender=...` is no longer a recognised parameter and is silently ignored (unfiltered results), not rejected.
+
+        # Results Parameters:
+        - **has_results** - `true`/`false`; a trial counts as having results when any of `results_posted`, results completion date, results link, or results-available = "Yes" is set
+
+        # Date Range Parameters:
+        Filter by trial registration date (the date the trial was first registered with its registry).
+        Both parameters are optional and can be used independently or together.
+        Invalid or non-ISO-8601 dates return **400 Bad Request**.
+        - **date_registration_after** - trials registered on or after this date (YYYY-MM-DD, inclusive)
+        - **date_registration_before** - trials registered on or before this date (YYYY-MM-DD, inclusive)
+
+        # Examples:
+        - All trials as CSV: `/trials/?format=csv&all_results=true`
+        - Multi-subject OR: `/trials/?subjects_any=1,2`
+        - Filtered trials: `/trials/?team_id=1&status=Recruiting&format=csv&all_results=true`
+        - Trials with results posted: `/trials/?has_results=true`
+        - Trials registered in 2019–2022: `/trials/?date_registration_after=2019-01-01&date_registration_before=2022-12-31`
+        - Phase III trials registered since 2020: `/trials/?phase_normalized=phase_3&date_registration_after=2020-01-01`
+        - Date range + subject + CSV: `/trials/?team_id=1&subjects=1&date_registration_after=2019-01-01&date_registration_before=2022-12-31&format=csv&all_results=true`
+      parameters:
+      - in: query
+        name: acronym
+        schema:
+          type: array
+          items:
+            type: string
+            nullable: true
+        description: Trial acronym(s), comma-separated, matches any (case-insensitive),
+          e.g. ?acronym=ReCOVER,MODIF-MS.
+        explode: false
+        style: form
+      - in: query
+        name: age_eligible
+        schema:
+          type: number
+        description: Trials whose eligible age range (inclusion_age_min_years...inclusion_age_max_years,
+          in years) includes this age, e.g. ?age_eligible=40. A null min is treated
+          as no lower bound; a null max as no upper bound.
+      - in: query
+        name: category_id
+        schema:
+          type: integer
+        description: Filter by category ID (see /categories/).
+      - in: query
+        name: category_modality
+        schema:
+          type: string
+          nullable: true
+          enum:
+          - biologic_antibody
+          - cell_gene_therapy
+          - device_neuromodulation
+          - natural_product
+          - other
+          - rehabilitation
+          - research_topic
+          - small_molecule
+        description: |-
+          Filter by the intervention modality of the trial's categories; one of the CategoryModality values.
+
+          * `small_molecule` - Small-molecule drug
+          * `biologic_antibody` - Antibody / biologic
+          * `cell_gene_therapy` - Cell / gene therapy
+          * `rehabilitation` - Rehabilitation / physical
+          * `device_neuromodulation` - Device / neuromodulation
+          * `natural_product` - Natural product / supplement
+          * `research_topic` - Research topic (not an intervention)
+          * `other` - Other
+      - in: query
+        name: category_slug
+        schema:
+          type: string
+        description: Filter by category slug (see /categories/).
+      - in: query
+        name: condition
+        schema:
+          type: string
+        description: Filter by medical condition (case-insensitive substring).
+      - in: query
+        name: countries
+        schema:
+          type: string
+        description: Raw-text case-insensitive substring filter on the registry's
+          own countries string — free text, so it silently misses spelling/format
+          variants across registries. See country for the normalized equivalent.
+      - in: query
+        name: country
+        schema:
+          type: string
+        description: Match against one or more normalized country codes (ISO 3166-1
+          alpha-2), comma-separated, OR semantics (e.g. ?country=DE or ?country=DE,FR),
+          derived from every source's raw country data.
+      - in: query
+        name: ctis
+        schema:
+          type: array
+          items:
+            type: string
+        description: CTIS number(s), comma-separated, matches any (case-insensitive).
+        explode: false
+        style: form
+      - in: query
+        name: date_registration_after
+        schema:
+          type: string
+          format: date
+        description: Trials registered on or after this date (YYYY-MM-DD, inclusive).
+          Invalid or non-ISO-8601 dates return 400 Bad Request.
+      - in: query
+        name: date_registration_before
+        schema:
+          type: string
+          format: date
+        description: Trials registered on or before this date (YYYY-MM-DD, inclusive).
+          Invalid or non-ISO-8601 dates return 400 Bad Request.
+      - in: query
+        name: euct
+        schema:
+          type: array
+          items:
+            type: string
+        description: EU CT / EUCTR number(s), comma-separated, matches any (case-insensitive).
+          Matches either the euct or euctr identifier key.
+        explode: false
+        style: form
+      - in: query
+        name: eudract
+        schema:
+          type: array
+          items:
+            type: string
+        description: EudraCT number(s), comma-separated, matches any (case-insensitive).
+        explode: false
+        style: form
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: query
+        name: has_results
+        schema:
+          type: boolean
+        description: true/false; a trial counts as having results when any of results_posted,
+          results completion date, results link, or results-available = "Yes" is set.
+      - in: query
+        name: identifiers
+        schema:
+          type: array
+          items:
+            nullable: true
+        description: Mixed list of registry identifiers, comma-separated, matched
+          across all registry keys at once (NCT/EudraCT/EUCT/EUCTR/CTIS), case-insensitive,
+          e.g. ?identifiers=NCT02521311,2020-001234-12. Acronyms are excluded (not
+          unique) — use acronym for those.
+        explode: false
+        style: form
+      - in: query
+        name: inclusion_agemax
+        schema:
+          type: string
+        description: Exact match against the raw inclusion age-maximum criteria string.
+          Prefer age_eligible for a numeric range check.
+      - in: query
+        name: inclusion_agemin
+        schema:
+          type: string
+        description: Exact match against the raw inclusion age-minimum criteria string.
+          Prefer age_eligible for a numeric range check.
+      - in: query
+        name: inclusion_gender_normalized
+        schema:
+          type: string
+          nullable: true
+          enum:
+          - all
+          - female
+          - male
+        description: |-
+          Exact match against canonical sex eligibility; one of: all, female, male. Replaces the removed legacy inclusion_gender substring filter, which returned confidently wrong results (?inclusion_gender=Female matched "Female, Male", a both-sexes trial). **Breaking change (2026-07-20):** ?inclusion_gender=... is no longer a recognised parameter and is silently ignored (unfiltered results), not rejected — see docs/trials-field-normalization.md.
+
+          * `all` - All sexes
+          * `female` - Female only
+          * `male` - Male only
+      - in: query
+        name: internal_number
+        schema:
+          type: string
+        description: Filter by WHO internal number (case-insensitive substring).
+      - in: query
+        name: intervention
+        schema:
+          type: string
+        description: Filter by intervention type (case-insensitive substring).
+      - in: query
+        name: nct
+        schema:
+          type: array
+          items:
+            type: string
+        description: ClinicalTrials.gov NCT id(s), comma-separated, matches any (case-insensitive),
+          e.g. ?nct=NCT02521311,NCT06065670.
+        explode: false
+        style: form
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: phase
+        schema:
+          type: string
+        description: Raw-text contains filter on the registry's own phase string (Phase
+          I, II, III, etc.) — free text, so it silently misses spelling/format variants
+          (e.g. "Phase III" vs "Phase 3"). Prefer phase_normalized.
+      - in: query
+        name: phase_normalized
+        schema:
+          type: array
+          items:
+            type: string
+            nullable: true
+            enum:
+            - early_phase_1
+            - not_applicable
+            - other
+            - phase_1
+            - phase_1_2
+            - phase_2
+            - phase_2_3
+            - phase_3
+            - phase_3_4
+            - phase_4
+            - post_market
+        description: |-
+          Exact match against the canonical phase; accepts one or more comma-separated values (OR semantics). One of: early_phase_1, phase_1, phase_1_2, phase_2, phase_2_3, phase_3, phase_3_4, phase_4, post_market, not_applicable, other.
+
+          * `early_phase_1` - Early Phase 1
+          * `phase_1` - Phase 1
+          * `phase_1_2` - Phase 1/2
+          * `phase_2` - Phase 2
+          * `phase_2_3` - Phase 2/3
+          * `phase_3` - Phase 3
+          * `phase_3_4` - Phase 3/4
+          * `phase_4` - Phase 4
+          * `post_market` - Post-market
+          * `not_applicable` - Not applicable
+          * `other` - Other
+        explode: false
+        style: form
+      - in: query
+        name: primary_sponsor
+        schema:
+          type: string
+        description: Legacy free-text case-insensitive substring filter on the raw
+          registry sponsor string — silently misses spelling/duplicate variants across
+          registries; prefer sponsor_id/sponsor_slug.
+      - in: query
+        name: recruitment_status
+        schema:
+          type: string
+        description: Raw-text case-insensitive exact match against the registry's
+          own recruitment-status string (e.g. "Recruiting" matches "RECRUITING" but
+          not "Not Recruiting") — free text, so it silently misses spelling/format
+          variants across registries. Prefer recruitment_status_normalized.
+      - in: query
+        name: recruitment_status_normalized
+        schema:
+          type: array
+          items:
+            type: string
+            nullable: true
+            enum:
+            - active_not_recruiting
+            - completed
+            - enrolling_by_invitation
+            - not_recruiting
+            - not_yet_recruiting
+            - other
+            - recruiting
+            - suspended
+            - terminated
+            - unknown
+            - withdrawn
+        description: |-
+          Exact match against the canonical recruitment status; accepts one or more comma-separated values (OR semantics). One of: not_yet_recruiting, recruiting, enrolling_by_invitation, active_not_recruiting, not_recruiting, suspended, completed, terminated, withdrawn, unknown, other.
+
+          * `not_yet_recruiting` - Not yet recruiting
+          * `recruiting` - Recruiting
+          * `enrolling_by_invitation` - Enrolling by invitation
+          * `active_not_recruiting` - Active, not recruiting
+          * `not_recruiting` - Not recruiting
+          * `suspended` - Suspended
+          * `completed` - Completed
+          * `terminated` - Terminated
+          * `withdrawn` - Withdrawn
+          * `unknown` - Unknown
+          * `other` - Other
+        explode: false
+        style: form
+      - in: query
+        name: region
+        schema:
+          type: string
+          enum:
+          - africa
+          - asia
+          - europe
+          - north_america
+          - oceania
+          - south_america
+        description: |-
+          Exact match against a normalized region derived from the trial's countries; one of: africa, asia, europe, north_america, south_america, oceania (e.g. ?region=europe).
+
+          * `africa` - Africa
+          * `asia` - Asia
+          * `europe` - Europe
+          * `north_america` - North America
+          * `south_america` - South America
+          * `oceania` - Oceania
+      - in: query
+        name: search
+        schema:
+          type: string
+        description: Boolean search across title and summary. Bare terms are AND-ed;
+          uppercase OR/NOT and "quoted phrases" are supported.
+      - in: query
+        name: site_id
+        schema:
+          type: number
+        description: Filter by Django Site ID; returns trials belonging to any team
+          attached to that site (see Team.site).
+      - in: query
+        name: source_id
+        schema:
+          type: integer
+        description: Filter by source ID (see /sources/).
+      - in: query
+        name: source_register
+        schema:
+          type: string
+        description: Filter by source registry (case-insensitive substring).
+      - in: query
+        name: sponsor_id
+        schema:
+          type: number
+        description: Exact match against a canonical sponsor's id (see /sponsors/).
+      - in: query
+        name: sponsor_slug
+        schema:
+          type: string
+        description: Exact match against a canonical sponsor's slug (see /sponsors/).
+      - in: query
+        name: status
+        schema:
+          type: string
+        description: Legacy alias for recruitment_status — same raw-text, case-insensitive
+          exact match. Prefer recruitment_status_normalized.
+      - in: query
+        name: study_type
+        schema:
+          type: string
+        description: Legacy free-text case-insensitive substring filter on the raw
+          registry study-type string — can both overmatch and undermatch across registries
+          (e.g. matches "Interventional clinical trial of medicinal product" but misses
+          "Intervention"); prefer study_type_normalized.
+      - in: query
+        name: study_type_normalized
+        schema:
+          type: string
+          nullable: true
+          enum:
+          - basic_science
+          - expanded_access
+          - interventional
+          - observational
+          - other
+        description: |-
+          Exact match against the canonical study type; one of: interventional, observational, expanded_access, basic_science, other.
+
+          * `interventional` - Interventional
+          * `observational` - Observational
+          * `expanded_access` - Expanded access
+          * `basic_science` - Basic science
+          * `other` - Other
+      - in: query
+        name: subject_id
+        schema:
+          type: integer
+        description: Filter by subject ID (see /subjects/).
+      - in: query
+        name: subjects
+        schema:
+          type: array
+          items:
+            type: integer
+        description: Comma-separated list of subject IDs with AND semantics — returns
+          only trials tagged with *all* listed subjects, e.g. ?subjects=1,2.
+        explode: false
+        style: form
+      - in: query
+        name: subjects_any
+        schema:
+          type: array
+          items:
+            type: string
+        description: Comma-separated list of subject IDs with OR semantics — returns
+          trials tagged with *any* of the listed subjects, e.g. ?subjects_any=1,2.
+        explode: false
+        style: form
+      - in: query
+        name: summary
+        schema:
+          type: string
+        description: Case-insensitive substring match against the summary only.
+      - in: query
+        name: team_id
+        schema:
+          type: integer
+        description: Filter by team ID.
+      - in: query
+        name: therapeutic_areas
+        schema:
+          type: string
+        description: Filter by therapeutic areas (case-insensitive substring).
+      - in: query
+        name: title
+        schema:
+          type: string
+        description: Case-insensitive substring match against the title only.
+      - in: query
+        name: trial_id
+        schema:
+          type: integer
+        description: Filter by a specific trial ID.
+      tags:
+      - trials
+      security:
+      - {}
+      - basicAuth: []
+      - jwtAuth: []
+      - cookieAuth: []
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedTrialList'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/PaginatedTrialList'
+          description: ''
+  /trials/{trial_id}/:
+    get:
+      operationId: trials_retrieve
+      description: |-
+        List all clinical trials by discovery date with comprehensive filtering options.
+        CSV responses are automatically streamed for better performance with large datasets.
+
+        # Core Query Parameters:
+        - **trial_id** - filter by specific trial ID
+        - **team_id** - filter by team ID
+        - **site_id** - filter by Django Site ID; returns trials belonging to any team attached to that site (see Team.site)
+        - **subject_id** - filter by subject ID
+        - **subjects** - comma-separated list of subject IDs with AND semantics — returns only trials tagged with *all* listed subjects (e.g., `?subjects=1,2`)
+        - **subjects_any** - comma-separated list of subject IDs with OR semantics — returns trials tagged with *any* of the listed subjects (e.g., `?subjects_any=1,2`)
+        - **category_slug** - filter by category slug
+        - **category_id** - filter by category ID
+        - **category_modality** - filter by the intervention modality of the trial's categories; one of the `CategoryModality` values
+        - **source_id** - filter by source ID
+        - **status/recruitment_status** - filter by recruitment status
+        - **search** - search in title and summary (supports boolean operators, e.g. `a OR b`)
+        - **title** - search only in the title field (case-insensitive substring)
+        - **summary** - search only in the summary field (case-insensitive substring)
+        - **page** - page number for pagination
+        - **page_size** - items per page (max 100)
+        - **all_results** - set to 'true' to bypass pagination and get all results (useful for CSV export)
+
+        # Ordering:
+        `?ordering=<field>` (prefix with `-` to reverse). Accepted values:
+        - **discovery_date** - when Gregory first ingested the trial (default: `-discovery_date`, newest first)
+        - **published_date** - registry publication date
+        - **title**
+        - **trial_id**
+        - **last_updated**
+        - **recruiting_first** - recruitment-availability order, NOT alphabetical on
+          `recruitment_status_normalized`: `recruiting` → `enrolling_by_invitation` →
+          `not_yet_recruiting` → `active_not_recruiting` → `suspended` →
+          `not_recruiting` → `unknown` → `other` → `completed` → `terminated` →
+          `withdrawn`, with null status last — that ordering is for plain
+          `?ordering=recruiting_first` (ascending); `?ordering=-recruiting_first`
+          reverses the whole scale, so null-status trials come first there instead.
+          Ties (many trials share a rank) are broken by `-discovery_date`
+          automatically, in both directions.
+
+        Unrecognised `ordering` values are silently ignored (not rejected) — a DRF
+        `OrderingFilter` default — so a typo or stale field name falls back to the
+        default ordering rather than erroring.
+
+        # Sites:
+        Per-site rows (`TrialSite` — name/city/state/country/coordinates, sourced from CTIS
+        retrieve enrichment and/or ClinicalTrials.gov) are **detail-only**: `trial_sites`
+        appears on `GET /trials/{id}/` but never on the list/CSV/search responses (sites fan
+        out, mean ~12/trial, so nesting them on every list row would bloat those responses for
+        a field most callers don't need there). For a flat, filterable, paginated listing
+        across many trials — e.g. to build a site-level pin map — use `GET /trials/sites/`
+        instead, which accepts the same filters as this endpoint (team_id, subject_id,
+        country, recruitment_status_normalized, …) plus `latitude__isnull`, and rejects
+        `all_results=true` (it is not a bulk export). See TRIAL-GEOGRAPHY-PLAN.md PR G2/G3.
+
+        # Stats Endpoint:
+        `GET /trials/stats/` returns `total`, `no_status` (recruitment_status_normalized is
+        null), one key per `TrialRecruitmentStatus` bucket — `not_yet_recruiting`, `recruiting`,
+        `enrolling_by_invitation`, `active_not_recruiting`, `not_recruiting`, `suspended`,
+        `completed`, `terminated`, `withdrawn`, `unknown`, `other` (always present, 0 when
+        empty) — plus five facet breakdowns computed over the filtered queryset:
+        - `by_subject` — `[{subject_id, subject_name, count}]`, distinct per trial,
+          restricted to subjects visible to the caller. Sums to `total`.
+        - `by_phase` — `{phase_slug: count, ...}`, one key per `TrialPhase` value
+          (always present, 0 when empty) plus `no_phase` (raw `phase` was never set).
+          Sums to `total`.
+        - `by_region` — `{region_slug: count, ...}`, one key per `TrialRegion` value
+          (always present, 0 when empty) plus `no_region` (`regions_normalized` is
+          null or empty). Does **not** sum to `total` — a trial spanning several
+          regions counts once per region.
+        - `by_country` — `[{country: alpha2_or_null, count}]`, sorted by `-count`
+          then country code, zero-count countries omitted, a trailing
+          `{"country": null, ...}` entry for trials with no `TrialCountry` rows
+          (omitted when 0). Does **not** sum to `total` — multi-country trials count
+          once per country.
+        - `by_year` — `[{year: int_or_null, count}]`, ascending by year, zero-count
+          years omitted, a trailing `{"year": null, ...}` entry for trials with no
+          `date_registration` (omitted when 0). Derived from `date_registration`
+          only (no `published_date` fallback). Sums to `total`.
+        - `by_sponsor` — `[{sponsor_id, slug, name, sponsor_type, count}]`, top 25 by
+          count then sponsor name, over the canonical `Sponsor` entity a trial's raw
+          `primary_sponsor` resolves to (see docs/trials-field-normalization.md) —
+          excludes trials with no resolved sponsor yet, reported separately as the
+          sibling key `no_sponsor`. Does not sum to `total` once truncated to 25.
+        - `by_sponsor_type` — `{sponsor_type_slug: count, ...}`, one key per
+          `SponsorType` value (always present, 0 when empty) plus `no_type`
+          (resolved sponsor, no sponsor_type derived yet) — excludes the same
+          null-FK group as `no_sponsor`.
+        - `by_modality` — `{modality_slug: count, ...}`, one key per
+          `CategoryModality` value (always present, 0 when empty) plus
+          `no_modality`, over the trial's `team_categories.modality`. **Not** a
+          partition of `total` and **not** safe to sum: this joins an M2M, so a
+          trial carrying two categories of different modalities is counted once
+          *per modality*. `no_modality` also conflates two different things —
+          "trial has no category at all" (most trials; categories are a curated
+          lens over a small subset) and "trial has a category that isn't
+          curated with a modality yet" — deliberately, to avoid the extra query
+          cost of splitting them out as separate keys; use `?category_slug=` when
+          the distinction matters.
+        - `by_study_type` — `{study_type_slug: count, ...}`, one key per
+          `TrialStudyType` value (always present, 0 when empty) plus
+          `no_study_type`. `no_study_type` is large (~13.2k globally) because most
+          of it is legacy rows with no `source_register` at all, not a
+          normalization gap — see docs/trials-field-normalization.md.
+        - `by_sex` — `{sex_slug: count, ...}`, one key per `TrialSexEligibility`
+          value (always present, 0 when empty) plus `no_sex_data`. `no_sex_data`
+          is large (~46% of trials globally) because it includes the legacy
+          `source_register IS NULL` population that also lacks sponsors and
+          countries — same caveat as `no_modality`/`no_sponsor`. See
+          docs/trials-field-normalization.md and
+          INCLUSION-GENDER-NORMALIZATION-PLAN.md.
+
+        Recruitment-status buckets and `by_phase`/`by_region`/`by_country`/`by_study_type`/`by_sex` are counted on the
+        `*_normalized` canonical vocabularies (same as their respective filters), not on the
+        raw registry strings — see docs/trials-field-normalization.md. It accepts the
+        same query parameters as the list endpoint, so e.g.
+        `/trials/stats/?team_id=1&recruitment_status_normalized=recruiting` scopes the totals
+        exactly like the equivalent list request — including composition across facets, e.g.
+        `/trials/stats/?phase_normalized=phase_3` makes `by_country` the phase-3 × country
+        slice of the matrix. Results are cached server-side for
+        STATS_CACHE_TTL seconds (default 600). **Breaking change:** the `stats` block that used
+        to be embedded in every paginated list response has moved here — list responses no
+        longer include it, and clients that relied on `response.data["stats"]` must call
+        `/trials/stats/` instead.
+
+        # Registry Identifier Parameters:
+        Each accepts one or more comma-separated values and returns trials matching *any* of them
+        (case-insensitive). Combine with other filters (team, subject, status) as usual.
+        - **identifiers** - mixed list matched across all registry keys at once (NCT/EudraCT/EUCT/EUCTR/CTIS),
+          e.g. `?identifiers=NCT02521311,2020-001234-12`. Acronyms are excluded (not unique) — use `acronym` for those.
+        - **nct** - ClinicalTrials.gov NCT id(s), e.g. `?nct=NCT02521311,NCT06065670`
+        - **eudract** - EudraCT number(s)
+        - **euct** - EU CT / EUCTR number(s) (matches either `euct` or `euctr` keys)
+        - **ctis** - CTIS number(s)
+        - **acronym** - trial acronym(s), e.g. `?acronym=ReCOVER,MODIF-MS`
+
+        # Trial-Specific Parameters:
+        - **internal_number** - filter by WHO internal number
+        - **phase** - raw-text contains filter on the registry's own phase string (Phase I, II, III, etc.) — free text, so it silently misses spelling/format variants (e.g. "Phase III" vs "Phase 3")
+        - **phase_normalized** - exact match against the canonical phase; one of: early_phase_1, phase_1, phase_1_2, phase_2, phase_2_3, phase_3, phase_3_4, phase_4, post_market, not_applicable, other
+        - **status** / **recruitment_status** - raw-text `iexact` filters against the registry's own recruitment-status string (e.g. "Recruiting", "RECRUITING", "recruiting" all match each other, but "Not Recruiting" does not match "not_yet_recruiting") — free text, so it silently misses spelling/format variants across registries
+        - **recruitment_status_normalized** - exact match against the canonical recruitment status; one of: not_yet_recruiting, recruiting, enrolling_by_invitation, active_not_recruiting, not_recruiting, suspended, completed, terminated, withdrawn, unknown, other
+        - **study_type** - legacy free-text case-insensitive substring (`icontains`) filter on the raw registry study-type string — it can both overmatch and undermatch across registries (e.g. matches "Interventional clinical trial of medicinal product" but misses "Intervention"); prefer **study_type_normalized** below
+        - **study_type_normalized** - exact match against the canonical study type; one of: interventional, observational, expanded_access, basic_science, other
+        - **primary_sponsor** - legacy free-text `icontains` filter on the raw registry sponsor string — silently misses spelling/duplicate variants across registries; prefer **sponsor_id**/**sponsor_slug** below (same legacy treatment as `phase` vs `phase_normalized`)
+        - **sponsor_id** - exact match against a canonical sponsor's id (see `/sponsors/`)
+        - **sponsor_slug** - exact match against a canonical sponsor's slug (see `/sponsors/`)
+        - **source_register** - filter by source registry
+        - **countries** - raw-text `icontains` filter on the registry's own countries string — free text, so it silently misses spelling/format variants across registries (see **country** below for the normalized equivalent)
+        - **country** - match against one or more normalized country codes (ISO 3166-1 alpha-2), comma-separated, OR semantics (e.g. `?country=DE` or `?country=DE,FR`), derived from every source's raw country data — see docs/trials-field-normalization.md
+        - **region** - exact match against a normalized region derived from the trial's countries; one of: africa, asia, europe, north_america, south_america, oceania (e.g. `?region=europe`)
+
+        # Medical/Research Parameters:
+        - **condition** - filter by medical condition
+        - **intervention** - filter by intervention type
+        - **therapeutic_areas** - filter by therapeutic areas
+        - **inclusion_agemin/agemax** - filter by age inclusion criteria
+        - **inclusion_gender_normalized** - exact match against canonical sex eligibility; one of: all, female, male. Replaces the removed legacy `inclusion_gender` substring filter, which returned confidently wrong results (`?inclusion_gender=Female` matched "Female, Male", a both-sexes trial) — see docs/trials-field-normalization.md. **Breaking change (2026-07-20):** `?inclusion_gender=...` is no longer a recognised parameter and is silently ignored (unfiltered results), not rejected.
+
+        # Results Parameters:
+        - **has_results** - `true`/`false`; a trial counts as having results when any of `results_posted`, results completion date, results link, or results-available = "Yes" is set
+
+        # Date Range Parameters:
+        Filter by trial registration date (the date the trial was first registered with its registry).
+        Both parameters are optional and can be used independently or together.
+        Invalid or non-ISO-8601 dates return **400 Bad Request**.
+        - **date_registration_after** - trials registered on or after this date (YYYY-MM-DD, inclusive)
+        - **date_registration_before** - trials registered on or before this date (YYYY-MM-DD, inclusive)
+
+        # Examples:
+        - All trials as CSV: `/trials/?format=csv&all_results=true`
+        - Multi-subject OR: `/trials/?subjects_any=1,2`
+        - Filtered trials: `/trials/?team_id=1&status=Recruiting&format=csv&all_results=true`
+        - Trials with results posted: `/trials/?has_results=true`
+        - Trials registered in 2019–2022: `/trials/?date_registration_after=2019-01-01&date_registration_before=2022-12-31`
+        - Phase III trials registered since 2020: `/trials/?phase_normalized=phase_3&date_registration_after=2020-01-01`
+        - Date range + subject + CSV: `/trials/?team_id=1&subjects=1&date_registration_after=2019-01-01&date_registration_before=2022-12-31&format=csv&all_results=true`
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: path
+        name: trial_id
+        schema:
+          type: integer
+        description: A unique integer value identifying this trials.
+        required: true
+      tags:
+      - trials
+      security:
+      - {}
+      - basicAuth: []
+      - jwtAuth: []
+      - cookieAuth: []
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrialDetail'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/TrialDetail'
+          description: ''
+  /trials/edit/:
+    post:
+      operationId: trials_edit_create
+      description: 'Edit per-organisation editorial fields on an existing trial. Lookup
+        is by `identifiers` dict (required, same format as post_article''s trial branch:
+        keys `nct`, `euct`, `eudract`). Raises 404 if not found, 409 if multiple trials
+        match (dedup issue). Only per-org fields (`takeaways`, `summary_plain_english`)
+        are editable — trial metadata comes from registries and is not client-editable.'
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - trials
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: {}
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              additionalProperties: {}
+          multipart/form-data:
+            schema:
+              type: object
+              additionalProperties: {}
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+            text/csv:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /trials/search/:
+    get:
+      operationId: trials_search_list
+      description: |-
+        Advanced search for clinical trials by title, summary, and recruitment status.
+
+        This endpoint accepts both GET and POST requests with team_id and subject_id
+        parameters, along with optional search parameters. Every filter on
+        TrialFilter works identically on both verbs — for GET, put them on the query
+        string; for POST, put them in the JSON body. BodyParamsAsQueryParamsMixin
+        merges the body into query_params before filtering, so both paths run
+        through the same DjangoFilterBackend/OrderingFilter code; if the same filter
+        key is set in both places, the query string wins. team_id and subject_id are
+        the exception — they're forced from the body on POST (identity_params),
+        both for get_queryset()'s own validation and for TrialFilter's identically
+        named fields, so a mismatched query-string team_id/subject_id has no effect
+        at all rather than silently narrowing the filterset against a different
+        team/subject than the one validated.
+
+        Parameters (can be sent as query params for GET or in request body for POST):
+        - title: Search only in title field
+        - summary: Search only in summary/abstract field
+        - search: Search in both title and summary fields
+        - status: Filter by recruitment status (e.g., 'Recruiting', 'Completed')
+        - team_id: Required - Team ID to filter trials by (must be provided)
+        - subject_id: Required - Subject ID to filter trials by (must be provided)
+        - page: Page number for pagination (default: 1)
+        - page_size: Number of results per page (default: 10, max: 100)
+        - all_results: Set to 'true' to retrieve all results without pagination (useful for CSV export)
+        - ordering: Order results by field (e.g., -discovery_date, -published_date, title, trial_id, -last_updated)
+
+        Every other TrialFilter field also applies here, e.g.
+        date_registration_after / date_registration_before, has_results,
+        phase_normalized, country, sponsor_id:
+        - Registered in 2024: /trials/search/?team_id=1&subject_id=1&date_registration_after=2024-01-01&date_registration_before=2024-12-31
+
+        Prefer GET where practical — it's cacheable and linkable. POST exists for
+        `search` strings with long boolean expressions that would exceed practical
+        URL length limits.
+
+        Results are ordered by discovery date (newest first) by default.
+
+        To download all search results as CSV, add format=csv and all_results=true to the query parameters.
+        Example: /trials/search/?team_id=1&subject_id=1&search=covid&format=csv&all_results=true
+      parameters:
+      - in: query
+        name: acronym
+        schema:
+          type: array
+          items:
+            type: string
+            nullable: true
+        description: Trial acronym(s), comma-separated, matches any (case-insensitive),
+          e.g. ?acronym=ReCOVER,MODIF-MS.
+        explode: false
+        style: form
+      - in: query
+        name: age_eligible
+        schema:
+          type: number
+        description: Trials whose eligible age range (inclusion_age_min_years...inclusion_age_max_years,
+          in years) includes this age, e.g. ?age_eligible=40. A null min is treated
+          as no lower bound; a null max as no upper bound.
+      - in: query
+        name: category_id
+        schema:
+          type: integer
+        description: Filter by category ID (see /categories/).
+      - in: query
+        name: category_modality
+        schema:
+          type: string
+          nullable: true
+          enum:
+          - biologic_antibody
+          - cell_gene_therapy
+          - device_neuromodulation
+          - natural_product
+          - other
+          - rehabilitation
+          - research_topic
+          - small_molecule
+        description: |-
+          Filter by the intervention modality of the trial's categories; one of the CategoryModality values.
+
+          * `small_molecule` - Small-molecule drug
+          * `biologic_antibody` - Antibody / biologic
+          * `cell_gene_therapy` - Cell / gene therapy
+          * `rehabilitation` - Rehabilitation / physical
+          * `device_neuromodulation` - Device / neuromodulation
+          * `natural_product` - Natural product / supplement
+          * `research_topic` - Research topic (not an intervention)
+          * `other` - Other
+      - in: query
+        name: category_slug
+        schema:
+          type: string
+        description: Filter by category slug (see /categories/).
+      - in: query
+        name: condition
+        schema:
+          type: string
+        description: Filter by medical condition (case-insensitive substring).
+      - in: query
+        name: countries
+        schema:
+          type: string
+        description: Raw-text case-insensitive substring filter on the registry's
+          own countries string — free text, so it silently misses spelling/format
+          variants across registries. See country for the normalized equivalent.
+      - in: query
+        name: country
+        schema:
+          type: string
+        description: Match against one or more normalized country codes (ISO 3166-1
+          alpha-2), comma-separated, OR semantics (e.g. ?country=DE or ?country=DE,FR),
+          derived from every source's raw country data.
+      - in: query
+        name: ctis
+        schema:
+          type: array
+          items:
+            type: string
+        description: CTIS number(s), comma-separated, matches any (case-insensitive).
+        explode: false
+        style: form
+      - in: query
+        name: date_registration_after
+        schema:
+          type: string
+          format: date
+        description: Trials registered on or after this date (YYYY-MM-DD, inclusive).
+          Invalid or non-ISO-8601 dates return 400 Bad Request.
+      - in: query
+        name: date_registration_before
+        schema:
+          type: string
+          format: date
+        description: Trials registered on or before this date (YYYY-MM-DD, inclusive).
+          Invalid or non-ISO-8601 dates return 400 Bad Request.
+      - in: query
+        name: euct
+        schema:
+          type: array
+          items:
+            type: string
+        description: EU CT / EUCTR number(s), comma-separated, matches any (case-insensitive).
+          Matches either the euct or euctr identifier key.
+        explode: false
+        style: form
+      - in: query
+        name: eudract
+        schema:
+          type: array
+          items:
+            type: string
+        description: EudraCT number(s), comma-separated, matches any (case-insensitive).
+        explode: false
+        style: form
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: query
+        name: has_results
+        schema:
+          type: boolean
+        description: true/false; a trial counts as having results when any of results_posted,
+          results completion date, results link, or results-available = "Yes" is set.
+      - in: query
+        name: identifiers
+        schema:
+          type: array
+          items:
+            nullable: true
+        description: Mixed list of registry identifiers, comma-separated, matched
+          across all registry keys at once (NCT/EudraCT/EUCT/EUCTR/CTIS), case-insensitive,
+          e.g. ?identifiers=NCT02521311,2020-001234-12. Acronyms are excluded (not
+          unique) — use acronym for those.
+        explode: false
+        style: form
+      - in: query
+        name: inclusion_agemax
+        schema:
+          type: string
+        description: Exact match against the raw inclusion age-maximum criteria string.
+          Prefer age_eligible for a numeric range check.
+      - in: query
+        name: inclusion_agemin
+        schema:
+          type: string
+        description: Exact match against the raw inclusion age-minimum criteria string.
+          Prefer age_eligible for a numeric range check.
+      - in: query
+        name: inclusion_gender_normalized
+        schema:
+          type: string
+          nullable: true
+          enum:
+          - all
+          - female
+          - male
+        description: |-
+          Exact match against canonical sex eligibility; one of: all, female, male. Replaces the removed legacy inclusion_gender substring filter, which returned confidently wrong results (?inclusion_gender=Female matched "Female, Male", a both-sexes trial). **Breaking change (2026-07-20):** ?inclusion_gender=... is no longer a recognised parameter and is silently ignored (unfiltered results), not rejected — see docs/trials-field-normalization.md.
+
+          * `all` - All sexes
+          * `female` - Female only
+          * `male` - Male only
+      - in: query
+        name: internal_number
+        schema:
+          type: string
+        description: Filter by WHO internal number (case-insensitive substring).
+      - in: query
+        name: intervention
+        schema:
+          type: string
+        description: Filter by intervention type (case-insensitive substring).
+      - in: query
+        name: nct
+        schema:
+          type: array
+          items:
+            type: string
+        description: ClinicalTrials.gov NCT id(s), comma-separated, matches any (case-insensitive),
+          e.g. ?nct=NCT02521311,NCT06065670.
+        explode: false
+        style: form
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: phase
+        schema:
+          type: string
+        description: Raw-text contains filter on the registry's own phase string (Phase
+          I, II, III, etc.) — free text, so it silently misses spelling/format variants
+          (e.g. "Phase III" vs "Phase 3"). Prefer phase_normalized.
+      - in: query
+        name: phase_normalized
+        schema:
+          type: array
+          items:
+            type: string
+            nullable: true
+            enum:
+            - early_phase_1
+            - not_applicable
+            - other
+            - phase_1
+            - phase_1_2
+            - phase_2
+            - phase_2_3
+            - phase_3
+            - phase_3_4
+            - phase_4
+            - post_market
+        description: |-
+          Exact match against the canonical phase; accepts one or more comma-separated values (OR semantics). One of: early_phase_1, phase_1, phase_1_2, phase_2, phase_2_3, phase_3, phase_3_4, phase_4, post_market, not_applicable, other.
+
+          * `early_phase_1` - Early Phase 1
+          * `phase_1` - Phase 1
+          * `phase_1_2` - Phase 1/2
+          * `phase_2` - Phase 2
+          * `phase_2_3` - Phase 2/3
+          * `phase_3` - Phase 3
+          * `phase_3_4` - Phase 3/4
+          * `phase_4` - Phase 4
+          * `post_market` - Post-market
+          * `not_applicable` - Not applicable
+          * `other` - Other
+        explode: false
+        style: form
+      - in: query
+        name: primary_sponsor
+        schema:
+          type: string
+        description: Legacy free-text case-insensitive substring filter on the raw
+          registry sponsor string — silently misses spelling/duplicate variants across
+          registries; prefer sponsor_id/sponsor_slug.
+      - in: query
+        name: recruitment_status
+        schema:
+          type: string
+        description: Raw-text case-insensitive exact match against the registry's
+          own recruitment-status string (e.g. "Recruiting" matches "RECRUITING" but
+          not "Not Recruiting") — free text, so it silently misses spelling/format
+          variants across registries. Prefer recruitment_status_normalized.
+      - in: query
+        name: recruitment_status_normalized
+        schema:
+          type: array
+          items:
+            type: string
+            nullable: true
+            enum:
+            - active_not_recruiting
+            - completed
+            - enrolling_by_invitation
+            - not_recruiting
+            - not_yet_recruiting
+            - other
+            - recruiting
+            - suspended
+            - terminated
+            - unknown
+            - withdrawn
+        description: |-
+          Exact match against the canonical recruitment status; accepts one or more comma-separated values (OR semantics). One of: not_yet_recruiting, recruiting, enrolling_by_invitation, active_not_recruiting, not_recruiting, suspended, completed, terminated, withdrawn, unknown, other.
+
+          * `not_yet_recruiting` - Not yet recruiting
+          * `recruiting` - Recruiting
+          * `enrolling_by_invitation` - Enrolling by invitation
+          * `active_not_recruiting` - Active, not recruiting
+          * `not_recruiting` - Not recruiting
+          * `suspended` - Suspended
+          * `completed` - Completed
+          * `terminated` - Terminated
+          * `withdrawn` - Withdrawn
+          * `unknown` - Unknown
+          * `other` - Other
+        explode: false
+        style: form
+      - in: query
+        name: region
+        schema:
+          type: string
+          enum:
+          - africa
+          - asia
+          - europe
+          - north_america
+          - oceania
+          - south_america
+        description: |-
+          Exact match against a normalized region derived from the trial's countries; one of: africa, asia, europe, north_america, south_america, oceania (e.g. ?region=europe).
+
+          * `africa` - Africa
+          * `asia` - Asia
+          * `europe` - Europe
+          * `north_america` - North America
+          * `south_america` - South America
+          * `oceania` - Oceania
+      - in: query
+        name: search
+        schema:
+          type: string
+        description: Boolean search across title and summary. Bare terms are AND-ed;
+          uppercase OR/NOT and "quoted phrases" are supported.
+      - in: query
+        name: site_id
+        schema:
+          type: number
+        description: Filter by Django Site ID; returns trials belonging to any team
+          attached to that site (see Team.site).
+      - in: query
+        name: source_id
+        schema:
+          type: integer
+        description: Filter by source ID (see /sources/).
+      - in: query
+        name: source_register
+        schema:
+          type: string
+        description: Filter by source registry (case-insensitive substring).
+      - in: query
+        name: sponsor_id
+        schema:
+          type: number
+        description: Exact match against a canonical sponsor's id (see /sponsors/).
+      - in: query
+        name: sponsor_slug
+        schema:
+          type: string
+        description: Exact match against a canonical sponsor's slug (see /sponsors/).
+      - in: query
+        name: status
+        schema:
+          type: string
+        description: Legacy alias for recruitment_status — same raw-text, case-insensitive
+          exact match. Prefer recruitment_status_normalized.
+      - in: query
+        name: study_type
+        schema:
+          type: string
+        description: Legacy free-text case-insensitive substring filter on the raw
+          registry study-type string — can both overmatch and undermatch across registries
+          (e.g. matches "Interventional clinical trial of medicinal product" but misses
+          "Intervention"); prefer study_type_normalized.
+      - in: query
+        name: study_type_normalized
+        schema:
+          type: string
+          nullable: true
+          enum:
+          - basic_science
+          - expanded_access
+          - interventional
+          - observational
+          - other
+        description: |-
+          Exact match against the canonical study type; one of: interventional, observational, expanded_access, basic_science, other.
+
+          * `interventional` - Interventional
+          * `observational` - Observational
+          * `expanded_access` - Expanded access
+          * `basic_science` - Basic science
+          * `other` - Other
+      - in: query
+        name: subject_id
+        schema:
+          type: integer
+        description: Filter by subject ID (see /subjects/).
+      - in: query
+        name: subjects
+        schema:
+          type: array
+          items:
+            type: integer
+        description: Comma-separated list of subject IDs with AND semantics — returns
+          only trials tagged with *all* listed subjects, e.g. ?subjects=1,2.
+        explode: false
+        style: form
+      - in: query
+        name: subjects_any
+        schema:
+          type: array
+          items:
+            type: string
+        description: Comma-separated list of subject IDs with OR semantics — returns
+          trials tagged with *any* of the listed subjects, e.g. ?subjects_any=1,2.
+        explode: false
+        style: form
+      - in: query
+        name: summary
+        schema:
+          type: string
+        description: Case-insensitive substring match against the summary only.
+      - in: query
+        name: team_id
+        schema:
+          type: integer
+        description: Filter by team ID.
+      - in: query
+        name: therapeutic_areas
+        schema:
+          type: string
+        description: Filter by therapeutic areas (case-insensitive substring).
+      - in: query
+        name: title
+        schema:
+          type: string
+        description: Case-insensitive substring match against the title only.
+      - in: query
+        name: trial_id
+        schema:
+          type: integer
+        description: Filter by a specific trial ID.
+      tags:
+      - trials
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedTrialList'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/PaginatedTrialList'
+          description: ''
+    post:
+      operationId: trials_search_create
+      description: |-
+        Advanced search for clinical trials by title, summary, and recruitment status.
+
+        This endpoint accepts both GET and POST requests with team_id and subject_id
+        parameters, along with optional search parameters. Every filter on
+        TrialFilter works identically on both verbs — for GET, put them on the query
+        string; for POST, put them in the JSON body. BodyParamsAsQueryParamsMixin
+        merges the body into query_params before filtering, so both paths run
+        through the same DjangoFilterBackend/OrderingFilter code; if the same filter
+        key is set in both places, the query string wins. team_id and subject_id are
+        the exception — they're forced from the body on POST (identity_params),
+        both for get_queryset()'s own validation and for TrialFilter's identically
+        named fields, so a mismatched query-string team_id/subject_id has no effect
+        at all rather than silently narrowing the filterset against a different
+        team/subject than the one validated.
+
+        Parameters (can be sent as query params for GET or in request body for POST):
+        - title: Search only in title field
+        - summary: Search only in summary/abstract field
+        - search: Search in both title and summary fields
+        - status: Filter by recruitment status (e.g., 'Recruiting', 'Completed')
+        - team_id: Required - Team ID to filter trials by (must be provided)
+        - subject_id: Required - Subject ID to filter trials by (must be provided)
+        - page: Page number for pagination (default: 1)
+        - page_size: Number of results per page (default: 10, max: 100)
+        - all_results: Set to 'true' to retrieve all results without pagination (useful for CSV export)
+        - ordering: Order results by field (e.g., -discovery_date, -published_date, title, trial_id, -last_updated)
+
+        Every other TrialFilter field also applies here, e.g.
+        date_registration_after / date_registration_before, has_results,
+        phase_normalized, country, sponsor_id:
+        - Registered in 2024: /trials/search/?team_id=1&subject_id=1&date_registration_after=2024-01-01&date_registration_before=2024-12-31
+
+        Prefer GET where practical — it's cacheable and linkable. POST exists for
+        `search` strings with long boolean expressions that would exceed practical
+        URL length limits.
+
+        Results are ordered by discovery date (newest first) by default.
+
+        To download all search results as CSV, add format=csv and all_results=true to the query parameters.
+        Example: /trials/search/?team_id=1&subject_id=1&search=covid&format=csv&all_results=true
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - trials
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                trial_id:
+                  type: number
+                  description: Filter by a specific trial ID.
+                title:
+                  type: string
+                  description: Case-insensitive substring match against the title
+                    only.
+                summary:
+                  type: string
+                  description: Case-insensitive substring match against the summary
+                    only.
+                search:
+                  type: string
+                  description: Boolean search across title and summary. Bare terms
+                    are AND-ed; uppercase OR/NOT and "quoted phrases" are supported.
+                recruitment_status:
+                  type: string
+                  description: Raw-text case-insensitive exact match against the registry's
+                    own recruitment-status string (e.g. "Recruiting" matches "RECRUITING"
+                    but not "Not Recruiting") — free text, so it silently misses spelling/format
+                    variants across registries. Prefer recruitment_status_normalized.
+                status:
+                  type: string
+                  description: Legacy alias for recruitment_status — same raw-text,
+                    case-insensitive exact match. Prefer recruitment_status_normalized.
+                recruitment_status_normalized:
+                  type: array
+                  items:
+                    type: string
+                  description: 'Exact match against the canonical recruitment status;
+                    accepts one or more comma-separated values (OR semantics). One
+                    of: not_yet_recruiting, recruiting, enrolling_by_invitation, active_not_recruiting,
+                    not_recruiting, suspended, completed, terminated, withdrawn, unknown,
+                    other.'
+                team_id:
+                  type: number
+                  description: Filter by team ID.
+                site_id:
+                  type: number
+                  description: Filter by Django Site ID; returns trials belonging
+                    to any team attached to that site (see Team.site).
+                subject_id:
+                  type: number
+                  description: Filter by subject ID (see /subjects/).
+                category_slug:
+                  type: string
+                  description: Filter by category slug (see /categories/).
+                category_id:
+                  type: number
+                  description: Filter by category ID (see /categories/).
+                category_modality:
+                  type: string
+                  description: Filter by the intervention modality of the trial's
+                    categories; one of the CategoryModality values.
+                source_id:
+                  type: number
+                  description: Filter by source ID (see /sources/).
+                identifiers:
+                  type: array
+                  items:
+                    type: string
+                  description: Mixed list of registry identifiers, comma-separated,
+                    matched across all registry keys at once (NCT/EudraCT/EUCT/EUCTR/CTIS),
+                    case-insensitive, e.g. ?identifiers=NCT02521311,2020-001234-12.
+                    Acronyms are excluded (not unique) — use acronym for those.
+                nct:
+                  type: array
+                  items:
+                    type: string
+                  description: ClinicalTrials.gov NCT id(s), comma-separated, matches
+                    any (case-insensitive), e.g. ?nct=NCT02521311,NCT06065670.
+                eudract:
+                  type: array
+                  items:
+                    type: string
+                  description: EudraCT number(s), comma-separated, matches any (case-insensitive).
+                euct:
+                  type: array
+                  items:
+                    type: string
+                  description: EU CT / EUCTR number(s), comma-separated, matches any
+                    (case-insensitive). Matches either the euct or euctr identifier
+                    key.
+                ctis:
+                  type: array
+                  items:
+                    type: string
+                  description: CTIS number(s), comma-separated, matches any (case-insensitive).
+                acronym:
+                  type: array
+                  items:
+                    type: string
+                  description: Trial acronym(s), comma-separated, matches any (case-insensitive),
+                    e.g. ?acronym=ReCOVER,MODIF-MS.
+                internal_number:
+                  type: string
+                  description: Filter by WHO internal number (case-insensitive substring).
+                phase:
+                  type: string
+                  description: Raw-text contains filter on the registry's own phase
+                    string (Phase I, II, III, etc.) — free text, so it silently misses
+                    spelling/format variants (e.g. "Phase III" vs "Phase 3"). Prefer
+                    phase_normalized.
+                phase_normalized:
+                  type: array
+                  items:
+                    type: string
+                  description: 'Exact match against the canonical phase; accepts one
+                    or more comma-separated values (OR semantics). One of: early_phase_1,
+                    phase_1, phase_1_2, phase_2, phase_2_3, phase_3, phase_3_4, phase_4,
+                    post_market, not_applicable, other.'
+                study_type:
+                  type: string
+                  description: Legacy free-text case-insensitive substring filter
+                    on the raw registry study-type string — can both overmatch and
+                    undermatch across registries (e.g. matches "Interventional clinical
+                    trial of medicinal product" but misses "Intervention"); prefer
+                    study_type_normalized.
+                study_type_normalized:
+                  type: string
+                  description: 'Exact match against the canonical study type; one
+                    of: interventional, observational, expanded_access, basic_science,
+                    other.'
+                primary_sponsor:
+                  type: string
+                  description: Legacy free-text case-insensitive substring filter
+                    on the raw registry sponsor string — silently misses spelling/duplicate
+                    variants across registries; prefer sponsor_id/sponsor_slug.
+                sponsor_id:
+                  type: number
+                  description: Exact match against a canonical sponsor's id (see /sponsors/).
+                sponsor_slug:
+                  type: string
+                  description: Exact match against a canonical sponsor's slug (see
+                    /sponsors/).
+                source_register:
+                  type: string
+                  description: Filter by source registry (case-insensitive substring).
+                countries:
+                  type: string
+                  description: Raw-text case-insensitive substring filter on the registry's
+                    own countries string — free text, so it silently misses spelling/format
+                    variants across registries. See country for the normalized equivalent.
+                country:
+                  type: string
+                  description: Match against one or more normalized country codes
+                    (ISO 3166-1 alpha-2), comma-separated, OR semantics (e.g. ?country=DE
+                    or ?country=DE,FR), derived from every source's raw country data.
+                region:
+                  type: string
+                  description: 'Exact match against a normalized region derived from
+                    the trial''s countries; one of: africa, asia, europe, north_america,
+                    south_america, oceania (e.g. ?region=europe).'
+                condition:
+                  type: string
+                  description: Filter by medical condition (case-insensitive substring).
+                intervention:
+                  type: string
+                  description: Filter by intervention type (case-insensitive substring).
+                therapeutic_areas:
+                  type: string
+                  description: Filter by therapeutic areas (case-insensitive substring).
+                inclusion_agemin:
+                  type: string
+                  description: Exact match against the raw inclusion age-minimum criteria
+                    string. Prefer age_eligible for a numeric range check.
+                inclusion_agemax:
+                  type: string
+                  description: Exact match against the raw inclusion age-maximum criteria
+                    string. Prefer age_eligible for a numeric range check.
+                age_eligible:
+                  type: number
+                  description: Trials whose eligible age range (inclusion_age_min_years...inclusion_age_max_years,
+                    in years) includes this age, e.g. ?age_eligible=40. A null min
+                    is treated as no lower bound; a null max as no upper bound.
+                inclusion_gender_normalized:
+                  type: string
+                  description: 'Exact match against canonical sex eligibility; one
+                    of: all, female, male. Replaces the removed legacy inclusion_gender
+                    substring filter, which returned confidently wrong results (?inclusion_gender=Female
+                    matched "Female, Male", a both-sexes trial). **Breaking change
+                    (2026-07-20):** ?inclusion_gender=... is no longer a recognised
+                    parameter and is silently ignored (unfiltered results), not rejected
+                    — see docs/trials-field-normalization.md.'
+                has_results:
+                  type: boolean
+                  description: true/false; a trial counts as having results when any
+                    of results_posted, results completion date, results link, or results-available
+                    = "Yes" is set.
+                date_registration_after:
+                  type: string
+                  format: date
+                  description: Trials registered on or after this date (YYYY-MM-DD,
+                    inclusive). Invalid or non-ISO-8601 dates return 400 Bad Request.
+                date_registration_before:
+                  type: string
+                  format: date
+                  description: Trials registered on or before this date (YYYY-MM-DD,
+                    inclusive). Invalid or non-ISO-8601 dates return 400 Bad Request.
+                subjects:
+                  type: array
+                  items:
+                    type: string
+                  description: Comma-separated list of subject IDs with AND semantics
+                    — returns only trials tagged with *all* listed subjects, e.g.
+                    ?subjects=1,2.
+                subjects_any:
+                  type: array
+                  items:
+                    type: string
+                  description: Comma-separated list of subject IDs with OR semantics
+                    — returns trials tagged with *any* of the listed subjects, e.g.
+                    ?subjects_any=1,2.
+              required:
+              - team_id
+              - subject_id
+              description: Every TrialFilter field is accepted here (identical semantics
+                to the matching GET query parameter — see /trials/). team_id and subject_id
+                are required.
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+            text/csv:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /trials/sites/:
+    get:
+      operationId: trials_sites_list
+      description: |-
+        Flat, paginated listing of TrialSite rows across the filtered trial set —
+        accepts the same query parameters as the list endpoint (team_id,
+        subject_id, country, recruitment_status_normalized, …), so the map reuses
+        the same filter rail. Rows are ``{trial_id, name, city, country, latitude,
+        longitude}`` — no per-trial nesting; see TrialDetailSerializer for that.
+
+        ``?all_results=true`` is rejected (400): unlike ``/trials/``, this endpoint
+        is never a bulk export — at mean ~12 sites/trial an unfiltered request over
+        a several-thousand-trial subject would be tens of thousands of rows.
+        ``?latitude__isnull=true`` (or ``1``/``yes``) narrows to sites without
+        coordinates (all CTIS sites, currently — see TRIAL-GEOGRAPHY-PLAN.md PR
+        G2); ``=false`` (or ``0``/``no``) narrows to sites with a pin. Any other
+        value is rejected (400).
+      parameters:
+      - in: query
+        name: acronym
+        schema:
+          type: array
+          items:
+            type: string
+            nullable: true
+        description: Trial acronym(s), comma-separated, matches any (case-insensitive),
+          e.g. ?acronym=ReCOVER,MODIF-MS.
+        explode: false
+        style: form
+      - in: query
+        name: age_eligible
+        schema:
+          type: number
+        description: Trials whose eligible age range (inclusion_age_min_years...inclusion_age_max_years,
+          in years) includes this age, e.g. ?age_eligible=40. A null min is treated
+          as no lower bound; a null max as no upper bound.
+      - in: query
+        name: category_id
+        schema:
+          type: integer
+        description: Filter by category ID (see /categories/).
+      - in: query
+        name: category_modality
+        schema:
+          type: string
+          nullable: true
+          enum:
+          - biologic_antibody
+          - cell_gene_therapy
+          - device_neuromodulation
+          - natural_product
+          - other
+          - rehabilitation
+          - research_topic
+          - small_molecule
+        description: |-
+          Filter by the intervention modality of the trial's categories; one of the CategoryModality values.
+
+          * `small_molecule` - Small-molecule drug
+          * `biologic_antibody` - Antibody / biologic
+          * `cell_gene_therapy` - Cell / gene therapy
+          * `rehabilitation` - Rehabilitation / physical
+          * `device_neuromodulation` - Device / neuromodulation
+          * `natural_product` - Natural product / supplement
+          * `research_topic` - Research topic (not an intervention)
+          * `other` - Other
+      - in: query
+        name: category_slug
+        schema:
+          type: string
+        description: Filter by category slug (see /categories/).
+      - in: query
+        name: condition
+        schema:
+          type: string
+        description: Filter by medical condition (case-insensitive substring).
+      - in: query
+        name: countries
+        schema:
+          type: string
+        description: Raw-text case-insensitive substring filter on the registry's
+          own countries string — free text, so it silently misses spelling/format
+          variants across registries. See country for the normalized equivalent.
+      - in: query
+        name: country
+        schema:
+          type: string
+        description: Match against one or more normalized country codes (ISO 3166-1
+          alpha-2), comma-separated, OR semantics (e.g. ?country=DE or ?country=DE,FR),
+          derived from every source's raw country data.
+      - in: query
+        name: ctis
+        schema:
+          type: array
+          items:
+            type: string
+        description: CTIS number(s), comma-separated, matches any (case-insensitive).
+        explode: false
+        style: form
+      - in: query
+        name: date_registration_after
+        schema:
+          type: string
+          format: date
+        description: Trials registered on or after this date (YYYY-MM-DD, inclusive).
+          Invalid or non-ISO-8601 dates return 400 Bad Request.
+      - in: query
+        name: date_registration_before
+        schema:
+          type: string
+          format: date
+        description: Trials registered on or before this date (YYYY-MM-DD, inclusive).
+          Invalid or non-ISO-8601 dates return 400 Bad Request.
+      - in: query
+        name: euct
+        schema:
+          type: array
+          items:
+            type: string
+        description: EU CT / EUCTR number(s), comma-separated, matches any (case-insensitive).
+          Matches either the euct or euctr identifier key.
+        explode: false
+        style: form
+      - in: query
+        name: eudract
+        schema:
+          type: array
+          items:
+            type: string
+        description: EudraCT number(s), comma-separated, matches any (case-insensitive).
+        explode: false
+        style: form
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      - in: query
+        name: has_results
+        schema:
+          type: boolean
+        description: true/false; a trial counts as having results when any of results_posted,
+          results completion date, results link, or results-available = "Yes" is set.
+      - in: query
+        name: identifiers
+        schema:
+          type: array
+          items:
+            nullable: true
+        description: Mixed list of registry identifiers, comma-separated, matched
+          across all registry keys at once (NCT/EudraCT/EUCT/EUCTR/CTIS), case-insensitive,
+          e.g. ?identifiers=NCT02521311,2020-001234-12. Acronyms are excluded (not
+          unique) — use acronym for those.
+        explode: false
+        style: form
+      - in: query
+        name: inclusion_agemax
+        schema:
+          type: string
+        description: Exact match against the raw inclusion age-maximum criteria string.
+          Prefer age_eligible for a numeric range check.
+      - in: query
+        name: inclusion_agemin
+        schema:
+          type: string
+        description: Exact match against the raw inclusion age-minimum criteria string.
+          Prefer age_eligible for a numeric range check.
+      - in: query
+        name: inclusion_gender_normalized
+        schema:
+          type: string
+          nullable: true
+          enum:
+          - all
+          - female
+          - male
+        description: |-
+          Exact match against canonical sex eligibility; one of: all, female, male. Replaces the removed legacy inclusion_gender substring filter, which returned confidently wrong results (?inclusion_gender=Female matched "Female, Male", a both-sexes trial). **Breaking change (2026-07-20):** ?inclusion_gender=... is no longer a recognised parameter and is silently ignored (unfiltered results), not rejected — see docs/trials-field-normalization.md.
+
+          * `all` - All sexes
+          * `female` - Female only
+          * `male` - Male only
+      - in: query
+        name: internal_number
+        schema:
+          type: string
+        description: Filter by WHO internal number (case-insensitive substring).
+      - in: query
+        name: intervention
+        schema:
+          type: string
+        description: Filter by intervention type (case-insensitive substring).
+      - in: query
+        name: latitude__isnull
+        schema:
+          type: boolean
+        description: Narrow to sites without coordinates (true/1/yes) or with a pin
+          (false/0/no). Any other value is rejected (400).
+      - in: query
+        name: nct
+        schema:
+          type: array
+          items:
+            type: string
+        description: ClinicalTrials.gov NCT id(s), comma-separated, matches any (case-insensitive),
+          e.g. ?nct=NCT02521311,NCT06065670.
+        explode: false
+        style: form
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: phase
+        schema:
+          type: string
+        description: Raw-text contains filter on the registry's own phase string (Phase
+          I, II, III, etc.) — free text, so it silently misses spelling/format variants
+          (e.g. "Phase III" vs "Phase 3"). Prefer phase_normalized.
+      - in: query
+        name: phase_normalized
+        schema:
+          type: array
+          items:
+            type: string
+            nullable: true
+            enum:
+            - early_phase_1
+            - not_applicable
+            - other
+            - phase_1
+            - phase_1_2
+            - phase_2
+            - phase_2_3
+            - phase_3
+            - phase_3_4
+            - phase_4
+            - post_market
+        description: |-
+          Exact match against the canonical phase; accepts one or more comma-separated values (OR semantics). One of: early_phase_1, phase_1, phase_1_2, phase_2, phase_2_3, phase_3, phase_3_4, phase_4, post_market, not_applicable, other.
+
+          * `early_phase_1` - Early Phase 1
+          * `phase_1` - Phase 1
+          * `phase_1_2` - Phase 1/2
+          * `phase_2` - Phase 2
+          * `phase_2_3` - Phase 2/3
+          * `phase_3` - Phase 3
+          * `phase_3_4` - Phase 3/4
+          * `phase_4` - Phase 4
+          * `post_market` - Post-market
+          * `not_applicable` - Not applicable
+          * `other` - Other
+        explode: false
+        style: form
+      - in: query
+        name: primary_sponsor
+        schema:
+          type: string
+        description: Legacy free-text case-insensitive substring filter on the raw
+          registry sponsor string — silently misses spelling/duplicate variants across
+          registries; prefer sponsor_id/sponsor_slug.
+      - in: query
+        name: recruitment_status
+        schema:
+          type: string
+        description: Raw-text case-insensitive exact match against the registry's
+          own recruitment-status string (e.g. "Recruiting" matches "RECRUITING" but
+          not "Not Recruiting") — free text, so it silently misses spelling/format
+          variants across registries. Prefer recruitment_status_normalized.
+      - in: query
+        name: recruitment_status_normalized
+        schema:
+          type: array
+          items:
+            type: string
+            nullable: true
+            enum:
+            - active_not_recruiting
+            - completed
+            - enrolling_by_invitation
+            - not_recruiting
+            - not_yet_recruiting
+            - other
+            - recruiting
+            - suspended
+            - terminated
+            - unknown
+            - withdrawn
+        description: |-
+          Exact match against the canonical recruitment status; accepts one or more comma-separated values (OR semantics). One of: not_yet_recruiting, recruiting, enrolling_by_invitation, active_not_recruiting, not_recruiting, suspended, completed, terminated, withdrawn, unknown, other.
+
+          * `not_yet_recruiting` - Not yet recruiting
+          * `recruiting` - Recruiting
+          * `enrolling_by_invitation` - Enrolling by invitation
+          * `active_not_recruiting` - Active, not recruiting
+          * `not_recruiting` - Not recruiting
+          * `suspended` - Suspended
+          * `completed` - Completed
+          * `terminated` - Terminated
+          * `withdrawn` - Withdrawn
+          * `unknown` - Unknown
+          * `other` - Other
+        explode: false
+        style: form
+      - in: query
+        name: region
+        schema:
+          type: string
+          enum:
+          - africa
+          - asia
+          - europe
+          - north_america
+          - oceania
+          - south_america
+        description: |-
+          Exact match against a normalized region derived from the trial's countries; one of: africa, asia, europe, north_america, south_america, oceania (e.g. ?region=europe).
+
+          * `africa` - Africa
+          * `asia` - Asia
+          * `europe` - Europe
+          * `north_america` - North America
+          * `south_america` - South America
+          * `oceania` - Oceania
+      - in: query
+        name: search
+        schema:
+          type: string
+        description: Boolean search across title and summary. Bare terms are AND-ed;
+          uppercase OR/NOT and "quoted phrases" are supported.
+      - in: query
+        name: site_id
+        schema:
+          type: number
+        description: Filter by Django Site ID; returns trials belonging to any team
+          attached to that site (see Team.site).
+      - in: query
+        name: source_id
+        schema:
+          type: integer
+        description: Filter by source ID (see /sources/).
+      - in: query
+        name: source_register
+        schema:
+          type: string
+        description: Filter by source registry (case-insensitive substring).
+      - in: query
+        name: sponsor_id
+        schema:
+          type: number
+        description: Exact match against a canonical sponsor's id (see /sponsors/).
+      - in: query
+        name: sponsor_slug
+        schema:
+          type: string
+        description: Exact match against a canonical sponsor's slug (see /sponsors/).
+      - in: query
+        name: status
+        schema:
+          type: string
+        description: Legacy alias for recruitment_status — same raw-text, case-insensitive
+          exact match. Prefer recruitment_status_normalized.
+      - in: query
+        name: study_type
+        schema:
+          type: string
+        description: Legacy free-text case-insensitive substring filter on the raw
+          registry study-type string — can both overmatch and undermatch across registries
+          (e.g. matches "Interventional clinical trial of medicinal product" but misses
+          "Intervention"); prefer study_type_normalized.
+      - in: query
+        name: study_type_normalized
+        schema:
+          type: string
+          nullable: true
+          enum:
+          - basic_science
+          - expanded_access
+          - interventional
+          - observational
+          - other
+        description: |-
+          Exact match against the canonical study type; one of: interventional, observational, expanded_access, basic_science, other.
+
+          * `interventional` - Interventional
+          * `observational` - Observational
+          * `expanded_access` - Expanded access
+          * `basic_science` - Basic science
+          * `other` - Other
+      - in: query
+        name: subject_id
+        schema:
+          type: integer
+        description: Filter by subject ID (see /subjects/).
+      - in: query
+        name: subjects
+        schema:
+          type: array
+          items:
+            type: integer
+        description: Comma-separated list of subject IDs with AND semantics — returns
+          only trials tagged with *all* listed subjects, e.g. ?subjects=1,2.
+        explode: false
+        style: form
+      - in: query
+        name: subjects_any
+        schema:
+          type: array
+          items:
+            type: string
+        description: Comma-separated list of subject IDs with OR semantics — returns
+          trials tagged with *any* of the listed subjects, e.g. ?subjects_any=1,2.
+        explode: false
+        style: form
+      - in: query
+        name: summary
+        schema:
+          type: string
+        description: Case-insensitive substring match against the summary only.
+      - in: query
+        name: team_id
+        schema:
+          type: integer
+        description: Filter by team ID.
+      - in: query
+        name: therapeutic_areas
+        schema:
+          type: string
+        description: Filter by therapeutic areas (case-insensitive substring).
+      - in: query
+        name: title
+        schema:
+          type: string
+        description: Case-insensitive substring match against the title only.
+      - in: query
+        name: trial_id
+        schema:
+          type: integer
+        description: Filter by a specific trial ID.
+      tags:
+      - trials
+      security:
+      - {}
+      - basicAuth: []
+      - jwtAuth: []
+      - cookieAuth: []
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedTrialSiteRowList'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/PaginatedTrialSiteRowList'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
+  /trials/stats/:
+    get:
+      operationId: trials_stats_retrieve
+      description: |-
+        Recruitment-status totals (by ``recruitment_status_normalized``) over the
+        filtered queryset.
+
+        Accepts the same query parameters as the list endpoint (team_id,
+        subject_id, recruitment_status_normalized, search, registry identifiers, …)
+        and the same org-visibility scoping, so the totals always match what the
+        equivalent list request would return. Cached server-side; see
+        ``CachedStatsActionMixin``.
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - trials
+      security:
+      - {}
+      - basicAuth: []
+      - jwtAuth: []
+      - cookieAuth: []
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrialsStats'
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/TrialsStats'
+          description: ''
+components:
+  schemas:
+    AccessEnum:
+      enum:
+      - unknown
+      - open
+      - restricted
+      type: string
+      description: |-
+        * `unknown` - Unknown
+        * `open` - Open
+        * `restricted` - Restricted
+    AlgorithmEnum:
+      enum:
+      - pubmed_bert
+      - lgbm_tfidf
+      - lstm
+      - unknown
+      type: string
+      description: |-
+        * `pubmed_bert` - PubMed BERT
+        * `lgbm_tfidf` - LGBM TF-IDF
+        * `lstm` - LSTM
+        * `unknown` - Unknown
+    Article:
+      type: object
+      description: |-
+        Mixin for DRF serializers that strips nested associations belonging to
+        organisations the caller cannot see.
+
+        Usage::
+
+            class ArticleSerializer(OrgScopedSerializerMixin,
+                                    serializers.HyperlinkedModelSerializer):
+                ...
+
+        Set ``_per_org_fields`` to a list of field names that should be omitted
+        entirely when there is no organisation context (spec §6.2).
+      properties:
+        article_id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+        summary:
+          type: string
+          nullable: true
+        summary_plain_english:
+          type: string
+          nullable: true
+          description: Return plain-English summary from ArticleOrgContent for the
+            caller's org, or None.
+          readOnly: true
+        link:
+          type: string
+          format: uri
+          description: First URL seen for this article; stable after first import.
+            Corresponds to "link" in the API response.
+          maxLength: 2000
+        links:
+          nullable: true
+          description: All known URLs for this article, keyed by registry slug (e.g.
+            "ctgov") for known registries or by hostname otherwise. Managed automatically.
+            Corresponds to "links" in the API response.
+        published_date:
+          type: string
+          format: date-time
+          nullable: true
+        sources:
+          type: array
+          items:
+            type: string
+            nullable: true
+          readOnly: true
+        teams:
+          type: array
+          items:
+            $ref: '#/components/schemas/Team'
+          readOnly: true
+        subjects:
+          type: array
+          items:
+            $ref: '#/components/schemas/Subjects'
+          readOnly: true
+        publisher:
+          type: string
+          nullable: true
+          maxLength: 150
+        container_title:
+          type: string
+          nullable: true
+          maxLength: 150
+        authors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArticleAuthor'
+          readOnly: true
+        discovery_date:
+          type: string
+          format: date-time
+          readOnly: true
+        article_subject_relevances:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArticleSubjectRelevance'
+          readOnly: true
+        doi:
+          type: string
+          nullable: true
+          maxLength: 280
+        access:
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/AccessEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        takeaways:
+          type: string
+          nullable: true
+          description: Return takeaways from ArticleOrgContent for the caller's org,
+            or None.
+          readOnly: true
+        team_categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/TeamCategory'
+          readOnly: true
+        ml_predictions:
+          type: array
+          items:
+            $ref: '#/components/schemas/MLPredictions'
+          readOnly: true
+        ml_score:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+          description: Average ML probability score across the latest prediction per
+            (algorithm, subject) pair. Updated automatically when predictions are
+            saved.
+        clinical_trials:
+          type: array
+          items: {}
+          description: Get trials referenced in the article
+          readOnly: true
+      required:
+      - article_id
+      - article_subject_relevances
+      - authors
+      - clinical_trials
+      - discovery_date
+      - link
+      - ml_predictions
+      - ml_score
+      - sources
+      - subjects
+      - summary_plain_english
+      - takeaways
+      - team_categories
+      - teams
+      - title
+    ArticleAuthor:
+      type: object
+      properties:
+        author_id:
+          type: integer
+          readOnly: true
+        given_name:
+          type: string
+          maxLength: 150
+        family_name:
+          type: string
+          maxLength: 150
+        full_name:
+          type: string
+          readOnly: true
+        ORCID:
+          type: string
+          nullable: true
+          maxLength: 150
+        country:
+          type: string
+          nullable: true
+          readOnly: true
+      required:
+      - author_id
+      - country
+      - family_name
+      - full_name
+      - given_name
+    ArticleSubjectRelevance:
+      type: object
+      properties:
+        subject:
+          allOf:
+          - $ref: '#/components/schemas/Subjects'
+          readOnly: true
+        subject_id:
+          type: integer
+          writeOnly: true
+        is_relevant:
+          type: boolean
+          nullable: true
+          description: Indicates if the article is relevant for the subject. NULL
+            means not reviewed.
+      required:
+      - subject
+      - subject_id
+    ArticlesByAccess:
+      type: object
+      properties:
+        open:
+          type: integer
+        restricted:
+          type: integer
+        unknown:
+          type: integer
+      required:
+      - open
+      - restricted
+      - unknown
+    ArticlesStats:
+      type: object
+      description: Response of ``GET /articles/stats/`` — see ArticleViewSet.build_stats_payload.
+      properties:
+        total:
+          type: integer
+          description: Distinct articles matching the filtered queryset.
+        by_access:
+          $ref: '#/components/schemas/ArticlesByAccess'
+        relevant:
+          type: integer
+          description: Count matching the same semantics as ?relevant=true on the
+            list endpoint.
+        retracted:
+          type: integer
+        missing_doi:
+          type: integer
+        by_subject:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubjectCount'
+      required:
+      - by_access
+      - by_subject
+      - missing_doi
+      - relevant
+      - retracted
+      - total
+    Author:
+      type: object
+      properties:
+        author_id:
+          type: integer
+          readOnly: true
+        given_name:
+          type: string
+          maxLength: 150
+        family_name:
+          type: string
+          maxLength: 150
+        full_name:
+          type: string
+          nullable: true
+          description: Auto-generated from given_name and family_name
+          maxLength: 301
+        ORCID:
+          type: string
+          nullable: true
+          maxLength: 150
+        country:
+          type: string
+          nullable: true
+          readOnly: true
+        biography:
+          type: string
+          nullable: true
+        credit_name:
+          type: string
+          nullable: true
+          description: Researcher's preferred display name from ORCID (person.name.credit-name).
+          maxLength: 301
+        orcid_keywords:
+          description: Research keywords from ORCID.
+        external_ids:
+          description: External identifiers from ORCID, e.g. [{'type', 'value', 'url'}].
+        researcher_urls:
+          description: Researcher URLs from ORCID, e.g. [{'name', 'url'}].
+        current_affiliation:
+          type: string
+          nullable: true
+          description: Organization name of the author's current (or most recent)
+            employment from ORCID.
+          maxLength: 255
+        orcid_claimed:
+          type: boolean
+          nullable: true
+          description: Whether the ORCID record has been claimed by the researcher.
+        orcid_verified_email:
+          type: boolean
+          nullable: true
+          description: Whether the ORCID record has a verified email.
+        articles_count:
+          type: integer
+          readOnly: true
+        relevant_articles_count:
+          type: integer
+          readOnly: true
+        articles_list:
+          type: string
+          readOnly: true
+      required:
+      - articles_count
+      - articles_list
+      - author_id
+      - country
+      - family_name
+      - given_name
+      - relevant_articles_count
+    BlankEnum:
+      enum:
+      - ''
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        category_description:
+          type: string
+          nullable: true
+        category_name:
+          type: string
+          maxLength: 200
+        category_slug:
+          nullable: true
+          oneOf:
+          - type: string
+            maxLength: 50
+            pattern: ^[-a-zA-Z0-9_]+$
+          - type: string
+            maxLength: 0
+        category_terms:
+          type: array
+          items:
+            type: string
+            maxLength: 100
+          title: Terms to include in category (comma separated)
+          description: Add terms separated by commas.
+        modality:
+          nullable: true
+          description: |-
+            Intervention modality group. Curated by hand (seeded by sync_category_modalities); null means not yet classified.
+
+            * `small_molecule` - Small-molecule drug
+            * `biologic_antibody` - Antibody / biologic
+            * `cell_gene_therapy` - Cell / gene therapy
+            * `rehabilitation` - Rehabilitation / physical
+            * `device_neuromodulation` - Device / neuromodulation
+            * `natural_product` - Natural product / supplement
+            * `research_topic` - Research topic (not an intervention)
+            * `other` - Other
+          oneOf:
+          - $ref: '#/components/schemas/ModalityEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        article_count_total:
+          type: integer
+          description: |-
+            Prefer the queryset's Count(..., distinct=True) annotation; fall
+            back to a live count for an un-annotated instance (e.g. built
+            directly in a test).
+          readOnly: true
+        trials_count_total:
+          type: integer
+          description: |-
+            Prefer the queryset's Count(..., distinct=True) annotation; fall
+            back to a live count for an un-annotated instance.
+          readOnly: true
+        authors_count:
+          type: integer
+          description: Optimized authors count avoiding complex JOINs
+          readOnly: true
+        top_authors:
+          type: array
+          items: {}
+          description: Optimized top authors calculation avoiding complex JOINs
+          readOnly: true
+        monthly_counts:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          description: Get monthly counts of articles and trials when requested
+          readOnly: true
+      required:
+      - article_count_total
+      - authors_count
+      - category_name
+      - id
+      - monthly_counts
+      - top_authors
+      - trials_count_total
+    CategoryTypeEnum:
+      enum:
+      - manual
+      - automatic
+      type: string
+      description: |-
+        * `manual` - Manual
+        * `automatic` - Automatic
+    ErrorResponse:
+      type: object
+      description: 'Generic ``{"error": "..."}`` shape used by hand-written error
+        responses.'
+      properties:
+        error:
+          type: string
+      required:
+      - error
+    GlobalStats:
+      type: object
+      description: Response of ``GET /stats/`` — see StatsView.get.
+      properties:
+        articles:
+          type: integer
+        trials:
+          type: integer
+        subscribers:
+          type: integer
+        authors:
+          type: integer
+        sources:
+          $ref: '#/components/schemas/GlobalStatsSources'
+        by_subject:
+          type: array
+          items:
+            $ref: '#/components/schemas/GlobalStatsBySubject'
+          description: Present only when ?subject= is given — every in-scope subject,
+            including zero-count ones.
+      required:
+      - articles
+      - authors
+      - by_subject
+      - sources
+      - subscribers
+      - trials
+    GlobalStatsByDomain:
+      type: object
+      properties:
+        domain:
+          type: string
+        count:
+          type: integer
+      required:
+      - count
+      - domain
+    GlobalStatsBySubject:
+      type: object
+      properties:
+        subject_id:
+          type: integer
+        subject_name:
+          type: string
+        articles:
+          type: integer
+        trials:
+          type: integer
+        authors:
+          type: integer
+        sources:
+          type: integer
+      required:
+      - articles
+      - authors
+      - sources
+      - subject_id
+      - subject_name
+      - trials
+    GlobalStatsSources:
+      type: object
+      properties:
+        total:
+          type: integer
+          description: Distinct source domains.
+        by_type:
+          type: object
+          additionalProperties:
+            type: integer
+          description: '{source_for: distinct domain count}'
+        by_domain:
+          type: array
+          items:
+            $ref: '#/components/schemas/GlobalStatsByDomain'
+      required:
+      - by_domain
+      - by_type
+      - total
+    MLPredictionSubject:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        subject_name:
+          type: string
+          maxLength: 50
+        description:
+          type: string
+          nullable: true
+      required:
+      - id
+      - subject_name
+    MLPredictions:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        algorithm:
+          allOf:
+          - $ref: '#/components/schemas/AlgorithmEnum'
+          description: |-
+            ML algorithm used for prediction
+
+            * `pubmed_bert` - PubMed BERT
+            * `lgbm_tfidf` - LGBM TF-IDF
+            * `lstm` - LSTM
+            * `unknown` - Unknown
+        model_version:
+          type: string
+          nullable: true
+          description: Version identifier of the ML model used
+          maxLength: 100
+        probability_score:
+          type: number
+          format: double
+          nullable: true
+          description: Probability score from the ML model prediction
+        predicted_relevant:
+          type: boolean
+          nullable: true
+          description: Whether the ML model predicted this article as relevant
+        created_date:
+          type: string
+          format: date-time
+          readOnly: true
+        subject:
+          allOf:
+          - $ref: '#/components/schemas/MLPredictionSubject'
+          readOnly: true
+      required:
+      - created_date
+      - id
+      - subject
+    ModalityEnum:
+      enum:
+      - small_molecule
+      - biologic_antibody
+      - cell_gene_therapy
+      - rehabilitation
+      - device_neuromodulation
+      - natural_product
+      - research_topic
+      - other
+      type: string
+      description: |-
+        * `small_molecule` - Small-molecule drug
+        * `biologic_antibody` - Antibody / biologic
+        * `cell_gene_therapy` - Cell / gene therapy
+        * `rehabilitation` - Rehabilitation / physical
+        * `device_neuromodulation` - Device / neuromodulation
+        * `natural_product` - Natural product / supplement
+        * `research_topic` - Research topic (not an intervention)
+        * `other` - Other
+    NullEnum:
+      enum:
+      - null
+    PaginatedArticleList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Article'
+    PaginatedAuthorList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Author'
+    PaginatedCategoryList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Category'
+    PaginatedSourceList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Source'
+    PaginatedSponsorList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Sponsor'
+    PaginatedSubjectsList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Subjects'
+    PaginatedTeamList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Team'
+    PaginatedTrialList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Trial'
+    PaginatedTrialSiteRowList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrialSiteRow'
+    Source:
+      type: object
+      properties:
+        source_id:
+          type: integer
+          readOnly: true
+        source_for:
+          $ref: '#/components/schemas/SourceForEnum'
+        name:
+          type: string
+          nullable: true
+          maxLength: 255
+        description:
+          type: string
+          nullable: true
+        link:
+          nullable: true
+          oneOf:
+          - type: string
+            format: uri
+            maxLength: 2000
+          - type: string
+            maxLength: 0
+        subject_id:
+          type: integer
+          nullable: true
+          readOnly: true
+        team_id:
+          type: integer
+          nullable: true
+          readOnly: true
+      required:
+      - source_id
+      - subject_id
+      - team_id
+    SourceForEnum:
+      enum:
+      - science paper
+      - trials
+      - news article
+      type: string
+      description: |-
+        * `science paper` - Science Paper
+        * `trials` - Trials
+        * `news article` - News Article
+    Sponsor:
+      type: object
+      description: |-
+        Used by SponsorViewSet (``/sponsors/``). ``trials_count`` is populated by an
+        annotation on the viewset's queryset, not a model field.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        slug:
+          type: string
+          maxLength: 200
+          pattern: ^[-a-zA-Z0-9_]+$
+        name:
+          type: string
+          maxLength: 500
+        sponsor_type:
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/SponsorTypeEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        trials_count:
+          type: integer
+          readOnly: true
+      required:
+      - id
+      - name
+      - slug
+      - trials_count
+    SponsorTypeEnum:
+      enum:
+      - industry
+      - academic_medical
+      - government
+      - nonprofit
+      - other
+      type: string
+      description: |-
+        * `industry` - Industry
+        * `academic_medical` - Academic / medical
+        * `government` - Government
+        * `nonprofit` - Non-profit / patient organisation
+        * `other` - Other
+    StatusEnum:
+      enum:
+      - not_yet_recruiting
+      - recruiting
+      - enrolling_by_invitation
+      - active_not_recruiting
+      - not_recruiting
+      - suspended
+      - completed
+      - terminated
+      - withdrawn
+      - unknown
+      - other
+      type: string
+      description: |-
+        * `not_yet_recruiting` - Not yet recruiting
+        * `recruiting` - Recruiting
+        * `enrolling_by_invitation` - Enrolling by invitation
+        * `active_not_recruiting` - Active, not recruiting
+        * `not_recruiting` - Not recruiting
+        * `suspended` - Suspended
+        * `completed` - Completed
+        * `terminated` - Terminated
+        * `withdrawn` - Withdrawn
+        * `unknown` - Unknown
+        * `other` - Other
+    SubjectCount:
+      type: object
+      properties:
+        subject_id:
+          type: integer
+        subject_name:
+          type: string
+        count:
+          type: integer
+      required:
+      - count
+      - subject_id
+      - subject_name
+    Subjects:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        subject_name:
+          type: string
+          maxLength: 50
+        description:
+          type: string
+          nullable: true
+        team_id:
+          type: integer
+          readOnly: true
+      required:
+      - id
+      - subject_name
+      - team_id
+    Team:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          description: Team name within the organization
+          maxLength: 200
+        slug:
+          type: string
+          maxLength: 50
+          pattern: ^[-a-zA-Z0-9_]+$
+        organization:
+          type: integer
+        is_active:
+          type: boolean
+          description: 'Inactive teams are soft-deleted: their data is preserved and
+            can be reassigned to another team.'
+      required:
+      - id
+      - name
+      - organization
+      - slug
+    TeamCategory:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        category_name:
+          type: string
+          maxLength: 200
+        category_description:
+          type: string
+          nullable: true
+        category_slug:
+          nullable: true
+          oneOf:
+          - type: string
+            maxLength: 50
+            pattern: ^[-a-zA-Z0-9_]+$
+          - type: string
+            maxLength: 0
+        category_terms:
+          type: array
+          items:
+            type: string
+            maxLength: 100
+          title: Terms to include in category (comma separated)
+          description: Add terms separated by commas.
+        category_type:
+          allOf:
+          - $ref: '#/components/schemas/CategoryTypeEnum'
+          description: |-
+            Automatic categories are populated by the rebuild_categories command from the term list (manual assignments are still allowed and preserved). Manual categories are curated entirely by hand and are never touched by the command.
+
+            * `manual` - Manual
+            * `automatic` - Automatic
+        modality:
+          nullable: true
+          description: |-
+            Intervention modality group. Curated by hand (seeded by sync_category_modalities); null means not yet classified.
+
+            * `small_molecule` - Small-molecule drug
+            * `biologic_antibody` - Antibody / biologic
+            * `cell_gene_therapy` - Cell / gene therapy
+            * `rehabilitation` - Rehabilitation / physical
+            * `device_neuromodulation` - Device / neuromodulation
+            * `natural_product` - Natural product / supplement
+            * `research_topic` - Research topic (not an intervention)
+            * `other` - Other
+          oneOf:
+          - $ref: '#/components/schemas/ModalityEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+          - $ref: '#/components/schemas/NullEnum'
+      required:
+      - category_name
+      - id
+    TokenObtainPair:
+      type: object
+      properties:
+        username:
+          type: string
+          writeOnly: true
+        password:
+          type: string
+          writeOnly: true
+        access:
+          type: string
+          readOnly: true
+        refresh:
+          type: string
+          readOnly: true
+      required:
+      - access
+      - password
+      - refresh
+      - username
+    Trial:
+      type: object
+      description: |-
+        Mixin for DRF serializers that strips nested associations belonging to
+        organisations the caller cannot see.
+
+        Usage::
+
+            class ArticleSerializer(OrgScopedSerializerMixin,
+                                    serializers.HyperlinkedModelSerializer):
+                ...
+
+        Set ``_per_org_fields`` to a list of field names that should be omitted
+        entirely when there is no organisation context (spec §6.2).
+      properties:
+        trial_id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+        summary:
+          type: string
+          nullable: true
+        summary_plain_english:
+          type: string
+          nullable: true
+          description: Return plain-English summary from TrialOrgContent for the caller's
+            org, or None.
+          readOnly: true
+        ctg_detailed_description:
+          type: string
+          nullable: true
+          description: Detailed description from ClinicalTrials.gov API
+        published_date:
+          type: string
+          format: date-time
+          nullable: true
+        discovery_date:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        last_updated:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        link:
+          type: string
+          format: uri
+          maxLength: 2000
+        links:
+          nullable: true
+          description: Registry URLs keyed by registry slug; "link" holds the canonical
+            one
+        sources:
+          type: array
+          items:
+            type: string
+            nullable: true
+          readOnly: true
+        identifiers:
+          nullable: true
+        team_categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/TeamCategory'
+          readOnly: true
+        export_date:
+          type: string
+          format: date-time
+          nullable: true
+        internal_number:
+          type: string
+          nullable: true
+          maxLength: 100
+        last_refreshed_on:
+          type: string
+          format: date
+          nullable: true
+        acronym:
+          type: string
+          nullable: true
+          maxLength: 200
+        scientific_title:
+          type: string
+          nullable: true
+        primary_sponsor:
+          type: string
+          nullable: true
+        secondary_sponsor:
+          type: string
+          nullable: true
+        sponsor_type:
+          type: string
+          nullable: true
+          maxLength: 500
+        sponsor:
+          allOf:
+          - $ref: '#/components/schemas/TrialSponsor'
+          readOnly: true
+        prospective_registration:
+          type: string
+          nullable: true
+          maxLength: 10
+        date_registration:
+          type: string
+          format: date
+          nullable: true
+        source_register:
+          type: string
+          nullable: true
+          maxLength: 200
+        recruitment_status:
+          type: string
+          nullable: true
+          maxLength: 200
+        recruitment_status_normalized:
+          type: string
+          readOnly: true
+          nullable: true
+          description: Canonical recruitment status derived from the raw 'recruitment_status'
+            value; recomputed on every save.
+        other_records:
+          type: string
+          nullable: true
+          maxLength: 200
+        inclusion_agemin:
+          type: string
+          nullable: true
+          maxLength: 100
+        inclusion_agemax:
+          type: string
+          nullable: true
+          maxLength: 100
+        inclusion_age_min_years:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+          description: Canonical minimum eligible age in years, derived from 'inclusion_agemin';
+            recomputed on every save.
+        inclusion_age_max_years:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+          description: Canonical maximum eligible age in years, derived from 'inclusion_agemax';
+            recomputed on every save.
+        inclusion_gender:
+          type: string
+          nullable: true
+          maxLength: 500
+        inclusion_gender_normalized:
+          type: string
+          readOnly: true
+          nullable: true
+          description: Canonical sex eligibility (all/female/male) derived from the
+            raw 'inclusion_gender' value; recomputed on every save.
+        date_enrollement:
+          type: string
+          format: date
+          nullable: true
+        target_size:
+          type: string
+          nullable: true
+        study_type:
+          type: string
+          nullable: true
+        study_type_normalized:
+          type: string
+          readOnly: true
+          nullable: true
+          description: Canonical study type derived from the raw 'study_type' value;
+            recomputed on every save.
+        study_design:
+          type: string
+          nullable: true
+        phase:
+          type: string
+          nullable: true
+        phase_normalized:
+          type: string
+          readOnly: true
+          nullable: true
+          description: Canonical trial phase derived from the raw 'phase' value; recomputed
+            on every save.
+        countries:
+          type: string
+          nullable: true
+        countries_normalized:
+          type: array
+          items: {}
+          nullable: true
+          description: |-
+            Flat, sorted list of normalized country codes (e.g. ["DE", "FR", "US"]) — the
+            codes on trial_countries, without the per-country status/source detail. Uses the
+            same prefetched cache as the `trial_countries` field.
+          readOnly: true
+        trial_countries:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrialCountry'
+          readOnly: true
+        regions_normalized:
+          readOnly: true
+          nullable: true
+          description: Canonical region slugs (africa, asia, europe, north_america,
+            south_america, oceania) derived from the trial's countries; recomputed
+            on every save.
+        inclusion_criteria:
+          type: string
+          nullable: true
+        exclusion_criteria:
+          type: string
+          nullable: true
+        condition:
+          type: string
+          nullable: true
+        intervention:
+          type: string
+          nullable: true
+        primary_outcome:
+          type: string
+          nullable: true
+        secondary_outcome:
+          type: string
+          nullable: true
+        secondary_id:
+          type: string
+          nullable: true
+        source_support:
+          type: string
+          nullable: true
+        ethics_review_status:
+          type: string
+          nullable: true
+        ethics_review_approval_date:
+          type: string
+          format: date
+          nullable: true
+        ethics_review_contact_name:
+          nullable: true
+          oneOf:
+          - type: string
+            format: email
+            maxLength: 1000
+          - type: string
+            maxLength: 0
+        ethics_review_contact_address:
+          type: string
+          nullable: true
+        ethics_review_contact_phone:
+          type: string
+          nullable: true
+        ethics_review_contact_email:
+          nullable: true
+          oneOf:
+          - type: string
+            format: email
+            maxLength: 1000
+          - type: string
+            maxLength: 0
+        results_date_completed:
+          type: string
+          format: date
+          nullable: true
+        results_url_link:
+          nullable: true
+          oneOf:
+          - type: string
+            format: uri
+            maxLength: 2000
+          - type: string
+            maxLength: 0
+        results_yes_no:
+          type: string
+          nullable: true
+          maxLength: 10
+        results_ipd_plan:
+          type: string
+          nullable: true
+          maxLength: 10
+        results_ipd_description:
+          type: string
+          nullable: true
+        therapeutic_areas:
+          type: string
+          nullable: true
+        country_status:
+          type: string
+          nullable: true
+        trial_region:
+          type: string
+          nullable: true
+          maxLength: 500
+        results_posted:
+          type: boolean
+        overall_decision_date:
+          type: string
+          format: date
+          nullable: true
+        countries_decision_date:
+          nullable: true
+        takeaways:
+          type: string
+          nullable: true
+          description: Return takeaways from TrialOrgContent for the caller's org,
+            or None.
+          readOnly: true
+        articles:
+          type: array
+          items: {}
+          description: |-
+            Get articles that reference this trial.
+
+            Uses the prefetched ``article_references`` cache when available (populated
+            by TrialViewSet via prefetch_related('article_references__article'))
+            to avoid one query per trial on list responses.
+          readOnly: true
+      required:
+      - articles
+      - countries_normalized
+      - discovery_date
+      - inclusion_age_max_years
+      - inclusion_age_min_years
+      - inclusion_gender_normalized
+      - last_updated
+      - link
+      - phase_normalized
+      - recruitment_status_normalized
+      - regions_normalized
+      - sources
+      - sponsor
+      - study_type_normalized
+      - summary_plain_english
+      - takeaways
+      - team_categories
+      - title
+      - trial_countries
+      - trial_id
+    TrialCountry:
+      type: object
+      description: |-
+        The normalized per-country rows (see docs/trials-field-normalization.md).
+        ``country`` is rendered as its ISO 3166-1 alpha-2 code.
+      properties:
+        country:
+          type: string
+          nullable: true
+          readOnly: true
+        status:
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/StatusEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        decision_date:
+          type: string
+          format: date
+          nullable: true
+        recruitment_start_date:
+          type: string
+          format: date
+          nullable: true
+        sources: {}
+      required:
+      - country
+    TrialDetail:
+      type: object
+      description: |-
+        TrialSerializer plus the per-site breakdown (``trial_sites``), used only for
+        the retrieve (single-trial) response — see TrialViewSet.get_serializer_class.
+        Kept off the list serializer because sites fan out (mean ~12/trial, max in the
+        hundreds for large multi-country trials): nesting them on every list row would
+        bloat list/CSV responses for a field most callers don't need there.
+        TrialViewSet.get_queryset() prefetches "trial_sites" only for the retrieve
+        action to back this field without an N+1.
+      properties:
+        trial_id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+        summary:
+          type: string
+          nullable: true
+        summary_plain_english:
+          type: string
+          nullable: true
+          description: Return plain-English summary from TrialOrgContent for the caller's
+            org, or None.
+          readOnly: true
+        ctg_detailed_description:
+          type: string
+          nullable: true
+          description: Detailed description from ClinicalTrials.gov API
+        published_date:
+          type: string
+          format: date-time
+          nullable: true
+        discovery_date:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        last_updated:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        link:
+          type: string
+          format: uri
+          maxLength: 2000
+        links:
+          nullable: true
+          description: Registry URLs keyed by registry slug; "link" holds the canonical
+            one
+        sources:
+          type: array
+          items:
+            type: string
+            nullable: true
+          readOnly: true
+        identifiers:
+          nullable: true
+        team_categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/TeamCategory'
+          readOnly: true
+        export_date:
+          type: string
+          format: date-time
+          nullable: true
+        internal_number:
+          type: string
+          nullable: true
+          maxLength: 100
+        last_refreshed_on:
+          type: string
+          format: date
+          nullable: true
+        acronym:
+          type: string
+          nullable: true
+          maxLength: 200
+        scientific_title:
+          type: string
+          nullable: true
+        primary_sponsor:
+          type: string
+          nullable: true
+        secondary_sponsor:
+          type: string
+          nullable: true
+        sponsor_type:
+          type: string
+          nullable: true
+          maxLength: 500
+        sponsor:
+          allOf:
+          - $ref: '#/components/schemas/TrialSponsor'
+          readOnly: true
+        prospective_registration:
+          type: string
+          nullable: true
+          maxLength: 10
+        date_registration:
+          type: string
+          format: date
+          nullable: true
+        source_register:
+          type: string
+          nullable: true
+          maxLength: 200
+        recruitment_status:
+          type: string
+          nullable: true
+          maxLength: 200
+        recruitment_status_normalized:
+          type: string
+          readOnly: true
+          nullable: true
+          description: Canonical recruitment status derived from the raw 'recruitment_status'
+            value; recomputed on every save.
+        other_records:
+          type: string
+          nullable: true
+          maxLength: 200
+        inclusion_agemin:
+          type: string
+          nullable: true
+          maxLength: 100
+        inclusion_agemax:
+          type: string
+          nullable: true
+          maxLength: 100
+        inclusion_age_min_years:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+          description: Canonical minimum eligible age in years, derived from 'inclusion_agemin';
+            recomputed on every save.
+        inclusion_age_max_years:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+          description: Canonical maximum eligible age in years, derived from 'inclusion_agemax';
+            recomputed on every save.
+        inclusion_gender:
+          type: string
+          nullable: true
+          maxLength: 500
+        inclusion_gender_normalized:
+          type: string
+          readOnly: true
+          nullable: true
+          description: Canonical sex eligibility (all/female/male) derived from the
+            raw 'inclusion_gender' value; recomputed on every save.
+        date_enrollement:
+          type: string
+          format: date
+          nullable: true
+        target_size:
+          type: string
+          nullable: true
+        study_type:
+          type: string
+          nullable: true
+        study_type_normalized:
+          type: string
+          readOnly: true
+          nullable: true
+          description: Canonical study type derived from the raw 'study_type' value;
+            recomputed on every save.
+        study_design:
+          type: string
+          nullable: true
+        phase:
+          type: string
+          nullable: true
+        phase_normalized:
+          type: string
+          readOnly: true
+          nullable: true
+          description: Canonical trial phase derived from the raw 'phase' value; recomputed
+            on every save.
+        countries:
+          type: string
+          nullable: true
+        countries_normalized:
+          type: array
+          items: {}
+          nullable: true
+          description: |-
+            Flat, sorted list of normalized country codes (e.g. ["DE", "FR", "US"]) — the
+            codes on trial_countries, without the per-country status/source detail. Uses the
+            same prefetched cache as the `trial_countries` field.
+          readOnly: true
+        trial_countries:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrialCountry'
+          readOnly: true
+        regions_normalized:
+          readOnly: true
+          nullable: true
+          description: Canonical region slugs (africa, asia, europe, north_america,
+            south_america, oceania) derived from the trial's countries; recomputed
+            on every save.
+        inclusion_criteria:
+          type: string
+          nullable: true
+        exclusion_criteria:
+          type: string
+          nullable: true
+        condition:
+          type: string
+          nullable: true
+        intervention:
+          type: string
+          nullable: true
+        primary_outcome:
+          type: string
+          nullable: true
+        secondary_outcome:
+          type: string
+          nullable: true
+        secondary_id:
+          type: string
+          nullable: true
+        source_support:
+          type: string
+          nullable: true
+        ethics_review_status:
+          type: string
+          nullable: true
+        ethics_review_approval_date:
+          type: string
+          format: date
+          nullable: true
+        ethics_review_contact_name:
+          nullable: true
+          oneOf:
+          - type: string
+            format: email
+            maxLength: 1000
+          - type: string
+            maxLength: 0
+        ethics_review_contact_address:
+          type: string
+          nullable: true
+        ethics_review_contact_phone:
+          type: string
+          nullable: true
+        ethics_review_contact_email:
+          nullable: true
+          oneOf:
+          - type: string
+            format: email
+            maxLength: 1000
+          - type: string
+            maxLength: 0
+        results_date_completed:
+          type: string
+          format: date
+          nullable: true
+        results_url_link:
+          nullable: true
+          oneOf:
+          - type: string
+            format: uri
+            maxLength: 2000
+          - type: string
+            maxLength: 0
+        results_yes_no:
+          type: string
+          nullable: true
+          maxLength: 10
+        results_ipd_plan:
+          type: string
+          nullable: true
+          maxLength: 10
+        results_ipd_description:
+          type: string
+          nullable: true
+        therapeutic_areas:
+          type: string
+          nullable: true
+        country_status:
+          type: string
+          nullable: true
+        trial_region:
+          type: string
+          nullable: true
+          maxLength: 500
+        results_posted:
+          type: boolean
+        overall_decision_date:
+          type: string
+          format: date
+          nullable: true
+        countries_decision_date:
+          nullable: true
+        takeaways:
+          type: string
+          nullable: true
+          description: Return takeaways from TrialOrgContent for the caller's org,
+            or None.
+          readOnly: true
+        articles:
+          type: array
+          items: {}
+          description: |-
+            Get articles that reference this trial.
+
+            Uses the prefetched ``article_references`` cache when available (populated
+            by TrialViewSet via prefetch_related('article_references__article'))
+            to avoid one query per trial on list responses.
+          readOnly: true
+        trial_sites:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrialSite'
+          readOnly: true
+      required:
+      - articles
+      - countries_normalized
+      - discovery_date
+      - inclusion_age_max_years
+      - inclusion_age_min_years
+      - inclusion_gender_normalized
+      - last_updated
+      - link
+      - phase_normalized
+      - recruitment_status_normalized
+      - regions_normalized
+      - sources
+      - sponsor
+      - study_type_normalized
+      - summary_plain_english
+      - takeaways
+      - team_categories
+      - title
+      - trial_countries
+      - trial_id
+      - trial_sites
+    TrialSite:
+      type: object
+      description: |-
+        Per-site rows from CTIS retrieve enrichment and/or ClinicalTrials.gov — see
+        TRIAL-GEOGRAPHY-PLAN.md PR G2/G3. ``country`` is rendered as its ISO 3166-1
+        alpha-2 code. Nested only on the trial detail response (``trial_sites`` is not
+        part of ``TrialSerializer``'s fields, so it never appears on the list endpoint)
+        — use ``GET /trials/sites/`` for a bulk, flat listing across many trials.
+      properties:
+        name:
+          type: string
+          nullable: true
+          maxLength: 500
+        site_type:
+          type: string
+          nullable: true
+          maxLength: 200
+        address:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+          maxLength: 200
+        state:
+          type: string
+          nullable: true
+          maxLength: 200
+        postcode:
+          type: string
+          nullable: true
+          maxLength: 50
+        country:
+          type: string
+          nullable: true
+          readOnly: true
+        investigator_name:
+          type: string
+          nullable: true
+          maxLength: 300
+        latitude:
+          type: number
+          format: double
+          nullable: true
+        longitude:
+          type: number
+          format: double
+          nullable: true
+        sources: {}
+      required:
+      - country
+    TrialSiteRow:
+      type: object
+      description: Row shape of ``GET /trials/sites/`` — see TrialViewSet.sites.
+      properties:
+        trial_id:
+          type: integer
+        name:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        country:
+          type: string
+          nullable: true
+        latitude:
+          type: number
+          format: double
+          nullable: true
+        longitude:
+          type: number
+          format: double
+          nullable: true
+      required:
+      - city
+      - country
+      - latitude
+      - longitude
+      - name
+      - trial_id
+    TrialSponsor:
+      type: object
+      description: |-
+        The canonical sponsor entity a trial's raw ``primary_sponsor`` resolves to —
+        see docs/trials-field-normalization.md. Nested on TrialSerializer as ``sponsor``;
+        null when the raw string hasn't been resolved yet.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        slug:
+          type: string
+          maxLength: 200
+          pattern: ^[-a-zA-Z0-9_]+$
+        name:
+          type: string
+          maxLength: 500
+        sponsor_type:
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/SponsorTypeEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+          - $ref: '#/components/schemas/NullEnum'
+      required:
+      - id
+      - name
+      - slug
+    TrialsByCountry:
+      type: object
+      properties:
+        country:
+          type: string
+          nullable: true
+          description: ISO 3166-1 alpha-2 code, or null for trials with no TrialCountry
+            rows.
+        count:
+          type: integer
+      required:
+      - count
+      - country
+    TrialsBySponsor:
+      type: object
+      properties:
+        sponsor_id:
+          type: integer
+        slug:
+          type: string
+        name:
+          type: string
+        sponsor_type:
+          type: string
+          nullable: true
+        count:
+          type: integer
+      required:
+      - count
+      - name
+      - slug
+      - sponsor_id
+      - sponsor_type
+    TrialsByYear:
+      type: object
+      properties:
+        year:
+          type: integer
+          nullable: true
+          description: Registration year, or null for trials with no date_registration.
+        count:
+          type: integer
+      required:
+      - count
+      - year
+    TrialsStats:
+      type: object
+      description: |-
+        Response of ``GET /trials/stats/`` — see TrialViewSet.build_stats_payload.
+
+        The recruitment-status bucket keys (``recruiting``, ``completed``, ...) are
+        one key per ``TrialRecruitmentStatus`` value plus ``no_status`` — declared
+        here as a representative subset via ``extra_fields``-style documentation in
+        the field help text rather than one IntegerField per enum member, since the
+        bucket set is derived from the enum at runtime (see
+        docs/03-api-and-rss-feeds.md for the full key list).
+      properties:
+        total:
+          type: integer
+        no_status:
+          type: integer
+        by_subject:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubjectCount'
+        by_phase:
+          type: object
+          additionalProperties:
+            type: integer
+          description: '{phase_slug: count, ..., ''no_phase'': count} — one key per
+            TrialPhase value.'
+        by_region:
+          type: object
+          additionalProperties:
+            type: integer
+          description: '{region_slug: count, ..., ''no_region'': count} — one key
+            per TrialRegion value. Does not sum to total (a trial can span multiple
+            regions).'
+        by_country:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrialsByCountry'
+        by_year:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrialsByYear'
+        by_sponsor:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrialsBySponsor'
+          description: Top 25 canonical sponsors by count, excluding unresolved sponsors.
+        no_sponsor:
+          type: integer
+        by_sponsor_type:
+          type: object
+          additionalProperties:
+            type: integer
+          description: '{sponsor_type_slug: count, ..., ''no_type'': count} — one
+            key per SponsorType value.'
+        by_modality:
+          type: object
+          additionalProperties:
+            type: integer
+          description: '{modality_slug: count, ..., ''no_modality'': count} — one
+            key per CategoryModality value. Not a partition of total (a trial can
+            carry categories of several modalities).'
+        by_study_type:
+          type: object
+          additionalProperties:
+            type: integer
+          description: '{study_type_slug: count, ..., ''no_study_type'': count} —
+            one key per TrialStudyType value.'
+        by_sex:
+          type: object
+          additionalProperties:
+            type: integer
+          description: '{sex_slug: count, ..., ''no_sex_data'': count} — one key per
+            TrialSexEligibility value.'
+      required:
+      - by_country
+      - by_modality
+      - by_phase
+      - by_region
+      - by_sex
+      - by_sponsor
+      - by_sponsor_type
+      - by_study_type
+      - by_subject
+      - by_year
+      - no_sponsor
+      - no_status
+      - total
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: Raw API key (no "Bearer"/"Basic" prefix) issued per organisation.
+        Required for write endpoints (articles/post, articles/edit, trials/edit);
+        optional on read endpoints, where it scopes org-visibility and unlocks per-org
+        fields (takeaways, summary_plain_english).
+    basicAuth:
+      type: http
+      scheme: basic
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: sessionid
+    jwtAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -6,6 +6,20 @@ GregoryAI's API is open and does not require authentication unless you need to c
 
 ---
 
+## OpenAPI schema
+
+The API also publishes a generated [OpenAPI 3](https://swagger.io/specification/) schema, built from the views/filtersets/serializers themselves via [drf-spectacular](https://drf-spectacular.readthedocs.io/) — it cannot drift from the code the way this hand-written page can.
+
+| Resource | URL |
+|:---------|:----|
+| Raw schema (YAML/JSON) | `GET /api/schema/` |
+| Swagger UI | `GET /api/schema/swagger-ui/` |
+| ReDoc | `GET /api/schema/redoc/` |
+
+This page stays the canonical *prose* reference — narrative context, examples, changelogs, and the "why" behind a parameter. The schema is the canonical *machine-checkable* reference for exact parameter names, types, and response shapes. When the two disagree, treat it as a bug: fix the mismatch (see `CLAUDE.md`'s docs rule), don't just pick one and move on. CI generation guard: `python manage.py spectacular --fail-on-warn` (see `gregory/tests/test_openapi_schema.py`).
+
+---
+
 ## RSS feeds
 
 | Feed | URL pattern |
@@ -59,7 +73,6 @@ This prevents open-redirect attacks — only explicitly whitelisted domains are 
 | Endpoint | Description |
 |:---------|:------------|
 | `POST /api/token/` | Obtain JWT token |
-| `POST /api/token/get/` | Obtain auth token (alternative) |
 | `GET /protected_endpoint/` | Test protected endpoint (requires auth header) |
 
 ---
@@ -124,7 +137,6 @@ The `/articles/` endpoint supports the following filters. Multiple parameters ca
 | `ml_threshold` | float 0–1 | Minimum ML prediction confidence. Scoped to `subject_id` when provided. |
 | `open_access` | boolean | Open access articles only |
 | `has_clinical_trials` | boolean | Filter by whether articles are linked to at least one trial |
-| `unsent` | boolean | Articles not yet sent to subscribers |
 | `last_days` | integer | Articles from the last N days |
 | `week` | integer 1–52 | Filter by week number (requires `year`) |
 | `year` | integer | Year for week filtering |

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -16,7 +16,7 @@ The API also publishes a generated [OpenAPI 3](https://swagger.io/specification/
 | Swagger UI | `GET /api/schema/swagger-ui/` |
 | ReDoc | `GET /api/schema/redoc/` |
 
-This page stays the canonical *prose* reference — narrative context, examples, changelogs, and the "why" behind a parameter. The schema is the canonical *machine-checkable* reference for exact parameter names, types, and response shapes. When the two disagree, treat it as a bug: fix the mismatch (see `CLAUDE.md`'s docs rule), don't just pick one and move on. CI generation guard: `python manage.py spectacular --fail-on-warn` (see `gregory/tests/test_openapi_schema.py`).
+This page stays the canonical *prose* reference — narrative context, examples, changelogs, and the "why" behind a parameter. The schema is the canonical *machine-checkable* reference for exact parameter names, types, and response shapes. When the two disagree, treat it as a bug: fix the mismatch (see `CLAUDE.md`'s docs rule), don't just pick one and move on. CI generation guard: `python manage.py spectacular --fail-on-warn` (see `api/tests/test_openapi_schema.py`).
 
 ---
 


### PR DESCRIPTION
## Summary

Stage 1 of the MCP server plan: generates a machine-checkable OpenAPI schema from the existing views/filtersets/serializers, so it can't drift from the code the way the prose API docs can. Stage 2 (a follow-up, not part of this PR) will build MCP tools against this schema instead of hand-parsing `docs/03-api-and-rss-feeds.md`.

- Wires up `drf-spectacular`: `INSTALLED_APPS`, `DEFAULT_SCHEMA_CLASS`, and routes `/api/schema/`, `/api/schema/swagger-ui/`, `/api/schema/redoc/`
- Adds `help_text` to all ~86 filter fields across the 7 FilterSets (`ArticleFilter`, `TrialFilter`, `AuthorFilter`, `SourceFilter`, `CategoryFilter`, `SponsorFilter`, `SubjectFilter`)
- Annotates the endpoints drf-spectacular can't introspect on its own via `@extend_schema`/`@extend_schema_view`:
  - The three `POST /*/search/` request bodies — built programmatically from the matching FilterSet (`api/schema_serializers.py:filterset_request_schema`) so the body schema can't drift from the GET query parameters
  - `/stats/`, `/articles/stats/`, `/trials/stats/`, `/trials/sites/` — typed response serializers instead of an untyped blob
  - A custom `apiKeyAuth` security scheme for the raw-header API key (`ApiKeyMiddleware` isn't a DRF authentication class, so drf-spectacular can't discover it automatically) — required on the three write endpoints, optional-but-declared on `ArticleViewSet`/`TrialViewSet`
- Fixes type hints on `SerializerMethodField` getters and django-filter method fields so `python manage.py spectacular --fail-on-warn` passes clean (baseline audit found 5 error types + ~20 warnings, all resolved)
- Adds a regression test (`api/tests/test_openapi_schema.py`) that fails if schema generation produces warnings/errors or an invalid schema, so a future un-annotated endpoint breaks CI instead of shipping silently wrong
- Commits `schema.yml` for diffable review
- Reconciles `docs/03-api-and-rss-feeds.md` against the generated schema: drops two phantom entries (`POST /api/token/get/` and an `unsent` filter — neither exists in code) and adds a section pointing at `/api/schema/`
- Updates `CLAUDE.md`'s docs rule to cover regenerating the schema

## Test plan

- [x] `python manage.py spectacular --fail-on-warn` exits clean
- [x] `python manage.py test` — full suite passes (2521 tests)
- [x] Verified `/api/schema/`, `/api/schema/swagger-ui/`, `/api/schema/redoc/` all return 200 with real Swagger UI / ReDoc markup
- [x] Spot-checked generated schema: comma-separated enum filters (e.g. `phase_normalized`) type as arrays, search-endpoint POST bodies list every filter field with `team_id`/`subject_id` required, security schemes scoped correctly (required on write, optional on reads)

## Known gaps (flagged, not fixed here)

- `OrganizationsViewSet` is still unrouted (pre-existing, out of scope per the plan)
- Optional `apiKeyAuth` visibility is only wired onto `ArticleViewSet`/`TrialViewSet` (the two biggest per the plan's priority order) — `SourceViewSet`/`SubjectsViewSet`/`TeamsViewSet` still show only the DRF-detected auth schemes, which is accurate but incomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)