### PR TITLE
Cache the tool catalog: tools/list was returning ttlMs=0

### DIFF
--- a/mcp-server/gregory_mcp/server.py
+++ b/mcp-server/gregory_mcp/server.py
@@ -25,6 +25,33 @@ READ_ONLY = ToolAnnotations(read_only_hint=True, idempotent_hint=True, open_worl
 # and share the cached value across callers (nothing in the payload is caller-specific).
 CATALOG_CACHE = CacheHint(ttl_ms=CATALOG_CACHE_TTL_MS, scope="public")
 
+# Tool/prompt schemas and server capabilities are static *between deploys* — unlike
+# the reference data above they change only when this code changes, so they get their
+# own TTL rather than inheriting one that exists to bound data staleness.
+#
+# Worth caching: tools/list alone is ~17 KB (~4.2k tokens) of schemas that otherwise
+# gets refetched on every reconnect, and it lands in the model's system prompt, so
+# refetching it risks invalidating the upstream prompt cache — the "keep upstream
+# prompt caches stable across reconnects" the 2026-07-28 release notes call out.
+#
+# 30 minutes bounds how long a client can hold a stale catalog after a deploy.
+# Staleness here is benign in both directions: a client missing a NEW parameter is
+# merely degraded, and one sending a REMOVED parameter is rejected against the
+# current schema. Neither is the silent-wrong-results failure mode that unknown
+# *API* query params cause, since django-filter ignores those instead of erroring.
+STATIC_CACHE = CacheHint(ttl_ms=30 * 60 * 1000, scope="public")
+
+# Module-level so tests can assert on it: MCPServer keeps no public accessor for
+# the hints it was constructed with, and a missing entry degrades silently to
+# ttlMs=0 ("never cache"), which is indistinguishable from working.
+CACHE_HINTS = {
+	"resources/list": CATALOG_CACHE,
+	"resources/read": CATALOG_CACHE,
+	"tools/list": STATIC_CACHE,
+	"prompts/list": STATIC_CACHE,
+	"server/discover": STATIC_CACHE,
+}
+
 
 def build_server() -> MCPServer:
 	server = MCPServer(
@@ -35,10 +62,7 @@ def build_server() -> MCPServer:
 			"trials, authors, subjects, categories, and sponsors."
 		),
 		version="0.1.0",
-		cache_hints={
-			"resources/list": CATALOG_CACHE,
-			"resources/read": CATALOG_CACHE,
-		},
+		cache_hints=CACHE_HINTS,
 	)
 
 	server.add_tool(catalog.list_subjects, annotations=READ_ONLY)

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -47,11 +47,14 @@ async def test_server_registers_three_prompts(server):
 	}
 
 
-def test_every_cacheable_list_method_carries_a_hint():
+def test_every_cacheable_method_carries_a_hint():
 	"""A missing cache hint means ttlMs=0 — "never cache" — which is the SDK
 	default and therefore fails silently. tools/list is ~17 KB of schemas that
 	lands in the model's system prompt, so losing this hint quietly reintroduces
 	a refetch on every reconnect. Assert the wiring rather than trusting it.
+
+	Not only *list* methods: resources/read and server/discover are cacheable
+	too, and are covered here for the same reason.
 
 	Asserts the dict we pass in, not the server: MCPServer exposes no accessor
 	for the hints it was constructed with. That the SDK honours them was verified
@@ -59,7 +62,13 @@ def test_every_cacheable_list_method_carries_a_hint():
 	"""
 	from gregory_mcp.server import CACHE_HINTS as hints
 
-	for method in ("tools/list", "prompts/list", "resources/list", "resources/read"):
+	for method in (
+		"tools/list",
+		"prompts/list",
+		"resources/list",
+		"resources/read",
+		"server/discover",
+	):
 		assert method in hints, f"{method} has no cache hint — clients will refetch it every time"
 		assert hints[method].ttl_ms > 0, f"{method} hint is ttl_ms=0, same as no hint at all"
 		assert hints[method].scope == "public", (

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -47,6 +47,27 @@ async def test_server_registers_three_prompts(server):
 	}
 
 
+def test_every_cacheable_list_method_carries_a_hint():
+	"""A missing cache hint means ttlMs=0 — "never cache" — which is the SDK
+	default and therefore fails silently. tools/list is ~17 KB of schemas that
+	lands in the model's system prompt, so losing this hint quietly reintroduces
+	a refetch on every reconnect. Assert the wiring rather than trusting it.
+
+	Asserts the dict we pass in, not the server: MCPServer exposes no accessor
+	for the hints it was constructed with. That the SDK honours them was verified
+	on the wire (tools/list -> ttlMs 1800000, scope public).
+	"""
+	from gregory_mcp.server import CACHE_HINTS as hints
+
+	for method in ("tools/list", "prompts/list", "resources/list", "resources/read"):
+		assert method in hints, f"{method} has no cache hint — clients will refetch it every time"
+		assert hints[method].ttl_ms > 0, f"{method} hint is ttl_ms=0, same as no hint at all"
+		assert hints[method].scope == "public", (
+			f"{method} is identical for every caller (this server has no auth), "
+			"so a shared cache should be allowed to serve it"
+		)
+
+
 def test_client_exposes_no_write_methods():
 	"""The server issues GET only — assert the client has no write verbs at all."""
 	for verb in ("post", "put", "patch", "delete"):


### PR DESCRIPTION
The server declared cache hints only for `resources/list` and `resources/read`, so `tools/list` came back `ttlMs: 0, cacheScope: private` — "never cache this."

Measured against the live deployment, that means clients refetch **16,939 bytes (~4,200 tokens)** of tool schemas on every reconnect.

## Why it matters beyond bandwidth

Tool definitions land in the model's system prompt. Refetching them risks invalidating the upstream prompt cache on each reconnect, which means reprocessing the conversation prefix. Keeping those caches stable is precisely why the `2026-07-28` release added `ttlMs`/`cacheScope` to list responses — we just weren't using it for the largest response we serve.

`cacheScope: private` compounded it: the response is identical for every caller (this server has no auth), so a shared cache should be allowed to serve it.

## The change

A `STATIC_CACHE` hint (30 min, `public`) for `tools/list`, `prompts/list` and `server/discover`.

Deliberately a **separate constant** from `CATALOG_CACHE` rather than reusing `CATALOG_CACHE_TTL_MS`. That number exists to bound *data* staleness for `/subjects/` and `/categories/`; these are schemas that change only when this code changes. Coupling them would mean tuning one silently moved the other.

**Staleness is benign in both directions** — a client missing a NEW parameter is merely degraded, and one sending a REMOVED parameter is rejected against the current schema. Neither is the silent-wrong-results mode that unknown *API* query params cause, since django-filter ignores those rather than erroring.

## Verified on the wire

Built the container and called each method:

| Method | `ttlMs` | `cacheScope` |
|---|---|---|
| `tools/list` | 1800000 | public |
| `prompts/list` | 1800000 | public |
| `resources/list` | 600000 | public |

## Testability

The hints dict moves to a module-level `CACHE_HINTS`. `MCPServer` exposes no accessor for what it was constructed with, and a missing entry degrades to `ttlMs=0` — indistinguishable from working. The new test asserts every cacheable list method carries a non-zero, `public` hint, and **was confirmed to fail when the `tools/list` entry is removed** rather than being assumed to work.

## Test plan

- [x] 83 tests pass (82 + the new one) via the exact CI command
- [x] New test verified to fail on a removed hint, then the file restored
- [x] Hints confirmed on the wire in a built container

🤖 Generated with [Claude Code](https://claude.com/claude-code)