### PR TITLE
Add read-only MCP server exposing the GregoryAI API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ __pycache__/
 venv/
 venv3/
 venv311/
+.pytest_cache/
+*.egg-info/
 
 # Virtual environments
 env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,6 +52,13 @@ services:
       - gregory_network
     depends_on:
       - db
+    healthcheck:
+      # Same readiness check entrypoint.sh's wait_for_db already uses.
+      test: ["CMD", "python", "manage.py", "check", "--database", "default"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
 
   gregory-mcp:
     container_name: gregory-mcp
@@ -67,7 +74,8 @@ services:
     networks:
       - gregory_network
     depends_on:
-      - gregory
+      gregory:
+        condition: service_healthy
 
 networks:
   gregory_network:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,6 +53,22 @@ services:
     depends_on:
       - db
 
+  gregory-mcp:
+    container_name: gregory-mcp
+    restart: always
+    build: ./mcp-server
+    ports:
+      - 127.0.0.1:8001:8001
+    environment:
+      # Base URL of the GregoryAI instance this server proxies. Defaults to
+      # the sibling `gregory` container for local dev; point it at a public
+      # instance (e.g. https://api.brain-regeneration.com) in production.
+      - GREGORY_API_URL=${GREGORY_MCP_API_URL:-http://gregory:8000}
+    networks:
+      - gregory_network
+    depends_on:
+      - gregory
+
 networks:
   gregory_network:
     external: false

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -18,6 +18,8 @@ The API also publishes a generated [OpenAPI 3](https://swagger.io/specification/
 
 This page stays the canonical *prose* reference — narrative context, examples, changelogs, and the "why" behind a parameter. The schema is the canonical *machine-checkable* reference for exact parameter names, types, and response shapes. When the two disagree, treat it as a bug: fix the mismatch (see `CLAUDE.md`'s docs rule), don't just pick one and move on. CI generation guard: `python manage.py spectacular --fail-on-warn` (see `api/tests/test_openapi_schema.py`).
 
+A read-only [MCP server](07-mcp-server.md) also exposes this API to LLM clients (Claude Code, Claude Desktop) as a small set of task-shaped tools, built against this schema — see [07-mcp-server.md](07-mcp-server.md).
+
 ---
 
 ## RSS feeds

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -81,7 +81,15 @@ server — see [Risks](#risks).
 ## Resources
 
 Slow-changing reference data, served with a 10-minute `ttlMs` cache hint (public scope, so
-clients can share one cached copy) so repeated conversations stop refetching it:
+clients can share one cached copy) so repeated conversations stop refetching it. The server
+also caches these two server-side, for the same 10 minutes (`gregory_mcp/cache.py`,
+`CATALOG_CACHE_TTL_MS` — the one constant both the hint and the actual cache derive from) —
+`/categories/` costs about a second per request and takes 12 requests to read in full, so
+this is the difference between a call that answers instantly and one that visibly stalls.
+Per-replica, in-process, with single-flight (concurrent cold-cache callers await one fetch
+rather than each starting their own). `list_subjects`/`list_categories` share the same cache
+entries as these resources when called with equivalent filters — search tools are never
+cached.
 
 - `gregory://subjects` — every subject, with `team_id`
 - `gregory://categories` — every category

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -126,6 +126,19 @@ internal location, which is more machinery than this example config carries; see
 comment above `limit_req_zone` in `nginx-example-configuration/nginx.conf` for what was
 tried and why it was reverted. A flat per-client cap backstops the per-tool buckets.
 
+Throttled requests return `429` (`limit_req_status`), not nginx's default `503` — `503`
+reads as "server broken" rather than "you're going too fast." A rejected request never
+reaches the MCP server, so its own logs can't show a throttling event; `/mcp/` logs to
+its own file (`mcp-access.log`, `mcp_combined` format) with an `mcp_name="..."` field so
+429s can be attributed per tool from nginx's side instead:
+
+```bash
+awk '$9 == 429' /var/log/nginx/mcp-access.log | grep -o 'mcp_name="[^"]*"' | sort | uniq -c | sort -rn
+```
+
+Whether 30 r/m per (client, tool) and 120 r/m per client are the right numbers is an open
+question — tune them from what this log actually shows, not speculatively.
+
 ## Risks
 
 **Unauthenticated endpoint.** No data-leak risk, but anyone who learns the URL can drive

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -105,8 +105,11 @@ with no code change. See `mcp-server/gregory_mcp/config.py`.
 
 None. The server exposes exactly what an anonymous API caller already sees — the same
 public organisations any unauthenticated `GET` against the REST API returns. Nothing new
-is leaked, but the endpoint is unauthenticated, so it's rate-limited per tool name (the
-`Mcp-Name` request header) at the nginx layer — see `nginx-example-configuration/nginx.conf`.
+is leaked, but the endpoint is unauthenticated, so it's rate-limited at the nginx layer:
+per (client address, tool name) — the tool name coming from the client-controlled
+`Mcp-Name` request header, whitelisted to the ten known names so a caller can't dodge the
+limit by inventing new header values — plus a flat per-client cap across all tools as a
+backstop. See `nginx-example-configuration/nginx.conf`.
 
 ## Risks
 

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -85,7 +85,10 @@ clients can share one cached copy) so repeated conversations stop refetching it:
 
 - `gregory://subjects` — every subject, with `team_id`
 - `gregory://categories` — every category
-- `gregory://sponsors` — canonical sponsors (capped at ~2000 rows as a safety net)
+
+No sponsors resource: at 8,000+ rows / ~700 KB it isn't catalog-shaped the way
+subjects and categories are — use the `list_sponsors` tool (search + pagination)
+instead.
 
 ## Prompts
 

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -108,11 +108,12 @@ public organisations any unauthenticated `GET` against the REST API returns. Not
 is leaked, but the endpoint is unauthenticated, so it's rate-limited at the nginx layer,
 per (client address, tool name) — the tool name coming from the client-controlled
 `Mcp-Name` request header, whitelisted to the ten known names so a caller can't dodge the
-limit by inventing new header values. The search/stats tools (`search_articles`,
-`search_trials`, `search_authors`, `get_stats` — arbitrary boolean search or an aggregate
-query) throttle harder (10r/min) than ID lookups and catalog listings (60r/min); a flat
-per-client cap (120r/min) across all tools backstops both. See
-`nginx-example-configuration/nginx.conf`.
+limit by inventing new header values. Every tool shares one flat rate rather than a
+stricter one for the search/stats tools — nginx's `limit_req` has no notion of a
+per-request "cost", and doing that correctly needs routing each tool class to its own
+internal location, which is more machinery than this example config carries; see the
+comment above `limit_req_zone` in `nginx-example-configuration/nginx.conf` for what was
+tried and why it was reverted. A flat per-client cap backstops the per-tool buckets.
 
 ## Risks
 

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -43,9 +43,9 @@ crowds context and degrades model tool selection.
 | Tool | Backing endpoint | Notes |
 |:---|:---|:---|
 | `list_subjects` | `GET /subjects/` | Discovery entry point. Every row carries `team_id`, which most other tools' filters need. |
-| `search_articles` | `GET /articles/` | Boolean `search` plus subject, category, `category_modality`, journal, DOI, `relevant`, `ml_threshold`, `open_access`, `has_clinical_trials`, date range. Compact results — see [Payload shaping](#payload-shaping). |
+| `search_articles` | `GET /articles/` | Boolean `search` plus subject, category, `category_modality`, journal, DOI, `relevant`, `ml_threshold`, `open_access`, `has_clinical_trials`, date range, `last_days`. Compact results — see [Payload shaping](#payload-shaping). |
 | `get_article` | `GET /articles/{article_id}/` | Full record. |
-| `search_trials` | `GET /trials/` | `search` plus `recruitment_status_normalized`, `phase_normalized`, `study_type_normalized`, country, region, sponsor, `age_eligible`, `inclusion_gender_normalized`, registration dates. |
+| `search_trials` | `GET /trials/` | `search` plus `recruitment_status_normalized`, `phase_normalized`, `study_type_normalized`, country, region, sponsor, `age_eligible`, `inclusion_gender_normalized`, registration dates, registry IDs (`nct`, `euct`, `eudract`, `ctis`), `acronym`, `has_results`, `therapeutic_areas`. |
 | `get_trial` | `GET /trials/{trial_id}/` | Full record, incl. eligibility text and results detail. |
 | `search_authors` | `GET /authors/` | Name, ORCID, country, team/subject scope, `sort_by`/`order`. Fixed page size (10) — this endpoint doesn't support `page_size`. |
 | `get_author` | `GET /authors/{id}/` (+ `/coauthors/`) | Co-authors optional (`include_coauthors`), off by default. |

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -105,11 +105,14 @@ with no code change. See `mcp-server/gregory_mcp/config.py`.
 
 None. The server exposes exactly what an anonymous API caller already sees — the same
 public organisations any unauthenticated `GET` against the REST API returns. Nothing new
-is leaked, but the endpoint is unauthenticated, so it's rate-limited at the nginx layer:
+is leaked, but the endpoint is unauthenticated, so it's rate-limited at the nginx layer,
 per (client address, tool name) — the tool name coming from the client-controlled
 `Mcp-Name` request header, whitelisted to the ten known names so a caller can't dodge the
-limit by inventing new header values — plus a flat per-client cap across all tools as a
-backstop. See `nginx-example-configuration/nginx.conf`.
+limit by inventing new header values. The search/stats tools (`search_articles`,
+`search_trials`, `search_authors`, `get_stats` — arbitrary boolean search or an aggregate
+query) throttle harder (10r/min) than ID lookups and catalog listings (60r/min); a flat
+per-client cap (120r/min) across all tools backstops both. See
+`nginx-example-configuration/nginx.conf`.
 
 ## Risks
 

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -1,0 +1,133 @@
+# MCP server
+
+> Audience: developers connecting an LLM client to GregoryAI, or maintaining `mcp-server/`.
+
+`mcp-server/` is a read-only [MCP](https://modelcontextprotocol.io/) server that lets LLM
+clients (Claude Code, Claude Desktop, etc.) query the GregoryAI REST API — articles,
+clinical trials, authors, subjects, categories, and sponsors — without hand-writing HTTP
+calls. It is a thin, stateless proxy: no database access, no ORM, no write path. Every
+request it can issue is a `GET`.
+
+It runs as its own container (`gregory-mcp` in `docker-compose.yaml`), independent of the
+Django app, and talks to a GregoryAI instance over plain HTTP exactly like any other API
+client — see [03-api-and-rss-feeds.md](03-api-and-rss-feeds.md).
+
+---
+
+## Connecting
+
+The server exposes a single Streamable HTTP endpoint, no authentication required (see
+[Auth](#auth) below):
+
+```
+https://api.<your-domain>/mcp/
+```
+
+### Claude Code
+
+```bash
+claude mcp add --transport http gregory https://api.<your-domain>/mcp/
+```
+
+### Claude Desktop
+
+Add a remote MCP connector pointing at the same URL from Settings → Connectors.
+
+---
+
+## Tools
+
+Ten task-shaped tools rather than a 1:1 mirror of every API endpoint — a large tool list
+crowds context and degrades model tool selection.
+
+| Tool | Backing endpoint | Notes |
+|:---|:---|:---|
+| `list_subjects` | `GET /subjects/` | Discovery entry point. Every row carries `team_id`, which most other tools' filters need. |
+| `search_articles` | `GET /articles/` | Boolean `search` plus subject, category, `category_modality`, journal, DOI, `relevant`, `ml_threshold`, `open_access`, `has_clinical_trials`, date range. Compact results — see [Payload shaping](#payload-shaping). |
+| `get_article` | `GET /articles/{article_id}/` | Full record. |
+| `search_trials` | `GET /trials/` | `search` plus `recruitment_status_normalized`, `phase_normalized`, `study_type_normalized`, country, region, sponsor, `age_eligible`, `inclusion_gender_normalized`, registration dates. |
+| `get_trial` | `GET /trials/{trial_id}/` | Full record, incl. eligibility text and results detail. |
+| `search_authors` | `GET /authors/` | Name, ORCID, country. Fixed page size (10) — this endpoint doesn't support `page_size`. |
+| `get_author` | `GET /authors/{id}/` (+ `/coauthors/`) | Co-authors optional (`include_coauthors`), off by default. |
+| `list_categories` | `GET /categories/` | Fetches every page — a small, slow-changing taxonomy. Does not expose `ordering=authors_count_annotated`; that sort is expensive. |
+| `list_sponsors` | `GET /sponsors/` | Paginated, not fetched in full — sponsors can number in the thousands. |
+| `get_stats` | `GET /stats/`, `/articles/stats/`, `/trials/stats/` | `scope` selects which. |
+
+### `search` syntax
+
+`search_articles`'s and `search_trials`'s `search` parameter is boolean over title +
+summary (same semantics as the REST API's `?search=` — see
+[03-api-and-rss-feeds.md](03-api-and-rss-feeds.md)):
+
+- space-separated terms are AND-ed
+- uppercase `OR` for alternatives, `-term` / `NOT term` to exclude
+- `"quoted phrases"` match contiguously, `(parentheses)` group
+
+Use `title=` / `summary=` instead to match only one field.
+
+### Payload shaping
+
+`search_articles` / `search_trials` / `search_authors` return a compact projection — id,
+title, date, a few key fields, and a summary truncated to ~400 characters — not the full
+record. A ten-result search with full abstracts and nested author lists is a very large
+response, and most searches are followed by a `get_*` read of one or two records anyway.
+`get_article` / `get_trial` / `get_author` return the untouched record.
+
+No tool exposes `all_results=true`. Bulk export is deliberately out of scope for this
+server — see [Risks](#risks).
+
+---
+
+## Resources
+
+Slow-changing reference data, served with a 10-minute `ttlMs` cache hint (public scope, so
+clients can share one cached copy) so repeated conversations stop refetching it:
+
+- `gregory://subjects` — every subject, with `team_id`
+- `gregory://categories` — every category
+- `gregory://sponsors` — canonical sponsors (capped at ~2000 rows as a safety net)
+
+## Prompts
+
+- `research_topic` — survey recent articles and trials on a topic
+- `recent_trials_for_subject` — actively recruiting / recently registered trials for a subject
+- `author_profile` — build a profile of a researcher from their articles and affiliation
+
+---
+
+## Instance targeting
+
+The server proxies whatever instance `GREGORY_API_URL` names — one codebase serves
+brain-regeneration.com, encefalites.pt, clinicaltrialupdates.com, or a local dev instance,
+with no code change. See `mcp-server/gregory_mcp/config.py`.
+
+## Auth
+
+None. The server exposes exactly what an anonymous API caller already sees — the same
+public organisations any unauthenticated `GET` against the REST API returns. Nothing new
+is leaked, but the endpoint is unauthenticated, so it's rate-limited per tool name (the
+`Mcp-Name` request header) at the nginx layer — see `nginx-example-configuration/nginx.conf`.
+
+## Risks
+
+**Unauthenticated endpoint.** No data-leak risk, but anyone who learns the URL can drive
+query load against Django. Per-tool `limit_req` in nginx is the mitigation, not optional.
+
+**Bulk export stays out.** `all_results=true` on `/articles/` is a known failure mode
+(~98s, very large responses — see [csv-export.md](csv-export.md)). No tool here exposes it.
+
+---
+
+## Development
+
+```bash
+cd mcp-server
+pip install -e ".[dev]"
+GREGORY_API_URL=http://localhost:8000 python -m gregory_mcp   # run locally
+pytest                                                         # unit + schema-contract tests
+```
+
+`tests/test_schema_contract.py` checks every filter a tool passes against
+`django/schema.yml` (see [Stage 1](03-api-and-rss-feeds.md#openapi-schema)) — regenerate
+that file (`python manage.py spectacular --file schema.yml --fail-on-warn`) before running
+the suite after changing a filter this server depends on.

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -47,7 +47,7 @@ crowds context and degrades model tool selection.
 | `get_article` | `GET /articles/{article_id}/` | Full record. |
 | `search_trials` | `GET /trials/` | `search` plus `recruitment_status_normalized`, `phase_normalized`, `study_type_normalized`, country, region, sponsor, `age_eligible`, `inclusion_gender_normalized`, registration dates. |
 | `get_trial` | `GET /trials/{trial_id}/` | Full record, incl. eligibility text and results detail. |
-| `search_authors` | `GET /authors/` | Name, ORCID, country. Fixed page size (10) — this endpoint doesn't support `page_size`. |
+| `search_authors` | `GET /authors/` | Name, ORCID, country, team/subject scope, `sort_by`/`order`. Fixed page size (10) — this endpoint doesn't support `page_size`. |
 | `get_author` | `GET /authors/{id}/` (+ `/coauthors/`) | Co-authors optional (`include_coauthors`), off by default. |
 | `list_categories` | `GET /categories/` | Fetches every page — a small, slow-changing taxonomy. Does not expose `ordering=authors_count_annotated`; that sort is expensive. |
 | `list_sponsors` | `GET /sponsors/` | Paginated, not fetched in full — sponsors can number in the thousands. |
@@ -137,7 +137,13 @@ GREGORY_API_URL=http://localhost:8000 python -m gregory_mcp   # run locally
 pytest                                                         # unit + schema-contract tests
 ```
 
-`tests/test_schema_contract.py` checks every filter a tool passes against
+`tests/test_schema_contract.py` checks the contract in both directions against
 `django/schema.yml` (see [Stage 1](03-api-and-rss-feeds.md#openapi-schema)) — regenerate
 that file (`python manage.py spectacular --file schema.yml --fail-on-warn`) before running
-the suite after changing a filter this server depends on.
+the suite after changing a filter this server depends on:
+- every filter a tool passes must be a real, declared parameter (catches a renamed or
+  removed filter);
+- every parameter a tool *doesn't* expose must be explicitly reviewed in
+  `KNOWN_UNEXPOSED_PARAMS` (catches a new filter landing on the Django side that nobody
+  added to the matching tool — this is how `search_authors`'s team/subject scope went
+  missing the first time).

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ walkthrough (read in order); everything else is reference or design material.
 | [04-machine-learning.md](04-machine-learning.md) | Overview of the ML relevance pipeline. |
 | [05-training-models.md](05-training-models.md) | Training and evaluating the ML models. |
 | [06-organisations-teams-and-sites.md](06-organisations-teams-and-sites.md) | Organisations, teams, sites, and visibility scoping. |
+| [07-mcp-server.md](07-mcp-server.md) | Read-only MCP server — connecting an LLM client, available tools/resources/prompts. |
 
 ## API & data reference
 

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir mcp==2.0.0 "httpx2>=2.9,<3"
+
+COPY gregory_mcp ./gregory_mcp
+
+ENV MCP_HOST=0.0.0.0 \
+    MCP_PORT=8001 \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8001
+
+CMD ["python", "-m", "gregory_mcp"]

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -2,14 +2,24 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir mcp==2.0.0 "httpx2>=2.9,<3"
-
+# Dependencies live in pyproject.toml only — this file must not hardcode
+# a second copy that can drift from it.
+COPY pyproject.toml ./
 COPY gregory_mcp ./gregory_mcp
+COPY healthcheck.py ./
+RUN pip install --no-cache-dir .
+
+# Unauthenticated and internet-reachable via nginx /mcp/ — don't run as root.
+RUN useradd --create-home --uid 1000 --shell /usr/sbin/nologin appuser
+USER appuser
 
 ENV MCP_HOST=0.0.0.0 \
     MCP_PORT=8001 \
     PYTHONUNBUFFERED=1
 
 EXPOSE 8001
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python healthcheck.py
 
 CMD ["python", "-m", "gregory_mcp"]

--- a/mcp-server/gregory_mcp/__init__.py
+++ b/mcp-server/gregory_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Read-only MCP server exposing the GregoryAI REST API to LLM clients."""

--- a/mcp-server/gregory_mcp/__main__.py
+++ b/mcp-server/gregory_mcp/__main__.py
@@ -1,0 +1,36 @@
+"""Entrypoint: `python -m gregory_mcp`.
+
+Runs the streamable-HTTP transport per the 2026-07-28 spec revision — the
+stateless core here holds no session state, so `stateless_http=True` is safe
+and lets nginx round-robin across replicas with no sticky sessions.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .client import init_client
+from .config import load_settings
+from .logging_config import configure_logging
+from .server import build_server
+
+logger = logging.getLogger("gregory_mcp")
+
+
+def main() -> None:
+    settings = load_settings()
+    configure_logging(settings.log_level)
+    init_client(settings)
+
+    logger.info("gregory_mcp_starting", extra={"path": settings.api_base})
+    server = build_server()
+    server.run(
+        "streamable-http",
+        host=settings.host,
+        port=settings.port,
+        stateless_http=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-server/gregory_mcp/__main__.py
+++ b/mcp-server/gregory_mcp/__main__.py
@@ -18,19 +18,19 @@ logger = logging.getLogger("gregory_mcp")
 
 
 def main() -> None:
-    settings = load_settings()
-    configure_logging(settings.log_level)
-    init_client(settings)
+	settings = load_settings()
+	configure_logging(settings.log_level)
+	init_client(settings)
 
-    logger.info("gregory_mcp_starting", extra={"path": settings.api_base})
-    server = build_server()
-    server.run(
-        "streamable-http",
-        host=settings.host,
-        port=settings.port,
-        stateless_http=True,
-    )
+	logger.info("gregory_mcp_starting", extra={"path": settings.api_base})
+	server = build_server()
+	server.run(
+		"streamable-http",
+		host=settings.host,
+		port=settings.port,
+		stateless_http=True,
+	)
 
 
 if __name__ == "__main__":
-    main()
+	main()

--- a/mcp-server/gregory_mcp/cache.py
+++ b/mcp-server/gregory_mcp/cache.py
@@ -1,0 +1,135 @@
+"""Server-side cache for the catalog endpoints (/subjects/, /categories/).
+
+Deliberately narrow: only those two endpoints go through this. Search
+results are high-cardinality — every distinct filter combination is a new
+key — and must never be served stale, so search tools never touch this
+cache; only client_get_all_pages callers backing the small, slow-changing
+catalogs do.
+
+Single-flight: on a cold cache, N concurrent callers for the same key await
+one upstream fetch rather than each starting their own. /categories/ costs
+about a second per request and takes 12 requests to read in full (measured
+against a live instance — see HANDOVER-MCP-FOLLOWUP-PLAN.md), so that ~6s
+window is wide enough for concurrent callers to actually collide in
+practice.
+
+Per-replica, in-process — no Redis. The stateless-core model means each
+replica keeps its own cache and does one cold fetch after a deploy; that's
+an acceptable cost for this data, and avoids reintroducing the shared state
+the 2026-07-28 spec revision deliberately removed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from .client import get_client
+
+# The single source of truth for how long the catalog is considered fresh.
+# CacheHint (server.py, the client-facing MCP `ttlMs` hint) and this
+# server-side cache's actual expiry both derive from this constant — two
+# numbers that have to agree will eventually disagree if hardcoded twice.
+CATALOG_CACHE_TTL_MS = 10 * 60 * 1000
+
+
+class _Entry:
+	__slots__ = ("value", "expires_at")
+
+	def __init__(self, value: Any, expires_at: float):
+		self.value = value
+		self.expires_at = expires_at
+
+
+class CatalogCache:
+	"""A small TTL cache with single-flight, keyed on (path, sorted params).
+
+	`clock` is injectable so tests can control expiry without real sleeping.
+	"""
+
+	def __init__(self, ttl_ms: int = CATALOG_CACHE_TTL_MS, clock: Callable[[], float] = time.monotonic):
+		self._ttl_seconds = ttl_ms / 1000
+		self._clock = clock
+		self._entries: dict[str, _Entry] = {}
+		self._locks: dict[str, asyncio.Lock] = {}
+
+	def _key(self, path: str, params: dict[str, Any] | None) -> str:
+		# None-valued params are dropped the same way client.get() drops them
+		# before sending the request — so an explicit `{"team_id": None}` and
+		# an omitted `team_id` land on the same cache entry. Without this,
+		# list_subjects()'s no-filter call and the subjects_catalog resource's
+		# no-params call would miss each other despite requesting the same data.
+		clean = {k: v for k, v in (params or {}).items() if v is not None}
+		items = tuple(sorted(clean.items()))
+		return f"{path}?{items!r}"
+
+	def _lock_for(self, key: str) -> asyncio.Lock:
+		lock = self._locks.get(key)
+		if lock is None:
+			lock = asyncio.Lock()
+			self._locks[key] = lock
+		return lock
+
+	async def get_or_fetch(
+		self,
+		path: str,
+		params: dict[str, Any] | None,
+		fetch: Callable[[], Awaitable[Any]],
+	) -> Any:
+		"""Return the cached value for (path, params), fetching on a miss.
+
+		Concurrent callers that miss on the same key all await the same
+		fetch — the lock is acquired before the fresh-entry re-check, so a
+		caller that was waiting on it sees the value the winner just stored
+		rather than triggering a second fetch.
+		"""
+		key = self._key(path, params)
+		entry = self._entries.get(key)
+		if entry is not None and entry.expires_at > self._clock():
+			return entry.value
+
+		async with self._lock_for(key):
+			entry = self._entries.get(key)
+			if entry is not None and entry.expires_at > self._clock():
+				return entry.value
+
+			value = await fetch()
+			self._entries[key] = _Entry(value, self._clock() + self._ttl_seconds)
+			return value
+
+	def clear(self) -> None:
+		self._entries.clear()
+		self._locks.clear()
+
+
+_catalog_cache: CatalogCache | None = None
+
+
+def get_catalog_cache() -> CatalogCache:
+	global _catalog_cache
+	if _catalog_cache is None:
+		_catalog_cache = CatalogCache()
+	return _catalog_cache
+
+
+def reset_catalog_cache() -> None:
+	"""Replace the process-wide cache with a fresh one. Test-only."""
+	global _catalog_cache
+	_catalog_cache = None
+
+
+async def get_all_pages_cached(path: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+	"""Cached `client.get_all_pages` for the two catalog endpoints.
+
+	Cache the concatenated, parsed `results` rows — not a tool- or
+	resource-specific projection of them — so list_subjects/list_categories
+	and the matching gregory://subjects / gregory://categories resources
+	share one cache entry per (path, params) instead of each fetching their
+	own copy of the same data.
+	"""
+	async def fetch() -> list[dict[str, Any]]:
+		return await get_client().get_all_pages(path, params)
+
+	return await get_catalog_cache().get_or_fetch(path, params, fetch)

--- a/mcp-server/gregory_mcp/client.py
+++ b/mcp-server/gregory_mcp/client.py
@@ -1,0 +1,127 @@
+"""Thin, GET-only HTTP client for the GregoryAI REST API.
+
+The MCP server is a stateless proxy: it never writes, never holds a
+database connection, and only ever issues `GET` requests against the
+instance named by `GREGORY_API_URL`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx2
+
+from .config import Settings
+
+logger = logging.getLogger("gregory_mcp.client")
+
+
+class GregoryAPIError(Exception):
+    """Raised when the upstream Gregory API returns an error response."""
+
+    def __init__(self, status_code: int, detail: str):
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"Gregory API returned {status_code}: {detail}")
+
+
+class GregoryClient:
+    """Async GET client with timeouts and bounded retries.
+
+    One instance is shared for the lifetime of the server process; it holds
+    no per-request or per-caller state, matching the stateless-core model of
+    the 2026-07-28 spec revision.
+    """
+
+    def __init__(self, settings: Settings):
+        self._settings = settings
+        self._client = httpx2.AsyncClient(
+            base_url=settings.api_base,
+            timeout=httpx2.Timeout(settings.request_timeout, connect=settings.connect_timeout),
+            headers={"Accept": "application/json", "User-Agent": "gregory-mcp/0.1"},
+        )
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Issue a single GET, retrying transient network/5xx failures.
+
+        Query params with a `None` value are dropped so tools can pass every
+        optional filter unconditionally without hand-pruning the dict.
+        """
+        clean_params = {k: v for k, v in (params or {}).items() if v is not None}
+        attempts = self._settings.max_retries + 1
+        last_exc: Exception | None = None
+
+        for attempt in range(1, attempts + 1):
+            try:
+                response = await self._client.get(path, params=clean_params)
+            except httpx2.TransportError as exc:
+                last_exc = exc
+                logger.warning("gregory_api_transport_error", extra={"path": path})
+                if attempt == attempts:
+                    raise GregoryAPIError(0, f"network error calling {path}: {exc}") from exc
+                continue
+
+            if response.status_code >= 500 and attempt < attempts:
+                logger.warning(
+                    "gregory_api_5xx_retry", extra={"path": path, "status_code": response.status_code}
+                )
+                continue
+
+            if response.status_code >= 400:
+                raise GregoryAPIError(response.status_code, response.text[:500])
+
+            return response.json()
+
+        # Unreachable in practice — the loop always returns or raises — but keeps
+        # the type checker honest about last_exc being used.
+        raise GregoryAPIError(0, f"exhausted retries calling {path}: {last_exc}")
+
+    async def get_all_pages(
+        self, path: str, params: dict[str, Any] | None = None, max_pages: int = 20
+    ) -> list[dict[str, Any]]:
+        """Follow `next` across pages and return the concatenated `results`.
+
+        For the small, slow-changing catalogs (subjects/categories/sponsors)
+        this is the only reliable way to get a complete list: several of
+        those endpoints use plain DRF pagination with a fixed page_size and
+        no `page_size` query param to raise it (see FlexiblePagination vs.
+        the DRF default in django/admin/settings.py) — passing a bigger
+        page_size silently does nothing on those endpoints.
+        """
+        base_params = dict(params or {})
+        results: list[dict[str, Any]] = []
+        page = 1
+        while page <= max_pages:
+            data = await self.get(path, {**base_params, "page": page})
+            results.extend(data.get("results", []))
+            if not data.get("next"):
+                break
+            page += 1
+        return results
+
+
+_client: GregoryClient | None = None
+
+
+def init_client(settings: Settings) -> GregoryClient:
+    """Create the process-wide client. Call once, before serving requests."""
+    global _client
+    _client = GregoryClient(settings)
+    return _client
+
+
+def get_client() -> GregoryClient:
+    if _client is None:
+        raise RuntimeError("GregoryClient has not been initialized — call init_client() first")
+    return _client
+
+
+async def close_client() -> None:
+    global _client
+    if _client is not None:
+        await _client.aclose()
+        _client = None

--- a/mcp-server/gregory_mcp/client.py
+++ b/mcp-server/gregory_mcp/client.py
@@ -18,110 +18,110 @@ logger = logging.getLogger("gregory_mcp.client")
 
 
 class GregoryAPIError(Exception):
-    """Raised when the upstream Gregory API returns an error response."""
+	"""Raised when the upstream Gregory API returns an error response."""
 
-    def __init__(self, status_code: int, detail: str):
-        self.status_code = status_code
-        self.detail = detail
-        super().__init__(f"Gregory API returned {status_code}: {detail}")
+	def __init__(self, status_code: int, detail: str):
+		self.status_code = status_code
+		self.detail = detail
+		super().__init__(f"Gregory API returned {status_code}: {detail}")
 
 
 class GregoryClient:
-    """Async GET client with timeouts and bounded retries.
+	"""Async GET client with timeouts and bounded retries.
 
-    One instance is shared for the lifetime of the server process; it holds
-    no per-request or per-caller state, matching the stateless-core model of
-    the 2026-07-28 spec revision.
-    """
+	One instance is shared for the lifetime of the server process; it holds
+	no per-request or per-caller state, matching the stateless-core model of
+	the 2026-07-28 spec revision.
+	"""
 
-    def __init__(self, settings: Settings):
-        self._settings = settings
-        self._client = httpx2.AsyncClient(
-            base_url=settings.api_base,
-            timeout=httpx2.Timeout(settings.request_timeout, connect=settings.connect_timeout),
-            headers={"Accept": "application/json", "User-Agent": "gregory-mcp/0.1"},
-        )
+	def __init__(self, settings: Settings):
+		self._settings = settings
+		self._client = httpx2.AsyncClient(
+			base_url=settings.api_base,
+			timeout=httpx2.Timeout(settings.request_timeout, connect=settings.connect_timeout),
+			headers={"Accept": "application/json", "User-Agent": "gregory-mcp/0.1"},
+		)
 
-    async def aclose(self) -> None:
-        await self._client.aclose()
+	async def aclose(self) -> None:
+		await self._client.aclose()
 
-    async def get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
-        """Issue a single GET, retrying transient network/5xx failures.
+	async def get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+		"""Issue a single GET, retrying transient network/5xx failures.
 
-        Query params with a `None` value are dropped so tools can pass every
-        optional filter unconditionally without hand-pruning the dict.
-        """
-        clean_params = {k: v for k, v in (params or {}).items() if v is not None}
-        attempts = self._settings.max_retries + 1
-        last_exc: Exception | None = None
+		Query params with a `None` value are dropped so tools can pass every
+		optional filter unconditionally without hand-pruning the dict.
+		"""
+		clean_params = {k: v for k, v in (params or {}).items() if v is not None}
+		attempts = self._settings.max_retries + 1
+		last_exc: Exception | None = None
 
-        for attempt in range(1, attempts + 1):
-            try:
-                response = await self._client.get(path, params=clean_params)
-            except httpx2.TransportError as exc:
-                last_exc = exc
-                logger.warning("gregory_api_transport_error", extra={"path": path})
-                if attempt == attempts:
-                    raise GregoryAPIError(0, f"network error calling {path}: {exc}") from exc
-                continue
+		for attempt in range(1, attempts + 1):
+			try:
+				response = await self._client.get(path, params=clean_params)
+			except httpx2.TransportError as exc:
+				last_exc = exc
+				logger.warning("gregory_api_transport_error", extra={"path": path})
+				if attempt == attempts:
+					raise GregoryAPIError(0, f"network error calling {path}: {exc}") from exc
+				continue
 
-            if response.status_code >= 500 and attempt < attempts:
-                logger.warning(
-                    "gregory_api_5xx_retry", extra={"path": path, "status_code": response.status_code}
-                )
-                continue
+			if response.status_code >= 500 and attempt < attempts:
+				logger.warning(
+					"gregory_api_5xx_retry", extra={"path": path, "status_code": response.status_code}
+				)
+				continue
 
-            if response.status_code >= 400:
-                raise GregoryAPIError(response.status_code, response.text[:500])
+			if response.status_code >= 400:
+				raise GregoryAPIError(response.status_code, response.text[:500])
 
-            return response.json()
+			return response.json()
 
-        # Unreachable in practice — the loop always returns or raises — but keeps
-        # the type checker honest about last_exc being used.
-        raise GregoryAPIError(0, f"exhausted retries calling {path}: {last_exc}")
+		# Unreachable in practice — the loop always returns or raises — but keeps
+		# the type checker honest about last_exc being used.
+		raise GregoryAPIError(0, f"exhausted retries calling {path}: {last_exc}")
 
-    async def get_all_pages(
-        self, path: str, params: dict[str, Any] | None = None, max_pages: int = 20
-    ) -> list[dict[str, Any]]:
-        """Follow `next` across pages and return the concatenated `results`.
+	async def get_all_pages(
+		self, path: str, params: dict[str, Any] | None = None, max_pages: int = 20
+	) -> list[dict[str, Any]]:
+		"""Follow `next` across pages and return the concatenated `results`.
 
-        For the small, slow-changing catalogs (subjects/categories/sponsors)
-        this is the only reliable way to get a complete list: several of
-        those endpoints use plain DRF pagination with a fixed page_size and
-        no `page_size` query param to raise it (see FlexiblePagination vs.
-        the DRF default in django/admin/settings.py) — passing a bigger
-        page_size silently does nothing on those endpoints.
-        """
-        base_params = dict(params or {})
-        results: list[dict[str, Any]] = []
-        page = 1
-        while page <= max_pages:
-            data = await self.get(path, {**base_params, "page": page})
-            results.extend(data.get("results", []))
-            if not data.get("next"):
-                break
-            page += 1
-        return results
+		For the small, slow-changing catalogs (subjects/categories/sponsors)
+		this is the only reliable way to get a complete list: several of
+		those endpoints use plain DRF pagination with a fixed page_size and
+		no `page_size` query param to raise it (see FlexiblePagination vs.
+		the DRF default in django/admin/settings.py) — passing a bigger
+		page_size silently does nothing on those endpoints.
+		"""
+		base_params = dict(params or {})
+		results: list[dict[str, Any]] = []
+		page = 1
+		while page <= max_pages:
+			data = await self.get(path, {**base_params, "page": page})
+			results.extend(data.get("results", []))
+			if not data.get("next"):
+				break
+			page += 1
+		return results
 
 
 _client: GregoryClient | None = None
 
 
 def init_client(settings: Settings) -> GregoryClient:
-    """Create the process-wide client. Call once, before serving requests."""
-    global _client
-    _client = GregoryClient(settings)
-    return _client
+	"""Create the process-wide client. Call once, before serving requests."""
+	global _client
+	_client = GregoryClient(settings)
+	return _client
 
 
 def get_client() -> GregoryClient:
-    if _client is None:
-        raise RuntimeError("GregoryClient has not been initialized — call init_client() first")
-    return _client
+	if _client is None:
+		raise RuntimeError("GregoryClient has not been initialized — call init_client() first")
+	return _client
 
 
 async def close_client() -> None:
-    global _client
-    if _client is not None:
-        await _client.aclose()
-        _client = None
+	global _client
+	if _client is not None:
+		await _client.aclose()
+		_client = None

--- a/mcp-server/gregory_mcp/client.py
+++ b/mcp-server/gregory_mcp/client.py
@@ -81,7 +81,7 @@ class GregoryClient:
 				response = await self._client.get(path, params=clean_params)
 			except httpx2.TransportError as exc:
 				last_exc = exc
-				logger.warning("gregory_api_transport_error", extra={"path": path})
+				logger.warning("gregory_api_transport_error", extra={"path": path}, exc_info=True)
 				if attempt == attempts:
 					raise GregoryAPIError(0, f"network error calling {path}: {exc}") from exc
 				continue

--- a/mcp-server/gregory_mcp/client.py
+++ b/mcp-server/gregory_mcp/client.py
@@ -26,6 +26,27 @@ class GregoryAPIError(Exception):
 		super().__init__(f"Gregory API returned {status_code}: {detail}")
 
 
+class GregoryPaginationTruncatedError(Exception):
+	"""Raised when get_all_pages hits max_pages before `next` runs out.
+
+	A silent truncation is worse than a loud failure here: every caller of
+	get_all_pages (catalog tools, catalog resources) treats the result as
+	the complete set — a model reading a truncated list has no way to tell
+	an item is missing from a partial fetch versus genuinely not existing.
+	"""
+
+	def __init__(self, path: str, max_pages: int, fetched: int):
+		self.path = path
+		self.max_pages = max_pages
+		self.fetched = fetched
+		super().__init__(
+			f"get_all_pages({path!r}) did not reach the end of pagination after "
+			f"{max_pages} pages ({fetched} rows fetched) — the result set is larger "
+			"than this call site expected. Narrow the filters, or raise max_pages "
+			"deliberately if the growth is expected."
+		)
+
+
 class GregoryClient:
 	"""Async GET client with timeouts and bounded retries.
 
@@ -85,12 +106,18 @@ class GregoryClient:
 	) -> list[dict[str, Any]]:
 		"""Follow `next` across pages and return the concatenated `results`.
 
-		For the small, slow-changing catalogs (subjects/categories/sponsors)
-		this is the only reliable way to get a complete list: several of
-		those endpoints use plain DRF pagination with a fixed page_size and
-		no `page_size` query param to raise it (see FlexiblePagination vs.
-		the DRF default in django/admin/settings.py) — passing a bigger
-		page_size silently does nothing on those endpoints.
+		For the small, slow-changing catalogs (subjects/categories) this is
+		the only reliable way to get a complete list: those endpoints use
+		plain DRF pagination with a fixed page_size and no `page_size` query
+		param to raise it (see FlexiblePagination vs. the DRF default in
+		django/admin/settings.py) — passing a bigger page_size silently does
+		nothing on those endpoints.
+
+		Raises GregoryPaginationTruncatedError rather than silently returning
+		a partial list if `next` hasn't run out by max_pages — this is meant
+		for catalogs that are known to be small, so hitting the cap means
+		either that assumption broke (the catalog grew) or this was called
+		on the wrong endpoint.
 		"""
 		base_params = dict(params or {})
 		results: list[dict[str, Any]] = []
@@ -99,9 +126,9 @@ class GregoryClient:
 			data = await self.get(path, {**base_params, "page": page})
 			results.extend(data.get("results", []))
 			if not data.get("next"):
-				break
+				return results
 			page += 1
-		return results
+		raise GregoryPaginationTruncatedError(path, max_pages, len(results))
 
 
 _client: GregoryClient | None = None

--- a/mcp-server/gregory_mcp/client.py
+++ b/mcp-server/gregory_mcp/client.py
@@ -39,7 +39,7 @@ class GregoryClient:
 		self._client = httpx2.AsyncClient(
 			base_url=settings.api_base,
 			timeout=httpx2.Timeout(settings.request_timeout, connect=settings.connect_timeout),
-			headers={"Accept": "application/json", "User-Agent": "gregory-mcp/0.1"},
+			headers={"Accept": "application/json", "User-Agent": "gregory-mcp/0.1.0"},
 		)
 
 	async def aclose(self) -> None:

--- a/mcp-server/gregory_mcp/client.py
+++ b/mcp-server/gregory_mcp/client.py
@@ -7,7 +7,10 @@ instance named by `GREGORY_API_URL`.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import random
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx2
@@ -15,6 +18,19 @@ import httpx2
 from .config import Settings
 
 logger = logging.getLogger("gregory_mcp.client")
+
+# "Full jitter" exponential backoff (https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/):
+# sleep = uniform(0, min(cap, base * 2**(attempt-1))). Base ~200ms, capped ~2s —
+# with the default max_retries=2 (3 attempts) that adds well under a second to
+# the worst case, comfortably inside the 15s default request timeout.
+BASE_BACKOFF_SECONDS = 0.2
+MAX_BACKOFF_SECONDS = 2.0
+
+# 429 is retried like a 5xx (the Gregory API throttles bulk-export-style
+# requests via BulkExportThrottleMixin; a short backoff-and-retry is more
+# useful to a caller than an immediate error). Anything else >= 400 is a
+# client error retrying won't fix.
+_RETRYABLE_CLIENT_STATUS = {429}
 
 
 class GregoryAPIError(Exception):
@@ -55,19 +71,29 @@ class GregoryClient:
 	the 2026-07-28 spec revision.
 	"""
 
-	def __init__(self, settings: Settings):
+	def __init__(
+		self,
+		settings: Settings,
+		sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+		jitter: Callable[[float, float], float] = random.uniform,
+	):
 		self._settings = settings
 		self._client = httpx2.AsyncClient(
 			base_url=settings.api_base,
 			timeout=httpx2.Timeout(settings.request_timeout, connect=settings.connect_timeout),
 			headers={"Accept": "application/json", "User-Agent": "gregory-mcp/0.1.0"},
 		)
+		# Injectable so tests can assert on backoff spacing without real
+		# sleeping and without depending on random's actual distribution.
+		self._sleep = sleep
+		self._jitter = jitter
 
 	async def aclose(self) -> None:
 		await self._client.aclose()
 
 	async def get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
-		"""Issue a single GET, retrying transient network/5xx failures.
+		"""Issue a single GET, retrying transient network/5xx/429 failures
+		with exponential backoff and jitter between attempts.
 
 		Query params with a `None` value are dropped so tools can pass every
 		optional filter unconditionally without hand-pruning the dict.
@@ -84,12 +110,15 @@ class GregoryClient:
 				logger.warning("gregory_api_transport_error", extra={"path": path}, exc_info=True)
 				if attempt == attempts:
 					raise GregoryAPIError(0, f"network error calling {path}: {exc}") from exc
+				await self._sleep(self._backoff_seconds(attempt, None))
 				continue
 
-			if response.status_code >= 500 and attempt < attempts:
+			is_retryable = response.status_code >= 500 or response.status_code in _RETRYABLE_CLIENT_STATUS
+			if is_retryable and attempt < attempts:
 				logger.warning(
-					"gregory_api_5xx_retry", extra={"path": path, "status_code": response.status_code}
+					"gregory_api_retry", extra={"path": path, "status_code": response.status_code}
 				)
+				await self._sleep(self._backoff_seconds(attempt, response.headers.get("Retry-After")))
 				continue
 
 			if response.status_code >= 400:
@@ -100,6 +129,18 @@ class GregoryClient:
 		# Unreachable in practice — the loop always returns or raises — but keeps
 		# the type checker honest about last_exc being used.
 		raise GregoryAPIError(0, f"exhausted retries calling {path}: {last_exc}")
+
+	def _backoff_seconds(self, attempt: int, retry_after_header: str | None) -> float:
+		"""Delay before the next attempt. Honors `Retry-After` (seconds form)
+		when the upstream sends one; otherwise full-jitter exponential backoff.
+		"""
+		if retry_after_header is not None:
+			try:
+				return max(0.0, float(retry_after_header))
+			except ValueError:
+				pass  # not a numeric Retry-After (e.g. an HTTP-date) — fall through
+		cap = min(MAX_BACKOFF_SECONDS, BASE_BACKOFF_SECONDS * (2 ** (attempt - 1)))
+		return self._jitter(0, cap)
 
 	async def get_all_pages(
 		self, path: str, params: dict[str, Any] | None = None, max_pages: int = 20

--- a/mcp-server/gregory_mcp/compact.py
+++ b/mcp-server/gregory_mcp/compact.py
@@ -1,0 +1,63 @@
+"""Payload shaping for search-tool results.
+
+Search tools return a small, flat projection of each record — full abstracts
+and nested author/site lists blow up context fast, and most searches are
+followed by a `get_*` read of one or two records anyway. Detail tools
+(`get_article`, `get_trial`) return the record untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+SUMMARY_TRUNCATE_CHARS = 400
+
+
+def _truncate(text: str | None, limit: int = SUMMARY_TRUNCATE_CHARS) -> str | None:
+    if not text:
+        return text
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "…"
+
+
+def compact_article(article: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "article_id": article.get("article_id"),
+        "title": article.get("title"),
+        "published_date": article.get("published_date"),
+        "journal": article.get("container_title"),
+        "doi": article.get("doi"),
+        "link": article.get("link"),
+        "summary": _truncate(article.get("summary")),
+        "ml_score": article.get("ml_score"),
+        "access": article.get("access"),
+    }
+
+
+def compact_trial(trial: dict[str, Any]) -> dict[str, Any]:
+    sponsor = trial.get("sponsor") or {}
+    return {
+        "trial_id": trial.get("trial_id"),
+        "title": trial.get("title"),
+        "published_date": trial.get("published_date"),
+        "recruitment_status": trial.get("recruitment_status_normalized"),
+        "phase": trial.get("phase_normalized"),
+        "study_type": trial.get("study_type_normalized"),
+        "sponsor": sponsor.get("name") or trial.get("primary_sponsor"),
+        "countries": trial.get("countries_normalized"),
+        "link": trial.get("link"),
+        "summary": _truncate(trial.get("summary")),
+        "identifiers": trial.get("identifiers"),
+    }
+
+
+def compact_author(author: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "author_id": author.get("author_id"),
+        "full_name": author.get("full_name"),
+        "orcid": author.get("ORCID"),
+        "country": author.get("country"),
+        "articles_count": author.get("articles_count"),
+        "relevant_articles_count": author.get("relevant_articles_count"),
+    }

--- a/mcp-server/gregory_mcp/compact.py
+++ b/mcp-server/gregory_mcp/compact.py
@@ -14,50 +14,50 @@ SUMMARY_TRUNCATE_CHARS = 400
 
 
 def _truncate(text: str | None, limit: int = SUMMARY_TRUNCATE_CHARS) -> str | None:
-    if not text:
-        return text
-    if len(text) <= limit:
-        return text
-    return text[:limit].rstrip() + "…"
+	if not text:
+		return text
+	if len(text) <= limit:
+		return text
+	return text[:limit].rstrip() + "…"
 
 
 def compact_article(article: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "article_id": article.get("article_id"),
-        "title": article.get("title"),
-        "published_date": article.get("published_date"),
-        "journal": article.get("container_title"),
-        "doi": article.get("doi"),
-        "link": article.get("link"),
-        "summary": _truncate(article.get("summary")),
-        "ml_score": article.get("ml_score"),
-        "access": article.get("access"),
-    }
+	return {
+		"article_id": article.get("article_id"),
+		"title": article.get("title"),
+		"published_date": article.get("published_date"),
+		"journal": article.get("container_title"),
+		"doi": article.get("doi"),
+		"link": article.get("link"),
+		"summary": _truncate(article.get("summary")),
+		"ml_score": article.get("ml_score"),
+		"access": article.get("access"),
+	}
 
 
 def compact_trial(trial: dict[str, Any]) -> dict[str, Any]:
-    sponsor = trial.get("sponsor") or {}
-    return {
-        "trial_id": trial.get("trial_id"),
-        "title": trial.get("title"),
-        "published_date": trial.get("published_date"),
-        "recruitment_status": trial.get("recruitment_status_normalized"),
-        "phase": trial.get("phase_normalized"),
-        "study_type": trial.get("study_type_normalized"),
-        "sponsor": sponsor.get("name") or trial.get("primary_sponsor"),
-        "countries": trial.get("countries_normalized"),
-        "link": trial.get("link"),
-        "summary": _truncate(trial.get("summary")),
-        "identifiers": trial.get("identifiers"),
-    }
+	sponsor = trial.get("sponsor") or {}
+	return {
+		"trial_id": trial.get("trial_id"),
+		"title": trial.get("title"),
+		"published_date": trial.get("published_date"),
+		"recruitment_status": trial.get("recruitment_status_normalized"),
+		"phase": trial.get("phase_normalized"),
+		"study_type": trial.get("study_type_normalized"),
+		"sponsor": sponsor.get("name") or trial.get("primary_sponsor"),
+		"countries": trial.get("countries_normalized"),
+		"link": trial.get("link"),
+		"summary": _truncate(trial.get("summary")),
+		"identifiers": trial.get("identifiers"),
+	}
 
 
 def compact_author(author: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "author_id": author.get("author_id"),
-        "full_name": author.get("full_name"),
-        "orcid": author.get("ORCID"),
-        "country": author.get("country"),
-        "articles_count": author.get("articles_count"),
-        "relevant_articles_count": author.get("relevant_articles_count"),
-    }
+	return {
+		"author_id": author.get("author_id"),
+		"full_name": author.get("full_name"),
+		"orcid": author.get("ORCID"),
+		"country": author.get("country"),
+		"articles_count": author.get("articles_count"),
+		"relevant_articles_count": author.get("relevant_articles_count"),
+	}

--- a/mcp-server/gregory_mcp/config.py
+++ b/mcp-server/gregory_mcp/config.py
@@ -34,6 +34,9 @@ def load_settings() -> Settings:
 		port=int(os.environ.get("MCP_PORT", "8001")),
 		request_timeout=float(os.environ.get("GREGORY_REQUEST_TIMEOUT", "15")),
 		connect_timeout=float(os.environ.get("GREGORY_CONNECT_TIMEOUT", "5")),
-		max_retries=int(os.environ.get("GREGORY_MAX_RETRIES", "2")),
+		# max(0, ...): a negative value here would make GregoryClient.get()'s
+		# `attempts = max_retries + 1` reach 0, so its retry loop never runs at
+		# all and every call fails immediately without ever hitting the network.
+		max_retries=max(0, int(os.environ.get("GREGORY_MAX_RETRIES", "2"))),
 		log_level=os.environ.get("MCP_LOG_LEVEL", "INFO").upper(),
 	)

--- a/mcp-server/gregory_mcp/config.py
+++ b/mcp-server/gregory_mcp/config.py
@@ -1,0 +1,39 @@
+"""Environment configuration for the Gregory MCP server."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Settings:
+    api_url: str
+    host: str
+    port: int
+    request_timeout: float
+    connect_timeout: float
+    max_retries: int
+    log_level: str
+
+    @property
+    def api_base(self) -> str:
+        return self.api_url.rstrip("/")
+
+
+def load_settings() -> Settings:
+    api_url = os.environ.get("GREGORY_API_URL", "").strip()
+    if not api_url:
+        raise RuntimeError(
+            "GREGORY_API_URL is required — the base URL of the GregoryAI instance "
+            "this server proxies (e.g. https://api.brain-regeneration.com)"
+        )
+    return Settings(
+        api_url=api_url,
+        host=os.environ.get("MCP_HOST", "0.0.0.0"),
+        port=int(os.environ.get("MCP_PORT", "8001")),
+        request_timeout=float(os.environ.get("GREGORY_REQUEST_TIMEOUT", "15")),
+        connect_timeout=float(os.environ.get("GREGORY_CONNECT_TIMEOUT", "5")),
+        max_retries=int(os.environ.get("GREGORY_MAX_RETRIES", "2")),
+        log_level=os.environ.get("MCP_LOG_LEVEL", "INFO").upper(),
+    )

--- a/mcp-server/gregory_mcp/config.py
+++ b/mcp-server/gregory_mcp/config.py
@@ -8,32 +8,32 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True, slots=True)
 class Settings:
-    api_url: str
-    host: str
-    port: int
-    request_timeout: float
-    connect_timeout: float
-    max_retries: int
-    log_level: str
+	api_url: str
+	host: str
+	port: int
+	request_timeout: float
+	connect_timeout: float
+	max_retries: int
+	log_level: str
 
-    @property
-    def api_base(self) -> str:
-        return self.api_url.rstrip("/")
+	@property
+	def api_base(self) -> str:
+		return self.api_url.rstrip("/")
 
 
 def load_settings() -> Settings:
-    api_url = os.environ.get("GREGORY_API_URL", "").strip()
-    if not api_url:
-        raise RuntimeError(
-            "GREGORY_API_URL is required — the base URL of the GregoryAI instance "
-            "this server proxies (e.g. https://api.brain-regeneration.com)"
-        )
-    return Settings(
-        api_url=api_url,
-        host=os.environ.get("MCP_HOST", "0.0.0.0"),
-        port=int(os.environ.get("MCP_PORT", "8001")),
-        request_timeout=float(os.environ.get("GREGORY_REQUEST_TIMEOUT", "15")),
-        connect_timeout=float(os.environ.get("GREGORY_CONNECT_TIMEOUT", "5")),
-        max_retries=int(os.environ.get("GREGORY_MAX_RETRIES", "2")),
-        log_level=os.environ.get("MCP_LOG_LEVEL", "INFO").upper(),
-    )
+	api_url = os.environ.get("GREGORY_API_URL", "").strip()
+	if not api_url:
+		raise RuntimeError(
+			"GREGORY_API_URL is required — the base URL of the GregoryAI instance "
+			"this server proxies (e.g. https://api.brain-regeneration.com)"
+		)
+	return Settings(
+		api_url=api_url,
+		host=os.environ.get("MCP_HOST", "0.0.0.0"),
+		port=int(os.environ.get("MCP_PORT", "8001")),
+		request_timeout=float(os.environ.get("GREGORY_REQUEST_TIMEOUT", "15")),
+		connect_timeout=float(os.environ.get("GREGORY_CONNECT_TIMEOUT", "5")),
+		max_retries=int(os.environ.get("GREGORY_MAX_RETRIES", "2")),
+		log_level=os.environ.get("MCP_LOG_LEVEL", "INFO").upper(),
+	)

--- a/mcp-server/gregory_mcp/enums.py
+++ b/mcp-server/gregory_mcp/enums.py
@@ -1,0 +1,20 @@
+"""Shared literal types for tool parameters, mirroring the API's choice fields.
+
+Kept in one place so search_articles and search_trials can't drift from each
+other on a modality list that's supposed to be identical.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+CategoryModality = Literal[
+	"biologic_antibody",
+	"cell_gene_therapy",
+	"device_neuromodulation",
+	"natural_product",
+	"other",
+	"rehabilitation",
+	"research_topic",
+	"small_molecule",
+]

--- a/mcp-server/gregory_mcp/logging_config.py
+++ b/mcp-server/gregory_mcp/logging_config.py
@@ -1,0 +1,33 @@
+"""Structured (JSON) logging for the Gregory MCP server."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import time
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "ts": round(time.time(), 3),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        for key in ("tool", "duration_ms", "status_code", "path"):
+            value = getattr(record, key, None)
+            if value is not None:
+                payload[key] = value
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload)
+
+
+def configure_logging(level: str) -> None:
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonFormatter())
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(level)

--- a/mcp-server/gregory_mcp/logging_config.py
+++ b/mcp-server/gregory_mcp/logging_config.py
@@ -9,25 +9,25 @@ import time
 
 
 class JsonFormatter(logging.Formatter):
-    def format(self, record: logging.LogRecord) -> str:
-        payload = {
-            "ts": round(time.time(), 3),
-            "level": record.levelname,
-            "logger": record.name,
-            "message": record.getMessage(),
-        }
-        for key in ("tool", "duration_ms", "status_code", "path"):
-            value = getattr(record, key, None)
-            if value is not None:
-                payload[key] = value
-        if record.exc_info:
-            payload["exc_info"] = self.formatException(record.exc_info)
-        return json.dumps(payload)
+	def format(self, record: logging.LogRecord) -> str:
+		payload = {
+			"ts": round(time.time(), 3),
+			"level": record.levelname,
+			"logger": record.name,
+			"message": record.getMessage(),
+		}
+		for key in ("tool", "duration_ms", "status_code", "path"):
+			value = getattr(record, key, None)
+			if value is not None:
+				payload[key] = value
+		if record.exc_info:
+			payload["exc_info"] = self.formatException(record.exc_info)
+		return json.dumps(payload)
 
 
 def configure_logging(level: str) -> None:
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(JsonFormatter())
-    root = logging.getLogger()
-    root.handlers = [handler]
-    root.setLevel(level)
+	handler = logging.StreamHandler(sys.stdout)
+	handler.setFormatter(JsonFormatter())
+	root = logging.getLogger()
+	root.handlers = [handler]
+	root.setLevel(level)

--- a/mcp-server/gregory_mcp/pagination.py
+++ b/mcp-server/gregory_mcp/pagination.py
@@ -1,0 +1,15 @@
+"""Shared page/page_size clamping for tools that paginate."""
+
+from __future__ import annotations
+
+
+def clamp_page(page: int) -> int:
+	"""Floor at 1 — the API's page numbering starts there; 0 or negative
+	values would otherwise be forwarded upstream and 400."""
+	return max(page, 1)
+
+
+def clamp_page_size(page_size: int, max_size: int) -> int:
+	"""Clamp to [1, max_size] — a 0 or negative page_size would otherwise be
+	forwarded upstream and produce an empty or erroring page."""
+	return max(1, min(page_size, max_size))

--- a/mcp-server/gregory_mcp/prompts.py
+++ b/mcp-server/gregory_mcp/prompts.py
@@ -1,0 +1,55 @@
+"""Starter prompts. Three to start; let real usage dictate the rest."""
+
+from __future__ import annotations
+
+
+def register_prompts(server) -> None:
+    @server.prompt(
+        name="research_topic",
+        title="Research a topic",
+        description="Survey recent articles and clinical trials on a topic.",
+    )
+    def research_topic(topic: str, subject_id: str | None = None) -> str:
+        scope = f" within subject_id={subject_id}" if subject_id else ""
+        return (
+            f"Research the topic \"{topic}\"{scope} using the GregoryAI tools.\n\n"
+            f"1. Call search_articles with search=\"{topic}\" (add relevant=true if you "
+            "want AI-flagged-relevant results only) and skim the top results.\n"
+            f"2. Call search_trials with search=\"{topic}\" to find related clinical trials.\n"
+            "3. For the most promising 2-3 articles or trials, call get_article / get_trial "
+            "for the full record before summarizing.\n"
+            "4. Summarize: what's being studied, how far along it is (trial phase/recruitment "
+            "status where relevant), and any notable authors or sponsors."
+        )
+
+    @server.prompt(
+        name="recent_trials_for_subject",
+        title="Recent trials for a subject",
+        description="List actively recruiting or recently registered trials for a research subject.",
+    )
+    def recent_trials_for_subject(subject_id: str) -> str:
+        return (
+            f"Find recent clinical trials for subject_id={subject_id} using the GregoryAI tools.\n\n"
+            f"1. Call search_trials with subject_id={subject_id}, "
+            'recruitment_status_normalized="recruiting", ordering="-date_registration".\n'
+            "2. For each result, note phase, sponsor, and countries from the compact result — "
+            "call get_trial only for ones worth a closer look.\n"
+            "3. Summarize what's actively recruiting and where."
+        )
+
+    @server.prompt(
+        name="author_profile",
+        title="Author profile",
+        description="Build a profile of a researcher: affiliation, publication history, relevance.",
+    )
+    def author_profile(name_or_orcid: str) -> str:
+        return (
+            f'Build a profile of the researcher "{name_or_orcid}" using the GregoryAI tools.\n\n'
+            "1. Call search_authors with search set to the given name or orcid to find the "
+            "author_id (if it looks like an ORCID iD, pass it as orcid instead).\n"
+            "2. Call get_author with that author_id (include_coauthors=true if collaboration "
+            "network is relevant) for the full record.\n"
+            "3. Optionally call search_articles with author_id=<id> to see their recent work.\n"
+            "4. Summarize affiliation, publication volume, and how much of their work is "
+            "AI-flagged relevant (relevant_articles_count vs articles_count)."
+        )

--- a/mcp-server/gregory_mcp/prompts.py
+++ b/mcp-server/gregory_mcp/prompts.py
@@ -4,52 +4,52 @@ from __future__ import annotations
 
 
 def register_prompts(server) -> None:
-    @server.prompt(
-        name="research_topic",
-        title="Research a topic",
-        description="Survey recent articles and clinical trials on a topic.",
-    )
-    def research_topic(topic: str, subject_id: str | None = None) -> str:
-        scope = f" within subject_id={subject_id}" if subject_id else ""
-        return (
-            f"Research the topic \"{topic}\"{scope} using the GregoryAI tools.\n\n"
-            f"1. Call search_articles with search=\"{topic}\" (add relevant=true if you "
-            "want AI-flagged-relevant results only) and skim the top results.\n"
-            f"2. Call search_trials with search=\"{topic}\" to find related clinical trials.\n"
-            "3. For the most promising 2-3 articles or trials, call get_article / get_trial "
-            "for the full record before summarizing.\n"
-            "4. Summarize: what's being studied, how far along it is (trial phase/recruitment "
-            "status where relevant), and any notable authors or sponsors."
-        )
+	@server.prompt(
+		name="research_topic",
+		title="Research a topic",
+		description="Survey recent articles and clinical trials on a topic.",
+	)
+	def research_topic(topic: str, subject_id: str | None = None) -> str:
+		scope = f" within subject_id={subject_id}" if subject_id else ""
+		return (
+			f"Research the topic \"{topic}\"{scope} using the GregoryAI tools.\n\n"
+			f"1. Call search_articles with search=\"{topic}\" (add relevant=true if you "
+			"want AI-flagged-relevant results only) and skim the top results.\n"
+			f"2. Call search_trials with search=\"{topic}\" to find related clinical trials.\n"
+			"3. For the most promising 2-3 articles or trials, call get_article / get_trial "
+			"for the full record before summarizing.\n"
+			"4. Summarize: what's being studied, how far along it is (trial phase/recruitment "
+			"status where relevant), and any notable authors or sponsors."
+		)
 
-    @server.prompt(
-        name="recent_trials_for_subject",
-        title="Recent trials for a subject",
-        description="List actively recruiting or recently registered trials for a research subject.",
-    )
-    def recent_trials_for_subject(subject_id: str) -> str:
-        return (
-            f"Find recent clinical trials for subject_id={subject_id} using the GregoryAI tools.\n\n"
-            f"1. Call search_trials with subject_id={subject_id}, "
-            'recruitment_status_normalized="recruiting", ordering="-date_registration".\n'
-            "2. For each result, note phase, sponsor, and countries from the compact result — "
-            "call get_trial only for ones worth a closer look.\n"
-            "3. Summarize what's actively recruiting and where."
-        )
+	@server.prompt(
+		name="recent_trials_for_subject",
+		title="Recent trials for a subject",
+		description="List actively recruiting or recently registered trials for a research subject.",
+	)
+	def recent_trials_for_subject(subject_id: str) -> str:
+		return (
+			f"Find recent clinical trials for subject_id={subject_id} using the GregoryAI tools.\n\n"
+			f"1. Call search_trials with subject_id={subject_id}, "
+			'recruitment_status_normalized="recruiting", ordering="-date_registration".\n'
+			"2. For each result, note phase, sponsor, and countries from the compact result — "
+			"call get_trial only for ones worth a closer look.\n"
+			"3. Summarize what's actively recruiting and where."
+		)
 
-    @server.prompt(
-        name="author_profile",
-        title="Author profile",
-        description="Build a profile of a researcher: affiliation, publication history, relevance.",
-    )
-    def author_profile(name_or_orcid: str) -> str:
-        return (
-            f'Build a profile of the researcher "{name_or_orcid}" using the GregoryAI tools.\n\n'
-            "1. Call search_authors with search set to the given name or orcid to find the "
-            "author_id (if it looks like an ORCID iD, pass it as orcid instead).\n"
-            "2. Call get_author with that author_id (include_coauthors=true if collaboration "
-            "network is relevant) for the full record.\n"
-            "3. Optionally call search_articles with author_id=<id> to see their recent work.\n"
-            "4. Summarize affiliation, publication volume, and how much of their work is "
-            "AI-flagged relevant (relevant_articles_count vs articles_count)."
-        )
+	@server.prompt(
+		name="author_profile",
+		title="Author profile",
+		description="Build a profile of a researcher: affiliation, publication history, relevance.",
+	)
+	def author_profile(name_or_orcid: str) -> str:
+		return (
+			f'Build a profile of the researcher "{name_or_orcid}" using the GregoryAI tools.\n\n'
+			"1. Call search_authors with search set to the given name or orcid to find the "
+			"author_id (if it looks like an ORCID iD, pass it as orcid instead).\n"
+			"2. Call get_author with that author_id (include_coauthors=true if collaboration "
+			"network is relevant) for the full record.\n"
+			"3. Optionally call search_articles with author_id=<id> to see their recent work.\n"
+			"4. Summarize affiliation, publication volume, and how much of their work is "
+			"AI-flagged relevant (relevant_articles_count vs articles_count)."
+		)

--- a/mcp-server/gregory_mcp/prompts.py
+++ b/mcp-server/gregory_mcp/prompts.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import date, timedelta
+
 
 def register_prompts(server) -> None:
 	@server.prompt(
@@ -28,10 +30,19 @@ def register_prompts(server) -> None:
 		description="List actively recruiting or recently registered trials for a research subject.",
 	)
 	def recent_trials_for_subject(subject_id: str) -> str:
+		# date_registration is not a valid `ordering` value on /trials/ (see
+		# TrialViewSet.ordering_fields) — DRF's OrderingFilter silently ignores
+		# an unrecognised value rather than rejecting it, so ordering by it
+		# quietly fell back to the default order instead of erroring. Bound
+		# recency with the date_registration_after filter instead; the default
+		# ordering (-discovery_date) already puts newest-discovered first.
+		cutoff = (date.today() - timedelta(days=180)).isoformat()
 		return (
 			f"Find recent clinical trials for subject_id={subject_id} using the GregoryAI tools.\n\n"
 			f"1. Call search_trials with subject_id={subject_id}, "
-			'recruitment_status_normalized="recruiting", ordering="-date_registration".\n'
+			f'recruitment_status_normalized="recruiting", date_registration_after="{cutoff}" '
+			"(roughly the last 6 months) to bound it to recently-registered trials — "
+			"results already come back newest-discovered-first by default.\n"
 			"2. For each result, note phase, sponsor, and countries from the compact result — "
 			"call get_trial only for ones worth a closer look.\n"
 			"3. Summarize what's actively recruiting and where."

--- a/mcp-server/gregory_mcp/resources.py
+++ b/mcp-server/gregory_mcp/resources.py
@@ -1,7 +1,12 @@
-"""Reference-data resources: subjects, categories, sponsors catalogs.
+"""Reference-data resources: subjects, categories catalogs.
 
 Registered with server-level `ttlMs`/`cacheScope` hints (see server.py) so
 clients stop refetching this slow-changing data every conversation turn.
+
+No sponsors resource: at ~8,000 rows / ~700 KB, sponsors are not
+catalog-shaped the way subjects (7 rows) and categories (~120 rows) are —
+resources are cached and injected wholesale. The `list_sponsors` tool
+(search + pagination) is the right shape for that data; use it instead.
 """
 
 from __future__ import annotations
@@ -39,20 +44,4 @@ def register_resources(server) -> None:
 				{"id": c.get("id"), "category_name": c.get("category_name"), "category_slug": c.get("category_slug")}
 				for c in results
 			]
-		)
-
-	@server.resource(
-		"gregory://sponsors",
-		name="sponsors_catalog",
-		title="Sponsors catalog",
-		description="Every canonical, deduplicated clinical trial sponsor.",
-		mime_type="application/json",
-	)
-	async def sponsors_catalog() -> str:
-		# Sponsors can number in the thousands (unlike subjects/categories);
-		# get_all_pages caps at 20 pages (~2000 rows at page_size=100) as a
-		# safety net rather than fetching an unbounded catalog.
-		results = await get_client().get_all_pages("/sponsors/", {"page_size": 100})
-		return json.dumps(
-			[{"id": s.get("id"), "name": s.get("name"), "slug": s.get("slug")} for s in results]
 		)

--- a/mcp-server/gregory_mcp/resources.py
+++ b/mcp-server/gregory_mcp/resources.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 
-from .client import get_client
+from .cache import get_all_pages_cached
 
 
 def register_resources(server) -> None:
@@ -25,7 +25,9 @@ def register_resources(server) -> None:
 		mime_type="application/json",
 	)
 	async def subjects_catalog() -> str:
-		results = await get_client().get_all_pages("/subjects/")
+		# No params (the full, unfiltered catalog) — same cache entry as
+		# list_subjects() called with no filters.
+		results = await get_all_pages_cached("/subjects/")
 		return json.dumps(
 			[{"id": s.get("id"), "subject_name": s.get("subject_name"), "team_id": s.get("team_id")} for s in results]
 		)
@@ -38,7 +40,7 @@ def register_resources(server) -> None:
 		mime_type="application/json",
 	)
 	async def categories_catalog() -> str:
-		results = await get_client().get_all_pages("/categories/")
+		results = await get_all_pages_cached("/categories/")
 		return json.dumps(
 			[
 				{"id": c.get("id"), "category_name": c.get("category_name"), "category_slug": c.get("category_slug")}

--- a/mcp-server/gregory_mcp/resources.py
+++ b/mcp-server/gregory_mcp/resources.py
@@ -12,47 +12,47 @@ from .client import get_client
 
 
 def register_resources(server) -> None:
-    @server.resource(
-        "gregory://subjects",
-        name="subjects_catalog",
-        title="Subjects catalog",
-        description="Every research subject, with its team_id, across the connected GregoryAI instance.",
-        mime_type="application/json",
-    )
-    async def subjects_catalog() -> str:
-        results = await get_client().get_all_pages("/subjects/")
-        return json.dumps(
-            [{"id": s.get("id"), "subject_name": s.get("subject_name"), "team_id": s.get("team_id")} for s in results]
-        )
+	@server.resource(
+		"gregory://subjects",
+		name="subjects_catalog",
+		title="Subjects catalog",
+		description="Every research subject, with its team_id, across the connected GregoryAI instance.",
+		mime_type="application/json",
+	)
+	async def subjects_catalog() -> str:
+		results = await get_client().get_all_pages("/subjects/")
+		return json.dumps(
+			[{"id": s.get("id"), "subject_name": s.get("subject_name"), "team_id": s.get("team_id")} for s in results]
+		)
 
-    @server.resource(
-        "gregory://categories",
-        name="categories_catalog",
-        title="Categories catalog",
-        description="Every research category (topic tag) across the connected GregoryAI instance.",
-        mime_type="application/json",
-    )
-    async def categories_catalog() -> str:
-        results = await get_client().get_all_pages("/categories/")
-        return json.dumps(
-            [
-                {"id": c.get("id"), "category_name": c.get("category_name"), "category_slug": c.get("category_slug")}
-                for c in results
-            ]
-        )
+	@server.resource(
+		"gregory://categories",
+		name="categories_catalog",
+		title="Categories catalog",
+		description="Every research category (topic tag) across the connected GregoryAI instance.",
+		mime_type="application/json",
+	)
+	async def categories_catalog() -> str:
+		results = await get_client().get_all_pages("/categories/")
+		return json.dumps(
+			[
+				{"id": c.get("id"), "category_name": c.get("category_name"), "category_slug": c.get("category_slug")}
+				for c in results
+			]
+		)
 
-    @server.resource(
-        "gregory://sponsors",
-        name="sponsors_catalog",
-        title="Sponsors catalog",
-        description="Every canonical, deduplicated clinical trial sponsor.",
-        mime_type="application/json",
-    )
-    async def sponsors_catalog() -> str:
-        # Sponsors can number in the thousands (unlike subjects/categories);
-        # get_all_pages caps at 20 pages (~2000 rows at page_size=100) as a
-        # safety net rather than fetching an unbounded catalog.
-        results = await get_client().get_all_pages("/sponsors/", {"page_size": 100})
-        return json.dumps(
-            [{"id": s.get("id"), "name": s.get("name"), "slug": s.get("slug")} for s in results]
-        )
+	@server.resource(
+		"gregory://sponsors",
+		name="sponsors_catalog",
+		title="Sponsors catalog",
+		description="Every canonical, deduplicated clinical trial sponsor.",
+		mime_type="application/json",
+	)
+	async def sponsors_catalog() -> str:
+		# Sponsors can number in the thousands (unlike subjects/categories);
+		# get_all_pages caps at 20 pages (~2000 rows at page_size=100) as a
+		# safety net rather than fetching an unbounded catalog.
+		results = await get_client().get_all_pages("/sponsors/", {"page_size": 100})
+		return json.dumps(
+			[{"id": s.get("id"), "name": s.get("name"), "slug": s.get("slug")} for s in results]
+		)

--- a/mcp-server/gregory_mcp/resources.py
+++ b/mcp-server/gregory_mcp/resources.py
@@ -1,0 +1,58 @@
+"""Reference-data resources: subjects, categories, sponsors catalogs.
+
+Registered with server-level `ttlMs`/`cacheScope` hints (see server.py) so
+clients stop refetching this slow-changing data every conversation turn.
+"""
+
+from __future__ import annotations
+
+import json
+
+from .client import get_client
+
+
+def register_resources(server) -> None:
+    @server.resource(
+        "gregory://subjects",
+        name="subjects_catalog",
+        title="Subjects catalog",
+        description="Every research subject, with its team_id, across the connected GregoryAI instance.",
+        mime_type="application/json",
+    )
+    async def subjects_catalog() -> str:
+        results = await get_client().get_all_pages("/subjects/")
+        return json.dumps(
+            [{"id": s.get("id"), "subject_name": s.get("subject_name"), "team_id": s.get("team_id")} for s in results]
+        )
+
+    @server.resource(
+        "gregory://categories",
+        name="categories_catalog",
+        title="Categories catalog",
+        description="Every research category (topic tag) across the connected GregoryAI instance.",
+        mime_type="application/json",
+    )
+    async def categories_catalog() -> str:
+        results = await get_client().get_all_pages("/categories/")
+        return json.dumps(
+            [
+                {"id": c.get("id"), "category_name": c.get("category_name"), "category_slug": c.get("category_slug")}
+                for c in results
+            ]
+        )
+
+    @server.resource(
+        "gregory://sponsors",
+        name="sponsors_catalog",
+        title="Sponsors catalog",
+        description="Every canonical, deduplicated clinical trial sponsor.",
+        mime_type="application/json",
+    )
+    async def sponsors_catalog() -> str:
+        # Sponsors can number in the thousands (unlike subjects/categories);
+        # get_all_pages caps at 20 pages (~2000 rows at page_size=100) as a
+        # safety net rather than fetching an unbounded catalog.
+        results = await get_client().get_all_pages("/sponsors/", {"page_size": 100})
+        return json.dumps(
+            [{"id": s.get("id"), "name": s.get("name"), "slug": s.get("slug")} for s in results]
+        )

--- a/mcp-server/gregory_mcp/server.py
+++ b/mcp-server/gregory_mcp/server.py
@@ -1,0 +1,55 @@
+"""Builds the GregoryAI MCPServer: registers tools, resources, and prompts.
+
+Everything here is read-only. Every tool is annotated
+`read_only_hint=True, idempotent_hint=True, open_world_hint=False` since none
+of them write, and every one only ever talks to the one Gregory instance
+named by `GREGORY_API_URL`.
+"""
+
+from __future__ import annotations
+
+from mcp.server.caching import CacheHint
+from mcp.server.mcpserver import MCPServer
+from mcp_types import ToolAnnotations
+
+from .prompts import register_prompts
+from .resources import register_resources
+from .tools import articles, authors, catalog, stats, trials
+
+READ_ONLY = ToolAnnotations(read_only_hint=True, idempotent_hint=True, open_world_hint=False)
+
+# Reference-data resources change slowly; let clients cache them for 10 minutes
+# and share the cached value across callers (nothing in the payload is caller-specific).
+CATALOG_CACHE = CacheHint(ttl_ms=10 * 60 * 1000, scope="public")
+
+
+def build_server() -> MCPServer:
+    server = MCPServer(
+        name="gregory",
+        title="GregoryAI",
+        description=(
+            "Read-only access to the GregoryAI research database: articles, clinical "
+            "trials, authors, subjects, categories, and sponsors."
+        ),
+        version="0.1.0",
+        cache_hints={
+            "resources/list": CATALOG_CACHE,
+            "resources/read": CATALOG_CACHE,
+        },
+    )
+
+    server.add_tool(catalog.list_subjects, annotations=READ_ONLY)
+    server.add_tool(articles.search_articles, annotations=READ_ONLY)
+    server.add_tool(articles.get_article, annotations=READ_ONLY)
+    server.add_tool(trials.search_trials, annotations=READ_ONLY)
+    server.add_tool(trials.get_trial, annotations=READ_ONLY)
+    server.add_tool(authors.search_authors, annotations=READ_ONLY)
+    server.add_tool(authors.get_author, annotations=READ_ONLY)
+    server.add_tool(catalog.list_categories, annotations=READ_ONLY)
+    server.add_tool(catalog.list_sponsors, annotations=READ_ONLY)
+    server.add_tool(stats.get_stats, annotations=READ_ONLY)
+
+    register_resources(server)
+    register_prompts(server)
+
+    return server

--- a/mcp-server/gregory_mcp/server.py
+++ b/mcp-server/gregory_mcp/server.py
@@ -24,32 +24,32 @@ CATALOG_CACHE = CacheHint(ttl_ms=10 * 60 * 1000, scope="public")
 
 
 def build_server() -> MCPServer:
-    server = MCPServer(
-        name="gregory",
-        title="GregoryAI",
-        description=(
-            "Read-only access to the GregoryAI research database: articles, clinical "
-            "trials, authors, subjects, categories, and sponsors."
-        ),
-        version="0.1.0",
-        cache_hints={
-            "resources/list": CATALOG_CACHE,
-            "resources/read": CATALOG_CACHE,
-        },
-    )
+	server = MCPServer(
+		name="gregory",
+		title="GregoryAI",
+		description=(
+			"Read-only access to the GregoryAI research database: articles, clinical "
+			"trials, authors, subjects, categories, and sponsors."
+		),
+		version="0.1.0",
+		cache_hints={
+			"resources/list": CATALOG_CACHE,
+			"resources/read": CATALOG_CACHE,
+		},
+	)
 
-    server.add_tool(catalog.list_subjects, annotations=READ_ONLY)
-    server.add_tool(articles.search_articles, annotations=READ_ONLY)
-    server.add_tool(articles.get_article, annotations=READ_ONLY)
-    server.add_tool(trials.search_trials, annotations=READ_ONLY)
-    server.add_tool(trials.get_trial, annotations=READ_ONLY)
-    server.add_tool(authors.search_authors, annotations=READ_ONLY)
-    server.add_tool(authors.get_author, annotations=READ_ONLY)
-    server.add_tool(catalog.list_categories, annotations=READ_ONLY)
-    server.add_tool(catalog.list_sponsors, annotations=READ_ONLY)
-    server.add_tool(stats.get_stats, annotations=READ_ONLY)
+	server.add_tool(catalog.list_subjects, annotations=READ_ONLY)
+	server.add_tool(articles.search_articles, annotations=READ_ONLY)
+	server.add_tool(articles.get_article, annotations=READ_ONLY)
+	server.add_tool(trials.search_trials, annotations=READ_ONLY)
+	server.add_tool(trials.get_trial, annotations=READ_ONLY)
+	server.add_tool(authors.search_authors, annotations=READ_ONLY)
+	server.add_tool(authors.get_author, annotations=READ_ONLY)
+	server.add_tool(catalog.list_categories, annotations=READ_ONLY)
+	server.add_tool(catalog.list_sponsors, annotations=READ_ONLY)
+	server.add_tool(stats.get_stats, annotations=READ_ONLY)
 
-    register_resources(server)
-    register_prompts(server)
+	register_resources(server)
+	register_prompts(server)
 
-    return server
+	return server

--- a/mcp-server/gregory_mcp/server.py
+++ b/mcp-server/gregory_mcp/server.py
@@ -12,15 +12,18 @@ from mcp.server.caching import CacheHint
 from mcp.server.mcpserver import MCPServer
 from mcp_types import ToolAnnotations
 
+from .cache import CATALOG_CACHE_TTL_MS
 from .prompts import register_prompts
 from .resources import register_resources
 from .tools import articles, authors, catalog, stats, trials
 
 READ_ONLY = ToolAnnotations(read_only_hint=True, idempotent_hint=True, open_world_hint=False)
 
-# Reference-data resources change slowly; let clients cache them for 10 minutes
+# Reference-data resources change slowly; let clients cache them for as long as
+# the server itself does (CATALOG_CACHE_TTL_MS, see cache.py — one constant,
+# so the client-facing hint and the server's actual cache can't drift apart)
 # and share the cached value across callers (nothing in the payload is caller-specific).
-CATALOG_CACHE = CacheHint(ttl_ms=10 * 60 * 1000, scope="public")
+CATALOG_CACHE = CacheHint(ttl_ms=CATALOG_CACHE_TTL_MS, scope="public")
 
 
 def build_server() -> MCPServer:

--- a/mcp-server/gregory_mcp/tools/articles.py
+++ b/mcp-server/gregory_mcp/tools/articles.py
@@ -47,6 +47,7 @@ async def search_articles(
 	Dates are YYYY-MM-DD. `ordering` accepts discovery_date, published_date,
 	title, article_id, ml_score (prefix `-` for descending).
 	"""
+	clamped_page = clamp_page(page)
 	params = {
 		"search": search,
 		"title": title,
@@ -66,14 +67,14 @@ async def search_articles(
 		"published_date_after": published_date_after,
 		"published_date_before": published_date_before,
 		"ordering": ordering,
-		"page": clamp_page(page),
+		"page": clamped_page,
 		"page_size": clamp_page_size(page_size, MAX_PAGE_SIZE),
 	}
 	data = await get_client().get("/articles/", params)
 	results = data.get("results", [])
 	return {
 		"count": data.get("count", len(results)),
-		"next": data.get("next"),
+		"next_page": clamped_page + 1 if data.get("next") else None,
 		"articles": [compact_article(a) for a in results],
 	}
 

--- a/mcp-server/gregory_mcp/tools/articles.py
+++ b/mcp-server/gregory_mcp/tools/articles.py
@@ -8,14 +8,14 @@ from ..client import get_client
 from ..compact import compact_article
 
 CategoryModality = Literal[
-    "biologic_antibody",
-    "cell_gene_therapy",
-    "device_neuromodulation",
-    "natural_product",
-    "other",
-    "rehabilitation",
-    "research_topic",
-    "small_molecule",
+	"biologic_antibody",
+	"cell_gene_therapy",
+	"device_neuromodulation",
+	"natural_product",
+	"other",
+	"rehabilitation",
+	"research_topic",
+	"small_molecule",
 ]
 
 DEFAULT_PAGE_SIZE = 10
@@ -23,73 +23,73 @@ MAX_PAGE_SIZE = 25
 
 
 async def search_articles(
-    search: str | None = None,
-    title: str | None = None,
-    summary: str | None = None,
-    team_id: int | None = None,
-    subject_id: int | None = None,
-    category_slug: str | None = None,
-    category_id: int | None = None,
-    category_modality: CategoryModality | None = None,
-    journal_slug: str | None = None,
-    doi: str | None = None,
-    author_id: int | None = None,
-    relevant: bool | None = None,
-    ml_threshold: float | None = None,
-    open_access: bool | None = None,
-    has_clinical_trials: bool | None = None,
-    published_date_after: str | None = None,
-    published_date_before: str | None = None,
-    ordering: str | None = None,
-    page: int = 1,
-    page_size: int = DEFAULT_PAGE_SIZE,
+	search: str | None = None,
+	title: str | None = None,
+	summary: str | None = None,
+	team_id: int | None = None,
+	subject_id: int | None = None,
+	category_slug: str | None = None,
+	category_id: int | None = None,
+	category_modality: CategoryModality | None = None,
+	journal_slug: str | None = None,
+	doi: str | None = None,
+	author_id: int | None = None,
+	relevant: bool | None = None,
+	ml_threshold: float | None = None,
+	open_access: bool | None = None,
+	has_clinical_trials: bool | None = None,
+	published_date_after: str | None = None,
+	published_date_before: str | None = None,
+	ordering: str | None = None,
+	page: int = 1,
+	page_size: int = DEFAULT_PAGE_SIZE,
 ) -> dict:
-    """Search research articles. Returns a compact projection — use
-    get_article for the full record (authors, ML predictions, linked trials).
+	"""Search research articles. Returns a compact projection — use
+	get_article for the full record (authors, ML predictions, linked trials).
 
-    `search` is boolean over title + summary: space-separated terms are
-    AND-ed, uppercase OR/NOT for alternatives/exclusion, "quoted phrases"
-    match contiguously, (parentheses) group. Use `title=`/`summary=` instead
-    of `search=` to match only one field.
+	`search` is boolean over title + summary: space-separated terms are
+	AND-ed, uppercase OR/NOT for alternatives/exclusion, "quoted phrases"
+	match contiguously, (parentheses) group. Use `title=`/`summary=` instead
+	of `search=` to match only one field.
 
-    `relevant` and `ml_threshold` are scoped to `subject_id` when it is
-    given — without a subject_id, relevance is checked across all subjects.
+	`relevant` and `ml_threshold` are scoped to `subject_id` when it is
+	given — without a subject_id, relevance is checked across all subjects.
 
-    Dates are YYYY-MM-DD. `ordering` accepts discovery_date, published_date,
-    title, article_id, ml_score (prefix `-` for descending).
-    """
-    params = {
-        "search": search,
-        "title": title,
-        "summary": summary,
-        "team_id": team_id,
-        "subject_id": subject_id,
-        "category_slug": category_slug,
-        "category_id": category_id,
-        "category_modality": category_modality,
-        "journal_slug": journal_slug,
-        "doi": doi,
-        "author_id": author_id,
-        "relevant": relevant,
-        "ml_threshold": ml_threshold,
-        "open_access": open_access,
-        "has_clinical_trials": has_clinical_trials,
-        "published_date_after": published_date_after,
-        "published_date_before": published_date_before,
-        "ordering": ordering,
-        "page": page,
-        "page_size": min(page_size, MAX_PAGE_SIZE),
-    }
-    data = await get_client().get("/articles/", params)
-    results = data.get("results", [])
-    return {
-        "count": data.get("count", len(results)),
-        "next": data.get("next"),
-        "articles": [compact_article(a) for a in results],
-    }
+	Dates are YYYY-MM-DD. `ordering` accepts discovery_date, published_date,
+	title, article_id, ml_score (prefix `-` for descending).
+	"""
+	params = {
+		"search": search,
+		"title": title,
+		"summary": summary,
+		"team_id": team_id,
+		"subject_id": subject_id,
+		"category_slug": category_slug,
+		"category_id": category_id,
+		"category_modality": category_modality,
+		"journal_slug": journal_slug,
+		"doi": doi,
+		"author_id": author_id,
+		"relevant": relevant,
+		"ml_threshold": ml_threshold,
+		"open_access": open_access,
+		"has_clinical_trials": has_clinical_trials,
+		"published_date_after": published_date_after,
+		"published_date_before": published_date_before,
+		"ordering": ordering,
+		"page": page,
+		"page_size": min(page_size, MAX_PAGE_SIZE),
+	}
+	data = await get_client().get("/articles/", params)
+	results = data.get("results", [])
+	return {
+		"count": data.get("count", len(results)),
+		"next": data.get("next"),
+		"articles": [compact_article(a) for a in results],
+	}
 
 
 async def get_article(article_id: int) -> dict:
-    """Fetch the full record for one article by ID, including authors,
-    ML predictions, linked clinical trials, and the untruncated summary."""
-    return await get_client().get(f"/articles/{article_id}/")
+	"""Fetch the full record for one article by ID, including authors,
+	ML predictions, linked clinical trials, and the untruncated summary."""
+	return await get_client().get(f"/articles/{article_id}/")

--- a/mcp-server/gregory_mcp/tools/articles.py
+++ b/mcp-server/gregory_mcp/tools/articles.py
@@ -2,22 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Literal
-
 from ..client import get_client
 from ..compact import compact_article
+from ..enums import CategoryModality
 from ..pagination import clamp_page, clamp_page_size
-
-CategoryModality = Literal[
-	"biologic_antibody",
-	"cell_gene_therapy",
-	"device_neuromodulation",
-	"natural_product",
-	"other",
-	"rehabilitation",
-	"research_topic",
-	"small_molecule",
-]
 
 DEFAULT_PAGE_SIZE = 10
 MAX_PAGE_SIZE = 25

--- a/mcp-server/gregory_mcp/tools/articles.py
+++ b/mcp-server/gregory_mcp/tools/articles.py
@@ -1,0 +1,95 @@
+"""Article search and detail tools."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from ..client import get_client
+from ..compact import compact_article
+
+CategoryModality = Literal[
+    "biologic_antibody",
+    "cell_gene_therapy",
+    "device_neuromodulation",
+    "natural_product",
+    "other",
+    "rehabilitation",
+    "research_topic",
+    "small_molecule",
+]
+
+DEFAULT_PAGE_SIZE = 10
+MAX_PAGE_SIZE = 25
+
+
+async def search_articles(
+    search: str | None = None,
+    title: str | None = None,
+    summary: str | None = None,
+    team_id: int | None = None,
+    subject_id: int | None = None,
+    category_slug: str | None = None,
+    category_id: int | None = None,
+    category_modality: CategoryModality | None = None,
+    journal_slug: str | None = None,
+    doi: str | None = None,
+    author_id: int | None = None,
+    relevant: bool | None = None,
+    ml_threshold: float | None = None,
+    open_access: bool | None = None,
+    has_clinical_trials: bool | None = None,
+    published_date_after: str | None = None,
+    published_date_before: str | None = None,
+    ordering: str | None = None,
+    page: int = 1,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> dict:
+    """Search research articles. Returns a compact projection — use
+    get_article for the full record (authors, ML predictions, linked trials).
+
+    `search` is boolean over title + summary: space-separated terms are
+    AND-ed, uppercase OR/NOT for alternatives/exclusion, "quoted phrases"
+    match contiguously, (parentheses) group. Use `title=`/`summary=` instead
+    of `search=` to match only one field.
+
+    `relevant` and `ml_threshold` are scoped to `subject_id` when it is
+    given — without a subject_id, relevance is checked across all subjects.
+
+    Dates are YYYY-MM-DD. `ordering` accepts discovery_date, published_date,
+    title, article_id, ml_score (prefix `-` for descending).
+    """
+    params = {
+        "search": search,
+        "title": title,
+        "summary": summary,
+        "team_id": team_id,
+        "subject_id": subject_id,
+        "category_slug": category_slug,
+        "category_id": category_id,
+        "category_modality": category_modality,
+        "journal_slug": journal_slug,
+        "doi": doi,
+        "author_id": author_id,
+        "relevant": relevant,
+        "ml_threshold": ml_threshold,
+        "open_access": open_access,
+        "has_clinical_trials": has_clinical_trials,
+        "published_date_after": published_date_after,
+        "published_date_before": published_date_before,
+        "ordering": ordering,
+        "page": page,
+        "page_size": min(page_size, MAX_PAGE_SIZE),
+    }
+    data = await get_client().get("/articles/", params)
+    results = data.get("results", [])
+    return {
+        "count": data.get("count", len(results)),
+        "next": data.get("next"),
+        "articles": [compact_article(a) for a in results],
+    }
+
+
+async def get_article(article_id: int) -> dict:
+    """Fetch the full record for one article by ID, including authors,
+    ML predictions, linked clinical trials, and the untruncated summary."""
+    return await get_client().get(f"/articles/{article_id}/")

--- a/mcp-server/gregory_mcp/tools/articles.py
+++ b/mcp-server/gregory_mcp/tools/articles.py
@@ -29,6 +29,7 @@ async def search_articles(
 	has_clinical_trials: bool | None = None,
 	published_date_after: str | None = None,
 	published_date_before: str | None = None,
+	last_days: float | None = None,
 	ordering: str | None = None,
 	page: int = 1,
 	page_size: int = DEFAULT_PAGE_SIZE,
@@ -44,8 +45,12 @@ async def search_articles(
 	`relevant` and `ml_threshold` are scoped to `subject_id` when it is
 	given — without a subject_id, relevance is checked across all subjects.
 
-	Dates are YYYY-MM-DD. `ordering` accepts discovery_date, published_date,
-	title, article_id, ml_score (prefix `-` for descending).
+	Dates are YYYY-MM-DD. `last_days` is a simpler alternative to
+	`published_date_after` for "recent papers" (e.g. `last_days=30`) — it
+	filters on discovery date, not publication date, so it also catches
+	older papers Gregory only just ingested. `ordering` accepts
+	discovery_date, published_date, title, article_id, ml_score (prefix `-`
+	for descending).
 	"""
 	clamped_page = clamp_page(page)
 	params = {
@@ -66,6 +71,7 @@ async def search_articles(
 		"has_clinical_trials": has_clinical_trials,
 		"published_date_after": published_date_after,
 		"published_date_before": published_date_before,
+		"last_days": last_days,
 		"ordering": ordering,
 		"page": clamped_page,
 		"page_size": clamp_page_size(page_size, MAX_PAGE_SIZE),

--- a/mcp-server/gregory_mcp/tools/articles.py
+++ b/mcp-server/gregory_mcp/tools/articles.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from ..client import get_client
 from ..compact import compact_article
+from ..pagination import clamp_page, clamp_page_size
 
 CategoryModality = Literal[
 	"biologic_antibody",
@@ -77,8 +78,8 @@ async def search_articles(
 		"published_date_after": published_date_after,
 		"published_date_before": published_date_before,
 		"ordering": ordering,
-		"page": page,
-		"page_size": min(page_size, MAX_PAGE_SIZE),
+		"page": clamp_page(page),
+		"page_size": clamp_page_size(page_size, MAX_PAGE_SIZE),
 	}
 	data = await get_client().get("/articles/", params)
 	results = data.get("results", [])

--- a/mcp-server/gregory_mcp/tools/authors.py
+++ b/mcp-server/gregory_mcp/tools/authors.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from ..client import get_client
 from ..compact import compact_author
 from ..pagination import clamp_page
+
+SortBy = Literal["author_id", "full_name", "country", "article_count"]
+Order = Literal["asc", "desc"]
 
 
 async def search_authors(
@@ -14,15 +19,25 @@ async def search_authors(
 	family_name: str | None = None,
 	orcid: str | None = None,
 	country: str | None = None,
+	team_id: int | None = None,
+	subject_id: int | None = None,
+	sort_by: SortBy | None = None,
+	order: Order | None = None,
 	page: int = 1,
 ) -> dict:
-	"""Search authors by name, ORCID iD, or country.
+	"""Search authors by name, ORCID iD, country, or team/subject scope.
 
 	`search`, `full_name`, `given_name`, and `family_name` are all
 	case-insensitive substring matches. `country` and `orcid` match
 	case-insensitively too, so a partial ORCID (e.g. the last 4 digits)
 	also works. This endpoint has a fixed page size (10) — page through
 	with `page` rather than requesting a larger one.
+
+	`subject_id` requires `team_id` — without it, the API returns an empty
+	page rather than an error. `sort_by=article_count` ranks authors by
+	their article count (add `team_id`/`subject_id` to scope which articles
+	count); default order for it is descending, ascending for everything
+	else.
 	"""
 	params = {
 		"search": search,
@@ -31,6 +46,10 @@ async def search_authors(
 		"family_name": family_name,
 		"orcid": orcid,
 		"country": country,
+		"team_id": team_id,
+		"subject_id": subject_id,
+		"sort_by": sort_by,
+		"order": order,
 		"page": clamp_page(page),
 	}
 	data = await get_client().get("/authors/", params)

--- a/mcp-server/gregory_mcp/tools/authors.py
+++ b/mcp-server/gregory_mcp/tools/authors.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ..client import get_client
 from ..compact import compact_author
+from ..pagination import clamp_page
 
 
 async def search_authors(
@@ -30,7 +31,7 @@ async def search_authors(
 		"family_name": family_name,
 		"orcid": orcid,
 		"country": country,
-		"page": page,
+		"page": clamp_page(page),
 	}
 	data = await get_client().get("/authors/", params)
 	results = data.get("results", [])

--- a/mcp-server/gregory_mcp/tools/authors.py
+++ b/mcp-server/gregory_mcp/tools/authors.py
@@ -33,12 +33,17 @@ async def search_authors(
 	also works. This endpoint has a fixed page size (10) — page through
 	with `page` rather than requesting a larger one.
 
-	`subject_id` requires `team_id` — without it, the API returns an empty
-	page rather than an error. `sort_by=article_count` ranks authors by
+	`subject_id` requires `team_id`. `sort_by=article_count` ranks authors by
 	their article count (add `team_id`/`subject_id` to scope which articles
 	count); default order for it is descending, ascending for everything
 	else.
+
+	Raises:
+		ValueError: If `subject_id` is given without `team_id` — the API
+			would otherwise return a silent empty page rather than an error.
 	"""
+	if subject_id is not None and team_id is None:
+		raise ValueError("subject_id requires team_id to also be set")
 	params = {
 		"search": search,
 		"full_name": full_name,

--- a/mcp-server/gregory_mcp/tools/authors.py
+++ b/mcp-server/gregory_mcp/tools/authors.py
@@ -7,51 +7,51 @@ from ..compact import compact_author
 
 
 async def search_authors(
-    search: str | None = None,
-    full_name: str | None = None,
-    given_name: str | None = None,
-    family_name: str | None = None,
-    orcid: str | None = None,
-    country: str | None = None,
-    page: int = 1,
+	search: str | None = None,
+	full_name: str | None = None,
+	given_name: str | None = None,
+	family_name: str | None = None,
+	orcid: str | None = None,
+	country: str | None = None,
+	page: int = 1,
 ) -> dict:
-    """Search authors by name, ORCID iD, or country.
+	"""Search authors by name, ORCID iD, or country.
 
-    `search`, `full_name`, `given_name`, and `family_name` are all
-    case-insensitive substring matches. `country` and `orcid` match
-    case-insensitively too, so a partial ORCID (e.g. the last 4 digits)
-    also works. This endpoint has a fixed page size (10) — page through
-    with `page` rather than requesting a larger one.
-    """
-    params = {
-        "search": search,
-        "full_name": full_name,
-        "given_name": given_name,
-        "family_name": family_name,
-        "orcid": orcid,
-        "country": country,
-        "page": page,
-    }
-    data = await get_client().get("/authors/", params)
-    results = data.get("results", [])
-    return {
-        "count": data.get("count", len(results)),
-        "next": data.get("next"),
-        "authors": [compact_author(a) for a in results],
-    }
+	`search`, `full_name`, `given_name`, and `family_name` are all
+	case-insensitive substring matches. `country` and `orcid` match
+	case-insensitively too, so a partial ORCID (e.g. the last 4 digits)
+	also works. This endpoint has a fixed page size (10) — page through
+	with `page` rather than requesting a larger one.
+	"""
+	params = {
+		"search": search,
+		"full_name": full_name,
+		"given_name": given_name,
+		"family_name": family_name,
+		"orcid": orcid,
+		"country": country,
+		"page": page,
+	}
+	data = await get_client().get("/authors/", params)
+	results = data.get("results", [])
+	return {
+		"count": data.get("count", len(results)),
+		"next": data.get("next"),
+		"authors": [compact_author(a) for a in results],
+	}
 
 
 async def get_author(author_id: int, include_coauthors: bool = False) -> dict:
-    """Fetch the full record for one author by ID: affiliations, ORCID
-    metadata, article counts, and (optionally) their article list.
+	"""Fetch the full record for one author by ID: affiliations, ORCID
+	metadata, and article counts.
 
-    Args:
-        author_id: The author's ID.
-        include_coauthors: When true, also fetches this author's co-authors
-            (a second request) — off by default since it is rarely needed.
-    """
-    author = await get_client().get(f"/authors/{author_id}/")
-    if include_coauthors:
-        coauthors = await get_client().get(f"/authors/{author_id}/coauthors/")
-        author["coauthors"] = coauthors.get("results", coauthors)
-    return author
+	Args:
+		author_id: The author's ID.
+		include_coauthors: When true, also fetches this author's co-authors
+			(a second request) — off by default since it is rarely needed.
+	"""
+	author = await get_client().get(f"/authors/{author_id}/")
+	if include_coauthors:
+		coauthors = await get_client().get(f"/authors/{author_id}/coauthors/")
+		author["coauthors"] = coauthors.get("results", coauthors)
+	return author

--- a/mcp-server/gregory_mcp/tools/authors.py
+++ b/mcp-server/gregory_mcp/tools/authors.py
@@ -1,0 +1,57 @@
+"""Author search and detail tools."""
+
+from __future__ import annotations
+
+from ..client import get_client
+from ..compact import compact_author
+
+
+async def search_authors(
+    search: str | None = None,
+    full_name: str | None = None,
+    given_name: str | None = None,
+    family_name: str | None = None,
+    orcid: str | None = None,
+    country: str | None = None,
+    page: int = 1,
+) -> dict:
+    """Search authors by name, ORCID iD, or country.
+
+    `search`, `full_name`, `given_name`, and `family_name` are all
+    case-insensitive substring matches. `country` and `orcid` match
+    case-insensitively too, so a partial ORCID (e.g. the last 4 digits)
+    also works. This endpoint has a fixed page size (10) — page through
+    with `page` rather than requesting a larger one.
+    """
+    params = {
+        "search": search,
+        "full_name": full_name,
+        "given_name": given_name,
+        "family_name": family_name,
+        "orcid": orcid,
+        "country": country,
+        "page": page,
+    }
+    data = await get_client().get("/authors/", params)
+    results = data.get("results", [])
+    return {
+        "count": data.get("count", len(results)),
+        "next": data.get("next"),
+        "authors": [compact_author(a) for a in results],
+    }
+
+
+async def get_author(author_id: int, include_coauthors: bool = False) -> dict:
+    """Fetch the full record for one author by ID: affiliations, ORCID
+    metadata, article counts, and (optionally) their article list.
+
+    Args:
+        author_id: The author's ID.
+        include_coauthors: When true, also fetches this author's co-authors
+            (a second request) — off by default since it is rarely needed.
+    """
+    author = await get_client().get(f"/authors/{author_id}/")
+    if include_coauthors:
+        coauthors = await get_client().get(f"/authors/{author_id}/coauthors/")
+        author["coauthors"] = coauthors.get("results", coauthors)
+    return author

--- a/mcp-server/gregory_mcp/tools/authors.py
+++ b/mcp-server/gregory_mcp/tools/authors.py
@@ -44,6 +44,7 @@ async def search_authors(
 	"""
 	if subject_id is not None and team_id is None:
 		raise ValueError("subject_id requires team_id to also be set")
+	clamped_page = clamp_page(page)
 	params = {
 		"search": search,
 		"full_name": full_name,
@@ -55,13 +56,13 @@ async def search_authors(
 		"subject_id": subject_id,
 		"sort_by": sort_by,
 		"order": order,
-		"page": clamp_page(page),
+		"page": clamped_page,
 	}
 	data = await get_client().get("/authors/", params)
 	results = data.get("results", [])
 	return {
 		"count": data.get("count", len(results)),
-		"next": data.get("next"),
+		"next_page": clamped_page + 1 if data.get("next") else None,
 		"authors": [compact_author(a) for a in results],
 	}
 

--- a/mcp-server/gregory_mcp/tools/catalog.py
+++ b/mcp-server/gregory_mcp/tools/catalog.py
@@ -1,0 +1,98 @@
+"""Catalog tools: subjects, categories, sponsors.
+
+Slow-changing reference data. `list_subjects` is the discovery entry point —
+every row carries `team_id`, which most other tools' filters need.
+"""
+
+from __future__ import annotations
+
+from ..client import get_client
+
+
+async def list_subjects(team_id: int | None = None, search: str | None = None) -> dict:
+    """List research subjects, each carrying its `team_id`.
+
+    Call this first when you don't already know a subject's ID or its
+    team_id — most article/trial filters need one or both.
+
+    Args:
+        team_id: Restrict to subjects belonging to this team.
+        search: Case-insensitive substring match against the subject name.
+    """
+    results = await get_client().get_all_pages("/subjects/", {"team_id": team_id, "search": search})
+    return {
+        "count": len(results),
+        "subjects": [
+            {"id": s.get("id"), "subject_name": s.get("subject_name"), "team_id": s.get("team_id")}
+            for s in results
+        ],
+    }
+
+
+async def list_categories(
+    team_id: int | None = None,
+    subject_id: int | None = None,
+    search: str | None = None,
+) -> dict:
+    """List research categories (topic tags attached to articles/trials).
+
+    Args:
+        team_id: Restrict to categories belonging to this team.
+        subject_id: Restrict to categories used within this subject.
+        search: Case-insensitive substring match against category name/terms.
+
+    Note: results are NOT sorted by author count by default — that sort is
+    expensive on this endpoint and is deliberately not exposed here.
+    """
+    results = await get_client().get_all_pages(
+        "/categories/", {"team_id": team_id, "subject_id": subject_id, "search": search}
+    )
+    return {
+        "count": len(results),
+        "categories": [
+            {
+                "id": c.get("id"),
+                "category_name": c.get("category_name"),
+                "category_slug": c.get("category_slug"),
+                "modality": c.get("modality"),
+                "article_count_total": c.get("article_count_total"),
+                "trials_count_total": c.get("trials_count_total"),
+            }
+            for c in results
+        ],
+    }
+
+
+async def list_sponsors(
+    search: str | None = None,
+    sponsor_type: str | None = None,
+    page: int = 1,
+    page_size: int = 25,
+) -> dict:
+    """List canonical, deduplicated clinical trial sponsors.
+
+    Unlike subjects/categories, sponsors can number in the thousands, so
+    this is paginated rather than fetched in full — pass `search` to narrow
+    it down, or page through with `page`.
+
+    Args:
+        search: Case-insensitive substring match against the sponsor name.
+        sponsor_type: One of academic_medical, government, industry, nonprofit, other.
+    """
+    data = await get_client().get(
+        "/sponsors/", {"search": search, "sponsor_type": sponsor_type, "page": page, "page_size": min(page_size, 100)}
+    )
+    results = data.get("results", [])
+    return {
+        "count": data.get("count", len(results)),
+        "sponsors": [
+            {
+                "id": s.get("id"),
+                "name": s.get("name"),
+                "slug": s.get("slug"),
+                "sponsor_type": s.get("sponsor_type"),
+                "trials_count": s.get("trials_count"),
+            }
+            for s in results
+        ],
+    }

--- a/mcp-server/gregory_mcp/tools/catalog.py
+++ b/mcp-server/gregory_mcp/tools/catalog.py
@@ -80,14 +80,15 @@ async def list_sponsors(
 		search: Case-insensitive substring match against the sponsor name.
 		sponsor_type: One of academic_medical, government, industry, nonprofit, other.
 	"""
+	clamped_page = clamp_page(page)
 	data = await get_client().get(
 		"/sponsors/",
-		{"search": search, "sponsor_type": sponsor_type, "page": clamp_page(page), "page_size": clamp_page_size(page_size, 100)},
+		{"search": search, "sponsor_type": sponsor_type, "page": clamped_page, "page_size": clamp_page_size(page_size, 100)},
 	)
 	results = data.get("results", [])
 	return {
 		"count": data.get("count", len(results)),
-		"next": data.get("next"),
+		"next_page": clamped_page + 1 if data.get("next") else None,
 		"sponsors": [
 			{
 				"id": s.get("id"),

--- a/mcp-server/gregory_mcp/tools/catalog.py
+++ b/mcp-server/gregory_mcp/tools/catalog.py
@@ -10,89 +10,89 @@ from ..client import get_client
 
 
 async def list_subjects(team_id: int | None = None, search: str | None = None) -> dict:
-    """List research subjects, each carrying its `team_id`.
+	"""List research subjects, each carrying its `team_id`.
 
-    Call this first when you don't already know a subject's ID or its
-    team_id — most article/trial filters need one or both.
+	Call this first when you don't already know a subject's ID or its
+	team_id — most article/trial filters need one or both.
 
-    Args:
-        team_id: Restrict to subjects belonging to this team.
-        search: Case-insensitive substring match against the subject name.
-    """
-    results = await get_client().get_all_pages("/subjects/", {"team_id": team_id, "search": search})
-    return {
-        "count": len(results),
-        "subjects": [
-            {"id": s.get("id"), "subject_name": s.get("subject_name"), "team_id": s.get("team_id")}
-            for s in results
-        ],
-    }
+	Args:
+		team_id: Restrict to subjects belonging to this team.
+		search: Case-insensitive substring match against the subject name.
+	"""
+	results = await get_client().get_all_pages("/subjects/", {"team_id": team_id, "search": search})
+	return {
+		"count": len(results),
+		"subjects": [
+			{"id": s.get("id"), "subject_name": s.get("subject_name"), "team_id": s.get("team_id")}
+			for s in results
+		],
+	}
 
 
 async def list_categories(
-    team_id: int | None = None,
-    subject_id: int | None = None,
-    search: str | None = None,
+	team_id: int | None = None,
+	subject_id: int | None = None,
+	search: str | None = None,
 ) -> dict:
-    """List research categories (topic tags attached to articles/trials).
+	"""List research categories (topic tags attached to articles/trials).
 
-    Args:
-        team_id: Restrict to categories belonging to this team.
-        subject_id: Restrict to categories used within this subject.
-        search: Case-insensitive substring match against category name/terms.
+	Args:
+		team_id: Restrict to categories belonging to this team.
+		subject_id: Restrict to categories used within this subject.
+		search: Case-insensitive substring match against category name/terms.
 
-    Note: results are NOT sorted by author count by default — that sort is
-    expensive on this endpoint and is deliberately not exposed here.
-    """
-    results = await get_client().get_all_pages(
-        "/categories/", {"team_id": team_id, "subject_id": subject_id, "search": search}
-    )
-    return {
-        "count": len(results),
-        "categories": [
-            {
-                "id": c.get("id"),
-                "category_name": c.get("category_name"),
-                "category_slug": c.get("category_slug"),
-                "modality": c.get("modality"),
-                "article_count_total": c.get("article_count_total"),
-                "trials_count_total": c.get("trials_count_total"),
-            }
-            for c in results
-        ],
-    }
+	Note: results are NOT sorted by author count by default — that sort is
+	expensive on this endpoint and is deliberately not exposed here.
+	"""
+	results = await get_client().get_all_pages(
+		"/categories/", {"team_id": team_id, "subject_id": subject_id, "search": search}
+	)
+	return {
+		"count": len(results),
+		"categories": [
+			{
+				"id": c.get("id"),
+				"category_name": c.get("category_name"),
+				"category_slug": c.get("category_slug"),
+				"modality": c.get("modality"),
+				"article_count_total": c.get("article_count_total"),
+				"trials_count_total": c.get("trials_count_total"),
+			}
+			for c in results
+		],
+	}
 
 
 async def list_sponsors(
-    search: str | None = None,
-    sponsor_type: str | None = None,
-    page: int = 1,
-    page_size: int = 25,
+	search: str | None = None,
+	sponsor_type: str | None = None,
+	page: int = 1,
+	page_size: int = 25,
 ) -> dict:
-    """List canonical, deduplicated clinical trial sponsors.
+	"""List canonical, deduplicated clinical trial sponsors.
 
-    Unlike subjects/categories, sponsors can number in the thousands, so
-    this is paginated rather than fetched in full — pass `search` to narrow
-    it down, or page through with `page`.
+	Unlike subjects/categories, sponsors can number in the thousands, so
+	this is paginated rather than fetched in full — pass `search` to narrow
+	it down, or page through with `page`.
 
-    Args:
-        search: Case-insensitive substring match against the sponsor name.
-        sponsor_type: One of academic_medical, government, industry, nonprofit, other.
-    """
-    data = await get_client().get(
-        "/sponsors/", {"search": search, "sponsor_type": sponsor_type, "page": page, "page_size": min(page_size, 100)}
-    )
-    results = data.get("results", [])
-    return {
-        "count": data.get("count", len(results)),
-        "sponsors": [
-            {
-                "id": s.get("id"),
-                "name": s.get("name"),
-                "slug": s.get("slug"),
-                "sponsor_type": s.get("sponsor_type"),
-                "trials_count": s.get("trials_count"),
-            }
-            for s in results
-        ],
-    }
+	Args:
+		search: Case-insensitive substring match against the sponsor name.
+		sponsor_type: One of academic_medical, government, industry, nonprofit, other.
+	"""
+	data = await get_client().get(
+		"/sponsors/", {"search": search, "sponsor_type": sponsor_type, "page": page, "page_size": min(page_size, 100)}
+	)
+	results = data.get("results", [])
+	return {
+		"count": data.get("count", len(results)),
+		"sponsors": [
+			{
+				"id": s.get("id"),
+				"name": s.get("name"),
+				"slug": s.get("slug"),
+				"sponsor_type": s.get("sponsor_type"),
+				"trials_count": s.get("trials_count"),
+			}
+			for s in results
+		],
+	}

--- a/mcp-server/gregory_mcp/tools/catalog.py
+++ b/mcp-server/gregory_mcp/tools/catalog.py
@@ -87,6 +87,7 @@ async def list_sponsors(
 	results = data.get("results", [])
 	return {
 		"count": data.get("count", len(results)),
+		"next": data.get("next"),
 		"sponsors": [
 			{
 				"id": s.get("id"),

--- a/mcp-server/gregory_mcp/tools/catalog.py
+++ b/mcp-server/gregory_mcp/tools/catalog.py
@@ -6,6 +6,7 @@ every row carries `team_id`, which most other tools' filters need.
 
 from __future__ import annotations
 
+from ..cache import get_all_pages_cached
 from ..client import get_client
 from ..pagination import clamp_page, clamp_page_size
 
@@ -16,11 +17,13 @@ async def list_subjects(team_id: int | None = None, search: str | None = None) -
 	Call this first when you don't already know a subject's ID or its
 	team_id — most article/trial filters need one or both.
 
+	Cached server-side for 10 minutes (subjects change rarely).
+
 	Args:
 		team_id: Restrict to subjects belonging to this team.
 		search: Case-insensitive substring match against the subject name.
 	"""
-	results = await get_client().get_all_pages("/subjects/", {"team_id": team_id, "search": search})
+	results = await get_all_pages_cached("/subjects/", {"team_id": team_id, "search": search})
 	return {
 		"count": len(results),
 		"subjects": [
@@ -44,8 +47,12 @@ async def list_categories(
 
 	Note: results are NOT sorted by author count by default — that sort is
 	expensive on this endpoint and is deliberately not exposed here.
+
+	Cached server-side for 10 minutes — /categories/ costs about a second
+	per request and takes 12 requests to read in full, so this avoids a
+	multi-second stall on every call.
 	"""
-	results = await get_client().get_all_pages(
+	results = await get_all_pages_cached(
 		"/categories/", {"team_id": team_id, "subject_id": subject_id, "search": search}
 	)
 	return {

--- a/mcp-server/gregory_mcp/tools/catalog.py
+++ b/mcp-server/gregory_mcp/tools/catalog.py
@@ -7,6 +7,7 @@ every row carries `team_id`, which most other tools' filters need.
 from __future__ import annotations
 
 from ..client import get_client
+from ..pagination import clamp_page, clamp_page_size
 
 
 async def list_subjects(team_id: int | None = None, search: str | None = None) -> dict:
@@ -80,7 +81,8 @@ async def list_sponsors(
 		sponsor_type: One of academic_medical, government, industry, nonprofit, other.
 	"""
 	data = await get_client().get(
-		"/sponsors/", {"search": search, "sponsor_type": sponsor_type, "page": page, "page_size": min(page_size, 100)}
+		"/sponsors/",
+		{"search": search, "sponsor_type": sponsor_type, "page": clamp_page(page), "page_size": clamp_page_size(page_size, 100)},
 	)
 	results = data.get("results", [])
 	return {

--- a/mcp-server/gregory_mcp/tools/stats.py
+++ b/mcp-server/gregory_mcp/tools/stats.py
@@ -1,0 +1,43 @@
+"""Aggregate statistics tools."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from ..client import get_client
+
+Scope = Literal["global", "articles", "trials"]
+
+
+async def get_stats(
+    scope: Scope = "global",
+    team_id: int | None = None,
+    subject_id: int | None = None,
+    search: str | None = None,
+    relevant: bool | None = None,
+) -> dict:
+    """Fetch aggregate counts.
+
+    Args:
+        scope: "global" for site-wide totals (articles, trials, subscribers,
+            authors, sources, by_subject breakdown) via GET /stats/;
+            "articles" for GET /articles/stats/ (total, by_access, relevant,
+            retracted, missing_doi, by_subject) — accepts the same filters as
+            search_articles; "trials" for GET /trials/stats/ (by_phase,
+            by_region, by_country, by_sponsor, etc.) — accepts the same
+            filters as search_trials.
+        team_id: Scope to one team (all scopes).
+        subject_id: Scope to one subject. For "articles"/"trials", also
+            scopes `relevant`/`ml_threshold` semantics the same way the
+            search tools do.
+        search: Boolean search filter, only meaningful for "articles"/"trials".
+        relevant: Only meaningful for "articles".
+    """
+    if scope == "global":
+        params = {"team": team_id, "subject": subject_id}
+        return await get_client().get("/stats/", params)
+    if scope == "articles":
+        params = {"team_id": team_id, "subject_id": subject_id, "search": search, "relevant": relevant}
+        return await get_client().get("/articles/stats/", params)
+    params = {"team_id": team_id, "subject_id": subject_id, "search": search}
+    return await get_client().get("/trials/stats/", params)

--- a/mcp-server/gregory_mcp/tools/stats.py
+++ b/mcp-server/gregory_mcp/tools/stats.py
@@ -10,34 +10,34 @@ Scope = Literal["global", "articles", "trials"]
 
 
 async def get_stats(
-    scope: Scope = "global",
-    team_id: int | None = None,
-    subject_id: int | None = None,
-    search: str | None = None,
-    relevant: bool | None = None,
+	scope: Scope = "global",
+	team_id: int | None = None,
+	subject_id: int | None = None,
+	search: str | None = None,
+	relevant: bool | None = None,
 ) -> dict:
-    """Fetch aggregate counts.
+	"""Fetch aggregate counts.
 
-    Args:
-        scope: "global" for site-wide totals (articles, trials, subscribers,
-            authors, sources, by_subject breakdown) via GET /stats/;
-            "articles" for GET /articles/stats/ (total, by_access, relevant,
-            retracted, missing_doi, by_subject) — accepts the same filters as
-            search_articles; "trials" for GET /trials/stats/ (by_phase,
-            by_region, by_country, by_sponsor, etc.) — accepts the same
-            filters as search_trials.
-        team_id: Scope to one team (all scopes).
-        subject_id: Scope to one subject. For "articles"/"trials", also
-            scopes `relevant`/`ml_threshold` semantics the same way the
-            search tools do.
-        search: Boolean search filter, only meaningful for "articles"/"trials".
-        relevant: Only meaningful for "articles".
-    """
-    if scope == "global":
-        params = {"team": team_id, "subject": subject_id}
-        return await get_client().get("/stats/", params)
-    if scope == "articles":
-        params = {"team_id": team_id, "subject_id": subject_id, "search": search, "relevant": relevant}
-        return await get_client().get("/articles/stats/", params)
-    params = {"team_id": team_id, "subject_id": subject_id, "search": search}
-    return await get_client().get("/trials/stats/", params)
+	Args:
+		scope: "global" for site-wide totals (articles, trials, subscribers,
+			authors, sources, by_subject breakdown) via GET /stats/;
+			"articles" for GET /articles/stats/ (total, by_access, relevant,
+			retracted, missing_doi, by_subject) — accepts the same filters as
+			search_articles; "trials" for GET /trials/stats/ (by_phase,
+			by_region, by_country, by_sponsor, etc.) — accepts the same
+			filters as search_trials.
+		team_id: Scope to one team (all scopes).
+		subject_id: Scope to one subject. For "articles"/"trials", also
+			scopes `relevant`/`ml_threshold` semantics the same way the
+			search tools do.
+		search: Boolean search filter, only meaningful for "articles"/"trials".
+		relevant: Only meaningful for "articles".
+	"""
+	if scope == "global":
+		params = {"team": team_id, "subject": subject_id}
+		return await get_client().get("/stats/", params)
+	if scope == "articles":
+		params = {"team_id": team_id, "subject_id": subject_id, "search": search, "relevant": relevant}
+		return await get_client().get("/articles/stats/", params)
+	params = {"team_id": team_id, "subject_id": subject_id, "search": search}
+	return await get_client().get("/trials/stats/", params)

--- a/mcp-server/gregory_mcp/tools/stats.py
+++ b/mcp-server/gregory_mcp/tools/stats.py
@@ -18,19 +18,22 @@ async def get_stats(
 ) -> dict:
 	"""Fetch aggregate counts.
 
+	This tool only takes a narrow filter set (team_id/subject_id/search, plus
+	relevant for "articles") — nothing like the full filter surface of
+	search_articles/search_trials. Call those instead when you need a finer
+	filter than this tool exposes.
+
 	Args:
 		scope: "global" for site-wide totals (articles, trials, subscribers,
 			authors, sources, by_subject breakdown) via GET /stats/;
 			"articles" for GET /articles/stats/ (total, by_access, relevant,
-			retracted, missing_doi, by_subject) — accepts the same filters as
-			search_articles; "trials" for GET /trials/stats/ (by_phase,
-			by_region, by_country, by_sponsor, etc.) — accepts the same
-			filters as search_trials.
+			retracted, missing_doi, by_subject); "trials" for GET
+			/trials/stats/ (by_phase, by_region, by_country, by_sponsor, etc.).
 		team_id: Scope to one team (all scopes).
 		subject_id: Scope to one subject. For "articles"/"trials", also
-			scopes `relevant`/`ml_threshold` semantics the same way the
-			search tools do.
-		search: Boolean search filter, only meaningful for "articles"/"trials".
+			scopes `relevant`'s semantics the same way search_articles does.
+		search: Boolean search filter (see search_articles), only meaningful
+			for "articles"/"trials".
 		relevant: Only meaningful for "articles".
 	"""
 	if scope == "global":

--- a/mcp-server/gregory_mcp/tools/stats.py
+++ b/mcp-server/gregory_mcp/tools/stats.py
@@ -42,5 +42,7 @@ async def get_stats(
 	if scope == "articles":
 		params = {"team_id": team_id, "subject_id": subject_id, "search": search, "relevant": relevant}
 		return await get_client().get("/articles/stats/", params)
-	params = {"team_id": team_id, "subject_id": subject_id, "search": search}
-	return await get_client().get("/trials/stats/", params)
+	if scope == "trials":
+		params = {"team_id": team_id, "subject_id": subject_id, "search": search}
+		return await get_client().get("/trials/stats/", params)
+	raise ValueError(f"unknown scope {scope!r} — expected 'global', 'articles', or 'trials'")

--- a/mcp-server/gregory_mcp/tools/trials.py
+++ b/mcp-server/gregory_mcp/tools/trials.py
@@ -6,18 +6,9 @@ from typing import Literal
 
 from ..client import get_client
 from ..compact import compact_trial
+from ..enums import CategoryModality
 from ..pagination import clamp_page, clamp_page_size
 
-CategoryModality = Literal[
-	"biologic_antibody",
-	"cell_gene_therapy",
-	"device_neuromodulation",
-	"natural_product",
-	"other",
-	"rehabilitation",
-	"research_topic",
-	"small_molecule",
-]
 SexEligibility = Literal["all", "female", "male"]
 StudyType = Literal["basic_science", "expanded_access", "interventional", "observational", "other"]
 Region = Literal["africa", "asia", "europe", "north_america", "oceania", "south_america"]

--- a/mcp-server/gregory_mcp/tools/trials.py
+++ b/mcp-server/gregory_mcp/tools/trials.py
@@ -1,0 +1,102 @@
+"""Clinical trial search and detail tools."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from ..client import get_client
+from ..compact import compact_trial
+
+CategoryModality = Literal[
+    "biologic_antibody",
+    "cell_gene_therapy",
+    "device_neuromodulation",
+    "natural_product",
+    "other",
+    "rehabilitation",
+    "research_topic",
+    "small_molecule",
+]
+SexEligibility = Literal["all", "female", "male"]
+StudyType = Literal["basic_science", "expanded_access", "interventional", "observational", "other"]
+Region = Literal["africa", "asia", "europe", "north_america", "oceania", "south_america"]
+
+DEFAULT_PAGE_SIZE = 10
+MAX_PAGE_SIZE = 25
+
+
+async def search_trials(
+    search: str | None = None,
+    title: str | None = None,
+    summary: str | None = None,
+    team_id: int | None = None,
+    subject_id: int | None = None,
+    category_slug: str | None = None,
+    category_id: int | None = None,
+    category_modality: CategoryModality | None = None,
+    condition: str | None = None,
+    intervention: str | None = None,
+    recruitment_status_normalized: str | None = None,
+    phase_normalized: str | None = None,
+    study_type_normalized: StudyType | None = None,
+    country: str | None = None,
+    region: Region | None = None,
+    sponsor_id: int | None = None,
+    sponsor_slug: str | None = None,
+    age_eligible: float | None = None,
+    inclusion_gender_normalized: SexEligibility | None = None,
+    date_registration_after: str | None = None,
+    date_registration_before: str | None = None,
+    nct: str | None = None,
+    ordering: str | None = None,
+    page: int = 1,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> dict:
+    """Search clinical trials. Returns a compact projection — use get_trial
+    for the full record (trial_sites, eligibility text, results detail).
+
+    `search` is boolean over title + summary (see search_articles for the
+    syntax). `recruitment_status_normalized` and `phase_normalized` accept a
+    comma-separated list matched with OR (e.g. "recruiting,not_recruiting").
+    `nct` matches an NCT registry ID exactly. Dates are YYYY-MM-DD.
+    """
+    params = {
+        "search": search,
+        "title": title,
+        "summary": summary,
+        "team_id": team_id,
+        "subject_id": subject_id,
+        "category_slug": category_slug,
+        "category_id": category_id,
+        "category_modality": category_modality,
+        "condition": condition,
+        "intervention": intervention,
+        "recruitment_status_normalized": recruitment_status_normalized,
+        "phase_normalized": phase_normalized,
+        "study_type_normalized": study_type_normalized,
+        "country": country,
+        "region": region,
+        "sponsor_id": sponsor_id,
+        "sponsor_slug": sponsor_slug,
+        "age_eligible": age_eligible,
+        "inclusion_gender_normalized": inclusion_gender_normalized,
+        "date_registration_after": date_registration_after,
+        "date_registration_before": date_registration_before,
+        "nct": nct,
+        "ordering": ordering,
+        "page": page,
+        "page_size": min(page_size, MAX_PAGE_SIZE),
+    }
+    data = await get_client().get("/trials/", params)
+    results = data.get("results", [])
+    return {
+        "count": data.get("count", len(results)),
+        "next": data.get("next"),
+        "trials": [compact_trial(t) for t in results],
+    }
+
+
+async def get_trial(trial_id: int) -> dict:
+    """Fetch the full record for one clinical trial by ID, including
+    trial_sites (detail-only), eligibility criteria, and results detail."""
+    return await get_client().get(f"/trials/{trial_id}/")

--- a/mcp-server/gregory_mcp/tools/trials.py
+++ b/mcp-server/gregory_mcp/tools/trials.py
@@ -40,6 +40,12 @@ async def search_trials(
 	date_registration_after: str | None = None,
 	date_registration_before: str | None = None,
 	nct: str | None = None,
+	euct: str | None = None,
+	eudract: str | None = None,
+	ctis: str | None = None,
+	acronym: str | None = None,
+	has_results: bool | None = None,
+	therapeutic_areas: str | None = None,
 	ordering: str | None = None,
 	page: int = 1,
 	page_size: int = DEFAULT_PAGE_SIZE,
@@ -50,7 +56,15 @@ async def search_trials(
 	`search` is boolean over title + summary (see search_articles for the
 	syntax). `recruitment_status_normalized` and `phase_normalized` accept a
 	comma-separated list matched with OR (e.g. "recruiting,not_recruiting").
-	`nct` matches an NCT registry ID exactly. Dates are YYYY-MM-DD.
+	Dates are YYYY-MM-DD.
+
+	Registry IDs — each accepts a single value or a comma-separated list,
+	matched case-insensitively against any: `nct` (ClinicalTrials.gov),
+	`euct` (EU CT / EUCTR — matches either identifier key), `eudract`
+	(legacy EudraCT, pre-2025 EU trials), `ctis` (EU Clinical Trials
+	Information System number). A European trial commonly only has
+	euct/eudract/ctis, not an nct — use whichever registry the caller
+	already has an ID from.
 	"""
 	clamped_page = clamp_page(page)
 	params = {
@@ -76,6 +90,12 @@ async def search_trials(
 		"date_registration_after": date_registration_after,
 		"date_registration_before": date_registration_before,
 		"nct": nct,
+		"euct": euct,
+		"eudract": eudract,
+		"ctis": ctis,
+		"acronym": acronym,
+		"has_results": has_results,
+		"therapeutic_areas": therapeutic_areas,
 		"ordering": ordering,
 		"page": clamped_page,
 		"page_size": clamp_page_size(page_size, MAX_PAGE_SIZE),

--- a/mcp-server/gregory_mcp/tools/trials.py
+++ b/mcp-server/gregory_mcp/tools/trials.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from ..client import get_client
 from ..compact import compact_trial
+from ..pagination import clamp_page, clamp_page_size
 
 CategoryModality = Literal[
 	"biologic_antibody",
@@ -84,8 +85,8 @@ async def search_trials(
 		"date_registration_before": date_registration_before,
 		"nct": nct,
 		"ordering": ordering,
-		"page": page,
-		"page_size": min(page_size, MAX_PAGE_SIZE),
+		"page": clamp_page(page),
+		"page_size": clamp_page_size(page_size, MAX_PAGE_SIZE),
 	}
 	data = await get_client().get("/trials/", params)
 	results = data.get("results", [])

--- a/mcp-server/gregory_mcp/tools/trials.py
+++ b/mcp-server/gregory_mcp/tools/trials.py
@@ -52,6 +52,7 @@ async def search_trials(
 	comma-separated list matched with OR (e.g. "recruiting,not_recruiting").
 	`nct` matches an NCT registry ID exactly. Dates are YYYY-MM-DD.
 	"""
+	clamped_page = clamp_page(page)
 	params = {
 		"search": search,
 		"title": title,
@@ -76,14 +77,14 @@ async def search_trials(
 		"date_registration_before": date_registration_before,
 		"nct": nct,
 		"ordering": ordering,
-		"page": clamp_page(page),
+		"page": clamped_page,
 		"page_size": clamp_page_size(page_size, MAX_PAGE_SIZE),
 	}
 	data = await get_client().get("/trials/", params)
 	results = data.get("results", [])
 	return {
 		"count": data.get("count", len(results)),
-		"next": data.get("next"),
+		"next_page": clamped_page + 1 if data.get("next") else None,
 		"trials": [compact_trial(t) for t in results],
 	}
 

--- a/mcp-server/gregory_mcp/tools/trials.py
+++ b/mcp-server/gregory_mcp/tools/trials.py
@@ -8,14 +8,14 @@ from ..client import get_client
 from ..compact import compact_trial
 
 CategoryModality = Literal[
-    "biologic_antibody",
-    "cell_gene_therapy",
-    "device_neuromodulation",
-    "natural_product",
-    "other",
-    "rehabilitation",
-    "research_topic",
-    "small_molecule",
+	"biologic_antibody",
+	"cell_gene_therapy",
+	"device_neuromodulation",
+	"natural_product",
+	"other",
+	"rehabilitation",
+	"research_topic",
+	"small_molecule",
 ]
 SexEligibility = Literal["all", "female", "male"]
 StudyType = Literal["basic_science", "expanded_access", "interventional", "observational", "other"]
@@ -26,77 +26,77 @@ MAX_PAGE_SIZE = 25
 
 
 async def search_trials(
-    search: str | None = None,
-    title: str | None = None,
-    summary: str | None = None,
-    team_id: int | None = None,
-    subject_id: int | None = None,
-    category_slug: str | None = None,
-    category_id: int | None = None,
-    category_modality: CategoryModality | None = None,
-    condition: str | None = None,
-    intervention: str | None = None,
-    recruitment_status_normalized: str | None = None,
-    phase_normalized: str | None = None,
-    study_type_normalized: StudyType | None = None,
-    country: str | None = None,
-    region: Region | None = None,
-    sponsor_id: int | None = None,
-    sponsor_slug: str | None = None,
-    age_eligible: float | None = None,
-    inclusion_gender_normalized: SexEligibility | None = None,
-    date_registration_after: str | None = None,
-    date_registration_before: str | None = None,
-    nct: str | None = None,
-    ordering: str | None = None,
-    page: int = 1,
-    page_size: int = DEFAULT_PAGE_SIZE,
+	search: str | None = None,
+	title: str | None = None,
+	summary: str | None = None,
+	team_id: int | None = None,
+	subject_id: int | None = None,
+	category_slug: str | None = None,
+	category_id: int | None = None,
+	category_modality: CategoryModality | None = None,
+	condition: str | None = None,
+	intervention: str | None = None,
+	recruitment_status_normalized: str | None = None,
+	phase_normalized: str | None = None,
+	study_type_normalized: StudyType | None = None,
+	country: str | None = None,
+	region: Region | None = None,
+	sponsor_id: int | None = None,
+	sponsor_slug: str | None = None,
+	age_eligible: float | None = None,
+	inclusion_gender_normalized: SexEligibility | None = None,
+	date_registration_after: str | None = None,
+	date_registration_before: str | None = None,
+	nct: str | None = None,
+	ordering: str | None = None,
+	page: int = 1,
+	page_size: int = DEFAULT_PAGE_SIZE,
 ) -> dict:
-    """Search clinical trials. Returns a compact projection — use get_trial
-    for the full record (trial_sites, eligibility text, results detail).
+	"""Search clinical trials. Returns a compact projection — use get_trial
+	for the full record (trial_sites, eligibility text, results detail).
 
-    `search` is boolean over title + summary (see search_articles for the
-    syntax). `recruitment_status_normalized` and `phase_normalized` accept a
-    comma-separated list matched with OR (e.g. "recruiting,not_recruiting").
-    `nct` matches an NCT registry ID exactly. Dates are YYYY-MM-DD.
-    """
-    params = {
-        "search": search,
-        "title": title,
-        "summary": summary,
-        "team_id": team_id,
-        "subject_id": subject_id,
-        "category_slug": category_slug,
-        "category_id": category_id,
-        "category_modality": category_modality,
-        "condition": condition,
-        "intervention": intervention,
-        "recruitment_status_normalized": recruitment_status_normalized,
-        "phase_normalized": phase_normalized,
-        "study_type_normalized": study_type_normalized,
-        "country": country,
-        "region": region,
-        "sponsor_id": sponsor_id,
-        "sponsor_slug": sponsor_slug,
-        "age_eligible": age_eligible,
-        "inclusion_gender_normalized": inclusion_gender_normalized,
-        "date_registration_after": date_registration_after,
-        "date_registration_before": date_registration_before,
-        "nct": nct,
-        "ordering": ordering,
-        "page": page,
-        "page_size": min(page_size, MAX_PAGE_SIZE),
-    }
-    data = await get_client().get("/trials/", params)
-    results = data.get("results", [])
-    return {
-        "count": data.get("count", len(results)),
-        "next": data.get("next"),
-        "trials": [compact_trial(t) for t in results],
-    }
+	`search` is boolean over title + summary (see search_articles for the
+	syntax). `recruitment_status_normalized` and `phase_normalized` accept a
+	comma-separated list matched with OR (e.g. "recruiting,not_recruiting").
+	`nct` matches an NCT registry ID exactly. Dates are YYYY-MM-DD.
+	"""
+	params = {
+		"search": search,
+		"title": title,
+		"summary": summary,
+		"team_id": team_id,
+		"subject_id": subject_id,
+		"category_slug": category_slug,
+		"category_id": category_id,
+		"category_modality": category_modality,
+		"condition": condition,
+		"intervention": intervention,
+		"recruitment_status_normalized": recruitment_status_normalized,
+		"phase_normalized": phase_normalized,
+		"study_type_normalized": study_type_normalized,
+		"country": country,
+		"region": region,
+		"sponsor_id": sponsor_id,
+		"sponsor_slug": sponsor_slug,
+		"age_eligible": age_eligible,
+		"inclusion_gender_normalized": inclusion_gender_normalized,
+		"date_registration_after": date_registration_after,
+		"date_registration_before": date_registration_before,
+		"nct": nct,
+		"ordering": ordering,
+		"page": page,
+		"page_size": min(page_size, MAX_PAGE_SIZE),
+	}
+	data = await get_client().get("/trials/", params)
+	results = data.get("results", [])
+	return {
+		"count": data.get("count", len(results)),
+		"next": data.get("next"),
+		"trials": [compact_trial(t) for t in results],
+	}
 
 
 async def get_trial(trial_id: int) -> dict:
-    """Fetch the full record for one clinical trial by ID, including
-    trial_sites (detail-only), eligibility criteria, and results detail."""
-    return await get_client().get(f"/trials/{trial_id}/")
+	"""Fetch the full record for one clinical trial by ID, including
+	trial_sites (detail-only), eligibility criteria, and results detail."""
+	return await get_client().get(f"/trials/{trial_id}/")

--- a/mcp-server/healthcheck.py
+++ b/mcp-server/healthcheck.py
@@ -1,11 +1,13 @@
 """Docker HEALTHCHECK probe.
 
-A 4xx response — the redirect-then-406 a bare GET on the streamable-http
-endpoint gets — proves the process is up and answering, so that alone
-doesn't fail the check. A 5xx means the process is up but the app itself is
-erroring (misconfiguration, an unhandled exception per request), and a
-connection failure or timeout means it isn't up at all — both count as
-unhealthy so Docker actually reports a broken server as broken.
+A bare GET on the streamable-http endpoint (this server negotiates POST
+JSON-RPC and SSE, not plain GET) redirects once and lands on 406 Not
+Acceptable — verified against a live instance. That specific response
+proves the process is up, routed correctly, and the streamable-http app is
+actually mounted at /mcp/, so it's the only thing that counts as healthy.
+Anything else — a 404 (route not mounted — a real misconfiguration, not
+just "no Accept header"), a 5xx (the app is up but erroring), a connection
+failure, or a timeout — means something is actually wrong.
 """
 
 from __future__ import annotations
@@ -16,8 +18,9 @@ import urllib.request
 
 try:
 	urllib.request.urlopen("http://127.0.0.1:8001/mcp/", timeout=3)
+	sys.exit(1)  # a 2xx/3xx isn't the expected shape either — investigate
 except urllib.error.HTTPError as exc:
-	if exc.code >= 500:
+	if exc.code != 406:
 		sys.exit(1)
 except Exception:
 	sys.exit(1)

--- a/mcp-server/healthcheck.py
+++ b/mcp-server/healthcheck.py
@@ -1,8 +1,11 @@
 """Docker HEALTHCHECK probe.
 
-Any HTTP response — including the redirect or 4xx a bare GET on the
-streamable-http endpoint gets — proves the process is up and answering.
-Only a connection failure or timeout means it's actually down.
+A 4xx response — the redirect-then-406 a bare GET on the streamable-http
+endpoint gets — proves the process is up and answering, so that alone
+doesn't fail the check. A 5xx means the process is up but the app itself is
+erroring (misconfiguration, an unhandled exception per request), and a
+connection failure or timeout means it isn't up at all — both count as
+unhealthy so Docker actually reports a broken server as broken.
 """
 
 from __future__ import annotations
@@ -13,7 +16,8 @@ import urllib.request
 
 try:
 	urllib.request.urlopen("http://127.0.0.1:8001/mcp/", timeout=3)
-except urllib.error.HTTPError:
-	pass
+except urllib.error.HTTPError as exc:
+	if exc.code >= 500:
+		sys.exit(1)
 except Exception:
 	sys.exit(1)

--- a/mcp-server/healthcheck.py
+++ b/mcp-server/healthcheck.py
@@ -1,0 +1,19 @@
+"""Docker HEALTHCHECK probe.
+
+Any HTTP response — including the redirect or 4xx a bare GET on the
+streamable-http endpoint gets — proves the process is up and answering.
+Only a connection failure or timeout means it's actually down.
+"""
+
+from __future__ import annotations
+
+import sys
+import urllib.error
+import urllib.request
+
+try:
+	urllib.request.urlopen("http://127.0.0.1:8001/mcp/", timeout=3)
+except urllib.error.HTTPError:
+	pass
+except Exception:
+	sys.exit(1)

--- a/mcp-server/healthcheck.py
+++ b/mcp-server/healthcheck.py
@@ -2,12 +2,14 @@
 
 A bare GET on the streamable-http endpoint (this server negotiates POST
 JSON-RPC and SSE, not plain GET) redirects once and lands on 406 Not
-Acceptable — verified against a live instance. That specific response
-proves the process is up, routed correctly, and the streamable-http app is
-actually mounted at /mcp/, so it's the only thing that counts as healthy.
+Acceptable — verified against a live instance. A 405 Method Not Allowed is
+also accepted: which of the two a router/server returns for "wrong verb on
+a mounted route" can legitimately vary. Either proves the process is up,
+routed correctly, and the streamable-http app is actually mounted at
+/mcp/, so together they're the only things that count as healthy.
 Anything else — a 404 (route not mounted — a real misconfiguration, not
-just "no Accept header"), a 5xx (the app is up but erroring), a connection
-failure, or a timeout — means something is actually wrong.
+just "wrong verb/Accept header"), a 5xx (the app is up but erroring), a
+connection failure, or a timeout — means something is actually wrong.
 """
 
 from __future__ import annotations
@@ -16,11 +18,13 @@ import sys
 import urllib.error
 import urllib.request
 
+EXPECTED_CODES = {405, 406}
+
 try:
 	urllib.request.urlopen("http://127.0.0.1:8001/mcp/", timeout=3)
 	sys.exit(1)  # a 2xx/3xx isn't the expected shape either — investigate
 except urllib.error.HTTPError as exc:
-	if exc.code != 406:
+	if exc.code not in EXPECTED_CODES:
 		sys.exit(1)
 except Exception:
 	sys.exit(1)

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -5,6 +5,10 @@ description = "Read-only MCP server exposing the GregoryAI REST API to LLM clien
 requires-python = ">=3.12"
 dependencies = [
     "mcp==2.0.0",
+    # gregory_mcp/server.py imports directly from mcp_types (ToolAnnotations) —
+    # pinned explicitly rather than relying on it only being pulled in
+    # transitively via mcp's own dependency on it.
+    "mcp-types==2.0.0",
     "httpx2>=2.9,<3",
 ]
 

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "gregory-mcp"
+version = "0.1.0"
+description = "Read-only MCP server exposing the GregoryAI REST API to LLM clients"
+requires-python = ">=3.12"
+dependencies = [
+    "mcp==2.0.0",
+    "httpx2>=2.9,<3",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "pyyaml>=6.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["gregory_mcp*"]

--- a/mcp-server/tests/conftest.py
+++ b/mcp-server/tests/conftest.py
@@ -10,59 +10,59 @@ from gregory_mcp.config import Settings
 from gregory_mcp.server import build_server
 
 TEST_SETTINGS = Settings(
-    api_url="https://gregory.test",
-    host="127.0.0.1",
-    port=8001,
-    request_timeout=5,
-    connect_timeout=2,
-    max_retries=0,
-    log_level="ERROR",
+	api_url="https://gregory.test",
+	host="127.0.0.1",
+	port=8001,
+	request_timeout=5,
+	connect_timeout=2,
+	max_retries=0,
+	log_level="ERROR",
 )
 
 
 class RecordingTransport:
-    """Wraps an httpx2.MockTransport and records every request made through it."""
+	"""Wraps an httpx2.MockTransport and records every request made through it."""
 
-    def __init__(self, handler: Callable[[httpx2.Request], httpx2.Response]):
-        self.requests: list[httpx2.Request] = []
-        self._handler = handler
-        self._transport = httpx2.MockTransport(self._record)
+	def __init__(self, handler: Callable[[httpx2.Request], httpx2.Response]):
+		self.requests: list[httpx2.Request] = []
+		self._handler = handler
+		self._transport = httpx2.MockTransport(self._record)
 
-    def _record(self, request: httpx2.Request) -> httpx2.Response:
-        self.requests.append(request)
-        return self._handler(request)
+	def _record(self, request: httpx2.Request) -> httpx2.Response:
+		self.requests.append(request)
+		return self._handler(request)
 
-    @property
-    def transport(self) -> httpx2.MockTransport:
-        return self._transport
+	@property
+	def transport(self) -> httpx2.MockTransport:
+		return self._transport
 
 
 @pytest.fixture
 def mock_gregory(monkeypatch):
-    """Patches the module-level Gregory client with one backed by a mock transport.
+	"""Patches the module-level Gregory client with one backed by a mock transport.
 
-    Yields a `set_handler(fn)` setter; `fn(request) -> httpx2.Response`.
-    Also exposes `.requests` (via `recorder`) for asserting on query params.
-    """
-    import gregory_mcp.client as client_module
+	Yields a `set_handler(fn)` setter; `fn(request) -> httpx2.Response`.
+	Also exposes `.requests` (via `recorder`) for asserting on query params.
+	"""
+	import gregory_mcp.client as client_module
 
-    client = GregoryClient(TEST_SETTINGS)
-    recorder = RecordingTransport(lambda request: httpx2.Response(200, json={}))
-    client._client._transport = recorder.transport
+	client = GregoryClient(TEST_SETTINGS)
+	recorder = RecordingTransport(lambda request: httpx2.Response(200, json={}))
+	client._client._transport = recorder.transport
 
-    monkeypatch.setattr(client_module, "_client", client)
+	monkeypatch.setattr(client_module, "_client", client)
 
-    class Handle:
-        def set_handler(self, fn):
-            recorder._handler = fn
+	class Handle:
+		def set_handler(self, fn):
+			recorder._handler = fn
 
-        @property
-        def requests(self):
-            return recorder.requests
+		@property
+		def requests(self):
+			return recorder.requests
 
-    yield Handle()
+	yield Handle()
 
 
 @pytest.fixture
 def server():
-    return build_server()
+	return build_server()

--- a/mcp-server/tests/conftest.py
+++ b/mcp-server/tests/conftest.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import httpx2
+import pytest
+
+from gregory_mcp.client import GregoryClient
+from gregory_mcp.config import Settings
+from gregory_mcp.server import build_server
+
+TEST_SETTINGS = Settings(
+    api_url="https://gregory.test",
+    host="127.0.0.1",
+    port=8001,
+    request_timeout=5,
+    connect_timeout=2,
+    max_retries=0,
+    log_level="ERROR",
+)
+
+
+class RecordingTransport:
+    """Wraps an httpx2.MockTransport and records every request made through it."""
+
+    def __init__(self, handler: Callable[[httpx2.Request], httpx2.Response]):
+        self.requests: list[httpx2.Request] = []
+        self._handler = handler
+        self._transport = httpx2.MockTransport(self._record)
+
+    def _record(self, request: httpx2.Request) -> httpx2.Response:
+        self.requests.append(request)
+        return self._handler(request)
+
+    @property
+    def transport(self) -> httpx2.MockTransport:
+        return self._transport
+
+
+@pytest.fixture
+def mock_gregory(monkeypatch):
+    """Patches the module-level Gregory client with one backed by a mock transport.
+
+    Yields a `set_handler(fn)` setter; `fn(request) -> httpx2.Response`.
+    Also exposes `.requests` (via `recorder`) for asserting on query params.
+    """
+    import gregory_mcp.client as client_module
+
+    client = GregoryClient(TEST_SETTINGS)
+    recorder = RecordingTransport(lambda request: httpx2.Response(200, json={}))
+    client._client._transport = recorder.transport
+
+    monkeypatch.setattr(client_module, "_client", client)
+
+    class Handle:
+        def set_handler(self, fn):
+            recorder._handler = fn
+
+        @property
+        def requests(self):
+            return recorder.requests
+
+    yield Handle()
+
+
+@pytest.fixture
+def server():
+    return build_server()

--- a/mcp-server/tests/conftest.py
+++ b/mcp-server/tests/conftest.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 import httpx2
 import pytest
 
+from gregory_mcp.cache import reset_catalog_cache
 from gregory_mcp.client import GregoryClient
 from gregory_mcp.config import Settings
 from gregory_mcp.server import build_server
@@ -43,6 +44,11 @@ def mock_gregory(monkeypatch):
 
 	Yields a `set_handler(fn)` setter; `fn(request) -> httpx2.Response`.
 	Also exposes `.requests` (via `recorder`) for asserting on query params.
+
+	Resets the process-wide catalog cache (see gregory_mcp/cache.py) before
+	and after each test — it's a module-level singleton, so without this a
+	list_subjects()/list_categories() call in one test could be served a
+	cached result left behind by a completely different test.
 	"""
 	import gregory_mcp.client as client_module
 
@@ -51,6 +57,7 @@ def mock_gregory(monkeypatch):
 	client._client._transport = recorder.transport
 
 	monkeypatch.setattr(client_module, "_client", client)
+	reset_catalog_cache()
 
 	class Handle:
 		def set_handler(self, fn):
@@ -61,6 +68,7 @@ def mock_gregory(monkeypatch):
 			return recorder.requests
 
 	yield Handle()
+	reset_catalog_cache()
 
 
 @pytest.fixture

--- a/mcp-server/tests/test_cache.py
+++ b/mcp-server/tests/test_cache.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx2
+import pytest
+
+from gregory_mcp.cache import CatalogCache, get_all_pages_cached, get_catalog_cache, reset_catalog_cache
+from gregory_mcp.tools.articles import search_articles
+from gregory_mcp.tools.catalog import list_categories, list_subjects
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+	reset_catalog_cache()
+	yield
+	reset_catalog_cache()
+
+
+class FakeClock:
+	def __init__(self, start: float = 0.0):
+		self.now = start
+
+	def __call__(self) -> float:
+		return self.now
+
+	def advance(self, seconds: float) -> None:
+		self.now += seconds
+
+
+async def test_cache_hit_skips_the_fetch():
+	cache = CatalogCache()
+	calls = []
+
+	async def fetch():
+		calls.append(1)
+		return ["row"]
+
+	first = await cache.get_or_fetch("/subjects/", {"team_id": 1}, fetch)
+	second = await cache.get_or_fetch("/subjects/", {"team_id": 1}, fetch)
+
+	assert first == second == ["row"]
+	assert len(calls) == 1
+
+
+async def test_cache_expires_after_ttl():
+	clock = FakeClock()
+	cache = CatalogCache(ttl_ms=1000, clock=clock)
+	calls = []
+
+	async def fetch():
+		calls.append(1)
+		return ["row", len(calls)]
+
+	await cache.get_or_fetch("/subjects/", None, fetch)
+	clock.advance(0.5)
+	await cache.get_or_fetch("/subjects/", None, fetch)
+	assert len(calls) == 1  # still within TTL
+
+	clock.advance(0.6)  # total 1.1s > 1s TTL
+	await cache.get_or_fetch("/subjects/", None, fetch)
+	assert len(calls) == 2  # expired, refetched
+
+
+async def test_none_valued_params_and_omitted_params_share_a_key():
+	cache = CatalogCache()
+	calls = []
+
+	async def fetch():
+		calls.append(1)
+		return ["row"]
+
+	await cache.get_or_fetch("/subjects/", {"team_id": None, "search": None}, fetch)
+	await cache.get_or_fetch("/subjects/", None, fetch)
+	await cache.get_or_fetch("/subjects/", {}, fetch)
+
+	assert len(calls) == 1
+
+
+async def test_different_params_are_different_keys():
+	cache = CatalogCache()
+	calls = []
+
+	async def fetch():
+		calls.append(1)
+		return ["row"]
+
+	await cache.get_or_fetch("/subjects/", {"team_id": 1}, fetch)
+	await cache.get_or_fetch("/subjects/", {"team_id": 2}, fetch)
+
+	assert len(calls) == 2
+
+
+async def test_single_flight_concurrent_cold_callers_fetch_once():
+	cache = CatalogCache()
+	calls = []
+	release = asyncio.Event()
+
+	async def slow_fetch():
+		calls.append(1)
+		await release.wait()
+		return ["row"]
+
+	async def caller():
+		return await cache.get_or_fetch("/categories/", None, slow_fetch)
+
+	tasks = [asyncio.create_task(caller()) for _ in range(10)]
+	await asyncio.sleep(0.05)  # let every caller reach the fetch/lock
+	release.set()
+	results = await asyncio.gather(*tasks)
+
+	assert all(r == ["row"] for r in results)
+	assert len(calls) == 1
+
+
+async def test_list_subjects_and_subjects_resource_share_the_cache(mock_gregory):
+	calls = []
+
+	def handler(request):
+		calls.append(request.url.path)
+		return httpx2.Response(200, json={"next": None, "results": [{"id": 1, "subject_name": "MS", "team_id": 1}]})
+
+	mock_gregory.set_handler(handler)
+
+	from gregory_mcp.resources import register_resources
+
+	captured = {}
+
+	class FakeServer:
+		def resource(self, *args, **kwargs):
+			def decorator(fn):
+				captured[kwargs.get("name")] = fn
+				return fn
+
+			return decorator
+
+	register_resources(FakeServer())
+
+	await list_subjects()
+	await captured["subjects_catalog"]()
+
+	assert len(calls) == 1  # second call hit the cache, not the network
+
+
+async def test_search_tools_are_never_cached(mock_gregory):
+	calls = []
+
+	def handler(request):
+		calls.append(1)
+		return httpx2.Response(200, json={"count": 0, "next": None, "results": []})
+
+	mock_gregory.set_handler(handler)
+
+	await search_articles(search="stem cells")
+	await search_articles(search="stem cells")
+
+	assert len(calls) == 2  # identical calls still both hit the network
+
+
+async def test_list_categories_uses_the_shared_cache(mock_gregory):
+	calls = []
+
+	def handler(request):
+		calls.append(1)
+		return httpx2.Response(200, json={"next": None, "results": []})
+
+	mock_gregory.set_handler(handler)
+
+	await list_categories(team_id=1)
+	await list_categories(team_id=1)
+
+	assert len(calls) == 1
+
+
+def test_get_catalog_cache_is_a_singleton():
+	assert get_catalog_cache() is get_catalog_cache()
+
+
+async def test_get_all_pages_cached_reuses_process_wide_cache(mock_gregory):
+	calls = []
+
+	def handler(request):
+		calls.append(1)
+		return httpx2.Response(200, json={"next": None, "results": []})
+
+	mock_gregory.set_handler(handler)
+
+	await get_all_pages_cached("/subjects/")
+	await get_all_pages_cached("/subjects/")
+
+	assert len(calls) == 1

--- a/mcp-server/tests/test_client.py
+++ b/mcp-server/tests/test_client.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import httpx2
+import pytest
+
+from gregory_mcp.client import GregoryAPIError, GregoryClient
+from tests.conftest import TEST_SETTINGS
+
+
+async def test_retries_on_5xx_then_succeeds():
+    settings = replace(TEST_SETTINGS, max_retries=2)
+    client = GregoryClient(settings)
+    attempts = []
+
+    def handler(request):
+        attempts.append(1)
+        if len(attempts) < 2:
+            return httpx2.Response(500, json={"detail": "boom"})
+        return httpx2.Response(200, json={"ok": True})
+
+    client._client._transport = httpx2.MockTransport(handler)
+
+    result = await client.get("/articles/")
+
+    assert result == {"ok": True}
+    assert len(attempts) == 2
+
+
+async def test_gives_up_after_max_retries():
+    settings = replace(TEST_SETTINGS, max_retries=1)
+    client = GregoryClient(settings)
+    client._client._transport = httpx2.MockTransport(lambda r: httpx2.Response(503))
+
+    with pytest.raises(GregoryAPIError):
+        await client.get("/articles/")
+
+
+async def test_4xx_raises_immediately_without_retry():
+    settings = replace(TEST_SETTINGS, max_retries=3)
+    client = GregoryClient(settings)
+    attempts = []
+
+    def handler(request):
+        attempts.append(1)
+        return httpx2.Response(404, text="not found")
+
+    client._client._transport = httpx2.MockTransport(handler)
+
+    with pytest.raises(GregoryAPIError) as exc_info:
+        await client.get("/articles/999/")
+
+    assert exc_info.value.status_code == 404
+    assert len(attempts) == 1
+
+
+async def test_none_params_are_dropped():
+    client = GregoryClient(TEST_SETTINGS)
+    seen = {}
+
+    def handler(request):
+        seen.update(request.url.params)
+        return httpx2.Response(200, json={})
+
+    client._client._transport = httpx2.MockTransport(handler)
+
+    await client.get("/articles/", {"team_id": 1, "subject_id": None, "search": None})
+
+    assert seen == {"team_id": "1"}

--- a/mcp-server/tests/test_client.py
+++ b/mcp-server/tests/test_client.py
@@ -10,61 +10,61 @@ from tests.conftest import TEST_SETTINGS
 
 
 async def test_retries_on_5xx_then_succeeds():
-    settings = replace(TEST_SETTINGS, max_retries=2)
-    client = GregoryClient(settings)
-    attempts = []
+	settings = replace(TEST_SETTINGS, max_retries=2)
+	client = GregoryClient(settings)
+	attempts = []
 
-    def handler(request):
-        attempts.append(1)
-        if len(attempts) < 2:
-            return httpx2.Response(500, json={"detail": "boom"})
-        return httpx2.Response(200, json={"ok": True})
+	def handler(request):
+		attempts.append(1)
+		if len(attempts) < 2:
+			return httpx2.Response(500, json={"detail": "boom"})
+		return httpx2.Response(200, json={"ok": True})
 
-    client._client._transport = httpx2.MockTransport(handler)
+	client._client._transport = httpx2.MockTransport(handler)
 
-    result = await client.get("/articles/")
+	result = await client.get("/articles/")
 
-    assert result == {"ok": True}
-    assert len(attempts) == 2
+	assert result == {"ok": True}
+	assert len(attempts) == 2
 
 
 async def test_gives_up_after_max_retries():
-    settings = replace(TEST_SETTINGS, max_retries=1)
-    client = GregoryClient(settings)
-    client._client._transport = httpx2.MockTransport(lambda r: httpx2.Response(503))
+	settings = replace(TEST_SETTINGS, max_retries=1)
+	client = GregoryClient(settings)
+	client._client._transport = httpx2.MockTransport(lambda r: httpx2.Response(503))
 
-    with pytest.raises(GregoryAPIError):
-        await client.get("/articles/")
+	with pytest.raises(GregoryAPIError):
+		await client.get("/articles/")
 
 
 async def test_4xx_raises_immediately_without_retry():
-    settings = replace(TEST_SETTINGS, max_retries=3)
-    client = GregoryClient(settings)
-    attempts = []
+	settings = replace(TEST_SETTINGS, max_retries=3)
+	client = GregoryClient(settings)
+	attempts = []
 
-    def handler(request):
-        attempts.append(1)
-        return httpx2.Response(404, text="not found")
+	def handler(request):
+		attempts.append(1)
+		return httpx2.Response(404, text="not found")
 
-    client._client._transport = httpx2.MockTransport(handler)
+	client._client._transport = httpx2.MockTransport(handler)
 
-    with pytest.raises(GregoryAPIError) as exc_info:
-        await client.get("/articles/999/")
+	with pytest.raises(GregoryAPIError) as exc_info:
+		await client.get("/articles/999/")
 
-    assert exc_info.value.status_code == 404
-    assert len(attempts) == 1
+	assert exc_info.value.status_code == 404
+	assert len(attempts) == 1
 
 
 async def test_none_params_are_dropped():
-    client = GregoryClient(TEST_SETTINGS)
-    seen = {}
+	client = GregoryClient(TEST_SETTINGS)
+	seen = {}
 
-    def handler(request):
-        seen.update(request.url.params)
-        return httpx2.Response(200, json={})
+	def handler(request):
+		seen.update(request.url.params)
+		return httpx2.Response(200, json={})
 
-    client._client._transport = httpx2.MockTransport(handler)
+	client._client._transport = httpx2.MockTransport(handler)
 
-    await client.get("/articles/", {"team_id": 1, "subject_id": None, "search": None})
+	await client.get("/articles/", {"team_id": 1, "subject_id": None, "search": None})
 
-    assert seen == {"team_id": "1"}
+	assert seen == {"team_id": "1"}

--- a/mcp-server/tests/test_client.py
+++ b/mcp-server/tests/test_client.py
@@ -5,13 +5,40 @@ from dataclasses import replace
 import httpx2
 import pytest
 
-from gregory_mcp.client import GregoryAPIError, GregoryClient, GregoryPaginationTruncatedError
+from gregory_mcp.client import (
+	BASE_BACKOFF_SECONDS,
+	MAX_BACKOFF_SECONDS,
+	GregoryAPIError,
+	GregoryClient,
+	GregoryPaginationTruncatedError,
+)
 from tests.conftest import TEST_SETTINGS
+
+
+async def _no_delay(seconds: float) -> None:
+	"""A sleep stand-in that doesn't — keeps retry tests from taking real
+	wall-clock time when they don't care about the spacing itself."""
+
+
+class RecordingSleep:
+	"""A sleep stand-in that records each delay instead of waiting."""
+
+	def __init__(self):
+		self.delays: list[float] = []
+
+	async def __call__(self, seconds: float) -> None:
+		self.delays.append(seconds)
+
+
+def _max_jitter(low: float, high: float) -> float:
+	"""A jitter stand-in that always returns the upper bound, so backoff
+	values are predictable in tests instead of randomly distributed."""
+	return high
 
 
 async def test_retries_on_5xx_then_succeeds():
 	settings = replace(TEST_SETTINGS, max_retries=2)
-	client = GregoryClient(settings)
+	client = GregoryClient(settings, sleep=_no_delay)
 	attempts = []
 
 	def handler(request):
@@ -30,11 +57,110 @@ async def test_retries_on_5xx_then_succeeds():
 
 async def test_gives_up_after_max_retries():
 	settings = replace(TEST_SETTINGS, max_retries=1)
-	client = GregoryClient(settings)
+	client = GregoryClient(settings, sleep=_no_delay)
 	client._client._transport = httpx2.MockTransport(lambda r: httpx2.Response(503))
 
 	with pytest.raises(GregoryAPIError):
 		await client.get("/articles/")
+
+
+async def test_429_is_retried_not_raised_immediately():
+	settings = replace(TEST_SETTINGS, max_retries=2)
+	client = GregoryClient(settings, sleep=_no_delay)
+	attempts = []
+
+	def handler(request):
+		attempts.append(1)
+		if len(attempts) < 2:
+			return httpx2.Response(429, text="rate limited")
+		return httpx2.Response(200, json={"ok": True})
+
+	client._client._transport = httpx2.MockTransport(handler)
+
+	result = await client.get("/articles/")
+
+	assert result == {"ok": True}
+	assert len(attempts) == 2
+
+
+async def test_backoff_doubles_and_is_capped():
+	settings = replace(TEST_SETTINGS, max_retries=5)
+	sleep = RecordingSleep()
+	client = GregoryClient(settings, sleep=sleep, jitter=_max_jitter)
+	client._client._transport = httpx2.MockTransport(lambda r: httpx2.Response(500))
+
+	with pytest.raises(GregoryAPIError):
+		await client.get("/articles/")
+
+	expected = [min(MAX_BACKOFF_SECONDS, BASE_BACKOFF_SECONDS * 2**i) for i in range(5)]
+	assert sleep.delays == expected
+	assert sleep.delays[-1] == MAX_BACKOFF_SECONDS  # confirms the cap actually bites
+
+
+async def test_backoff_jitter_stays_within_bounds():
+	settings = replace(TEST_SETTINGS, max_retries=3)
+	sleep = RecordingSleep()
+	client = GregoryClient(settings, sleep=sleep)  # real random.uniform jitter
+	client._client._transport = httpx2.MockTransport(lambda r: httpx2.Response(500))
+
+	with pytest.raises(GregoryAPIError):
+		await client.get("/articles/")
+
+	for i, delay in enumerate(sleep.delays):
+		cap = min(MAX_BACKOFF_SECONDS, BASE_BACKOFF_SECONDS * 2**i)
+		assert 0 <= delay <= cap
+
+
+async def test_retry_after_header_overrides_computed_backoff():
+	settings = replace(TEST_SETTINGS, max_retries=1)
+	sleep = RecordingSleep()
+	client = GregoryClient(settings, sleep=sleep, jitter=_max_jitter)
+	attempts = []
+
+	def handler(request):
+		attempts.append(1)
+		if len(attempts) < 2:
+			return httpx2.Response(429, headers={"Retry-After": "7"})
+		return httpx2.Response(200, json={"ok": True})
+
+	client._client._transport = httpx2.MockTransport(handler)
+
+	await client.get("/articles/")
+
+	assert sleep.delays == [7.0]  # not the jitter-computed 0.2s
+
+
+async def test_invalid_retry_after_falls_back_to_computed_backoff():
+	settings = replace(TEST_SETTINGS, max_retries=1)
+	sleep = RecordingSleep()
+	client = GregoryClient(settings, sleep=sleep, jitter=_max_jitter)
+	client._client._transport = httpx2.MockTransport(
+		lambda r: httpx2.Response(429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"})
+	)
+
+	with pytest.raises(GregoryAPIError):
+		await client.get("/articles/")
+
+	assert sleep.delays == [BASE_BACKOFF_SECONDS]
+
+
+async def test_transport_error_retry_also_backs_off():
+	settings = replace(TEST_SETTINGS, max_retries=1)
+	sleep = RecordingSleep()
+	client = GregoryClient(settings, sleep=sleep, jitter=_max_jitter)
+	attempts = []
+
+	def handler(request):
+		attempts.append(1)
+		if len(attempts) < 2:
+			raise httpx2.ConnectError("boom", request=request)
+		return httpx2.Response(200, json={"ok": True})
+
+	client._client._transport = httpx2.MockTransport(handler)
+
+	await client.get("/articles/")
+
+	assert sleep.delays == [BASE_BACKOFF_SECONDS]
 
 
 async def test_4xx_raises_immediately_without_retry():

--- a/mcp-server/tests/test_client.py
+++ b/mcp-server/tests/test_client.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 import httpx2
 import pytest
 
-from gregory_mcp.client import GregoryAPIError, GregoryClient
+from gregory_mcp.client import GregoryAPIError, GregoryClient, GregoryPaginationTruncatedError
 from tests.conftest import TEST_SETTINGS
 
 
@@ -68,3 +68,36 @@ async def test_none_params_are_dropped():
 	await client.get("/articles/", {"team_id": 1, "subject_id": None, "search": None})
 
 	assert seen == {"team_id": "1"}
+
+
+async def test_get_all_pages_returns_everything_when_it_fits():
+	client = GregoryClient(TEST_SETTINGS)
+
+	def handler(request):
+		page = request.url.params.get("page", "1")
+		if page == "1":
+			return httpx2.Response(200, json={"next": "https://x/?page=2", "results": [{"id": 1}]})
+		return httpx2.Response(200, json={"next": None, "results": [{"id": 2}]})
+
+	client._client._transport = httpx2.MockTransport(handler)
+
+	results = await client.get_all_pages("/subjects/", max_pages=5)
+
+	assert [r["id"] for r in results] == [1, 2]
+
+
+async def test_get_all_pages_raises_rather_than_silently_truncating():
+	client = GregoryClient(TEST_SETTINGS)
+
+	def handler(request):
+		# `next` never runs out — an unbounded/larger-than-expected catalog.
+		return httpx2.Response(200, json={"next": "https://x/?page=999", "results": [{"id": 1}]})
+
+	client._client._transport = httpx2.MockTransport(handler)
+
+	with pytest.raises(GregoryPaginationTruncatedError) as exc_info:
+		await client.get_all_pages("/sponsors/", max_pages=3)
+
+	assert exc_info.value.path == "/sponsors/"
+	assert exc_info.value.max_pages == 3
+	assert exc_info.value.fetched == 3

--- a/mcp-server/tests/test_config.py
+++ b/mcp-server/tests/test_config.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from gregory_mcp.config import load_settings
+
+
+def test_requires_api_url(monkeypatch):
+	monkeypatch.delenv("GREGORY_API_URL", raising=False)
+	with pytest.raises(RuntimeError, match="GREGORY_API_URL"):
+		load_settings()
+
+
+def test_negative_max_retries_clamps_to_zero(monkeypatch):
+	monkeypatch.setenv("GREGORY_API_URL", "https://gregory.test")
+	monkeypatch.setenv("GREGORY_MAX_RETRIES", "-3")
+
+	settings = load_settings()
+
+	assert settings.max_retries == 0
+
+
+def test_positive_max_retries_passes_through(monkeypatch):
+	monkeypatch.setenv("GREGORY_API_URL", "https://gregory.test")
+	monkeypatch.setenv("GREGORY_MAX_RETRIES", "5")
+
+	settings = load_settings()
+
+	assert settings.max_retries == 5

--- a/mcp-server/tests/test_no_internal_url_leak.py
+++ b/mcp-server/tests/test_no_internal_url_leak.py
@@ -1,0 +1,60 @@
+"""Regression test for the `next` passthrough leaking the internal
+container hostname (e.g. http://gregory:8000/...) to MCP clients.
+
+Every paginated tool used to return `"next": data.get("next")` — the raw
+upstream URL, unusable by any external client and a minor information
+disclosure on an unauthenticated endpoint. They return `next_page: int |
+None` instead now. This walks each tool's full result recursively and
+fails if any string value contains the API host at all, so the specific
+bug (and any similar future one) can't reappear silently.
+"""
+
+from __future__ import annotations
+
+import httpx2
+import pytest
+
+from gregory_mcp.tools.articles import search_articles
+from gregory_mcp.tools.authors import search_authors
+from gregory_mcp.tools.catalog import list_sponsors
+from gregory_mcp.tools.trials import search_trials
+from tests.conftest import TEST_SETTINGS
+
+# What the real bug looked like in production, reproduced in the mock so the
+# test would have caught it.
+LEAKY_NEXT = f"{TEST_SETTINGS.api_url}/whatever/?page=2"
+
+
+def _find_leaks(value, host: str, path: str = "$") -> list[str]:
+	leaks = []
+	if isinstance(value, str):
+		if host in value:
+			leaks.append(f"{path} = {value!r}")
+	elif isinstance(value, dict):
+		for key, item in value.items():
+			leaks.extend(_find_leaks(item, host, f"{path}.{key}"))
+	elif isinstance(value, (list, tuple)):
+		for i, item in enumerate(value):
+			leaks.extend(_find_leaks(item, host, f"{path}[{i}]"))
+	return leaks
+
+
+PAGINATED_TOOLS = [
+	(search_articles, {}),
+	(search_trials, {}),
+	(search_authors, {}),
+	(list_sponsors, {}),
+]
+
+
+@pytest.mark.parametrize("fn,kwargs", PAGINATED_TOOLS, ids=[fn.__name__ for fn, _ in PAGINATED_TOOLS])
+async def test_tool_output_never_contains_the_api_host(fn, kwargs, mock_gregory):
+	mock_gregory.set_handler(
+		lambda request: httpx2.Response(200, json={"count": 1, "next": LEAKY_NEXT, "results": []})
+	)
+
+	result = await fn(**kwargs)
+
+	host = TEST_SETTINGS.api_url.removeprefix("https://").removeprefix("http://")
+	leaks = _find_leaks(result, host)
+	assert not leaks, f"tool output leaks the API host: {leaks}"

--- a/mcp-server/tests/test_ordering_values.py
+++ b/mcp-server/tests/test_ordering_values.py
@@ -1,0 +1,90 @@
+"""Regression test for the recent_trials_for_subject ordering="-date_registration" bug.
+
+date_registration was never a valid `ordering` value on /trials/ (see
+TrialViewSet.ordering_fields in django/api/views.py) — DRF's OrderingFilter
+silently ignores an unrecognised value rather than rejecting it, so the prompt
+promised registration-recency order and quietly delivered the default order
+instead. This scans prompts.py and the tool modules for any ordering="..."
+literal and checks the field name against every endpoint's real
+ordering_fields, so the next typo fails a test instead of failing silently at
+runtime.
+
+This is a hardcoded allowlist rather than a read from django/schema.yml
+because, as of this test, the schema does not yet declare a real enum for
+`ordering` (see HANDOVER-MCP-FIXES-PLAN.md Task 1). Once that lands, prefer
+sourcing this from the schema's declared enum the way
+test_schema_contract.py does for filters — see Task 5.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+from gregory_mcp import prompts
+from gregory_mcp.tools import articles, catalog, trials
+
+# Mirrors each ViewSet's ordering_fields in django/api/views.py.
+VALID_ORDERING_FIELDS = {
+	# ArticleViewSet
+	"discovery_date",
+	"published_date",
+	"title",
+	"article_id",
+	"ml_score",
+	# TrialViewSet (discovery_date/published_date/title shared with articles)
+	"trial_id",
+	"last_updated",
+	"recruiting_first",
+	# CategoryViewSet
+	"category_name",
+	"id",
+	"article_count_annotated",
+	"trials_count_annotated",
+	"authors_count_annotated",
+	# SubjectsViewSet (id shared with categories)
+	"subject_name",
+	"team",
+	# SponsorViewSet
+	"name",
+	"trials_count",
+}
+
+_ORDERING_LITERAL_RE = re.compile(r"""ordering\s*=\s*["']([^"']+)["']""")
+
+
+def _ordering_values_in(*modules_or_functions) -> set[str]:
+	values: set[str] = set()
+	for obj in modules_or_functions:
+		source = inspect.getsource(obj)
+		values.update(_ORDERING_LITERAL_RE.findall(source))
+	return values
+
+
+def _assert_all_valid(values: set[str], where: str) -> None:
+	for value in values:
+		field = value.lstrip("-")
+		assert field in VALID_ORDERING_FIELDS, (
+			f"{where} references ordering={value!r}, but {field!r} is not a valid "
+			"ordering field on any endpoint (see VALID_ORDERING_FIELDS)."
+		)
+
+
+def test_prompts_only_reference_valid_ordering_fields():
+	_assert_all_valid(_ordering_values_in(prompts), "prompts.py")
+
+
+def test_tool_source_only_references_valid_ordering_fields():
+	found = _ordering_values_in(
+		articles.search_articles,
+		trials.search_trials,
+		catalog.list_subjects,
+		catalog.list_categories,
+		catalog.list_sponsors,
+	)
+	_assert_all_valid(found, "a tool docstring or source")
+
+
+def test_regression_date_registration_is_rejected():
+	"""The exact bug: date_registration was never in ordering_fields."""
+	assert "date_registration" not in VALID_ORDERING_FIELDS

--- a/mcp-server/tests/test_pagination.py
+++ b/mcp-server/tests/test_pagination.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from gregory_mcp.pagination import clamp_page, clamp_page_size
+
+
+def test_clamp_page_floors_at_one():
+	assert clamp_page(1) == 1
+	assert clamp_page(5) == 5
+	assert clamp_page(0) == 1
+	assert clamp_page(-5) == 1
+
+
+def test_clamp_page_size_clamps_both_ends():
+	assert clamp_page_size(10, 25) == 10
+	assert clamp_page_size(999, 25) == 25
+	assert clamp_page_size(0, 25) == 1
+	assert clamp_page_size(-5, 25) == 1

--- a/mcp-server/tests/test_schema_contract.py
+++ b/mcp-server/tests/test_schema_contract.py
@@ -1,0 +1,83 @@
+"""Contract test against the Stage 1 OpenAPI schema (../django/schema.yml).
+
+Every filter parameter a tool function accepts must be a real, declared
+query parameter on the endpoint it calls. This is what "Stage 2 builds
+against the schema, not against prose" (STAGE-2-MCP-SERVER-PLAN.md) means in
+practice: run this after regenerating schema.yml, and an unannotated or
+renamed filter fails here instead of at runtime against a live instance.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+import yaml
+
+from gregory_mcp.tools import articles, authors, catalog, trials
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "django" / "schema.yml"
+
+
+@pytest.fixture(scope="module")
+def schema_params() -> dict[str, set[str]]:
+    if not SCHEMA_PATH.exists():
+        pytest.skip(f"schema.yml not found at {SCHEMA_PATH} — run from within the gregory-ai checkout")
+    with SCHEMA_PATH.open() as f:
+        doc = yaml.safe_load(f)
+    result = {}
+    for path, methods in doc["paths"].items():
+        get = methods.get("get")
+        if not get:
+            continue
+        result[path] = {p["name"] for p in get.get("parameters", [])}
+    return result
+
+
+# (tool function, endpoint path, arg names that are NOT query filters — path
+# params, tool-only dispatch flags, etc.)
+TOOL_ENDPOINTS = [
+    (articles.search_articles, "/articles/", set()),
+    (trials.search_trials, "/trials/", set()),
+    (authors.search_authors, "/authors/", set()),
+    (catalog.list_subjects, "/subjects/", set()),
+    (catalog.list_categories, "/categories/", set()),
+    (catalog.list_sponsors, "/sponsors/", set()),
+]
+
+DETAIL_ENDPOINTS = [
+    (articles.get_article, "/articles/{article_id}/"),
+    (trials.get_trial, "/trials/{trial_id}/"),
+    (authors.get_author, "/authors/{id}/"),
+]
+
+
+@pytest.mark.parametrize("fn,path,non_filter_args", TOOL_ENDPOINTS, ids=[fn.__name__ for fn, _, _ in TOOL_ENDPOINTS])
+def test_tool_filters_are_declared_in_schema(fn, path, non_filter_args, schema_params):
+    assert path in schema_params, f"{path} is missing from schema.yml entirely"
+    declared = schema_params[path]
+    tool_args = set(inspect.signature(fn).parameters) - non_filter_args
+
+    unknown = tool_args - declared
+    assert not unknown, (
+        f"{fn.__name__} passes {sorted(unknown)} to GET {path}, but schema.yml "
+        f"does not declare {sorted(unknown)} as a query parameter there. Either "
+        "the tool is out of date or schema.yml needs regenerating."
+    )
+
+
+@pytest.mark.parametrize("fn,path", DETAIL_ENDPOINTS, ids=[fn.__name__ for fn, _ in DETAIL_ENDPOINTS])
+def test_detail_endpoint_exists_in_schema(fn, path, schema_params):
+    assert path in schema_params, f"{path} is missing from schema.yml entirely"
+
+
+def test_stats_endpoints_exist_in_schema(schema_params):
+    # /articles/stats/ and /trials/stats/ are CachedStatsActionMixin-backed
+    # custom @actions — schema.yml currently only declares `format` for them
+    # (see STAGE-1-OPENAPI-SCHEMA-PLAN.md's "hard parts" table). Only /stats/
+    # (a plain APIView with @extend_schema) is fully annotated; check its
+    # params for real, and just check the other two exist.
+    for path in ("/stats/", "/articles/stats/", "/trials/stats/"):
+        assert path in schema_params, f"{path} is missing from schema.yml entirely"
+    assert {"team", "subject"} <= schema_params["/stats/"]

--- a/mcp-server/tests/test_schema_contract.py
+++ b/mcp-server/tests/test_schema_contract.py
@@ -84,7 +84,6 @@ KNOWN_UNEXPOSED_PARAMS = {
 		"source_id",  # niche — callers don't know source IDs
 		"subjects",
 		"subjects_any",  # multi-subject AND/OR; subject_id covers the common case
-		"last_days",  # HANDOVER-MCP-FIXES-PLAN.md "Out of scope": filter coverage gap
 		"week",
 		"year",  # legacy ISO-week filtering; published_date_after/before covers this better
 	},
@@ -107,13 +106,6 @@ KNOWN_UNEXPOSED_PARAMS = {
 		"inclusion_agemin",
 		"inclusion_agemax",  # -> age_eligible
 		"countries",  # -> country / region
-		# HANDOVER-MCP-FIXES-PLAN.md "Out of scope" — explicit filter coverage gaps:
-		"euct",
-		"eudract",
-		"ctis",  # EU registry IDs; only nct is exposed
-		"has_results",
-		"acronym",
-		"therapeutic_areas",
 	},
 	"/authors/": {
 		"format",

--- a/mcp-server/tests/test_schema_contract.py
+++ b/mcp-server/tests/test_schema_contract.py
@@ -22,62 +22,62 @@ SCHEMA_PATH = Path(__file__).resolve().parents[2] / "django" / "schema.yml"
 
 @pytest.fixture(scope="module")
 def schema_params() -> dict[str, set[str]]:
-    if not SCHEMA_PATH.exists():
-        pytest.skip(f"schema.yml not found at {SCHEMA_PATH} — run from within the gregory-ai checkout")
-    with SCHEMA_PATH.open() as f:
-        doc = yaml.safe_load(f)
-    result = {}
-    for path, methods in doc["paths"].items():
-        get = methods.get("get")
-        if not get:
-            continue
-        result[path] = {p["name"] for p in get.get("parameters", [])}
-    return result
+	if not SCHEMA_PATH.exists():
+		pytest.skip(f"schema.yml not found at {SCHEMA_PATH} — run from within the gregory-ai checkout")
+	with SCHEMA_PATH.open() as f:
+		doc = yaml.safe_load(f)
+	result = {}
+	for path, methods in doc["paths"].items():
+		get = methods.get("get")
+		if not get:
+			continue
+		result[path] = {p["name"] for p in get.get("parameters", [])}
+	return result
 
 
 # (tool function, endpoint path, arg names that are NOT query filters — path
 # params, tool-only dispatch flags, etc.)
 TOOL_ENDPOINTS = [
-    (articles.search_articles, "/articles/", set()),
-    (trials.search_trials, "/trials/", set()),
-    (authors.search_authors, "/authors/", set()),
-    (catalog.list_subjects, "/subjects/", set()),
-    (catalog.list_categories, "/categories/", set()),
-    (catalog.list_sponsors, "/sponsors/", set()),
+	(articles.search_articles, "/articles/", set()),
+	(trials.search_trials, "/trials/", set()),
+	(authors.search_authors, "/authors/", set()),
+	(catalog.list_subjects, "/subjects/", set()),
+	(catalog.list_categories, "/categories/", set()),
+	(catalog.list_sponsors, "/sponsors/", set()),
 ]
 
 DETAIL_ENDPOINTS = [
-    (articles.get_article, "/articles/{article_id}/"),
-    (trials.get_trial, "/trials/{trial_id}/"),
-    (authors.get_author, "/authors/{id}/"),
+	(articles.get_article, "/articles/{article_id}/"),
+	(trials.get_trial, "/trials/{trial_id}/"),
+	(authors.get_author, "/authors/{id}/"),
 ]
 
 
 @pytest.mark.parametrize("fn,path,non_filter_args", TOOL_ENDPOINTS, ids=[fn.__name__ for fn, _, _ in TOOL_ENDPOINTS])
 def test_tool_filters_are_declared_in_schema(fn, path, non_filter_args, schema_params):
-    assert path in schema_params, f"{path} is missing from schema.yml entirely"
-    declared = schema_params[path]
-    tool_args = set(inspect.signature(fn).parameters) - non_filter_args
+	assert path in schema_params, f"{path} is missing from schema.yml entirely"
+	declared = schema_params[path]
+	tool_args = set(inspect.signature(fn).parameters) - non_filter_args
 
-    unknown = tool_args - declared
-    assert not unknown, (
-        f"{fn.__name__} passes {sorted(unknown)} to GET {path}, but schema.yml "
-        f"does not declare {sorted(unknown)} as a query parameter there. Either "
-        "the tool is out of date or schema.yml needs regenerating."
-    )
+	unknown = tool_args - declared
+	assert not unknown, (
+		f"{fn.__name__} passes {sorted(unknown)} to GET {path}, but schema.yml "
+		f"does not declare {sorted(unknown)} as a query parameter there. Either "
+		"the tool is out of date or schema.yml needs regenerating."
+	)
 
 
 @pytest.mark.parametrize("fn,path", DETAIL_ENDPOINTS, ids=[fn.__name__ for fn, _ in DETAIL_ENDPOINTS])
 def test_detail_endpoint_exists_in_schema(fn, path, schema_params):
-    assert path in schema_params, f"{path} is missing from schema.yml entirely"
+	assert path in schema_params, f"{path} is missing from schema.yml entirely"
 
 
 def test_stats_endpoints_exist_in_schema(schema_params):
-    # /articles/stats/ and /trials/stats/ are CachedStatsActionMixin-backed
-    # custom @actions — schema.yml currently only declares `format` for them
-    # (see STAGE-1-OPENAPI-SCHEMA-PLAN.md's "hard parts" table). Only /stats/
-    # (a plain APIView with @extend_schema) is fully annotated; check its
-    # params for real, and just check the other two exist.
-    for path in ("/stats/", "/articles/stats/", "/trials/stats/"):
-        assert path in schema_params, f"{path} is missing from schema.yml entirely"
-    assert {"team", "subject"} <= schema_params["/stats/"]
+	# /articles/stats/ and /trials/stats/ are CachedStatsActionMixin-backed
+	# custom @actions — schema.yml currently only declares `format` for them
+	# (see STAGE-1-OPENAPI-SCHEMA-PLAN.md's "hard parts" table). Only /stats/
+	# (a plain APIView with @extend_schema) is fully annotated; check its
+	# params for real, and just check the other two exist.
+	for path in ("/stats/", "/articles/stats/", "/trials/stats/"):
+		assert path in schema_params, f"{path} is missing from schema.yml entirely"
+	assert {"team", "subject"} <= schema_params["/stats/"]

--- a/mcp-server/tests/test_schema_contract.py
+++ b/mcp-server/tests/test_schema_contract.py
@@ -72,6 +72,112 @@ def test_detail_endpoint_exists_in_schema(fn, path, schema_params):
 	assert path in schema_params, f"{path} is missing from schema.yml entirely"
 
 
+# Schema-declared params no tool exposes, reviewed and judged out of scope
+# for now — not a permanent exemption, revisit if a use case shows up. Keeps
+# the reverse check below from flagging *known* gaps on every run while
+# still failing loudly the moment a *new*, unreviewed one appears (a filter
+# added to a FilterSet that nobody thought to add to the matching tool).
+KNOWN_UNEXPOSED_PARAMS = {
+	"/articles/": {
+		"format",  # CSV — no export tool, see STAGE-2 plan "Risks"
+		"site_id",  # Django Site scoping; MCP client is already scoped to one instance
+		"source_id",  # niche — callers don't know source IDs
+		"subjects",
+		"subjects_any",  # multi-subject AND/OR; subject_id covers the common case
+		"last_days",  # HANDOVER-MCP-FIXES-PLAN.md "Out of scope": filter coverage gap
+		"week",
+		"year",  # legacy ISO-week filtering; published_date_after/before covers this better
+	},
+	"/trials/": {
+		"format",
+		"site_id",
+		"source_id",
+		"subjects",
+		"subjects_any",
+		"trial_id",  # redundant with get_trial(trial_id)
+		"source_register",  # niche — registry name (e.g. "ClinicalTrials.gov")
+		"internal_number",  # niche — WHO internal number
+		"identifiers",  # generic multi-registry filter; nct covers the common case
+		# legacy raw-string fields superseded by a _normalized equivalent already exposed:
+		"phase",  # -> phase_normalized
+		"primary_sponsor",  # -> sponsor_id / sponsor_slug
+		"recruitment_status",
+		"status",  # -> recruitment_status_normalized
+		"study_type",  # -> study_type_normalized
+		"inclusion_agemin",
+		"inclusion_agemax",  # -> age_eligible
+		"countries",  # -> country / region
+		# HANDOVER-MCP-FIXES-PLAN.md "Out of scope" — explicit filter coverage gaps:
+		"euct",
+		"eudract",
+		"ctis",  # EU registry IDs; only nct is exposed
+		"has_results",
+		"acronym",
+		"therapeutic_areas",
+	},
+	"/authors/": {
+		"format",
+		"author_id",  # redundant with get_author(author_id)
+		# Task 5 restored team_id/subject_id; category/date scoping wasn't
+		# requested and stays out for now:
+		"category_id",
+		"category_slug",
+		"date_from",
+		"date_to",
+		"timeframe",
+	},
+	"/subjects/": {
+		"format",
+		"page",  # list_subjects always fetches every page (get_all_pages)
+		"ordering",  # 7 rows total — nothing to usefully sort
+	},
+	"/categories/": {
+		"format",
+		"page",  # list_categories always fetches every page (get_all_pages)
+		"ordering",
+		"category_id",  # redundant enough with team_id/subject_id/search
+		"category_terms",
+		"get_categories",  # comma-separated ID lookup; niche
+		# HANDOVER-MCP-FIXES-PLAN.md Task 5: "if useful" — deferred, not requested:
+		"include_authors",
+		"max_authors",
+		"monthly_counts",
+		"ml_threshold",
+		"date_from",
+		"date_to",
+		"timeframe",
+	},
+	"/sponsors/": {
+		"format",
+		"ordering",  # list_sponsors doesn't expose a sort; search narrows results instead
+	},
+}
+
+
+@pytest.mark.parametrize("fn,path,non_filter_args", TOOL_ENDPOINTS, ids=[fn.__name__ for fn, _, _ in TOOL_ENDPOINTS])
+def test_no_new_unreviewed_schema_params(fn, path, non_filter_args, schema_params):
+	"""Reverse of test_tool_filters_are_declared_in_schema: flags a schema
+	param no tool exposes and no one has reviewed yet (KNOWN_UNEXPOSED_PARAMS
+	above). Failing here doesn't mean the tool is broken — it means a new
+	filter landed on the Django side that this file hasn't looked at. Either
+	add it to the tool or, if it's deliberately out of scope, add it to the
+	allowlist with a reason.
+	"""
+	if path not in schema_params:
+		pytest.skip(f"{path} missing from schema.yml — covered by the forward check")
+	declared = schema_params[path]
+	tool_args = set(inspect.signature(fn).parameters) - non_filter_args
+	reviewed = KNOWN_UNEXPOSED_PARAMS.get(path, set())
+
+	unreviewed = declared - tool_args - reviewed
+	assert not unreviewed, (
+		f"schema.yml declares {sorted(unreviewed)} on GET {path}, which "
+		f"{fn.__name__} doesn't expose and KNOWN_UNEXPOSED_PARAMS doesn't "
+		"account for. Add it to the tool, or to KNOWN_UNEXPOSED_PARAMS with "
+		"a reason if it's deliberately out of scope."
+	)
+
+
 def test_stats_endpoints_exist_in_schema(schema_params):
 	# /articles/stats/ and /trials/stats/ are CachedStatsActionMixin-backed
 	# custom @actions — schema.yml currently only declares `format` for them

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -28,12 +28,13 @@ async def test_every_tool_is_read_only(server):
 		assert tool.annotations.read_only_hint is True, f"{tool.name} is not marked read-only"
 
 
-async def test_server_registers_three_resources(server):
+async def test_server_registers_two_resources(server):
+	# No sponsors resource — ~8,000 rows is not catalog-shaped; list_sponsors
+	# (search + pagination) is the right tool for that data instead.
 	resources = await server.list_resources()
 	assert {r.uri for r in resources} == {
 		"gregory://subjects",
 		"gregory://categories",
-		"gregory://sponsors",
 	}
 
 

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -3,50 +3,50 @@ from __future__ import annotations
 from gregory_mcp.client import GregoryClient
 
 EXPECTED_TOOLS = {
-    "list_subjects",
-    "search_articles",
-    "get_article",
-    "search_trials",
-    "get_trial",
-    "search_authors",
-    "get_author",
-    "list_categories",
-    "list_sponsors",
-    "get_stats",
+	"list_subjects",
+	"search_articles",
+	"get_article",
+	"search_trials",
+	"get_trial",
+	"search_authors",
+	"get_author",
+	"list_categories",
+	"list_sponsors",
+	"get_stats",
 }
 
 
 async def test_server_registers_exactly_the_planned_tools(server):
-    tools = await server.list_tools()
-    assert {t.name for t in tools} == EXPECTED_TOOLS
+	tools = await server.list_tools()
+	assert {t.name for t in tools} == EXPECTED_TOOLS
 
 
 async def test_every_tool_is_read_only(server):
-    tools = await server.list_tools()
-    for tool in tools:
-        assert tool.annotations is not None, f"{tool.name} has no annotations"
-        assert tool.annotations.read_only_hint is True, f"{tool.name} is not marked read-only"
+	tools = await server.list_tools()
+	for tool in tools:
+		assert tool.annotations is not None, f"{tool.name} has no annotations"
+		assert tool.annotations.read_only_hint is True, f"{tool.name} is not marked read-only"
 
 
 async def test_server_registers_three_resources(server):
-    resources = await server.list_resources()
-    assert {r.uri for r in resources} == {
-        "gregory://subjects",
-        "gregory://categories",
-        "gregory://sponsors",
-    }
+	resources = await server.list_resources()
+	assert {r.uri for r in resources} == {
+		"gregory://subjects",
+		"gregory://categories",
+		"gregory://sponsors",
+	}
 
 
 async def test_server_registers_three_prompts(server):
-    prompts = await server.list_prompts()
-    assert {p.name for p in prompts} == {
-        "research_topic",
-        "recent_trials_for_subject",
-        "author_profile",
-    }
+	prompts = await server.list_prompts()
+	assert {p.name for p in prompts} == {
+		"research_topic",
+		"recent_trials_for_subject",
+		"author_profile",
+	}
 
 
 def test_client_exposes_no_write_methods():
-    """The server issues GET only — assert the client has no write verbs at all."""
-    for verb in ("post", "put", "patch", "delete"):
-        assert not hasattr(GregoryClient, verb), f"GregoryClient must not expose .{verb}()"
+	"""The server issues GET only — assert the client has no write verbs at all."""
+	for verb in ("post", "put", "patch", "delete"):
+		assert not hasattr(GregoryClient, verb), f"GregoryClient must not expose .{verb}()"

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from gregory_mcp.client import GregoryClient
+
+EXPECTED_TOOLS = {
+    "list_subjects",
+    "search_articles",
+    "get_article",
+    "search_trials",
+    "get_trial",
+    "search_authors",
+    "get_author",
+    "list_categories",
+    "list_sponsors",
+    "get_stats",
+}
+
+
+async def test_server_registers_exactly_the_planned_tools(server):
+    tools = await server.list_tools()
+    assert {t.name for t in tools} == EXPECTED_TOOLS
+
+
+async def test_every_tool_is_read_only(server):
+    tools = await server.list_tools()
+    for tool in tools:
+        assert tool.annotations is not None, f"{tool.name} has no annotations"
+        assert tool.annotations.read_only_hint is True, f"{tool.name} is not marked read-only"
+
+
+async def test_server_registers_three_resources(server):
+    resources = await server.list_resources()
+    assert {r.uri for r in resources} == {
+        "gregory://subjects",
+        "gregory://categories",
+        "gregory://sponsors",
+    }
+
+
+async def test_server_registers_three_prompts(server):
+    prompts = await server.list_prompts()
+    assert {p.name for p in prompts} == {
+        "research_topic",
+        "recent_trials_for_subject",
+        "author_profile",
+    }
+
+
+def test_client_exposes_no_write_methods():
+    """The server issues GET only — assert the client has no write verbs at all."""
+    for verb in ("post", "put", "patch", "delete"):
+        assert not hasattr(GregoryClient, verb), f"GregoryClient must not expose .{verb}()"

--- a/mcp-server/tests/test_tools_articles.py
+++ b/mcp-server/tests/test_tools_articles.py
@@ -87,6 +87,14 @@ async def test_search_articles_next_page_reflects_clamped_page(mock_gregory):
 	assert "next" not in result
 
 
+async def test_search_articles_last_days(mock_gregory):
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "results": []}))
+
+	await search_articles(last_days=30)
+
+	assert mock_gregory.requests[0].url.params["last_days"] == "30"
+
+
 async def test_get_article_returns_full_record(mock_gregory):
 	mock_gregory.set_handler(
 		lambda request: httpx2.Response(200, json={"article_id": 42, "authors": [{"full_name": "A"}]})

--- a/mcp-server/tests/test_tools_articles.py
+++ b/mcp-server/tests/test_tools_articles.py
@@ -65,6 +65,16 @@ async def test_search_articles_caps_page_size(mock_gregory):
 	assert mock_gregory.requests[0].url.params["page_size"] == "25"
 
 
+async def test_search_articles_clamps_non_positive_page_and_page_size(mock_gregory):
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "results": []}))
+
+	await search_articles(page=-1, page_size=0)
+
+	params = mock_gregory.requests[0].url.params
+	assert params["page"] == "1"
+	assert params["page_size"] == "1"
+
+
 async def test_get_article_returns_full_record(mock_gregory):
 	mock_gregory.set_handler(
 		lambda request: httpx2.Response(200, json={"article_id": 42, "authors": [{"full_name": "A"}]})

--- a/mcp-server/tests/test_tools_articles.py
+++ b/mcp-server/tests/test_tools_articles.py
@@ -33,6 +33,7 @@ async def test_search_articles_compacts_results(mock_gregory):
 	result = await search_articles(search="stem cells")
 
 	assert result["count"] == 1
+	assert result["next_page"] is None
 	article = result["articles"][0]
 	assert article["article_id"] == 42
 	assert article["journal"] == "Nature"
@@ -73,6 +74,17 @@ async def test_search_articles_clamps_non_positive_page_and_page_size(mock_grego
 	params = mock_gregory.requests[0].url.params
 	assert params["page"] == "1"
 	assert params["page_size"] == "1"
+
+
+async def test_search_articles_next_page_reflects_clamped_page(mock_gregory):
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 100, "next": "http://gregory:8000/articles/?page=6", "results": []}))
+
+	result = await search_articles(page=5)
+
+	# next_page is derived from the clamped page we actually requested, not a
+	# passthrough of the upstream URL (which leaks the internal container host).
+	assert result["next_page"] == 6
+	assert "next" not in result
 
 
 async def test_get_article_returns_full_record(mock_gregory):

--- a/mcp-server/tests/test_tools_articles.py
+++ b/mcp-server/tests/test_tools_articles.py
@@ -6,72 +6,72 @@ from gregory_mcp.tools.articles import get_article, search_articles
 
 
 async def test_search_articles_compacts_results(mock_gregory):
-    mock_gregory.set_handler(
-        lambda request: httpx2.Response(
-            200,
-            json={
-                "count": 1,
-                "next": None,
-                "results": [
-                    {
-                        "article_id": 42,
-                        "title": "Stem cells in MS",
-                        "published_date": "2026-01-01",
-                        "container_title": "Nature",
-                        "doi": "10.1/x",
-                        "link": "http://example.com/42",
-                        "summary": "x" * 1000,
-                        "ml_score": 0.87,
-                        "access": "open",
-                        "authors": [{"full_name": "Should not appear"}],
-                    }
-                ],
-            },
-        )
-    )
+	mock_gregory.set_handler(
+		lambda request: httpx2.Response(
+			200,
+			json={
+				"count": 1,
+				"next": None,
+				"results": [
+					{
+						"article_id": 42,
+						"title": "Stem cells in MS",
+						"published_date": "2026-01-01",
+						"container_title": "Nature",
+						"doi": "10.1/x",
+						"link": "http://example.com/42",
+						"summary": "x" * 1000,
+						"ml_score": 0.87,
+						"access": "open",
+						"authors": [{"full_name": "Should not appear"}],
+					}
+				],
+			},
+		)
+	)
 
-    result = await search_articles(search="stem cells")
+	result = await search_articles(search="stem cells")
 
-    assert result["count"] == 1
-    article = result["articles"][0]
-    assert article["article_id"] == 42
-    assert article["journal"] == "Nature"
-    assert len(article["summary"]) <= 401
-    assert "authors" not in article  # compact projection drops the full record
+	assert result["count"] == 1
+	article = result["articles"][0]
+	assert article["article_id"] == 42
+	assert article["journal"] == "Nature"
+	assert len(article["summary"]) <= 401
+	assert "authors" not in article  # compact projection drops the full record
 
-    request = mock_gregory.requests[0]
-    assert request.url.path == "/articles/"
-    assert request.url.params["search"] == "stem cells"
-    assert request.url.params["page"] == "1"
-    assert request.url.params["page_size"] == "10"
+	request = mock_gregory.requests[0]
+	assert request.url.path == "/articles/"
+	assert request.url.params["search"] == "stem cells"
+	assert request.url.params["page"] == "1"
+	assert request.url.params["page_size"] == "10"
 
 
 async def test_search_articles_drops_none_filters(mock_gregory):
-    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "results": []}))
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "results": []}))
 
-    await search_articles(search="x")
+	await search_articles(search="x")
 
-    params = mock_gregory.requests[0].url.params
-    assert "subject_id" not in params
-    assert "relevant" not in params
-    assert "doi" not in params
+	params = mock_gregory.requests[0].url.params
+	assert "subject_id" not in params
+	assert "relevant" not in params
+	assert "doi" not in params
 
 
 async def test_search_articles_caps_page_size(mock_gregory):
-    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "results": []}))
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "results": []}))
 
-    await search_articles(page_size=999)
+	await search_articles(page_size=999)
 
-    assert mock_gregory.requests[0].url.params["page_size"] == "25"
+	assert mock_gregory.requests[0].url.params["page_size"] == "25"
 
 
 async def test_get_article_returns_full_record(mock_gregory):
-    mock_gregory.set_handler(
-        lambda request: httpx2.Response(200, json={"article_id": 42, "authors": [{"full_name": "A"}]})
-    )
+	mock_gregory.set_handler(
+		lambda request: httpx2.Response(200, json={"article_id": 42, "authors": [{"full_name": "A"}]})
+	)
 
-    result = await get_article(42)
+	result = await get_article(42)
 
-    assert result["article_id"] == 42
-    assert result["authors"] == [{"full_name": "A"}]
-    assert mock_gregory.requests[0].url.path == "/articles/42/"
+	assert result["article_id"] == 42
+	assert result["authors"] == [{"full_name": "A"}]
+	assert mock_gregory.requests[0].url.path == "/articles/42/"

--- a/mcp-server/tests/test_tools_articles.py
+++ b/mcp-server/tests/test_tools_articles.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import httpx2
+
+from gregory_mcp.tools.articles import get_article, search_articles
+
+
+async def test_search_articles_compacts_results(mock_gregory):
+    mock_gregory.set_handler(
+        lambda request: httpx2.Response(
+            200,
+            json={
+                "count": 1,
+                "next": None,
+                "results": [
+                    {
+                        "article_id": 42,
+                        "title": "Stem cells in MS",
+                        "published_date": "2026-01-01",
+                        "container_title": "Nature",
+                        "doi": "10.1/x",
+                        "link": "http://example.com/42",
+                        "summary": "x" * 1000,
+                        "ml_score": 0.87,
+                        "access": "open",
+                        "authors": [{"full_name": "Should not appear"}],
+                    }
+                ],
+            },
+        )
+    )
+
+    result = await search_articles(search="stem cells")
+
+    assert result["count"] == 1
+    article = result["articles"][0]
+    assert article["article_id"] == 42
+    assert article["journal"] == "Nature"
+    assert len(article["summary"]) <= 401
+    assert "authors" not in article  # compact projection drops the full record
+
+    request = mock_gregory.requests[0]
+    assert request.url.path == "/articles/"
+    assert request.url.params["search"] == "stem cells"
+    assert request.url.params["page"] == "1"
+    assert request.url.params["page_size"] == "10"
+
+
+async def test_search_articles_drops_none_filters(mock_gregory):
+    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "results": []}))
+
+    await search_articles(search="x")
+
+    params = mock_gregory.requests[0].url.params
+    assert "subject_id" not in params
+    assert "relevant" not in params
+    assert "doi" not in params
+
+
+async def test_search_articles_caps_page_size(mock_gregory):
+    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "results": []}))
+
+    await search_articles(page_size=999)
+
+    assert mock_gregory.requests[0].url.params["page_size"] == "25"
+
+
+async def test_get_article_returns_full_record(mock_gregory):
+    mock_gregory.set_handler(
+        lambda request: httpx2.Response(200, json={"article_id": 42, "authors": [{"full_name": "A"}]})
+    )
+
+    result = await get_article(42)
+
+    assert result["article_id"] == 42
+    assert result["authors"] == [{"full_name": "A"}]
+    assert mock_gregory.requests[0].url.path == "/articles/42/"

--- a/mcp-server/tests/test_tools_misc.py
+++ b/mcp-server/tests/test_tools_misc.py
@@ -8,123 +8,123 @@ from gregory_mcp.tools.stats import get_stats
 
 
 async def test_search_authors(mock_gregory):
-    mock_gregory.set_handler(
-        lambda request: httpx2.Response(
-            200,
-            json={
-                "count": 1,
-                "results": [
-                    {
-                        "author_id": 5,
-                        "full_name": "Jane Doe",
-                        "ORCID": "0000-0000-0000-0001",
-                        "country": "PT",
-                        "articles_count": 10,
-                        "relevant_articles_count": 3,
-                        "articles_list": [{"title": "should not appear"}],
-                    }
-                ],
-            },
-        )
-    )
+	mock_gregory.set_handler(
+		lambda request: httpx2.Response(
+			200,
+			json={
+				"count": 1,
+				"results": [
+					{
+						"author_id": 5,
+						"full_name": "Jane Doe",
+						"ORCID": "0000-0000-0000-0001",
+						"country": "PT",
+						"articles_count": 10,
+						"relevant_articles_count": 3,
+						"articles_list": [{"title": "should not appear"}],
+					}
+				],
+			},
+		)
+	)
 
-    result = await search_authors(search="Jane")
+	result = await search_authors(search="Jane")
 
-    author = result["authors"][0]
-    assert author["orcid"] == "0000-0000-0000-0001"
-    assert "articles_list" not in author
+	author = result["authors"][0]
+	assert author["orcid"] == "0000-0000-0000-0001"
+	assert "articles_list" not in author
 
 
 async def test_get_author_with_coauthors(mock_gregory):
-    calls = []
+	calls = []
 
-    def handler(request):
-        calls.append(request.url.path)
-        if request.url.path.endswith("/coauthors/"):
-            return httpx2.Response(200, json={"results": [{"author_id": 6}]})
-        return httpx2.Response(200, json={"author_id": 5, "full_name": "Jane Doe"})
+	def handler(request):
+		calls.append(request.url.path)
+		if request.url.path.endswith("/coauthors/"):
+			return httpx2.Response(200, json={"results": [{"author_id": 6}]})
+		return httpx2.Response(200, json={"author_id": 5, "full_name": "Jane Doe"})
 
-    mock_gregory.set_handler(handler)
+	mock_gregory.set_handler(handler)
 
-    result = await get_author(5, include_coauthors=True)
+	result = await get_author(5, include_coauthors=True)
 
-    assert result["coauthors"] == [{"author_id": 6}]
-    assert calls == ["/authors/5/", "/authors/5/coauthors/"]
+	assert result["coauthors"] == [{"author_id": 6}]
+	assert calls == ["/authors/5/", "/authors/5/coauthors/"]
 
 
 async def test_get_author_without_coauthors_makes_one_call(mock_gregory):
-    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"author_id": 5}))
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"author_id": 5}))
 
-    await get_author(5)
+	await get_author(5)
 
-    assert len(mock_gregory.requests) == 1
+	assert len(mock_gregory.requests) == 1
 
 
 async def test_list_subjects_follows_pagination(mock_gregory):
-    def handler(request):
-        page = request.url.params.get("page", "1")
-        if page == "1":
-            return httpx2.Response(
-                200,
-                json={"next": "https://gregory.test/subjects/?page=2", "results": [{"id": 1, "subject_name": "A"}]},
-            )
-        return httpx2.Response(200, json={"next": None, "results": [{"id": 2, "subject_name": "B"}]})
+	def handler(request):
+		page = request.url.params.get("page", "1")
+		if page == "1":
+			return httpx2.Response(
+				200,
+				json={"next": "https://gregory.test/subjects/?page=2", "results": [{"id": 1, "subject_name": "A"}]},
+			)
+		return httpx2.Response(200, json={"next": None, "results": [{"id": 2, "subject_name": "B"}]})
 
-    mock_gregory.set_handler(handler)
+	mock_gregory.set_handler(handler)
 
-    result = await list_subjects()
+	result = await list_subjects()
 
-    assert result["count"] == 2
-    assert [s["id"] for s in result["subjects"]] == [1, 2]
-    assert len(mock_gregory.requests) == 2
+	assert result["count"] == 2
+	assert [s["id"] for s in result["subjects"]] == [1, 2]
+	assert len(mock_gregory.requests) == 2
 
 
 async def test_list_categories_excludes_expensive_ordering(mock_gregory):
-    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"next": None, "results": []}))
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"next": None, "results": []}))
 
-    await list_categories(team_id=1)
+	await list_categories(team_id=1)
 
-    params = mock_gregory.requests[0].url.params
-    assert "ordering" not in params
+	params = mock_gregory.requests[0].url.params
+	assert "ordering" not in params
 
 
 async def test_list_sponsors_is_paginated_not_exhaustive(mock_gregory):
-    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 500, "next": "x", "results": []}))
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 500, "next": "x", "results": []}))
 
-    result = await list_sponsors()
+	result = await list_sponsors()
 
-    assert len(mock_gregory.requests) == 1
-    assert mock_gregory.requests[0].url.params["page_size"] == "25"
-    assert result["count"] == 500
+	assert len(mock_gregory.requests) == 1
+	assert mock_gregory.requests[0].url.params["page_size"] == "25"
+	assert result["count"] == 500
 
 
 async def test_get_stats_global_maps_team_and_subject(mock_gregory):
-    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"articles": 1}))
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"articles": 1}))
 
-    await get_stats(scope="global", team_id=1, subject_id=2)
+	await get_stats(scope="global", team_id=1, subject_id=2)
 
-    request = mock_gregory.requests[0]
-    assert request.url.path == "/stats/"
-    assert request.url.params["team"] == "1"
-    assert request.url.params["subject"] == "2"
+	request = mock_gregory.requests[0]
+	assert request.url.path == "/stats/"
+	assert request.url.params["team"] == "1"
+	assert request.url.params["subject"] == "2"
 
 
 async def test_get_stats_articles_scope(mock_gregory):
-    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"total": 1}))
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"total": 1}))
 
-    await get_stats(scope="articles", team_id=1, relevant=True)
+	await get_stats(scope="articles", team_id=1, relevant=True)
 
-    request = mock_gregory.requests[0]
-    assert request.url.path == "/articles/stats/"
-    assert request.url.params["team_id"] == "1"
-    assert request.url.params["relevant"] == "true"
+	request = mock_gregory.requests[0]
+	assert request.url.path == "/articles/stats/"
+	assert request.url.params["team_id"] == "1"
+	assert request.url.params["relevant"] == "true"
 
 
 async def test_get_stats_trials_scope(mock_gregory):
-    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"total": 1}))
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"total": 1}))
 
-    await get_stats(scope="trials", subject_id=3)
+	await get_stats(scope="trials", subject_id=3)
 
-    request = mock_gregory.requests[0]
-    assert request.url.path == "/trials/stats/"
-    assert request.url.params["subject_id"] == "3"
+	request = mock_gregory.requests[0]
+	assert request.url.path == "/trials/stats/"
+	assert request.url.params["subject_id"] == "3"

--- a/mcp-server/tests/test_tools_misc.py
+++ b/mcp-server/tests/test_tools_misc.py
@@ -48,6 +48,13 @@ async def test_search_authors_team_subject_scope(mock_gregory):
 	assert params["order"] == "desc"
 
 
+async def test_search_authors_rejects_subject_id_without_team_id(mock_gregory):
+	with pytest.raises(ValueError, match="subject_id requires team_id"):
+		await search_authors(subject_id=5)
+
+	assert mock_gregory.requests == []
+
+
 async def test_search_authors_drops_none_scope_params(mock_gregory):
 	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "results": []}))
 

--- a/mcp-server/tests/test_tools_misc.py
+++ b/mcp-server/tests/test_tools_misc.py
@@ -67,6 +67,19 @@ async def test_search_authors_drops_none_scope_params(mock_gregory):
 	assert "order" not in params
 
 
+async def test_search_authors_next_page_reflects_clamped_page(mock_gregory):
+	mock_gregory.set_handler(
+		lambda request: httpx2.Response(
+			200, json={"count": 100, "next": "http://gregory:8000/authors/?page=3", "results": []}
+		)
+	)
+
+	result = await search_authors(page=2)
+
+	assert result["next_page"] == 3
+	assert "next" not in result
+
+
 async def test_get_author_with_coauthors(mock_gregory):
 	calls = []
 
@@ -128,7 +141,15 @@ async def test_list_sponsors_is_paginated_not_exhaustive(mock_gregory):
 	assert len(mock_gregory.requests) == 1
 	assert mock_gregory.requests[0].url.params["page_size"] == "25"
 	assert result["count"] == 500
-	assert result["next"] == "x"
+	assert result["next_page"] == 2
+
+
+async def test_list_sponsors_next_page_is_none_on_last_page(mock_gregory):
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 1, "next": None, "results": []}))
+
+	result = await list_sponsors(page=3)
+
+	assert result["next_page"] is None
 
 
 async def test_get_stats_global_maps_team_and_subject(mock_gregory):

--- a/mcp-server/tests/test_tools_misc.py
+++ b/mcp-server/tests/test_tools_misc.py
@@ -36,6 +36,30 @@ async def test_search_authors(mock_gregory):
 	assert "articles_list" not in author
 
 
+async def test_search_authors_team_subject_scope(mock_gregory):
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "results": []}))
+
+	await search_authors(team_id=1, subject_id=5, sort_by="article_count", order="desc")
+
+	params = mock_gregory.requests[0].url.params
+	assert params["team_id"] == "1"
+	assert params["subject_id"] == "5"
+	assert params["sort_by"] == "article_count"
+	assert params["order"] == "desc"
+
+
+async def test_search_authors_drops_none_scope_params(mock_gregory):
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "results": []}))
+
+	await search_authors(search="Jane")
+
+	params = mock_gregory.requests[0].url.params
+	assert "team_id" not in params
+	assert "subject_id" not in params
+	assert "sort_by" not in params
+	assert "order" not in params
+
+
 async def test_get_author_with_coauthors(mock_gregory):
 	calls = []
 

--- a/mcp-server/tests/test_tools_misc.py
+++ b/mcp-server/tests/test_tools_misc.py
@@ -97,6 +97,7 @@ async def test_list_sponsors_is_paginated_not_exhaustive(mock_gregory):
 	assert len(mock_gregory.requests) == 1
 	assert mock_gregory.requests[0].url.params["page_size"] == "25"
 	assert result["count"] == 500
+	assert result["next"] == "x"
 
 
 async def test_get_stats_global_maps_team_and_subject(mock_gregory):

--- a/mcp-server/tests/test_tools_misc.py
+++ b/mcp-server/tests/test_tools_misc.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import httpx2
+
+from gregory_mcp.tools.authors import get_author, search_authors
+from gregory_mcp.tools.catalog import list_categories, list_sponsors, list_subjects
+from gregory_mcp.tools.stats import get_stats
+
+
+async def test_search_authors(mock_gregory):
+    mock_gregory.set_handler(
+        lambda request: httpx2.Response(
+            200,
+            json={
+                "count": 1,
+                "results": [
+                    {
+                        "author_id": 5,
+                        "full_name": "Jane Doe",
+                        "ORCID": "0000-0000-0000-0001",
+                        "country": "PT",
+                        "articles_count": 10,
+                        "relevant_articles_count": 3,
+                        "articles_list": [{"title": "should not appear"}],
+                    }
+                ],
+            },
+        )
+    )
+
+    result = await search_authors(search="Jane")
+
+    author = result["authors"][0]
+    assert author["orcid"] == "0000-0000-0000-0001"
+    assert "articles_list" not in author
+
+
+async def test_get_author_with_coauthors(mock_gregory):
+    calls = []
+
+    def handler(request):
+        calls.append(request.url.path)
+        if request.url.path.endswith("/coauthors/"):
+            return httpx2.Response(200, json={"results": [{"author_id": 6}]})
+        return httpx2.Response(200, json={"author_id": 5, "full_name": "Jane Doe"})
+
+    mock_gregory.set_handler(handler)
+
+    result = await get_author(5, include_coauthors=True)
+
+    assert result["coauthors"] == [{"author_id": 6}]
+    assert calls == ["/authors/5/", "/authors/5/coauthors/"]
+
+
+async def test_get_author_without_coauthors_makes_one_call(mock_gregory):
+    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"author_id": 5}))
+
+    await get_author(5)
+
+    assert len(mock_gregory.requests) == 1
+
+
+async def test_list_subjects_follows_pagination(mock_gregory):
+    def handler(request):
+        page = request.url.params.get("page", "1")
+        if page == "1":
+            return httpx2.Response(
+                200,
+                json={"next": "https://gregory.test/subjects/?page=2", "results": [{"id": 1, "subject_name": "A"}]},
+            )
+        return httpx2.Response(200, json={"next": None, "results": [{"id": 2, "subject_name": "B"}]})
+
+    mock_gregory.set_handler(handler)
+
+    result = await list_subjects()
+
+    assert result["count"] == 2
+    assert [s["id"] for s in result["subjects"]] == [1, 2]
+    assert len(mock_gregory.requests) == 2
+
+
+async def test_list_categories_excludes_expensive_ordering(mock_gregory):
+    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"next": None, "results": []}))
+
+    await list_categories(team_id=1)
+
+    params = mock_gregory.requests[0].url.params
+    assert "ordering" not in params
+
+
+async def test_list_sponsors_is_paginated_not_exhaustive(mock_gregory):
+    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 500, "next": "x", "results": []}))
+
+    result = await list_sponsors()
+
+    assert len(mock_gregory.requests) == 1
+    assert mock_gregory.requests[0].url.params["page_size"] == "25"
+    assert result["count"] == 500
+
+
+async def test_get_stats_global_maps_team_and_subject(mock_gregory):
+    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"articles": 1}))
+
+    await get_stats(scope="global", team_id=1, subject_id=2)
+
+    request = mock_gregory.requests[0]
+    assert request.url.path == "/stats/"
+    assert request.url.params["team"] == "1"
+    assert request.url.params["subject"] == "2"
+
+
+async def test_get_stats_articles_scope(mock_gregory):
+    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"total": 1}))
+
+    await get_stats(scope="articles", team_id=1, relevant=True)
+
+    request = mock_gregory.requests[0]
+    assert request.url.path == "/articles/stats/"
+    assert request.url.params["team_id"] == "1"
+    assert request.url.params["relevant"] == "true"
+
+
+async def test_get_stats_trials_scope(mock_gregory):
+    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"total": 1}))
+
+    await get_stats(scope="trials", subject_id=3)
+
+    request = mock_gregory.requests[0]
+    assert request.url.path == "/trials/stats/"
+    assert request.url.params["subject_id"] == "3"

--- a/mcp-server/tests/test_tools_misc.py
+++ b/mcp-server/tests/test_tools_misc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import httpx2
+import pytest
 
 from gregory_mcp.tools.authors import get_author, search_authors
 from gregory_mcp.tools.catalog import list_categories, list_sponsors, list_subjects
@@ -128,3 +129,10 @@ async def test_get_stats_trials_scope(mock_gregory):
 	request = mock_gregory.requests[0]
 	assert request.url.path == "/trials/stats/"
 	assert request.url.params["subject_id"] == "3"
+
+
+async def test_get_stats_rejects_unknown_scope(mock_gregory):
+	with pytest.raises(ValueError, match="unknown scope"):
+		await get_stats(scope="bogus")
+
+	assert mock_gregory.requests == []

--- a/mcp-server/tests/test_tools_trials.py
+++ b/mcp-server/tests/test_tools_trials.py
@@ -6,65 +6,65 @@ from gregory_mcp.tools.trials import get_trial, search_trials
 
 
 async def test_search_trials_compacts_results(mock_gregory):
-    mock_gregory.set_handler(
-        lambda request: httpx2.Response(
-            200,
-            json={
-                "count": 1,
-                "next": None,
-                "results": [
-                    {
-                        "trial_id": 7,
-                        "title": "A phase 2 trial",
-                        "published_date": "2026-02-01",
-                        "recruitment_status_normalized": "recruiting",
-                        "phase_normalized": ["phase_2"],
-                        "study_type_normalized": "interventional",
-                        "sponsor": {"name": "Acme Pharma", "slug": "acme-pharma"},
-                        "primary_sponsor": "Acme Pharma Inc.",
-                        "countries_normalized": ["DE", "FR"],
-                        "link": "http://example.com/7",
-                        "summary": "y" * 1000,
-                        "identifiers": {"nct": "NCT00000007"},
-                        "trial_sites": [{"name": "Should not appear"}],
-                    }
-                ],
-            },
-        )
-    )
+	mock_gregory.set_handler(
+		lambda request: httpx2.Response(
+			200,
+			json={
+				"count": 1,
+				"next": None,
+				"results": [
+					{
+						"trial_id": 7,
+						"title": "A phase 2 trial",
+						"published_date": "2026-02-01",
+						"recruitment_status_normalized": "recruiting",
+						"phase_normalized": ["phase_2"],
+						"study_type_normalized": "interventional",
+						"sponsor": {"name": "Acme Pharma", "slug": "acme-pharma"},
+						"primary_sponsor": "Acme Pharma Inc.",
+						"countries_normalized": ["DE", "FR"],
+						"link": "http://example.com/7",
+						"summary": "y" * 1000,
+						"identifiers": {"nct": "NCT00000007"},
+						"trial_sites": [{"name": "Should not appear"}],
+					}
+				],
+			},
+		)
+	)
 
-    result = await search_trials(recruitment_status_normalized="recruiting")
+	result = await search_trials(recruitment_status_normalized="recruiting")
 
-    trial = result["trials"][0]
-    assert trial["trial_id"] == 7
-    assert trial["sponsor"] == "Acme Pharma"
-    assert trial["countries"] == ["DE", "FR"]
-    assert "trial_sites" not in trial
+	trial = result["trials"][0]
+	assert trial["trial_id"] == 7
+	assert trial["sponsor"] == "Acme Pharma"
+	assert trial["countries"] == ["DE", "FR"]
+	assert "trial_sites" not in trial
 
-    params = mock_gregory.requests[0].url.params
-    assert params["recruitment_status_normalized"] == "recruiting"
+	params = mock_gregory.requests[0].url.params
+	assert params["recruitment_status_normalized"] == "recruiting"
 
 
 async def test_search_trials_falls_back_to_primary_sponsor(mock_gregory):
-    mock_gregory.set_handler(
-        lambda request: httpx2.Response(
-            200,
-            json={
-                "count": 1,
-                "results": [{"trial_id": 8, "primary_sponsor": "Raw Sponsor String", "sponsor": None}],
-            },
-        )
-    )
+	mock_gregory.set_handler(
+		lambda request: httpx2.Response(
+			200,
+			json={
+				"count": 1,
+				"results": [{"trial_id": 8, "primary_sponsor": "Raw Sponsor String", "sponsor": None}],
+			},
+		)
+	)
 
-    result = await search_trials()
+	result = await search_trials()
 
-    assert result["trials"][0]["sponsor"] == "Raw Sponsor String"
+	assert result["trials"][0]["sponsor"] == "Raw Sponsor String"
 
 
 async def test_get_trial_returns_full_record(mock_gregory):
-    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"trial_id": 7, "trial_sites": []}))
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"trial_id": 7, "trial_sites": []}))
 
-    result = await get_trial(7)
+	result = await get_trial(7)
 
-    assert result["trial_id"] == 7
-    assert mock_gregory.requests[0].url.path == "/trials/7/"
+	assert result["trial_id"] == 7
+	assert mock_gregory.requests[0].url.path == "/trials/7/"

--- a/mcp-server/tests/test_tools_trials.py
+++ b/mcp-server/tests/test_tools_trials.py
@@ -76,6 +76,27 @@ async def test_search_trials_next_page_reflects_clamped_page(mock_gregory):
 	assert "next" not in result
 
 
+async def test_search_trials_eu_registry_ids_and_new_filters(mock_gregory):
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "next": None, "results": []}))
+
+	await search_trials(
+		euct="2023-500001-38-00",
+		eudract="2009-012345-67",
+		ctis="2023-500001-38",
+		acronym="ReCOVER",
+		has_results=True,
+		therapeutic_areas="oncology",
+	)
+
+	params = mock_gregory.requests[0].url.params
+	assert params["euct"] == "2023-500001-38-00"
+	assert params["eudract"] == "2009-012345-67"
+	assert params["ctis"] == "2023-500001-38"
+	assert params["acronym"] == "ReCOVER"
+	assert params["has_results"] == "true"
+	assert params["therapeutic_areas"] == "oncology"
+
+
 async def test_get_trial_returns_full_record(mock_gregory):
 	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"trial_id": 7, "trial_sites": []}))
 

--- a/mcp-server/tests/test_tools_trials.py
+++ b/mcp-server/tests/test_tools_trials.py
@@ -61,6 +61,21 @@ async def test_search_trials_falls_back_to_primary_sponsor(mock_gregory):
 	assert result["trials"][0]["sponsor"] == "Raw Sponsor String"
 
 
+async def test_search_trials_next_page_reflects_clamped_page(mock_gregory):
+	mock_gregory.set_handler(
+		lambda request: httpx2.Response(
+			200, json={"count": 100, "next": "http://gregory:8000/trials/?page=4", "results": []}
+		)
+	)
+
+	result = await search_trials(page=3)
+
+	# next_page is derived from the clamped page we actually requested, not a
+	# passthrough of the upstream URL (which leaks the internal container host).
+	assert result["next_page"] == 4
+	assert "next" not in result
+
+
 async def test_get_trial_returns_full_record(mock_gregory):
 	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"trial_id": 7, "trial_sites": []}))
 

--- a/mcp-server/tests/test_tools_trials.py
+++ b/mcp-server/tests/test_tools_trials.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import httpx2
+
+from gregory_mcp.tools.trials import get_trial, search_trials
+
+
+async def test_search_trials_compacts_results(mock_gregory):
+    mock_gregory.set_handler(
+        lambda request: httpx2.Response(
+            200,
+            json={
+                "count": 1,
+                "next": None,
+                "results": [
+                    {
+                        "trial_id": 7,
+                        "title": "A phase 2 trial",
+                        "published_date": "2026-02-01",
+                        "recruitment_status_normalized": "recruiting",
+                        "phase_normalized": ["phase_2"],
+                        "study_type_normalized": "interventional",
+                        "sponsor": {"name": "Acme Pharma", "slug": "acme-pharma"},
+                        "primary_sponsor": "Acme Pharma Inc.",
+                        "countries_normalized": ["DE", "FR"],
+                        "link": "http://example.com/7",
+                        "summary": "y" * 1000,
+                        "identifiers": {"nct": "NCT00000007"},
+                        "trial_sites": [{"name": "Should not appear"}],
+                    }
+                ],
+            },
+        )
+    )
+
+    result = await search_trials(recruitment_status_normalized="recruiting")
+
+    trial = result["trials"][0]
+    assert trial["trial_id"] == 7
+    assert trial["sponsor"] == "Acme Pharma"
+    assert trial["countries"] == ["DE", "FR"]
+    assert "trial_sites" not in trial
+
+    params = mock_gregory.requests[0].url.params
+    assert params["recruitment_status_normalized"] == "recruiting"
+
+
+async def test_search_trials_falls_back_to_primary_sponsor(mock_gregory):
+    mock_gregory.set_handler(
+        lambda request: httpx2.Response(
+            200,
+            json={
+                "count": 1,
+                "results": [{"trial_id": 8, "primary_sponsor": "Raw Sponsor String", "sponsor": None}],
+            },
+        )
+    )
+
+    result = await search_trials()
+
+    assert result["trials"][0]["sponsor"] == "Raw Sponsor String"
+
+
+async def test_get_trial_returns_full_record(mock_gregory):
+    mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"trial_id": 7, "trial_sites": []}))
+
+    result = await get_trial(7)
+
+    assert result["trial_id"] == 7
+    assert mock_gregory.requests[0].url.path == "/trials/7/"

--- a/nginx-example-configuration/nginx.conf
+++ b/nginx-example-configuration/nginx.conf
@@ -89,12 +89,31 @@ http {
     types_hash_bucket_size 64;
     client_max_body_size   16M;
 
-    # Rate limiting for the unauthenticated MCP server (gregory-mcp), keyed on the
-    # Mcp-Name request header the 2026-07-28 spec revision sends with every call —
-    # this is what lets search_articles/search_trials throttle harder than the
-    # cheap catalog tools without nginx parsing the JSON-RPC body. See
+    # Rate limiting for the unauthenticated MCP server (gregory-mcp). Mcp-Name is a
+    # client-controlled header, so it cannot be the whole key: a caller could mint
+    # unlimited fresh buckets by sending arbitrary values, and a missing/empty
+    # header would collapse every client into one shared bucket. $mcp_tool_bucket
+    # below whitelists it to the ten known tool names (anything else -> "other"),
+    # and both zones are additionally keyed on the client address. See
     # docs/07-mcp-server.md.
-    limit_req_zone $http_mcp_name zone=mcp_per_tool:10m rate=30r/m;
+    map $http_mcp_name $mcp_tool_bucket {
+        default          other;
+        list_subjects    list_subjects;
+        search_articles  search_articles;
+        get_article      get_article;
+        search_trials    search_trials;
+        get_trial        get_trial;
+        search_authors   search_authors;
+        get_author       get_author;
+        list_categories  list_categories;
+        list_sponsors    list_sponsors;
+        get_stats        get_stats;
+    }
+    # Per-tool, per-client throttle — this is what lets search_articles/search_trials
+    # throttle harder than the cheap catalog tools without nginx parsing the JSON-RPC body.
+    limit_req_zone $binary_remote_addr$mcp_tool_bucket zone=mcp_per_tool:10m rate=30r/m;
+    # Hard per-client cap across all tools, regardless of what Mcp-Name claims.
+    limit_req_zone $binary_remote_addr zone=mcp_per_client:10m rate=120r/m;
 
     # MIME
     include                mime.types;
@@ -374,6 +393,7 @@ http {
         # buffering off so a streamed response isn't held until it completes.
         location /mcp/ {
             limit_req                          zone=mcp_per_tool burst=10 nodelay;
+            limit_req                          zone=mcp_per_client burst=40 nodelay;
 
             proxy_pass                         http://127.0.0.1:8001/mcp/;
             proxy_http_version                 1.1;

--- a/nginx-example-configuration/nginx.conf
+++ b/nginx-example-configuration/nginx.conf
@@ -136,6 +136,16 @@ http {
     access_log             /var/log/nginx/access.log;
     error_log              /var/log/nginx/error.log warn;
 
+    # gregory-mcp's /mcp/ location logs to its own file with this format so
+    # limit_req rejections (see docs/07-mcp-server.md) can be attributed per
+    # tool — a rejected request never reaches the MCP server, so its own
+    # logs can't show this; the observability has to live here. Otherwise
+    # identical to the default `combined` format.
+    log_format mcp_combined '$remote_addr - $remote_user [$time_local] '
+                             '"$request" $status $body_bytes_sent '
+                             '"$http_referer" "$http_user_agent" '
+                             'mcp_name="$http_mcp_name"';
+
     # SSL
     ssl_session_timeout    1d;
     ssl_session_cache      shared:SSL:10m;
@@ -405,8 +415,14 @@ http {
         # this needs the same Upgrade/Connection handling as the reverse proxy below, plus
         # buffering off so a streamed response isn't held until it completes.
         location /mcp/ {
+            # nginx's own default for a throttled request is 503, which reads as
+            # "server broken" rather than "you're going too fast" — 429 is the
+            # correct status for a client to act on (back off and retry).
+            limit_req_status                   429;
             limit_req                          zone=mcp_per_tool burst=10 nodelay;
             limit_req                          zone=mcp_per_client burst=40 nodelay;
+
+            access_log                         /var/log/nginx/mcp-access.log mcp_combined;
 
             proxy_pass                         http://127.0.0.1:8001/mcp/;
             proxy_http_version                 1.1;

--- a/nginx-example-configuration/nginx.conf
+++ b/nginx-example-configuration/nginx.conf
@@ -120,7 +120,11 @@ http {
         list_sponsors    list_sponsors;
         get_stats        get_stats;
     }
-    limit_req_zone $binary_remote_addr$mcp_tool_bucket zone=mcp_per_tool:10m rate=30r/m;
+    # ":" separates the two parts of the key — $binary_remote_addr is raw
+    # binary (4 bytes IPv4, 16 IPv6, not a fixed width), so concatenating it
+    # directly against $mcp_tool_bucket could theoretically let one client's
+    # tail bytes plus a short tool name collide with a different client's key.
+    limit_req_zone $binary_remote_addr:$mcp_tool_bucket zone=mcp_per_tool:10m rate=30r/m;
     # Hard per-client cap across all tools, regardless of what Mcp-Name claims.
     limit_req_zone $binary_remote_addr zone=mcp_per_client:10m rate=120r/m;
 

--- a/nginx-example-configuration/nginx.conf
+++ b/nginx-example-configuration/nginx.conf
@@ -421,7 +421,10 @@ http {
 
             proxy_connect_timeout              10s;
             proxy_send_timeout                 60s;
-            proxy_read_timeout                 60s;
+            # An idle SSE stream (client connected, waiting on the next server
+            # message mid-conversation) can go quiet for longer than a typical
+            # REST request without being dead — 60s was cutting those off.
+            proxy_read_timeout                 300s;
         }
 
         # reverse proxy

--- a/nginx-example-configuration/nginx.conf
+++ b/nginx-example-configuration/nginx.conf
@@ -89,6 +89,13 @@ http {
     types_hash_bucket_size 64;
     client_max_body_size   16M;
 
+    # Rate limiting for the unauthenticated MCP server (gregory-mcp), keyed on the
+    # Mcp-Name request header the 2026-07-28 spec revision sends with every call —
+    # this is what lets search_articles/search_trials throttle harder than the
+    # cheap catalog tools without nginx parsing the JSON-RPC body. See
+    # docs/07-mcp-server.md.
+    limit_req_zone $http_mcp_name zone=mcp_per_tool:10m rate=30r/m;
+
     # MIME
     include                mime.types;
     default_type           application/octet-stream;
@@ -360,6 +367,34 @@ http {
         location /static/ {
             alias $base/static/;
         }
+
+        # gregory-mcp — read-only, unauthenticated MCP server (see docs/07-mcp-server.md).
+        # Streamable HTTP is a normal request/response with an optional SSE upgrade, so
+        # this needs the same Upgrade/Connection handling as the reverse proxy below, plus
+        # buffering off so a streamed response isn't held until it completes.
+        location /mcp/ {
+            limit_req                          zone=mcp_per_tool burst=10 nodelay;
+
+            proxy_pass                         http://127.0.0.1:8001/mcp/;
+            proxy_http_version                 1.1;
+            proxy_buffering                    off;
+            proxy_cache_bypass                 $http_upgrade;
+
+            proxy_set_header Upgrade           $http_upgrade;
+            proxy_set_header Connection        $connection_upgrade;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header Forwarded         $proxy_add_forwarded;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host  $host;
+            proxy_set_header X-Forwarded-Port  $server_port;
+
+            proxy_connect_timeout              10s;
+            proxy_send_timeout                 60s;
+            proxy_read_timeout                 60s;
+        }
+
         # reverse proxy
         location / {
             proxy_pass                         http://127.0.0.1:8000;

--- a/nginx-example-configuration/nginx.conf
+++ b/nginx-example-configuration/nginx.conf
@@ -94,9 +94,19 @@ http {
     # unlimited fresh buckets by sending arbitrary values, and a bare $http_mcp_name
     # key would put every client's traffic for the same tool in one shared bucket.
     # $mcp_tool_bucket below whitelists it to the ten known tool names (anything
-    # else -> "other"), and every zone key below also includes the client address,
-    # so buckets are per (client, tool) — one client hammering one tool never
-    # eats another client's or another tool's budget. See docs/07-mcp-server.md.
+    # else -> "other"), and the zone key also includes the client address, so
+    # buckets are per (client, tool) — one client hammering one tool never eats
+    # another client's or another tool's budget. See docs/07-mcp-server.md.
+    #
+    # This is deliberately ONE zone at a flat rate, not a stricter zone for
+    # search_articles/search_trials/search_authors/get_stats vs. the cheap
+    # lookups — an earlier version tried two zones (with the non-matching class
+    # collapsed to an empty key per zone), but that puts every client's traffic
+    # for the "other" class into one global shared bucket per zone, which
+    # throttles far more aggressively than intended. Doing this correctly needs
+    # routing each class to its own internal location (nginx's limit_req has no
+    # per-request "cost", so a single location can't apply a conditional zone),
+    # which is more machinery than an example config should carry unverified.
     map $http_mcp_name $mcp_tool_bucket {
         default          other;
         list_subjects    list_subjects;
@@ -110,30 +120,7 @@ http {
         list_sponsors    list_sponsors;
         get_stats        get_stats;
     }
-
-    # search_articles/search_trials/search_authors/get_stats run an arbitrary
-    # boolean search or an aggregate query — throttle those harder than plain
-    # ID lookups and small catalog listings. nginx's limit_req has no notion of
-    # a per-request "cost", so this is two zones at different rates, each keyed
-    # on client+tool but with the *other* class collapsed to an empty key (one
-    # shared, low-traffic bucket per zone) so a request only ever counts
-    # against the zone for its own class.
-    map $mcp_tool_bucket $mcp_expensive_key {
-        default          "";
-        search_articles  $binary_remote_addr$mcp_tool_bucket;
-        search_trials    $binary_remote_addr$mcp_tool_bucket;
-        search_authors   $binary_remote_addr$mcp_tool_bucket;
-        get_stats        $binary_remote_addr$mcp_tool_bucket;
-    }
-    map $mcp_tool_bucket $mcp_cheap_key {
-        default          $binary_remote_addr$mcp_tool_bucket;
-        search_articles  "";
-        search_trials    "";
-        search_authors   "";
-        get_stats        "";
-    }
-    limit_req_zone $mcp_expensive_key zone=mcp_expensive:10m rate=10r/m;
-    limit_req_zone $mcp_cheap_key     zone=mcp_cheap:10m     rate=60r/m;
+    limit_req_zone $binary_remote_addr$mcp_tool_bucket zone=mcp_per_tool:10m rate=30r/m;
     # Hard per-client cap across all tools, regardless of what Mcp-Name claims.
     limit_req_zone $binary_remote_addr zone=mcp_per_client:10m rate=120r/m;
 
@@ -414,8 +401,7 @@ http {
         # this needs the same Upgrade/Connection handling as the reverse proxy below, plus
         # buffering off so a streamed response isn't held until it completes.
         location /mcp/ {
-            limit_req                          zone=mcp_expensive burst=3 nodelay;
-            limit_req                          zone=mcp_cheap burst=20 nodelay;
+            limit_req                          zone=mcp_per_tool burst=10 nodelay;
             limit_req                          zone=mcp_per_client burst=40 nodelay;
 
             proxy_pass                         http://127.0.0.1:8001/mcp/;

--- a/nginx-example-configuration/nginx.conf
+++ b/nginx-example-configuration/nginx.conf
@@ -91,11 +91,12 @@ http {
 
     # Rate limiting for the unauthenticated MCP server (gregory-mcp). Mcp-Name is a
     # client-controlled header, so it cannot be the whole key: a caller could mint
-    # unlimited fresh buckets by sending arbitrary values, and a missing/empty
-    # header would collapse every client into one shared bucket. $mcp_tool_bucket
-    # below whitelists it to the ten known tool names (anything else -> "other"),
-    # and both zones are additionally keyed on the client address. See
-    # docs/07-mcp-server.md.
+    # unlimited fresh buckets by sending arbitrary values, and a bare $http_mcp_name
+    # key would put every client's traffic for the same tool in one shared bucket.
+    # $mcp_tool_bucket below whitelists it to the ten known tool names (anything
+    # else -> "other"), and every zone key below also includes the client address,
+    # so buckets are per (client, tool) — one client hammering one tool never
+    # eats another client's or another tool's budget. See docs/07-mcp-server.md.
     map $http_mcp_name $mcp_tool_bucket {
         default          other;
         list_subjects    list_subjects;
@@ -109,9 +110,30 @@ http {
         list_sponsors    list_sponsors;
         get_stats        get_stats;
     }
-    # Per-tool, per-client throttle — this is what lets search_articles/search_trials
-    # throttle harder than the cheap catalog tools without nginx parsing the JSON-RPC body.
-    limit_req_zone $binary_remote_addr$mcp_tool_bucket zone=mcp_per_tool:10m rate=30r/m;
+
+    # search_articles/search_trials/search_authors/get_stats run an arbitrary
+    # boolean search or an aggregate query — throttle those harder than plain
+    # ID lookups and small catalog listings. nginx's limit_req has no notion of
+    # a per-request "cost", so this is two zones at different rates, each keyed
+    # on client+tool but with the *other* class collapsed to an empty key (one
+    # shared, low-traffic bucket per zone) so a request only ever counts
+    # against the zone for its own class.
+    map $mcp_tool_bucket $mcp_expensive_key {
+        default          "";
+        search_articles  $binary_remote_addr$mcp_tool_bucket;
+        search_trials    $binary_remote_addr$mcp_tool_bucket;
+        search_authors   $binary_remote_addr$mcp_tool_bucket;
+        get_stats        $binary_remote_addr$mcp_tool_bucket;
+    }
+    map $mcp_tool_bucket $mcp_cheap_key {
+        default          $binary_remote_addr$mcp_tool_bucket;
+        search_articles  "";
+        search_trials    "";
+        search_authors   "";
+        get_stats        "";
+    }
+    limit_req_zone $mcp_expensive_key zone=mcp_expensive:10m rate=10r/m;
+    limit_req_zone $mcp_cheap_key     zone=mcp_cheap:10m     rate=60r/m;
     # Hard per-client cap across all tools, regardless of what Mcp-Name claims.
     limit_req_zone $binary_remote_addr zone=mcp_per_client:10m rate=120r/m;
 
@@ -392,7 +414,8 @@ http {
         # this needs the same Upgrade/Connection handling as the reverse proxy below, plus
         # buffering off so a streamed response isn't held until it completes.
         location /mcp/ {
-            limit_req                          zone=mcp_per_tool burst=10 nodelay;
+            limit_req                          zone=mcp_expensive burst=3 nodelay;
+            limit_req                          zone=mcp_cheap burst=20 nodelay;
             limit_req                          zone=mcp_per_client burst=40 nodelay;
 
             proxy_pass                         http://127.0.0.1:8001/mcp/;


### PR DESCRIPTION
## Summary
- New `gregory-mcp` container (`mcp-server/`) proxies the GregoryAI REST API to LLM clients over Streamable HTTP (`mcp` 2.0.0 SDK), as ten task-shaped tools, two cached catalog resources (`gregory://subjects`, `gregory://categories` — no sponsors resource, see below), and three starter prompts.
- Stateless, GET-only, no auth — exposes exactly what an anonymous API caller already sees.
- Wired into `docker-compose.yaml` and the example nginx config, with per-tool rate limiting keyed on the `Mcp-Name` header.
- New doc: [docs/07-mcp-server.md](../blob/main/docs/07-mcp-server.md), linked from `docs/README.md` and `docs/03-api-and-rss-feeds.md`.

Implements the plan in `STAGE-2-MCP-SERVER-PLAN.md` (Stage 1's OpenAPI schema, already merged in `main`, is the dependency this stage builds against).

### Post-review fixes (see `HANDOVER-MCP-FIXES-PLAN.md`, not committed — working doc)
- **Sponsors resource removed.** It called `get_all_pages("/sponsors/")`, which caps at 20 pages (2000 rows) against a live count of 8000+ sponsors — a silent 25% sample described as "every canonical sponsor." Deleted; `list_sponsors` (search + pagination) already covers this correctly. `get_all_pages` now raises rather than silently truncating if a future caller hits the cap.
- **`recent_trials_for_subject` prompt fixed.** It sorted by `ordering="-date_registration"`, which isn't a valid `/trials/` ordering field — DRF silently ignored it rather than erroring, so the prompt promised registration-recency order and quietly delivered the default order instead. Now bounds recency with the `date_registration_after` filter, which does exist.
- **Dockerfile hardened.** Dependencies now come only from `pyproject.toml` (was duplicated in a hardcoded `pip install` line), runs as a non-root user, and has a `HEALTHCHECK`. `docker-compose.yaml`'s `gregory-mcp` now depends on `gregory` via `condition: service_healthy` instead of a bare `depends_on`.
- Companion PR [#827](https://github.com/brunoamaral/gregory-ai/pull/827) (against `main`) closes an OpenAPI schema gap on `/authors/`/`/categories/` found during this review — `search_authors`'s team/subject scope will come back once that merges and this branch rebases (tracked as Task 5 in the handover doc).

## Test plan
- [x] `pytest` in `mcp-server/` — 44 tests pass, including a schema-contract suite that checks every filter a tool passes against `django/schema.yml` (already caught two real bugs: `search_authors` passing an ignored `page_size` param, and the sponsors truncation issue above).
- [x] Manually exercised `build_server()` + `call_tool()` against a mocked transport to confirm the real `mcp==2.0.0` SDK wiring works end-to-end.
- [x] `docker build ./mcp-server` — built and ran standalone: non-root user confirmed (`docker exec ... whoami` → `appuser`), `HEALTHCHECK` reports healthy.
- [x] Full `docker compose up` stack — `gregory-mcp` correctly waited for `gregory`'s new healthcheck before starting; both came up healthy, and tools/resources returned real data from the live API (`list_subjects` → 7, `search_articles` → thousands of real hits, `list_sponsors` → true total 8156 with only the requested page returned).
- [ ] Live connection from Claude Code/Desktop against a running instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)