### PR TITLE
Add gregory-mcp to the CI build and deploy pipeline

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -9,15 +9,29 @@ on:
     branches: [main]
   workflow_dispatch:
 
-env:
-  IMAGE: amaralbruno/gregory-ai
-
 jobs:
   build-push:
     # Skip if tests failed (workflow_run conclusion is not 'success').
     # workflow_dispatch always proceeds so manual releases still work.
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    strategy:
+      # Both images build on every run, even when only one of them changed.
+      # gregory-mcp is two pip installs, so rebuilding it needlessly costs
+      # seconds — far less than the machinery to detect which paths changed
+      # (workflow_run triggers don't support `paths:` filters). Keeping them
+      # in lockstep also guarantees the deployed MCP server always matches the
+      # API it proxies; see the note in tests.yaml's mcp-tests job.
+      fail-fast: false
+      matrix:
+        include:
+          - image: amaralbruno/gregory-ai
+            context: .
+            file: Dockerfile
+          - image: amaralbruno/gregory-mcp
+            context: ./mcp-server
+            file: ./mcp-server/Dockerfile
+    name: build-push (${{ matrix.image }})
     steps:
       - uses: actions/checkout@v6
         with:
@@ -35,20 +49,21 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
-          context: .
-          file: Dockerfile
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
           # CI builds amd64 only (production servers are amd64).
           # For a local arm64 image (Apple Silicon) run:
           #   docker buildx build --platform linux/arm64 -t gregory-ai:local .
           platforms: linux/amd64
           push: true
           tags: |
-            ${{ env.IMAGE }}:latest
-            ${{ env.IMAGE }}:${{ github.event.workflow_run.head_sha || github.sha }}
+            ${{ matrix.image }}:latest
+            ${{ matrix.image }}:${{ github.event.workflow_run.head_sha || github.sha }}
           # Registry cache avoids the 10 GB cap of type=gha, which was being
           # exceeded by the torch/tensorflow wheels and causing full rebuilds.
-          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
-          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max
+          # Each image gets its own cache ref so they never evict each other.
+          cache-from: type=registry,ref=${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=${{ matrix.image }}:buildcache,mode=max
 
   deploy:
     needs: build-push
@@ -65,10 +80,16 @@ jobs:
           key: ${{ secrets.HOUSE_SSH_KEY }}
           script: |
             cd /home/gregory/gregory-ai
-            docker compose pull gregory
+            # NOTE: this script does not `git pull`, so it never updates
+            # docker-compose.yaml itself. Adding or changing a *service*
+            # definition needs a manual update of this checkout first — see
+            # "Deployment" in docs/07-mcp-server.md.
+            docker compose pull gregory gregory-mcp
             # Wait for any running management command to finish before restarting
             while docker exec gregory pgrep -f "manage\.py" > /dev/null 2>&1; do
               echo "Management command running, waiting 30s..."
               sleep 30
             done
-            docker compose up -d gregory
+            # Restarted together so the MCP server never proxies an API build
+            # it wasn't tested against. compose orders them via depends_on.
+            docker compose up -d gregory gregory-mcp

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -73,6 +73,37 @@ jobs:
         # drift the production schema from model state.
         run: python manage.py makemigrations --check --dry-run
 
+  # MCP server suite. Runs on a bare runner rather than inside the gregory-ai
+  # image: it needs only `mcp` + `httpx2` + pytest, so pulling the multi-GB ML
+  # image to run it would cost more than the tests themselves.
+  #
+  # This job gates the Docker build for BOTH images (build-push.yaml keys off
+  # this whole workflow's conclusion). That is deliberate: the MCP server
+  # encodes filter names lifted from django/schema.yml, and django-filter
+  # silently ignores unknown query params — so an API change that outruns the
+  # MCP server produces wrong results with no error. test_schema_contract.py
+  # is what catches that, and it is only worth anything if it runs here.
+  mcp-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: mcp-server/pyproject.toml
+
+      - name: Install mcp-server + dev deps
+        working-directory: mcp-server
+        run: pip install --quiet -e ".[dev]"
+
+      - name: Run pytest
+        working-directory: mcp-server
+        # test_schema_contract.py reads ../django/schema.yml from the checkout,
+        # so no Django runtime or database is needed here.
+        run: pytest -p no:cacheprovider
+
   # Static gate for "hollow" error handling: bare `except:` and `except: pass`
   # (the empty catch block). Runs on a bare runner — no ML image needed — so it
   # finishes in seconds, in parallel with the test suite. Config: ruff.toml.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,6 +63,11 @@ services:
   gregory-mcp:
     container_name: gregory-mcp
     restart: always
+    # Both keys, matching the `gregory` service: `image` is what CI pushes and
+    # what `docker compose pull gregory-mcp` resolves on the server; `build`
+    # is the local-dev path. Without `image` the deploy's pull is a silent
+    # no-op and the server keeps running a stale locally-built container.
+    image: amaralbruno/gregory-mcp:latest
     build: ./mcp-server
     ports:
       - 127.0.0.1:8001:8001

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -139,6 +139,83 @@ awk '$9 == 429' /var/log/nginx/mcp-access.log | grep -o 'mcp_name="[^"]*"' | sor
 Whether 30 r/m per (client, tool) and 120 r/m per client are the right numbers is an open
 question — tune them from what this log actually shows, not speculatively.
 
+## Deployment
+
+The image is `amaralbruno/gregory-mcp`, built and pushed by
+[`.github/workflows/build-push.yaml`](../.github/workflows/build-push.yaml) alongside
+`amaralbruno/gregory-ai`. Both build from the same matrix and deploy in the same step, so
+the MCP server is never left proxying an API build it wasn't tested against — which matters
+because django-filter silently ignores unknown query params, so a stale MCP server returns
+wrong results rather than an error.
+
+The gate is the `Tests` workflow: `pytest` (Django), `mcp-tests` (MCP), and `lint` all have
+to pass before either image is built.
+
+### One-time setup on the server
+
+The deploy step **does not `git pull`** — it only pulls images and restarts containers. So
+the `gregory-mcp` service definition has to reach `/home/gregory/gregory-ai` once, by hand,
+before the first automated deploy will do anything:
+
+```bash
+cd /home/gregory/gregory-ai
+git pull                                  # brings in the gregory-mcp compose service
+docker compose pull gregory-mcp
+docker compose up -d gregory-mcp
+docker compose ps gregory-mcp             # expect "healthy" within ~40s
+```
+
+Then add the `/mcp/` block to the live nginx config. The version in
+[`nginx-example-configuration/nginx.conf`](../nginx-example-configuration/nginx.conf) is an
+example, not the deployed file — it needs copying across, including the two `limit_req_zone`
+directives and the `map $http_mcp_name $mcp_tool_bucket` block, which live in the `http`
+context rather than the `server` block.
+
+```bash
+nginx -t && systemctl reload nginx
+```
+
+Verify from outside:
+
+```bash
+curl -s -o /dev/null -w '%{http_code} -> %{redirect_url}\n' https://<host>/mcp/
+```
+
+Expect **`307`** redirecting to `…/mcp`. A `404` means the location block isn't active; a
+`502` means nginx is up but the container isn't reachable on `127.0.0.1:8001`.
+
+> **Do not add `-L`.** Following the redirect with curl's default `Accept: */*` opens an SSE
+> stream that never closes, and the command hangs until you kill it. That is the server
+> working correctly, not a fault. (The container's own `HEALTHCHECK` avoids this by sending
+> no SSE-compatible `Accept` header, so it lands on `406` and exits.)
+
+### Known gap: the trailing slash
+
+The app is mounted at **`/mcp`** and redirects `/mcp/` → `/mcp`. The example nginx config
+only defines `location /mcp/`, so the redirect target has no matching block and falls
+through to `location /`, which proxies to Django and returns 404.
+
+**This has not been verified against a live nginx** — the MCP server has so far only been
+exercised directly on `127.0.0.1:8001`, bypassing nginx entirely. Check it explicitly on the
+first deploy. If it does break, the fix is a prefix match that covers both spellings and
+preserves the original URI:
+
+```nginx
+location /mcp {                        # no trailing slash — matches /mcp and /mcp/
+    proxy_pass http://127.0.0.1:8001;  # no path — don't rewrite the URI
+    # … limit_req and proxy_set_header lines unchanged …
+}
+```
+
+Confirm with a real client afterwards, not just curl: streamable HTTP uses POST, and a 307
+preserves the method and body, so the failure mode differs between the two.
+
+### After that
+
+Every push to `main` that passes `Tests` rebuilds and redeploys both containers with no
+manual step. The one exception is another change to a *service definition* in
+`docker-compose.yaml` — those still need the checkout on the server updating first.
+
 ## Risks
 
 **Unauthenticated endpoint.** No data-leak risk, but anyone who learns the URL can drive

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -21,6 +21,12 @@ dev = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+# Put the rootdir on sys.path. tests/test_client.py and
+# tests/test_no_internal_url_leak.py import `tests.conftest` absolutely, and
+# tests/ is not a package, so bare `pytest` cannot resolve it — only
+# `python -m pytest` worked, because that form prepends the CWD. Without this
+# the documented `pytest` invocation fails at collection.
+pythonpath = ["."]
 
 [build-system]
 requires = ["setuptools>=68"]


### PR DESCRIPTION
Builds and deploys the MCP server image alongside `gregory-ai` instead of leaving it as a local-only `build:` target.

## Changes

- **`tests.yaml`** — new `mcp-tests` job on a plain runner. The suite needs only `mcp` + `httpx2` + pytest, so pulling the multi-GB ML image to run it costs more than the tests do. Because `build-push` keys off this workflow's conclusion, this gates **both** images. That coupling is deliberate: the MCP server encodes filter names lifted from `django/schema.yml`, and django-filter silently ignores unknown query params — so an API change that outruns the MCP server produces wrong results with no error.
- **`build-push.yaml`** — `build-push` becomes a 2-leg matrix (`gregory-ai`, `gregory-mcp`) with per-image build cache refs so they never evict each other. `deploy` waits on both legs and restarts both services together.
- **`docker-compose.yaml`** — added the `image:` key to `gregory-mcp`. Without it, `docker compose pull gregory-mcp` is a silent no-op and the server keeps running a stale locally-built container.
- **`docs/07-mcp-server.md`** — deployment runbook, including the one-time manual steps on House.

Both images rebuild on every green run rather than using path filters: `gregory-mcp` is two `pip install`s, so a needless rebuild costs seconds — far less than the machinery to detect changed paths (`workflow_run` triggers don't support `paths:` filters), and lockstep keeps the proxy matched to the API it proxies.

## Test plan

- [x] All three YAML files parse; matrix resolves to the right contexts and Dockerfiles
- [x] `mcp-tests` job reproduced from a clean `git archive` checkout — **82 tests pass**
- [x] `docker build ./mcp-server` — **had never been run before**; PR #826 shipped it unverified. Builds clean on amd64
- [x] Container smoke-tested: healthy in ~8s, runs as `appuser`, fail-fasts without `GREGORY_API_URL`
- [ ] First deploy to House — needs the one-time manual steps in the runbook

## Two findings from the smoke test

Documented rather than silently patched:

1. `GET /mcp/` returns **307**, not the 405/406 the runbook first claimed. Following it with `curl -L` **hangs** — curl's default `Accept: */*` opens an SSE stream that never closes. The container's own healthcheck avoids this by sending no SSE-compatible `Accept` header.
2. **The example nginx config looks broken.** The app is mounted at `/mcp` and redirects `/mcp/` → `/mcp`, but the config defines only `location /mcp/`. The redirect target has no matching block, falls through to `location /`, and hits Django → 404.

That second one has **never been exercised** — the MCP server has so far only been reached directly on `127.0.0.1:8001`, bypassing nginx. It's flagged in the runbook with a suggested fix (`location /mcp` prefix match, `proxy_pass` with no path) rather than changed blind, since untested reverse-proxy changes are not something to merge on reasoning alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)