### PR TITLE
Correct MCP deploy docs and nginx example from the live rollout

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,6 +48,7 @@ services:
       - FERNET_SECRET_KEY=${FERNET_SECRET_KEY}
       - DJANGO_DEBUG=${DJANGO_DEBUG}
       - EXTRA_ALLOWED_HOSTS=${EXTRA_ALLOWED_HOSTS}
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS}
     networks:
       - gregory_network
     depends_on:

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -159,56 +159,75 @@ before the first automated deploy will do anything:
 
 ```bash
 cd /home/gregory/gregory-ai
-git pull                                  # brings in the gregory-mcp compose service
+git pull                                  # brings in the service's `image:` key
 docker compose pull gregory-mcp
 docker compose up -d gregory-mcp
 docker compose ps gregory-mcp             # expect "healthy" within ~40s
 ```
 
-Then add the `/mcp/` block to the live nginx config. The version in
+Then add the `/mcp` block to the live nginx config. The version in
 [`nginx-example-configuration/nginx.conf`](../nginx-example-configuration/nginx.conf) is an
 example, not the deployed file — it needs copying across, including the two `limit_req_zone`
 directives and the `map $http_mcp_name $mcp_tool_bucket` block, which live in the `http`
-context rather than the `server` block.
+context rather than the `server` block (on Debian/Ubuntu, `conf.d/` is included there).
+
+Two things that are easy to get wrong:
+
+- **`location /mcp`, no trailing slash, and `proxy_pass http://127.0.0.1:8001;` with no
+  path.** The app is mounted at `/mcp` and 307-redirects `/mcp/` → `/mcp`. A `location
+  /mcp/` block leaves that redirect target unmatched, so it falls through to `location /`,
+  reaches Django, and 404s. The prefix match catches both spellings and the pathless
+  `proxy_pass` preserves the URI.
+- **`http2` syntax depends on the nginx version.** Below 1.25.1 it is part of the listen
+  line (`listen 443 ssl http2;`, which is what the example config and House both use); from
+  1.25.1 it is a separate `http2 on;` directive and the old form warns. Using the wrong one
+  fails the config test with `unknown directive "http2"`.
 
 ```bash
 nginx -t && systemctl reload nginx
 ```
 
-Verify from outside:
+### Verifying
 
 ```bash
-curl -s -o /dev/null -w '%{http_code} -> %{redirect_url}\n' https://<host>/mcp/
+curl -s -o /dev/null --max-time 5 -H 'Accept: application/json' -w '%{http_code}\n' https://<host>/mcp
 ```
 
-Expect **`307`** redirecting to `…/mcp`. A `404` means the location block isn't active; a
-`502` means nginx is up but the container isn't reachable on `127.0.0.1:8001`.
+Expect **`406`**. A `404` means the location block isn't active; a `502` means nginx is up
+but the container isn't reachable on `127.0.0.1:8001`; `000` usually means TLS isn't
+serving that hostname yet.
 
-> **Do not add `-L`.** Following the redirect with curl's default `Accept: */*` opens an SSE
-> stream that never closes, and the command hangs until you kill it. That is the server
-> working correctly, not a fault. (The container's own `HEALTHCHECK` avoids this by sending
-> no SSE-compatible `Accept` header, so it lands on `406` and exits.)
+> **Never probe `/mcp` with curl's default `Accept: */*`.** That returns `200` and then an
+> open SSE stream — the command hangs until you kill it. It looks like a failure and is
+> actually the server working. Same reason not to add `-L` to a `/mcp/` request: following
+> the 307 lands on the streaming path. See `mcp-server/healthcheck.py` for the full matrix
+> of what each method and `Accept` combination returns.
 
-### Known gap: the trailing slash
+A status code only proves something is listening. This exercises the real protocol —
+note the `_meta` envelope is **mandatory** under the stateless `2026-07-28` core, since
+every request has to be self-describing; omit `protocolVersion` or `clientCapabilities` and
+the server returns `-32602`:
 
-The app is mounted at **`/mcp`** and redirects `/mcp/` → `/mcp`. The example nginx config
-only defines `location /mcp/`, so the redirect target has no matching block and falls
-through to `location /`, which proxies to Django and returns 404.
-
-**This has not been verified against a live nginx** — the MCP server has so far only been
-exercised directly on `127.0.0.1:8001`, bypassing nginx entirely. Check it explicitly on the
-first deploy. If it does break, the fix is a prefix match that covers both spellings and
-preserves the original URI:
-
-```nginx
-location /mcp {                        # no trailing slash — matches /mcp and /mcp/
-    proxy_pass http://127.0.0.1:8001;  # no path — don't rewrite the URI
-    # … limit_req and proxy_set_header lines unchanged …
-}
+```bash
+curl -s --max-time 10 -X POST https://<host>/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'MCP-Protocol-Version: 2026-07-28' \
+  -H 'Mcp-Method: tools/list' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{
+       "io.modelcontextprotocol/protocolVersion":"2026-07-28",
+       "io.modelcontextprotocol/clientInfo":{"name":"curl","version":"1.0"},
+       "io.modelcontextprotocol/clientCapabilities":{}}}}'
 ```
 
-Confirm with a real client afterwards, not just curl: streamable HTTP uses POST, and a 307
-preserves the method and body, so the failure mode differs between the two.
+Expect a JSON-RPC result listing all ten tools. This is the check that matters: it is a
+POST, which is what real clients use, and it is what proves the routing above is right.
+
+To confirm rate limiting is applied and returns `429` rather than nginx's default `503`,
+send the same request ~16 times in a row with `-H 'Mcp-Name: list_subjects'` — the first
+dozen should return `200` and the rest `429`.
+
+Client config URL, **without the trailing slash**: `https://<host>/mcp`
 
 ### After that
 

--- a/example.env
+++ b/example.env
@@ -9,7 +9,7 @@ DOMAIN_NAME=DOMAIN.COM
 # Use for server IPs, legacy domains, or staging hostnames.
 # Example: EXTRA_ALLOWED_HOSTS=203.0.113.42,legacy.example.com
 EXTRA_ALLOWED_HOSTS=
-
+CORS_ALLOWED_ORIGINS=
 # --- PostgreSQL ---
 POSTGRES_DB="PICK-A-DATABASE-NAME"
 POSTGRES_PASSWORD=PICK-A-PASSWORD

--- a/example.env
+++ b/example.env
@@ -9,7 +9,15 @@ DOMAIN_NAME=DOMAIN.COM
 # Use for server IPs, legacy domains, or staging hostnames.
 # Example: EXTRA_ALLOWED_HOSTS=203.0.113.42,legacy.example.com
 EXTRA_ALLOWED_HOSTS=
+# Optional: comma-separated browser origins allowed to call the API cross-site.
+# Every entry MUST include the scheme — django-cors-headers rejects a bare
+# domain with corsheaders.E013, which fails Django's system check at startup
+# and takes the whole app down, not just CORS. Leave blank if not needed:
+# https://DOMAIN_NAME and https://www.DOMAIN_NAME are added automatically, and
+# DEBUG=True allows all origins regardless. See django/admin/settings.py.
+# Example: CORS_ALLOWED_ORIGINS=https://example.com,https://app.example.com
 CORS_ALLOWED_ORIGINS=
+
 # --- PostgreSQL ---
 POSTGRES_DB="PICK-A-DATABASE-NAME"
 POSTGRES_PASSWORD=PICK-A-PASSWORD

--- a/mcp-server/healthcheck.py
+++ b/mcp-server/healthcheck.py
@@ -9,13 +9,16 @@ variance — measured against a live container on 2026-08-05:
     GET  /mcp   Accept: */*               -> 200, then an open SSE stream
     HEAD /mcp                             -> 405 Method Not Allowed
 
-urlopen() follows the 307 and sends no SSE-compatible Accept header, so it
-lands on 406. 405 is accepted too so the probe still passes if this is ever
-switched to a HEAD request. Both prove the process is up, routed correctly,
-and the streamable-http app is really mounted.
+So the probe requests /mcp directly with an explicit `Accept:
+application/json` and expects 406. Both parts are deliberate: hitting /mcp
+rather than /mcp/ avoids depending on redirect handling, and setting Accept
+ourselves avoids depending on urllib's default header behaviour — if that
+default ever became SSE-compatible, an implicit probe would match the 200
+row and hang on the stream until the timeout instead of returning.
 
-The 200 row is why this probe must never use a permissive Accept: it would
-hang on the stream until the timeout rather than returning. Anything else —
+405 is accepted alongside 406 so the probe still passes if it is ever
+switched to a HEAD request. Either proves the process is up, routed
+correctly, and the streamable-http app is really mounted. Anything else —
 404 (route not mounted, a real misconfiguration), 5xx (up but erroring), a
 connection failure, or a timeout — means something is actually wrong.
 """
@@ -28,8 +31,14 @@ import urllib.request
 
 EXPECTED_CODES = {405, 406}
 
+REQUEST = urllib.request.Request(
+	"http://127.0.0.1:8001/mcp",
+	headers={"Accept": "application/json"},
+	method="GET",
+)
+
 try:
-	urllib.request.urlopen("http://127.0.0.1:8001/mcp/", timeout=3)
+	urllib.request.urlopen(REQUEST, timeout=3)
 	sys.exit(1)  # a 2xx/3xx isn't the expected shape either — investigate
 except urllib.error.HTTPError as exc:
 	if exc.code not in EXPECTED_CODES:

--- a/mcp-server/healthcheck.py
+++ b/mcp-server/healthcheck.py
@@ -1,14 +1,22 @@
 """Docker HEALTHCHECK probe.
 
-A bare GET on the streamable-http endpoint (this server negotiates POST
-JSON-RPC and SSE, not plain GET) redirects once and lands on 406 Not
-Acceptable — verified against a live instance. A 405 Method Not Allowed is
-also accepted: which of the two a router/server returns for "wrong verb on
-a mounted route" can legitimately vary. Either proves the process is up,
-routed correctly, and the streamable-http app is actually mounted at
-/mcp/, so together they're the only things that count as healthy.
-Anything else — a 404 (route not mounted — a real misconfiguration, not
-just "wrong verb/Accept header"), a 5xx (the app is up but erroring), a
+This server negotiates POST JSON-RPC and SSE, not plain GET, so a GET is a
+cheap liveness probe. Which rejection you get is deterministic, not router
+variance — measured against a live container on 2026-08-05:
+
+    GET  /mcp/  (trailing slash)          -> 307 redirect to /mcp
+    GET  /mcp   Accept: application/json  -> 406 Not Acceptable
+    GET  /mcp   Accept: */*               -> 200, then an open SSE stream
+    HEAD /mcp                             -> 405 Method Not Allowed
+
+urlopen() follows the 307 and sends no SSE-compatible Accept header, so it
+lands on 406. 405 is accepted too so the probe still passes if this is ever
+switched to a HEAD request. Both prove the process is up, routed correctly,
+and the streamable-http app is really mounted.
+
+The 200 row is why this probe must never use a permissive Accept: it would
+hang on the stream until the timeout rather than returning. Anything else —
+404 (route not mounted, a real misconfiguration), 5xx (up but erroring), a
 connection failure, or a timeout — means something is actually wrong.
 """
 

--- a/nginx-example-configuration/nginx.conf
+++ b/nginx-example-configuration/nginx.conf
@@ -414,7 +414,14 @@ http {
         # Streamable HTTP is a normal request/response with an optional SSE upgrade, so
         # this needs the same Upgrade/Connection handling as the reverse proxy below, plus
         # buffering off so a streamed response isn't held until it completes.
-        location /mcp/ {
+        #
+        # No trailing slash, and proxy_pass carries no path — both matter. The app is
+        # mounted at /mcp and 307-redirects /mcp/ -> /mcp, so a `location /mcp/` block
+        # would route the redirect target nowhere (it falls through to `location /` and
+        # hits Django, 404). A prefix match on /mcp catches both spellings, and a
+        # pathless proxy_pass preserves the original URI instead of rewriting it.
+        # Verified in production 2026-08-05.
+        location /mcp {
             # nginx's own default for a throttled request is 503, which reads as
             # "server broken" rather than "you're going too fast" — 429 is the
             # correct status for a client to act on (back off and retry).
@@ -424,7 +431,7 @@ http {
 
             access_log                         /var/log/nginx/mcp-access.log mcp_combined;
 
-            proxy_pass                         http://127.0.0.1:8001/mcp/;
+            proxy_pass                         http://127.0.0.1:8001;
             proxy_http_version                 1.1;
             proxy_buffering                    off;
             proxy_cache_bypass                 $http_upgrade;


### PR DESCRIPTION
Deploying to House on 2026-08-05 disproved three things this repo asserted. All are now measured rather than reasoned about.

> **Scope note:** this branch also carries `5ea36cab "add missing env variable"` — a local commit that existed on `main` but had not been pushed, and which I inherited by branching from it. It adds the `CORS_ALLOWED_ORIGINS` passthrough to the `gregory` service and the key to `example.env`. That **is** a runtime configuration change, not docs. It is kept (it is intentional work and dropping it would strand the fix) and its format is now documented — see the last section.

## `nginx-example-configuration/nginx.conf`

`location /mcp/` with `proxy_pass http://127.0.0.1:8001/mcp/;` was **wrong**. The app is mounted at `/mcp` and 307-redirects `/mcp/` → `/mcp`, so the redirect target had no matching block, fell through to `location /`, reached Django and 404'd.

Now a prefix match on `/mcp` with a pathless `proxy_pass`, which preserves the URI and serves both spellings.

Verified in production:
- `POST /mcp` → `tools/list` returns all ten tools
- `POST /mcp/` now lands on the MCP server rather than Django
- 16 rapid requests → 12× `200` then `429` (not `503`, so `limit_req_status` applies and the per-`(client, tool)` bucket keys correctly)

## `mcp-server/healthcheck.py`

The docstring called 405-vs-406 router variance that "can legitimately vary." It doesn't — it is deterministic by method and `Accept` header:

| Request | Result |
|---|---|
| `GET /mcp/` | `307` → `/mcp` |
| `GET /mcp` + `Accept: application/json` | `406` |
| `GET /mcp` + `Accept: */*` | `200`, then an open SSE stream |
| `HEAD /mcp` | `405` |

Per review, the probe now **sets `Accept: application/json` explicitly and requests `/mcp` directly**. The determinism argument rests entirely on that header, so leaving it to a urllib default contradicted the docstring — and had that default ever become SSE-compatible, the probe would have matched the `200` row and hung until timeout. Verified: healthy in ~8s, probe exits 0.

## `docs/07-mcp-server.md`

- **The documented verification command hung.** It probed the path that streams. Now uses `-H 'Accept: application/json'` expecting `406`, with an explicit warning that the hang is the server working, not a fault.
- **Added a real `POST tools/list` check.** A status code only proves something is listening; this exercises the protocol, and it is a POST — what clients actually use, and what the routing question hinged on.
- **Documented the mandatory `_meta` envelope** (`protocolVersion` + `clientCapabilities`). Nothing in the repo mentioned it, and omitting it returns a bare `-32602`.
- **Noted the `http2` syntax split at nginx 1.25.1** — the old form on a new nginx warns; the new form on an old nginx fails the config test with `unknown directive "http2"`. This cost a round trip during rollout.
- **Dropped the "Known gap: the trailing slash / not verified" section** — settled, and the fix is now in the example config.
- Fixed a stale comment claiming `git pull` brings in the compose service. It was already present on House; what the pull brings is the `image:` key.

## `example.env` / `docker-compose.yaml` (the inherited commit)

`CORS_ALLOWED_ORIGINS` is now passed through to the container. Per review, its format is documented, because getting it wrong is worse than it looks: `django/admin/settings.py:81` parses it as a comma-separated list, and every entry needs its own scheme. A bare domain raises `corsheaders.E013`, which fails Django's system check **at startup** — taking the whole app down rather than just breaking CORS. The doc comment also records that `https://DOMAIN_NAME` and its `www` form are appended automatically, and that `DEBUG=True` allows all origins regardless.

## Test plan

- [x] `mcp-server` suite: 82 pass via the exact CI command
- [x] Revised healthcheck verified in a built container — healthy in ~8s, probe exit 0
- [x] Every claim above measured against the live deployment at `gregory-ai.brain-regeneration.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)