### PR TITLE
MCP server telemetry: request logging, query-shape, zero-result guidance, intent capture

### DIFF
--- a/MCP-TELEMETRY-PLAN.md
+++ b/MCP-TELEMETRY-PLAN.md
@@ -21,8 +21,20 @@ cycle (`telemetry -> query_shape -> cache -> client -> telemetry`, since client.
 import telemetry.py's `record_*` functions) — fixed with a lazy import inside
 `_annotate_query_shape`, confirmed via a fresh-process import of `gregory_mcp.server`.
 
-`tests/test_telemetry.py` (19 tests) + `tests/test_query_shape.py` (14 tests). Full suite: 116
-passed. Phases 3-6 not started.
+`tests/test_telemetry.py` (19 tests) + `tests/test_query_shape.py` (14 tests).
+
+Phase 3: `gregory_mcp/zero_result.py` (`guidance_for`) — search_articles/search_trials attach a
+`guidance` key (`applied_filters` + ranked suggestions) to a zero-hit response instead of the bare
+`{"count": 0, "articles": []}` dead end. Rule-based, not ML: relevance/threshold, date range,
+taxonomy ID, registry ID, boolean search, in that priority order, falling back to a generic
+suggestion. Filter *names* only, same boundary telemetry.py holds for `params_used` — verified no
+filter value ever appears in the guidance output. Confirmed end-to-end that it composes cleanly
+with Phase 1/2 telemetry (the new `guidance` dict doesn't perturb `_result_shape`'s list-scan for
+`result_count`, since it isn't a list). Docstrings updated for both tools.
+
+`tests/test_zero_result.py` (11 tests) + new cases in `test_tools_articles.py`/`test_tools_trials.py`.
+
+Full suite: 131 passed. Phases 4-6 not started.
 
 Goal: learn enough about how LLM clients actually use `mcp-server/` to improve it — which tools
 earn their place, which parameters are dead weight in a 17 KB schema payload, where searches come

--- a/MCP-TELEMETRY-PLAN.md
+++ b/MCP-TELEMETRY-PLAN.md
@@ -1,0 +1,368 @@
+# MCP server telemetry — plan
+
+Status: Phase 1 implemented on `fix/mcp-cache-tool-catalog` (not yet merged/deployed — see the
+deployment boundary below). `gregory_mcp/telemetry.py` (`TelemetryMiddleware`), instrumented
+`client.py`/`cache.py`, extended `logging_config.py`'s field allowlist, and `tests/test_telemetry.py`
+(12 tests). Verified against the real server stack, not just unit tests — driving actual
+`tools/call` requests through `build_server()` surfaced that our tools return plain `dict` with no
+declared output schema, so `CallToolResult.structured_content` is unset on the wire; the shape
+fields (`result_count`/`total_count`/`has_next`) fall back to parsing the same payload out of
+`content[0].text` instead. Phases 2-6 not started.
+
+Goal: learn enough about how LLM clients actually use `mcp-server/` to improve it — which tools
+earn their place, which parameters are dead weight in a 17 KB schema payload, where searches come
+back empty, which Gregory API endpoints are the latency floor, and **what people are asking for
+that we do not yet provide** — without building a record of what any individual person researched.
+
+---
+
+## Summary
+
+Three layers of instrumentation exist. Two are dark:
+
+| Layer | State |
+|:---|:---|
+| nginx `mcp-access.log` (`mcp_combined`) | Working. Only place that sees 429s. Tool name comes from the client-controlled `Mcp-Name` header. |
+| `JsonFormatter` (`gregory_mcp/logging_config.py`) | Built with `tool`/`duration_ms`/`status_code` fields. **Nothing emits them.** Three log lines exist in the whole package: startup, transport error, retry. |
+| `OpenTelemetryMiddleware` | Ships **on by default** in `mcp==2.0.0` (`lowlevel/server.py:439`), already emits per-method spans with `gen_ai.tool.name`. `opentelemetry-api` is already in the image. But no SDK and no exporter are installed, so **every span is a no-op**. |
+
+No tool call has ever been logged. That is the gap this plan closes.
+
+The hook point exists: `MCPServer(..., middleware=[...])` takes a `ServerMiddleware`, and each
+request's `ctx` carries `method`, `params` (`name` + `arguments` for `tools/call`), and
+`meta[io.modelcontextprotocol/clientInfo]` — client name and version, on every request under the
+stateless 2026-07-28 core.
+
+---
+
+## Deployment boundary
+
+**Nothing in this plan is applied to House directly.** House is production — the live GregoryAI
+instance — and every phase here delivers code, example config, and docs into the repo. Copying
+config across, reloading nginx, and deploying containers are Bruno's steps, taken deliberately.
+
+This matches how `mcp-server/` already shipped: `nginx-example-configuration/nginx.conf` is
+explicitly "an example, not the deployed file" (`docs/07-mcp-server.md:169`), and the CI deploy
+pulls images without touching the checkout.
+
+Practical consequence for every phase below: a change is not live when it lands on a branch, so
+"deployed" and "merged" are separate states in this document, and any phase that depends on real
+traffic depends on Bruno having deployed the phase before it.
+
+---
+
+## Decisions taken
+
+**2026-08-09 — `intent` is logged as full text, not classified.** An earlier draft proposed mapping
+intent to a fixed taxonomy of question types and logging only the class. Rejected: the class list
+cannot be written before the data has been seen, and at this server's volume a rising `other`
+bucket is an alarm with no diagnosis. Full text from day one, with bounded retention and a
+scheduled review that can act retroactively (Phase 4 / Phase 5). The assumption under test is that
+model-authored intent strings do not contain personally identifying information; the review exists
+to falsify it with evidence rather than confirm it by impression.
+
+---
+
+## The anonymity design
+
+Two fields carry user-derived text, and they are treated differently on purpose.
+
+### `search` — bagged
+
+The thing that makes a search query identifying is rarely the individual terms. `encephalitis` on
+encefalites.pt identifies nobody. What identifies is **co-occurrence** (`encephalitis` ∧
+`rituximab` ∧ `paediatric`) and **linkage** (that tuple tied to the same caller as yesterday's
+query). Both are destroyed at write time, cheaply:
+
+**1. Destroy co-occurrence.** Never log the query string or the term tuple. Split into terms and
+emit each as its own record with no key joining them. Both terms get counted; that one person
+asked for both is never written down.
+
+**2. Destroy linkage.** No IP, no session id, no stable client hash, timestamps truncated to the
+hour. `stateless_http=True` means there is no session id to leak in the first place. Without a
+correlation key the output is a term-frequency table, not a set of profiles.
+
+**3. Prefer a closed vocabulary.** Gregory already has one: `category_terms` on `/categories/`,
+which this server fetches and caches. Match terms against it and log the matched category slugs
+plus a count of terms matching nothing. The output alphabet is the site's own public category
+list, non-personal by construction.
+
+**4. k-anonymity on the remainder** (Phase 5, may never ship).
+
+### `intent` — full text, bounded window
+
+Bagging destroys exactly what makes intent useful: the shape of the ask is the signal. So `intent`
+is stored whole. The protection is **exposure duration and review**, not content reduction:
+
+- rolling 90-day window, hard delete; derived conclusions persist, raw rows do not
+- automated PII flagging on write (flag, do not block) into a separate review queue
+- a scheduled review with a defined pass/fail that can retire the field (Phase 5)
+
+**This asymmetry is deliberate, not an inconsistency.** `search` gets bagged because bagging is
+free there — the vocabulary signal survives it. `intent` is not bagged because bagging would leave
+nothing to analyse. Where content reduction costs nothing it is applied; where it would destroy
+the signal, exposure is bounded instead.
+
+### Not logged at any phase
+
+`search_authors(search=…)`, `full_name`, `given_name`, `family_name`, `orcid`, and `doi` are
+personal data about **third parties** — researchers who never interacted with us. "Someone looked
+up Dr. X" is a different record from "Dr. X's publication list is public." Shape only: term count,
+whether it looked like an ORCID. **`intent` is not collected on `search_authors` either**, since an
+intent phrased around a named person reintroduces exactly what the carve-out removes.
+
+### What does not work
+
+**Salted hashing.** The biomedical query space is small and enumerable; a dictionary attack over a
+MeSH vocabulary recovers plaintext in seconds. Not a protection.
+
+**Differential privacy.** Right at Google scale. At this volume Laplace noise swamps the signal.
+
+**Scrubbing after the fact.** Any design where the raw value lands somewhere first and is cleaned
+later has already lost — it is on disk, in a rotation, in a backup.
+
+### Separation is protection
+
+nginx keeps IPs. The app log keeps terms and intent. They must never be joinable: different files,
+different retention, no shared correlation key, and no request id appearing in both. Keeping them
+apart is free and does more than any amount of filtering.
+
+Note for the docs: pseudonymous data is still personal data under GDPR; only genuinely anonymous
+data falls outside it. Phase 6 adds the disclosure. That is a design note, not legal advice —
+worth a second opinion before Phase 4 ships.
+
+---
+
+## Phase 0 — nginx log format — **done**
+
+No app change, no privacy surface.
+
+`$http_mcp_method` added to the `mcp_combined` format in
+`nginx-example-configuration/nginx.conf`. This separates `tools/call` from `tools/list` at the
+edge, which directly validates the cache-hint work on `fix/mcp-cache-tool-catalog` — if
+`tools/list` per client per hour stays high, clients are ignoring `ttlMs` and that branch did not
+achieve what it set out to.
+
+Caveat for any analysis: both `Mcp-Name` and `Mcp-Method` are client-controlled. Treat an empty
+value as "unknown", not as "no tool" / "no method".
+
+**Not yet live.** Per the deployment boundary above, the example config is the deliverable; copying
+it to House and reloading nginx is Bruno's step, and until then this changes nothing about what is
+logged.
+
+---
+
+## Phase 1 — `TelemetryMiddleware`, no query content
+
+The bulk of the value, none of the privacy argument. Ship first and independently.
+
+**New file `gregory_mcp/telemetry.py`:**
+
+- `TelemetryMiddleware(ServerMiddleware)`, passed via `build_server()`'s `MCPServer(middleware=[…])`.
+  Runs inside the SDK's built-in OTel and request-state middleware, so it sees the sealed wire form.
+- Times `call_next`. Emits exactly one JSON line per request through the existing `JsonFormatter`
+  — the `tool` / `duration_ms` / `status_code` fields it already declares and never populates.
+- A `ContextVar` holding an upstream accumulator, set in the middleware and incremented in
+  `GregoryClient.get()`, gives `upstream_ms` and `upstream_calls` without threading state through
+  every tool signature.
+
+**Fields per event:**
+
+| Field | Why |
+|:---|:---|
+| `method`, `tool` | From server-side dispatch, **not** the `Mcp-Name` header |
+| `duration_ms`, `upstream_ms`, `upstream_calls` | Splits our overhead from Django's; doubles as an API profiler |
+| `outcome`, `error_kind` | ok / tool_error / validation_error / upstream_error; `GregoryAPIError` status, `ValueError`, `GregoryPaginationTruncatedError` |
+| `result_count`, `total_count`, `has_next` | Selectivity ("showed 10 of 4,200") and truncation pressure |
+| `params_used` | Sorted list of parameter **names** that were non-None. Never values. |
+| `page`, `page_size` | Is `DEFAULT_PAGE_SIZE = 10` too small? |
+| `subject_id`, `team_id`, `category_slug`, `category_modality` | Public taxonomy IDs, low cardinality, safe |
+| `client_name`, `client_version`, `protocol_version` | From `_meta`; tells us which clients honour cache hints |
+| `cache` | hit / miss / single-flight-wait, for the catalog tools |
+
+No IP. No session id. No free text of any kind at this phase.
+
+**Answers on its own:** zero-result rate per tool (highest-value single metric, broken down by
+`params_used`); parameter coverage — which of `search_articles`' 20 parameters are never used and
+can be cut from the schema; whether the 3 prompts and 2 resources are ever exercised; `tools/list`
+refetch rate; per-endpoint upstream latency; catalog cache hit rate; client mix.
+
+**Tests:** one record per request; `params_used` never contains a value; `search` / `full_name` /
+`orcid` / `doi` never appear in any emitted field (assert explicitly — it is the regression that
+matters); upstream accounting survives retries; a raising tool still emits an event.
+
+**Analysis:** `docker logs gregory-mcp | jq`, same ad-hoc style `docs/07-mcp-server.md` already
+uses for `mcp-access.log`. At these volumes, no sampling and no aggregation infrastructure.
+
+---
+
+## Phase 2 — query shape and taxonomy match
+
+Only after Phase 1 is deployed and the volume is known.
+
+**Tokenizer** (`gregory_mcp/query_shape.py`): lowercase, strip boolean operators and punctuation,
+split, drop stopwords and tokens under 3 characters.
+
+**Taxonomy match:** build the allowlist from `category_terms` + `category_name` on `/categories/`,
+reusing `get_all_pages_cached` — already held and refreshed every 10 minutes.
+
+**Emitted, for `search_articles` / `search_trials` / `list_categories` only:**
+
+- `matched_category_slugs` — closed vocabulary, public, non-personal by construction
+- `unmatched_term_count` — integer only at this phase
+- `term_count`, `has_boolean_ops`, `has_quoted_phrase`, `length_bucket`
+
+**Guardrail:** drop the query from shape analysis entirely if it contains `@`, a digit run of 7+,
+or exceeds a length cap. Cheap insurance against a pasted email or phone number.
+
+Tells us "models search for covered categories and get zero results N% of the time" — directly
+actionable against the corpus and the docstrings.
+
+---
+
+## Phase 3 — zero-result responses become useful
+
+A product change that ships independently of everything else, and the vehicle Phase 4 rides on.
+
+Today `search_articles` with no hits returns `{"count": 0, "articles": []}` — a dead end for the
+model and a wasted signal for us. Replace with a structured response carrying: which filters were
+applied, which are most likely over-constraining, and what to try instead (drop `relevant`, widen
+the date range, call `list_subjects` first).
+
+Worth doing on its own merits — it makes the failure case useful to the model — and it creates the
+natural moment to ask what was actually being looked for.
+
+---
+
+## Phase 4 — `intent` capture, full text
+
+Gated on Phase 1 volume data. If the server is seeing tens of calls a day, this reports nothing
+that could not be learned by reading the log by hand.
+
+### Why this field and not the user's prompt
+
+There is no protocol channel for the user's prompt. The reserved `_meta` keys under 2026-07-28 are
+exactly five — `protocolVersion`, `clientInfo`, `clientCapabilities`, `logLevel`, `serverInfo` —
+and none carries conversation context. `sampling`'s `include_context` came closest and is
+deprecated in the draft spec (`resolve.py:128`). So intent has to be *asked for*, not read.
+
+**And the largest blind spot is structural:** if the model decides we cannot help and never calls
+us, we see nothing. The gaps most worth finding — "user asked about survival curves, we have no
+such data, so the model answered from its own knowledge" — never touch this server. No amount of
+logging fixes that; it bounds what this phase can deliver.
+
+### Mechanism
+
+An optional `intent` parameter on `search_articles` / `search_trials` — model-authored, one short
+phrase describing the information need. Established pattern; the `qmd` MCP server takes exactly
+this on every search call. Works with every client, no capability negotiation.
+
+Parameter description carries the disclosure, so it is visible in the tool schema to anyone who
+inspects the server: *"One short phrase describing the information need. Recorded to identify gaps
+in the corpus. Do not include personal or identifying details."*
+
+**Note on the redaction argument:** the model paraphrasing the user is a *soft* control, weaker
+than it sounds. A helpful model turns "my 7-year-old was just diagnosed with X" into
+`intent="treatment options for paediatric X"` — it drops the first person and keeps the
+identifying triple. The flagging below therefore looks for **specificity patterns**, not just
+first-person phrasing, or it misses the case that matters most on encefalites.pt.
+
+Not collected on `search_authors` (see carve-out above).
+
+### Storage and flagging
+
+- Written to its own stream, separate from the Phase 1 telemetry and from `mcp-access.log`. No
+  shared correlation key.
+- **Rolling 90-day retention, hard delete.** Derived conclusions persist as conclusions; raw rows
+  do not.
+- A heuristic scan on write **flags without blocking**, into a review queue:
+
+| Pattern | Example |
+|:---|:---|
+| Email | `@` between word characters |
+| Phone / long identifiers | digit runs of 7+ |
+| First-person medical | `my/our son\|daughter\|child\|wife\|husband\|mother\|father`, `I was/am diagnosed\|treated` |
+| Age specificity | `N-year-old`, `aged N` |
+| Specificity co-occurrence | an age or geography token alongside a category term |
+
+Flag rate is itself the metric — a near-zero rate is a measured answer to "does this contain PII",
+not an impression.
+
+---
+
+## Phase 5 — the scheduled review
+
+**Trigger:** 1,000 collected intents **or** 6 months from first meaningful traffic, whichever comes
+first. The clock starts at real traffic, not at merge — a quiet first quarter would otherwise mean
+reviewing an empty window and re-confirming nothing.
+
+**Input:** every flagged record, plus a random sample of 100 unflagged ones.
+
+**Outcome, decided against this test rather than by impression:**
+
+| Verdict | Condition | Action |
+|:---|:---|:---|
+| **Pass** | Flag rate < 1% **and** no record in flagged-or-sampled set where an individual could plausibly be identified | Continue. Next review in 12 months. |
+| **Fail** | Any confirmed identifiable record, **or** flag rate ≥ 1% | Stop collecting `intent` text. Delete the current window. Fall back to classification-only. |
+| **Inconclusive** | Fewer than 1,000 intents | Extend; review again at the threshold. |
+
+The 90-day window is what makes **Fail** actionable rather than merely regrettable — the exposure
+drains rather than being permanent.
+
+### Phase 5b — k-anonymised unmatched search terms
+
+Separate, lower priority, **may never ship**. Unmatched terms from Phase 2, logged individually
+with no key joining terms from the same query, timestamps truncated to the hour, 7-day buffer. A
+rollup emits a term only when seen from **≥ k distinct request-hours** over 30 days; everything
+below k is discarded. Purpose: surface vocabulary worth adding categories for, at the point where
+enough distinct people use it that it is no longer identifying.
+
+Honest caveat: at low traffic this suppresses nearly everything. Phase 1 volume data decides
+whether it is worth building at all. `intent` (Phase 4) likely covers the same ground better.
+
+---
+
+## Phase 6 — retention, rotation, docs
+
+- Rotation and explicit retention on all three streams: Phase 1 telemetry, `intent` (90 days), and
+  the Phase 5b buffer (7 days). Aggregates and conclusions kept indefinitely.
+- Confirm nginx and app logs stay unjoinable — no shared request id.
+- New section in `docs/07-mcp-server.md`: what is collected, what is deliberately not, retention
+  windows, the review schedule and its pass/fail. Per `CLAUDE.md`, docs land in the same PR.
+- Revisit the nginx rate limits (30 r/m per client-tool, 120 r/m per client) against real data —
+  `docs/07-mcp-server.md:139` already flags those numbers as guesses.
+
+---
+
+## Explicitly out of scope
+
+**Writing telemetry to Postgres via the Django API.** The stateless, GET-only property is what this
+server's design rests on, and `tests/test_server.py:80` asserts the client exposes no write verbs.
+`APIAccessSchemeLog` exists on the Django side but reaching it means giving this server a write
+path.
+
+**Sampling the client's model to summarise intent.** Technically available. It spends the user's
+tokens and their model's time on our analytics without their agreement, and the conversation-context
+part is deprecated regardless.
+
+**Elicitation as a default.** `ctx.elicit()` is supported and has the best consent story of any
+option here — the person is asked directly and can decline. But it interrupts a conversation and
+needs the client's elicitation capability. Reasonable later as an opt-in "help us improve" mode;
+wrong as always-on.
+
+**Standing up an OTel collector.** The spans are already emitted and already free — enabling them
+needs only `opentelemetry-sdk` plus an exporter behind an env var. But that needs a backend
+running somewhere, and House is already load-sensitive (see `HOUSE-LOAD-SPIKE-PLAN.md`). The
+Phase 1 middleware is written so its attributes can be attached to the existing spans later without
+rework; flipping the exporter on is then a dependency change, not a redesign.
+
+---
+
+## Decisions needed
+
+1. **`intent` retention window.** 90 days is a starting suggestion, not a defended number. Shorter
+   is safer, longer gives the review more to work with.
+2. **Does Phase 5b ship at all?** Defer until Phase 1 reports two weeks of volume. At tens of
+   requests a day, k-anonymity yields nothing and the risk buys no information.
+3. **Second opinion on the GDPR framing** before Phase 4 ships, given the health-research context
+   and the rare-disease instance.

--- a/MCP-TELEMETRY-PLAN.md
+++ b/MCP-TELEMETRY-PLAN.md
@@ -57,6 +57,28 @@ tools, since it's never forwarded to Django).
 Full suite: 156 passed. Phases 5-6 not started — Phase 5 (the scheduled review) can't run for real
 until there's deployed traffic to review.
 
+**PR #831 Copilot review (2026-08-09), 5 findings, all fixed:**
+- `TelemetryMiddleware` read `_LOGGED_ARG_NAMES` values straight from `ctx.params` before schema
+  validation — a malformed/malicious client could put free text in `subject_id`/`category_slug`/etc.
+  and have it logged by value. Fixed with `_sanitized_logged_value`: int fields require a real
+  (non-bool) `int`, `category_slug` must match Django's slug alphabet, `category_modality` must be
+  one of `enums.CategoryModality`'s literal values — anything else is omitted, name-only.
+- `status_code` was a `str` on the protocol-error path but an `int` everywhere else. Now int
+  everywhere.
+- Cache status used undocumented `"wait"`; renamed to `"single-flight-wait"` to match the plan's
+  own taxonomy (`hit` / `miss` / `single-flight-wait`).
+- Both `JsonFormatter` and `IntentJsonFormatter` serialized full tracebacks via `exc_info` —
+  bypassing the explicit-allowlist boundary both formatters otherwise enforce (an exception message
+  can carry a request URL with the raw query string, or an arbitrary `ValueError` message). Now logs
+  only the exception's class name (`exc_type`), never the formatted traceback.
+
+Verified end-to-end (not just unit tests): a `subject_id`/`category_slug` carrying an email and
+`DROP TABLE`-style text produced a telemetry line with only the param *names*, no injected text
+anywhere; a transport error against a URL with a sensitive query string logged only
+`exc_type: "ConnectError"`.
+
+Full suite: 163 passed.
+
 Goal: learn enough about how LLM clients actually use `mcp-server/` to improve it — which tools
 earn their place, which parameters are dead weight in a 17 KB schema payload, where searches come
 back empty, which Gregory API endpoints are the latency floor, and **what people are asking for

--- a/MCP-TELEMETRY-PLAN.md
+++ b/MCP-TELEMETRY-PLAN.md
@@ -34,7 +34,28 @@ with Phase 1/2 telemetry (the new `guidance` dict doesn't perturb `_result_shape
 
 `tests/test_zero_result.py` (11 tests) + new cases in `test_tools_articles.py`/`test_tools_trials.py`.
 
-Full suite: 131 passed. Phases 4-6 not started.
+Phase 4: optional `intent: str | None` param on search_articles/search_trials only (not
+search_authors — the carve-out holds, asserted in tests), disclosed verbatim in the tool's `Args:`
+docstring. `gregory_mcp/intent.py` (`record`, `scan_for_pii`) logs full text to a genuinely separate
+OS stream — stderr, not stdout, `propagate=False`, its own `IntentJsonFormatter` with a 3-field
+allowlist (`tool`/`intent`/`pii_flags`) that structurally cannot emit anything from the telemetry
+stream's field set. Heuristic PII scan flags without blocking: email, long digit run, first-person
+medical, age specificity, and specificity co-occurrence (age/geography token + a taxonomy category
+match, reusing `query_shape.analyze`). Verified end-to-end with a real request carrying an email +
+age-specific intent: stdout showed `intent` only as a name in `params_used`, never its value; stderr
+carried the full text with `pii_flags: ["email", "age_specificity"]`. `specificity_co_occurrence`
+correctly didn't fire there because the email had already tripped `query_shape`'s own guardrail —
+not a bug, the `email` flag already dominates that case.
+
+90-day retention/hard-delete and actual downstream stream routing are deploy-side (Phase 6), not
+implemented here — same boundary as the rest of the plan's retention story.
+
+`tests/test_intent.py` (23 tests) + wiring cases in `test_tools_articles.py`/`test_tools_trials.py`
++ a `test_schema_contract.py` fix (`intent` added to the non-filter-args allowlist for both search
+tools, since it's never forwarded to Django).
+
+Full suite: 156 passed. Phases 5-6 not started — Phase 5 (the scheduled review) can't run for real
+until there's deployed traffic to review.
 
 Goal: learn enough about how LLM clients actually use `mcp-server/` to improve it — which tools
 earn their place, which parameters are dead weight in a 17 KB schema payload, where searches come

--- a/MCP-TELEMETRY-PLAN.md
+++ b/MCP-TELEMETRY-PLAN.md
@@ -1,13 +1,28 @@
 # MCP server telemetry — plan
 
-Status: Phase 1 implemented on `fix/mcp-cache-tool-catalog` (not yet merged/deployed — see the
-deployment boundary below). `gregory_mcp/telemetry.py` (`TelemetryMiddleware`), instrumented
-`client.py`/`cache.py`, extended `logging_config.py`'s field allowlist, and `tests/test_telemetry.py`
-(12 tests). Verified against the real server stack, not just unit tests — driving actual
-`tools/call` requests through `build_server()` surfaced that our tools return plain `dict` with no
-declared output schema, so `CallToolResult.structured_content` is unset on the wire; the shape
-fields (`result_count`/`total_count`/`has_next`) fall back to parsing the same payload out of
-`content[0].text` instead. Phases 2-6 not started.
+Status: Phases 1 and 2 implemented on `fix/mcp-cache-tool-catalog` (not yet merged/deployed — see
+the deployment boundary below).
+
+Phase 1: `gregory_mcp/telemetry.py` (`TelemetryMiddleware`), instrumented `client.py`/`cache.py`,
+extended `logging_config.py`'s field allowlist. Verified against the real server stack, not just
+unit tests — driving actual `tools/call` requests through `build_server()` surfaced that our tools
+return plain `dict` with no declared output schema, so `CallToolResult.structured_content` is unset
+on the wire; the shape fields (`result_count`/`total_count`/`has_next`) fall back to parsing the
+same payload out of `content[0].text` instead.
+
+Phase 2: `gregory_mcp/query_shape.py` (tokenizer, guardrails, taxonomy index/match), wired into
+`TelemetryMiddleware` for `search_articles`/`search_trials`/`list_categories` only, best-effort
+(a taxonomy-fetch failure never breaks the request it's describing). Started against Phase 1 with
+zero real traffic — deliberately, at the user's call, ahead of the plan's own "only after Phase 1
+is deployed" gate; thresholds (stopword list, length buckets, the 400-char/7-digit guardrails) are
+untuned defaults and worth revisiting once real query volume exists. Also surfaced and fixed a
+second real bug the same way: `telemetry.py` importing `query_shape` at module scope created a
+cycle (`telemetry -> query_shape -> cache -> client -> telemetry`, since client.py/cache.py already
+import telemetry.py's `record_*` functions) — fixed with a lazy import inside
+`_annotate_query_shape`, confirmed via a fresh-process import of `gregory_mcp.server`.
+
+`tests/test_telemetry.py` (19 tests) + `tests/test_query_shape.py` (14 tests). Full suite: 116
+passed. Phases 3-6 not started.
 
 Goal: learn enough about how LLM clients actually use `mcp-server/` to improve it — which tools
 earn their place, which parameters are dead weight in a 17 KB schema payload, where searches come

--- a/mcp-server/gregory_mcp/cache.py
+++ b/mcp-server/gregory_mcp/cache.py
@@ -27,6 +27,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from .client import get_client
+from .telemetry import record_cache_status
 
 # The single source of truth for how long the catalog is considered fresh.
 # CacheHint (server.py, the client-facing MCP `ttlMs` hint) and this
@@ -88,13 +89,17 @@ class CatalogCache:
 		key = self._key(path, params)
 		entry = self._entries.get(key)
 		if entry is not None and entry.expires_at > self._clock():
+			record_cache_status("hit")
 			return entry.value
 
 		async with self._lock_for(key):
 			entry = self._entries.get(key)
 			if entry is not None and entry.expires_at > self._clock():
+				# Another caller filled the entry while this one waited on the lock.
+				record_cache_status("wait")
 				return entry.value
 
+			record_cache_status("miss")
 			value = await fetch()
 			self._entries[key] = _Entry(value, self._clock() + self._ttl_seconds)
 			return value

--- a/mcp-server/gregory_mcp/cache.py
+++ b/mcp-server/gregory_mcp/cache.py
@@ -96,7 +96,7 @@ class CatalogCache:
 			entry = self._entries.get(key)
 			if entry is not None and entry.expires_at > self._clock():
 				# Another caller filled the entry while this one waited on the lock.
-				record_cache_status("wait")
+				record_cache_status("single-flight-wait")
 				return entry.value
 
 			record_cache_status("miss")

--- a/mcp-server/gregory_mcp/client.py
+++ b/mcp-server/gregory_mcp/client.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx2
 
 from .config import Settings
+from .telemetry import record_truncation_error, record_upstream_call, record_upstream_error
 
 logger = logging.getLogger("gregory_mcp.client")
 
@@ -103,16 +105,20 @@ class GregoryClient:
 		last_exc: Exception | None = None
 
 		for attempt in range(1, attempts + 1):
+			call_start = time.monotonic()
 			try:
 				response = await self._client.get(path, params=clean_params)
 			except httpx2.TransportError as exc:
+				record_upstream_call((time.monotonic() - call_start) * 1000)
 				last_exc = exc
 				logger.warning("gregory_api_transport_error", extra={"path": path}, exc_info=True)
 				if attempt == attempts:
+					record_upstream_error(0)
 					raise GregoryAPIError(0, f"network error calling {path}: {exc}") from exc
 				await self._sleep(self._backoff_seconds(attempt, None))
 				continue
 
+			record_upstream_call((time.monotonic() - call_start) * 1000)
 			is_retryable = response.status_code >= 500 or response.status_code in _RETRYABLE_CLIENT_STATUS
 			if is_retryable and attempt < attempts:
 				logger.warning(
@@ -122,6 +128,7 @@ class GregoryClient:
 				continue
 
 			if response.status_code >= 400:
+				record_upstream_error(response.status_code)
 				raise GregoryAPIError(response.status_code, response.text[:500])
 
 			return response.json()
@@ -169,6 +176,7 @@ class GregoryClient:
 			if not data.get("next"):
 				return results
 			page += 1
+		record_truncation_error()
 		raise GregoryPaginationTruncatedError(path, max_pages, len(results))
 
 

--- a/mcp-server/gregory_mcp/intent.py
+++ b/mcp-server/gregory_mcp/intent.py
@@ -1,0 +1,104 @@
+"""Model-authored `intent` capture for search_articles/search_trials.
+
+Phase 4 of MCP-TELEMETRY-PLAN.md. Unlike Phase 1/2's bagged, closed-vocabulary
+telemetry, `intent` is stored as the full phrase the model supplied — bagging
+would destroy exactly what makes it useful (the shape of the ask). The
+protection here is exposure duration and review, not content reduction:
+
+- its own log stream (see logging_config.INTENT_LOGGER_NAME /
+  IntentJsonFormatter) — no field this module emits is also emitted on a
+  telemetry.py `mcp_request` line, and neither carries a request id or
+  session id, so the two streams have nothing to join on
+- a 90-day rolling retention / hard delete window (deploy-side, Phase 6)
+- a heuristic PII scan on write that flags without blocking, feeding the
+  scheduled review in the plan's Phase 5
+
+Not collected on search_authors — an intent phrased around a named person
+would reintroduce exactly what that tool's own carve-out removes (see the
+plan's "not logged at any phase").
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from .logging_config import INTENT_LOGGER_NAME
+
+logger = logging.getLogger(INTENT_LOGGER_NAME)
+
+_EMAIL_RE = re.compile(r"[^\s@]+@[^\s@]+")
+_LONG_DIGIT_RUN_RE = re.compile(r"\d{7,}")
+_FIRST_PERSON_MEDICAL_RE = re.compile(
+	r"\b(my|our)\s+(son|daughter|child|wife|husband|mother|father)\b"
+	r"|\bi\s*(?:'m|\s+am|\s+was)\s+(?:being\s+)?(diagnosed|treated)\b",
+	re.IGNORECASE,
+)
+_AGE_RE = re.compile(r"\b\d{1,3}\s*-?\s*years?\s*-?\s*old\b|\baged\s+\d{1,3}\b", re.IGNORECASE)
+
+# Mirrors tools/trials.py's Region literal plus a few generic locational
+# nouns. Deliberately coarse — a cheap heuristic, not an exhaustive gazetteer
+# — and expected to be retuned against real flag-rate data during the
+# Phase 5 review rather than upfront.
+_GEOGRAPHY_HINTS = (
+	"africa", "asia", "europe", "oceania",
+	"hospital", "clinic", "city", "town", "village", "region",
+	"province", "county", "state", "country", "district",
+)
+_GEOGRAPHY_RE = re.compile(r"\b(" + "|".join(_GEOGRAPHY_HINTS) + r")\b", re.IGNORECASE)
+
+
+async def _matches_a_category_term(text: str) -> bool:
+	"""Reuses query_shape's taxonomy match (imported lazily — same
+	telemetry -> query_shape -> cache -> client -> telemetry cycle this
+	module sits inside of) to ask "does this text contain a term from
+	Gregory's own public category vocabulary?" without duplicating the
+	tokenizer/index. A taxonomy-fetch failure degrades to "no match" rather
+	than raising — this is one signal among several, not load-bearing.
+	"""
+	from . import query_shape
+
+	try:
+		shape = await query_shape.analyze(text)
+	except Exception:
+		return False
+	return bool(shape and shape.matched_category_slugs)
+
+
+async def scan_for_pii(text: str) -> list[str]:
+	"""Heuristic flags for `text`. Never blocks — only annotates the record
+	so the Phase 5 review can find it. Order matches the plan's pattern
+	table.
+	"""
+	flags: list[str] = []
+	if _EMAIL_RE.search(text):
+		flags.append("email")
+	if _LONG_DIGIT_RUN_RE.search(text):
+		flags.append("long_digit_run")
+	if _FIRST_PERSON_MEDICAL_RE.search(text):
+		flags.append("first_person_medical")
+
+	has_age = bool(_AGE_RE.search(text))
+	if has_age:
+		flags.append("age_specificity")
+
+	has_geography = bool(_GEOGRAPHY_RE.search(text))
+	if (has_age or has_geography) and await _matches_a_category_term(text):
+		flags.append("specificity_co_occurrence")
+
+	return flags
+
+
+async def record(tool: str, text: str) -> None:
+	"""Logs one intent event to its own stream. Best-effort: a failure here
+	(e.g. the taxonomy fetch inside the PII scan) must never fail the tool
+	call this intent was attached to.
+	"""
+	if not text or not text.strip():
+		return
+	try:
+		flags = await scan_for_pii(text)
+	except Exception:
+		logger.warning("intent_pii_scan_failed", exc_info=True)
+		flags = []
+	logger.info("mcp_intent", extra={"tool": tool, "intent": text, "pii_flags": flags})

--- a/mcp-server/gregory_mcp/logging_config.py
+++ b/mcp-server/gregory_mcp/logging_config.py
@@ -35,6 +35,12 @@ _EXTRA_FIELDS = (
 	"client_version",
 	"protocol_version",
 	"cache",
+	"term_count",
+	"has_boolean_ops",
+	"has_quoted_phrase",
+	"length_bucket",
+	"matched_category_slugs",
+	"unmatched_term_count",
 )
 
 

--- a/mcp-server/gregory_mcp/logging_config.py
+++ b/mcp-server/gregory_mcp/logging_config.py
@@ -8,6 +8,36 @@ import sys
 import time
 
 
+# Explicit allowlist, not "every extra field": this is the boundary that
+# keeps a stray `extra={"search": ...}` elsewhere in the codebase from ever
+# reaching the log. See gregory_mcp/telemetry.py and MCP-TELEMETRY-PLAN.md.
+_EXTRA_FIELDS = (
+	"tool",
+	"duration_ms",
+	"status_code",
+	"path",
+	"method",
+	"outcome",
+	"error_kind",
+	"upstream_ms",
+	"upstream_calls",
+	"result_count",
+	"total_count",
+	"has_next",
+	"params_used",
+	"page",
+	"page_size",
+	"subject_id",
+	"team_id",
+	"category_slug",
+	"category_modality",
+	"client_name",
+	"client_version",
+	"protocol_version",
+	"cache",
+)
+
+
 class JsonFormatter(logging.Formatter):
 	def format(self, record: logging.LogRecord) -> str:
 		payload = {
@@ -16,7 +46,7 @@ class JsonFormatter(logging.Formatter):
 			"logger": record.name,
 			"message": record.getMessage(),
 		}
-		for key in ("tool", "duration_ms", "status_code", "path"):
+		for key in _EXTRA_FIELDS:
 			value = getattr(record, key, None)
 			if value is not None:
 				payload[key] = value

--- a/mcp-server/gregory_mcp/logging_config.py
+++ b/mcp-server/gregory_mcp/logging_config.py
@@ -44,6 +44,22 @@ _EXTRA_FIELDS = (
 )
 
 
+def _add_exc_type(payload: dict, record: logging.LogRecord) -> None:
+	"""Adds the exception's *class name* only — never a formatted traceback.
+
+	A traceback routinely embeds exactly the kind of caller-controlled text
+	this module's two formatters exist to keep out: an httpx transport
+	error's message can carry the full request URL (query string and all),
+	a ValueError's message echoes whatever made it invalid. Both formatters
+	otherwise gate every field through an explicit allowlist for the same
+	reason (see _EXTRA_FIELDS/_INTENT_FIELDS above) — exc_info bypassed that
+	gate entirely until this function existed. The class name alone (e.g.
+	"ConnectError") is diagnostically useful without carrying any of that.
+	"""
+	if record.exc_info:
+		payload["exc_type"] = record.exc_info[0].__name__
+
+
 class JsonFormatter(logging.Formatter):
 	def format(self, record: logging.LogRecord) -> str:
 		payload = {
@@ -56,8 +72,7 @@ class JsonFormatter(logging.Formatter):
 			value = getattr(record, key, None)
 			if value is not None:
 				payload[key] = value
-		if record.exc_info:
-			payload["exc_info"] = self.formatException(record.exc_info)
+		_add_exc_type(payload, record)
 		return json.dumps(payload)
 
 
@@ -83,8 +98,7 @@ class IntentJsonFormatter(logging.Formatter):
 			value = getattr(record, key, None)
 			if value is not None:
 				payload[key] = value
-		if record.exc_info:
-			payload["exc_info"] = self.formatException(record.exc_info)
+		_add_exc_type(payload, record)
 		return json.dumps(payload)
 
 

--- a/mcp-server/gregory_mcp/logging_config.py
+++ b/mcp-server/gregory_mcp/logging_config.py
@@ -61,9 +61,50 @@ class JsonFormatter(logging.Formatter):
 		return json.dumps(payload)
 
 
+# `intent` (Phase 4 of MCP-TELEMETRY-PLAN.md) gets its own tiny, separate
+# allowlist rather than a few more entries on _EXTRA_FIELDS above — so
+# nothing from the telemetry stream's field set (duration_ms, upstream_ms,
+# a request id, ...) can end up on an intent log line even by accident, and
+# so an intent-only field can never end up on a telemetry line either. Two
+# independent boundaries, not one shared one.
+INTENT_LOGGER_NAME = "gregory_mcp.intent"
+_INTENT_FIELDS = ("tool", "intent", "pii_flags")
+
+
+class IntentJsonFormatter(logging.Formatter):
+	def format(self, record: logging.LogRecord) -> str:
+		payload = {
+			"ts": round(time.time(), 3),
+			"level": record.levelname,
+			"logger": record.name,
+			"message": record.getMessage(),
+		}
+		for key in _INTENT_FIELDS:
+			value = getattr(record, key, None)
+			if value is not None:
+				payload[key] = value
+		if record.exc_info:
+			payload["exc_info"] = self.formatException(record.exc_info)
+		return json.dumps(payload)
+
+
 def configure_logging(level: str) -> None:
 	handler = logging.StreamHandler(sys.stdout)
 	handler.setFormatter(JsonFormatter())
 	root = logging.getLogger()
 	root.handlers = [handler]
 	root.setLevel(level)
+
+	# `intent` goes to stderr, not stdout — a distinct OS-level stream, not
+	# just a distinct logger name, so it can be routed and retained
+	# separately downstream (see the plan's "separation is protection").
+	# propagate=False keeps it off the root handler above entirely: an
+	# intent event is written once, to this stream only. Retention (90-day
+	# hard delete) and actual downstream routing are deploy-side — Phase 6,
+	# same boundary as the rest of this file's rotation/retention story.
+	intent_logger = logging.getLogger(INTENT_LOGGER_NAME)
+	intent_handler = logging.StreamHandler(sys.stderr)
+	intent_handler.setFormatter(IntentJsonFormatter())
+	intent_logger.handlers = [intent_handler]
+	intent_logger.propagate = False
+	intent_logger.setLevel(level)

--- a/mcp-server/gregory_mcp/query_shape.py
+++ b/mcp-server/gregory_mcp/query_shape.py
@@ -1,0 +1,125 @@
+"""Query-shape and taxonomy-match analysis for free-text search arguments.
+
+Phase 2 of MCP-TELEMETRY-PLAN.md. The query string itself is never logged —
+only shape counts and matches against Gregory's own public category
+vocabulary (`category_terms` + `category_name` on `/categories/`). Splitting
+the query into individual terms and matching each independently destroys
+co-occurrence (the thing that actually identifies a caller — see the plan's
+"search — bagged" section), while the taxonomy match keeps the output
+alphabet limited to the site's own public category slugs.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .cache import get_all_pages_cached
+
+# A query tripping any of these is dropped from shape analysis entirely
+# rather than attempted-and-redacted — cheap insurance against a pasted
+# email or phone number, per the plan's guardrail.
+_EMAIL_RE = re.compile(r"[^\s@]+@[^\s@]+")
+_LONG_DIGIT_RUN_RE = re.compile(r"\d{7,}")
+_MAX_QUERY_LENGTH = 400
+
+_BOOLEAN_OP_RE = re.compile(r"\b(AND|OR|NOT)\b")
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+# A small, deliberately generic English stopword list — dropping these
+# keeps term_count and the taxonomy match on content words, not glue words.
+# Not biomedical-domain-aware by design: a domain stopword list would need
+# tuning against real query volume, which is exactly what Phase 2 is gated
+# on not having yet (see MCP-TELEMETRY-PLAN.md).
+_STOPWORDS = frozenset(
+	{
+		"the", "and", "or", "not", "for", "with", "from", "into", "onto",
+		"this", "that", "these", "those", "has", "have", "had", "was", "were",
+		"are", "is", "be", "been", "being", "its", "of", "in", "on", "to",
+		"as", "at", "by", "if", "so", "than", "then", "all", "any", "can",
+	}
+)
+
+# (upper length inclusive, label) — checked in order, so keep it ascending.
+_LENGTH_BUCKETS = ((20, "1-20"), (50, "21-50"), (100, "51-100"), (400, "101-400"))
+
+
+@dataclass(frozen=True)
+class QueryShape:
+	term_count: int
+	has_boolean_ops: bool
+	has_quoted_phrase: bool
+	length_bucket: str
+	matched_category_slugs: list[str]
+	unmatched_term_count: int
+
+
+def _length_bucket(length: int) -> str:
+	for ceiling, label in _LENGTH_BUCKETS:
+		if length <= ceiling:
+			return label
+	return _LENGTH_BUCKETS[-1][1]  # pragma: no cover — unreachable below the guardrail's own cap
+
+
+def _looks_identifying(text: str) -> bool:
+	return len(text) > _MAX_QUERY_LENGTH or bool(_EMAIL_RE.search(text) or _LONG_DIGIT_RUN_RE.search(text))
+
+
+def _tokenize(text: str) -> list[str]:
+	return [t for t in _TOKEN_RE.findall(text.lower()) if len(t) >= 3 and t not in _STOPWORDS]
+
+
+class TaxonomyIndex:
+	"""term -> owning category slugs, built from /categories/'s public
+	category_terms + category_name.
+
+	Rebuilt per call rather than cached separately: the categories list it's
+	built from already rides the 10-minute get_all_pages_cached entry every
+	catalog tool shares, and at the volumes Phase 2 is gated on this is a
+	few hundred string operations — not worth a second cache layer ahead of
+	seeing what real traffic looks like.
+	"""
+
+	def __init__(self, categories: list[dict]):
+		self._term_to_slugs: dict[str, set[str]] = {}
+		for category in categories:
+			slug = category.get("category_slug")
+			if not slug:
+				continue
+			terms = [*(category.get("category_terms") or []), category.get("category_name") or ""]
+			for term in terms:
+				for token in _tokenize(term):
+					self._term_to_slugs.setdefault(token, set()).add(slug)
+
+	def match(self, tokens: list[str]) -> tuple[list[str], int]:
+		matched_slugs: set[str] = set()
+		unmatched = 0
+		for token in tokens:
+			slugs = self._term_to_slugs.get(token)
+			if slugs:
+				matched_slugs.update(slugs)
+			else:
+				unmatched += 1
+		return sorted(matched_slugs), unmatched
+
+
+async def analyze(text: str) -> QueryShape | None:
+	"""Shape + taxonomy match for `text`, or None if it's blank or looks
+	like it might carry an identifier — analysis is skipped entirely in
+	that case, not attempted-and-redacted.
+	"""
+	if not text or not text.strip() or _looks_identifying(text):
+		return None
+
+	tokens = _tokenize(text)
+	categories = await get_all_pages_cached("/categories/")
+	matched_slugs, unmatched_term_count = TaxonomyIndex(categories).match(tokens)
+
+	return QueryShape(
+		term_count=len(tokens),
+		has_boolean_ops=bool(_BOOLEAN_OP_RE.search(text)),
+		has_quoted_phrase='"' in text,
+		length_bucket=_length_bucket(len(text)),
+		matched_category_slugs=matched_slugs,
+		unmatched_term_count=unmatched_term_count,
+	)

--- a/mcp-server/gregory_mcp/server.py
+++ b/mcp-server/gregory_mcp/server.py
@@ -15,6 +15,7 @@ from mcp_types import ToolAnnotations
 from .cache import CATALOG_CACHE_TTL_MS
 from .prompts import register_prompts
 from .resources import register_resources
+from .telemetry import TelemetryMiddleware
 from .tools import articles, authors, catalog, stats, trials
 
 READ_ONLY = ToolAnnotations(read_only_hint=True, idempotent_hint=True, open_world_hint=False)
@@ -63,6 +64,7 @@ def build_server() -> MCPServer:
 		),
 		version="0.1.0",
 		cache_hints=CACHE_HINTS,
+		middleware=[TelemetryMiddleware()],
 	)
 
 	server.add_tool(catalog.list_subjects, annotations=READ_ONLY)

--- a/mcp-server/gregory_mcp/server.py
+++ b/mcp-server/gregory_mcp/server.py
@@ -25,6 +25,33 @@ READ_ONLY = ToolAnnotations(read_only_hint=True, idempotent_hint=True, open_worl
 # and share the cached value across callers (nothing in the payload is caller-specific).
 CATALOG_CACHE = CacheHint(ttl_ms=CATALOG_CACHE_TTL_MS, scope="public")
 
+# Tool/prompt schemas and server capabilities are static *between deploys* — unlike
+# the reference data above they change only when this code changes, so they get their
+# own TTL rather than inheriting one that exists to bound data staleness.
+#
+# Worth caching: tools/list alone is ~17 KB (~4.2k tokens) of schemas that otherwise
+# gets refetched on every reconnect, and it lands in the model's system prompt, so
+# refetching it risks invalidating the upstream prompt cache — the "keep upstream
+# prompt caches stable across reconnects" the 2026-07-28 release notes call out.
+#
+# 30 minutes bounds how long a client can hold a stale catalog after a deploy.
+# Staleness here is benign in both directions: a client missing a NEW parameter is
+# merely degraded, and one sending a REMOVED parameter is rejected against the
+# current schema. Neither is the silent-wrong-results failure mode that unknown
+# *API* query params cause, since django-filter ignores those instead of erroring.
+STATIC_CACHE = CacheHint(ttl_ms=30 * 60 * 1000, scope="public")
+
+# Module-level so tests can assert on it: MCPServer keeps no public accessor for
+# the hints it was constructed with, and a missing entry degrades silently to
+# ttlMs=0 ("never cache"), which is indistinguishable from working.
+CACHE_HINTS = {
+	"resources/list": CATALOG_CACHE,
+	"resources/read": CATALOG_CACHE,
+	"tools/list": STATIC_CACHE,
+	"prompts/list": STATIC_CACHE,
+	"server/discover": STATIC_CACHE,
+}
+
 
 def build_server() -> MCPServer:
 	server = MCPServer(
@@ -35,10 +62,7 @@ def build_server() -> MCPServer:
 			"trials, authors, subjects, categories, and sponsors."
 		),
 		version="0.1.0",
-		cache_hints={
-			"resources/list": CATALOG_CACHE,
-			"resources/read": CATALOG_CACHE,
-		},
+		cache_hints=CACHE_HINTS,
 	)
 
 	server.add_tool(catalog.list_subjects, annotations=READ_ONLY)

--- a/mcp-server/gregory_mcp/telemetry.py
+++ b/mcp-server/gregory_mcp/telemetry.py
@@ -1,0 +1,249 @@
+"""Per-request telemetry: one structured JSON log line per inbound MCP request.
+
+Phase 1 of MCP-TELEMETRY-PLAN.md — timing, outcome, and selectivity only.
+No query content (`search`, `full_name`, `given_name`, `family_name`,
+`orcid`, `doi`) is logged at this phase, or ever for the author fields —
+see the plan's "not logged at any phase" section. `params_used` records
+which argument *names* a call supplied, never their values.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from mcp_types import CLIENT_INFO_META_KEY, CallToolResult
+from pydantic import ValidationError
+
+from mcp.server.context import CallNext, HandlerResult, ServerMiddleware, ServerRequestContext
+from mcp.shared.exceptions import MCPError
+
+logger = logging.getLogger("gregory_mcp.telemetry")
+
+# Argument names safe to log by value: public, low-cardinality taxonomy IDs
+# and pagination controls. Never add `search`, `title`, `summary`,
+# `full_name`, `given_name`, `family_name`, `orcid`, `doi`, `condition`,
+# `intervention`, or any other free-text/identifying field here — see
+# MCP-TELEMETRY-PLAN.md's "not logged at any phase".
+_LOGGED_ARG_NAMES = ("page", "page_size", "subject_id", "team_id", "category_slug", "category_modality")
+
+
+@dataclass
+class _UpstreamAccumulator:
+	"""Per-request scratch space.
+
+	`GregoryClient.get()` and `CatalogCache.get_or_fetch()` write into the
+	active request's accumulator as they run; `TelemetryMiddleware` reads it
+	back after `call_next()` returns. A `ContextVar` rather than a parameter
+	threaded through every tool signature — see MCP-TELEMETRY-PLAN.md Phase 1.
+	"""
+
+	upstream_ms: float = 0.0
+	upstream_calls: int = 0
+	error_kind: str | None = None
+	error_status: int | None = None
+	cache_status: str | None = None
+
+
+_accumulator: contextvars.ContextVar["_UpstreamAccumulator | None"] = contextvars.ContextVar(
+	"gregory_mcp_upstream_accumulator", default=None
+)
+
+
+def record_upstream_call(duration_ms: float) -> None:
+	"""Called by GregoryClient.get() after each HTTP attempt (including
+	retries, so upstream_calls > 1 signals a request that hit retry logic)."""
+	acc = _accumulator.get()
+	if acc is not None:
+		acc.upstream_ms += duration_ms
+		acc.upstream_calls += 1
+
+
+def record_upstream_error(status_code: int) -> None:
+	"""Called by GregoryClient.get() immediately before it raises
+	GregoryAPIError — the exception itself is swallowed by the SDK's tool-call
+	handler before it would otherwise reach TelemetryMiddleware, so the status
+	code has to be captured on the way up rather than read off the exception."""
+	acc = _accumulator.get()
+	if acc is not None:
+		acc.error_kind = "upstream_error"
+		acc.error_status = status_code
+
+
+def record_truncation_error() -> None:
+	"""Called by GregoryClient.get_all_pages() before it raises
+	GregoryPaginationTruncatedError, for the same reason as record_upstream_error."""
+	acc = _accumulator.get()
+	if acc is not None:
+		acc.error_kind = "truncation_error"
+
+
+def record_cache_status(status: str) -> None:
+	"""Called by CatalogCache.get_or_fetch() with 'hit', 'miss', or 'wait'."""
+	acc = _accumulator.get()
+	if acc is not None:
+		acc.cache_status = status
+
+
+def _extract_call_tool_result(result: HandlerResult) -> tuple[Any, bool]:
+	"""(payload, is_error) for a tools/call result.
+
+	TelemetryMiddleware is registered innermost (see build_server()), so
+	call_next() here returns the tool-call handler's own result directly —
+	normally a CallToolResult. The dict branch mirrors the wire alias shape
+	defensively, the same way OpenTelemetryMiddleware's own match does.
+
+	None of our tools declare a structured-output schema (they return plain
+	`dict`), so `structured_content` is unset on the wire; the same dict the
+	tool returned is what `content[0].text` holds instead (MCPServer
+	JSON-serializes it there — see func_metadata._convert_to_content). Fall
+	back to parsing that: it's the identical payload already sent to the
+	client, just read from the other place it landed.
+	"""
+	if isinstance(result, CallToolResult):
+		payload = result.structured_content
+		if payload is None:
+			payload = _parse_first_text_block(result.content)
+		return payload, result.is_error
+	if isinstance(result, dict):
+		payload = result.get("structuredContent")
+		if payload is None:
+			payload = _parse_first_text_block(result.get("content"))
+		return payload, bool(result.get("isError", False))
+	return None, False
+
+
+def _parse_first_text_block(content: Any) -> Any:
+	if not content:
+		return None
+	first = content[0]
+	text = getattr(first, "text", None) if not isinstance(first, dict) else first.get("text")
+	if not isinstance(text, str):
+		return None
+	try:
+		return json.loads(text)
+	except ValueError:
+		return None
+
+
+def _result_shape(payload: Any) -> tuple[int | None, int | None, bool | None]:
+	"""(result_count, total_count, has_next) from a tool's returned dict.
+
+	Generic over payload shape rather than special-cased per tool name: every
+	list/search tool's return dict carries `count` (see articles.py,
+	trials.py, authors.py, catalog.py) and, where paginated, `next_page`. The
+	item list itself is under a tool-specific key (`articles`, `trials`,
+	`subjects`, ...) — found here as "the first list-valued entry" rather
+	than naming each one.
+	"""
+	if not isinstance(payload, dict) or "count" not in payload:
+		return None, None, None
+	total_count = payload["count"]
+	has_next = payload.get("next_page") is not None if "next_page" in payload else None
+	result_count = None
+	for value in payload.values():
+		if isinstance(value, list):
+			result_count = len(value)
+			break
+	return result_count, total_count, has_next
+
+
+class TelemetryMiddleware(ServerMiddleware[Any]):
+	"""Emits one JSON log line per inbound request. No query content, ever.
+
+	Registered last in `MCPServer(middleware=[...])`, which the SDK places
+	after its own OpenTelemetry and RequestStateBoundary middleware — so this
+	runs innermost, and `call_next(ctx)` is params validation plus the actual
+	handler dispatch.
+	"""
+
+	async def __call__(self, ctx: ServerRequestContext[Any, Any], call_next: CallNext) -> HandlerResult:
+		if ctx.request_id is None:
+			# Notifications (notifications/cancelled, notifications/initialized, ...)
+			# aren't billable/latency-worthy requests.
+			return await call_next(ctx)
+
+		accumulator = _UpstreamAccumulator()
+		token = _accumulator.set(accumulator)
+		start = time.monotonic()
+		event: dict[str, Any] = {"method": ctx.method, "protocol_version": ctx.protocol_version}
+
+		params = ctx.params or {}
+		tool_name = params.get("name") if ctx.method == "tools/call" else None
+		if isinstance(tool_name, str):
+			event["tool"] = tool_name
+			arguments = params.get("arguments")
+			if isinstance(arguments, dict):
+				event["params_used"] = sorted(k for k, v in arguments.items() if v is not None)
+				for key in _LOGGED_ARG_NAMES:
+					value = arguments.get(key)
+					if value is not None:
+						event[key] = value
+
+		client_info = ctx.meta.get(CLIENT_INFO_META_KEY) if ctx.meta else None
+		if isinstance(client_info, dict):
+			name = client_info.get("name")
+			version = client_info.get("version")
+			if isinstance(name, str):
+				event["client_name"] = name
+			if isinstance(version, str):
+				event["client_version"] = version
+
+		try:
+			result = await call_next(ctx)
+		except MCPError as exc:
+			event["outcome"] = "error"
+			event["error_kind"] = "protocol_error"
+			event["status_code"] = str(exc.error.code)
+			_emit(event, start, accumulator)
+			_accumulator.reset(token)
+			raise
+		except ValidationError:
+			event["outcome"] = "error"
+			event["error_kind"] = "validation_error"
+			_emit(event, start, accumulator)
+			_accumulator.reset(token)
+			raise
+		except Exception:
+			event["outcome"] = "error"
+			event["error_kind"] = accumulator.error_kind or "internal_error"
+			_emit(event, start, accumulator)
+			_accumulator.reset(token)
+			raise
+
+		if ctx.method == "tools/call":
+			payload, is_error = _extract_call_tool_result(result)
+			if is_error:
+				event["outcome"] = "error"
+				event["error_kind"] = accumulator.error_kind or "tool_error"
+				if accumulator.error_status is not None:
+					event["status_code"] = accumulator.error_status
+			else:
+				event["outcome"] = "ok"
+				result_count, total_count, has_next = _result_shape(payload)
+				if result_count is not None:
+					event["result_count"] = result_count
+				if total_count is not None:
+					event["total_count"] = total_count
+				if has_next is not None:
+					event["has_next"] = has_next
+		else:
+			event["outcome"] = "ok"
+
+		_emit(event, start, accumulator)
+		_accumulator.reset(token)
+		return result
+
+
+def _emit(event: dict[str, Any], start: float, accumulator: _UpstreamAccumulator) -> None:
+	event["duration_ms"] = round((time.monotonic() - start) * 1000, 1)
+	if accumulator.upstream_calls:
+		event["upstream_ms"] = round(accumulator.upstream_ms, 1)
+		event["upstream_calls"] = accumulator.upstream_calls
+	if accumulator.cache_status is not None:
+		event["cache"] = accumulator.cache_status
+	logger.info("mcp_request", extra=event)

--- a/mcp-server/gregory_mcp/telemetry.py
+++ b/mcp-server/gregory_mcp/telemetry.py
@@ -1,10 +1,13 @@
 """Per-request telemetry: one structured JSON log line per inbound MCP request.
 
-Phase 1 of MCP-TELEMETRY-PLAN.md — timing, outcome, and selectivity only.
-No query content (`search`, `full_name`, `given_name`, `family_name`,
-`orcid`, `doi`) is logged at this phase, or ever for the author fields —
-see the plan's "not logged at any phase" section. `params_used` records
-which argument *names* a call supplied, never their values.
+Phase 1 of MCP-TELEMETRY-PLAN.md — timing, outcome, and selectivity.
+Phase 2 adds bagged query-shape/taxonomy-match fields for search_articles,
+search_trials, and list_categories (see query_shape.py) — still no query
+content: `search`/`title`/`summary` are analyzed and discarded, never
+logged. `full_name`, `given_name`, `family_name`, `orcid`, `doi` are never
+logged at any phase — see the plan's "not logged at any phase" section.
+`params_used` records which argument *names* a call supplied, never their
+values.
 """
 
 from __future__ import annotations
@@ -23,6 +26,15 @@ from mcp.server.context import CallNext, HandlerResult, ServerMiddleware, Server
 from mcp.shared.exceptions import MCPError
 
 logger = logging.getLogger("gregory_mcp.telemetry")
+
+# Which argument(s) hold the free-text query for a given tool, in
+# preference order (the first one present and non-empty wins). Only these
+# three tools get query-shape analysis — see MCP-TELEMETRY-PLAN.md Phase 2.
+_QUERY_ARGS_BY_TOOL = {
+	"search_articles": ("search", "title", "summary"),
+	"search_trials": ("search", "title", "summary"),
+	"list_categories": ("search",),
+}
 
 # Argument names safe to log by value: public, low-cardinality taxonomy IDs
 # and pagination controls. Never add `search`, `title`, `summary`,
@@ -152,6 +164,43 @@ def _result_shape(payload: Any) -> tuple[int | None, int | None, bool | None]:
 	return result_count, total_count, has_next
 
 
+async def _annotate_query_shape(event: dict[str, Any], tool_name: str, arguments: dict[str, Any]) -> None:
+	"""Adds Phase 2's shape/taxonomy fields to `event` for the three tools
+	that take a free-text query — a no-op for every other tool, and
+	best-effort here: a taxonomy-fetch failure (the Gregory API being down)
+	must never fail the request telemetry is describing, so any exception
+	is swallowed and logged rather than propagated.
+
+	Imports query_shape lazily: query_shape -> cache -> client -> telemetry
+	is a real cycle at module-load time (client.py and cache.py both call
+	back into this module's record_* functions), so this module can only
+	reach query_shape once every module in that chain has finished loading.
+	"""
+	query_arg_names = _QUERY_ARGS_BY_TOOL.get(tool_name)
+	if query_arg_names is None:
+		return
+	text = next((arguments[name] for name in query_arg_names if arguments.get(name)), None)
+	if not isinstance(text, str):
+		return
+
+	from . import query_shape
+
+	try:
+		shape = await query_shape.analyze(text)
+	except Exception:
+		logger.warning("query_shape_analysis_failed", exc_info=True)
+		return
+
+	if shape is None:
+		return
+	event["term_count"] = shape.term_count
+	event["has_boolean_ops"] = shape.has_boolean_ops
+	event["has_quoted_phrase"] = shape.has_quoted_phrase
+	event["length_bucket"] = shape.length_bucket
+	event["matched_category_slugs"] = shape.matched_category_slugs
+	event["unmatched_term_count"] = shape.unmatched_term_count
+
+
 class TelemetryMiddleware(ServerMiddleware[Any]):
 	"""Emits one JSON log line per inbound request. No query content, ever.
 
@@ -183,6 +232,7 @@ class TelemetryMiddleware(ServerMiddleware[Any]):
 					value = arguments.get(key)
 					if value is not None:
 						event[key] = value
+				await _annotate_query_shape(event, tool_name, arguments)
 
 		client_info = ctx.meta.get(CLIENT_INFO_META_KEY) if ctx.meta else None
 		if isinstance(client_info, dict):

--- a/mcp-server/gregory_mcp/telemetry.py
+++ b/mcp-server/gregory_mcp/telemetry.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import contextvars
 import json
 import logging
+import re
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -25,7 +26,14 @@ from pydantic import ValidationError
 from mcp.server.context import CallNext, HandlerResult, ServerMiddleware, ServerRequestContext
 from mcp.shared.exceptions import MCPError
 
+from .enums import CategoryModality
+
 logger = logging.getLogger("gregory_mcp.telemetry")
+
+_CATEGORY_MODALITY_VALUES = frozenset(CategoryModality.__args__)
+# Django's SlugField alphabet: ASCII letters, digits, hyphens, underscores.
+_SLUG_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+_MAX_SLUG_LENGTH = 100
 
 # Which argument(s) hold the free-text query for a given tool, in
 # preference order (the first one present and non-empty wins). Only these
@@ -42,6 +50,29 @@ _QUERY_ARGS_BY_TOOL = {
 # `intervention`, or any other free-text/identifying field here — see
 # MCP-TELEMETRY-PLAN.md's "not logged at any phase".
 _LOGGED_ARG_NAMES = ("page", "page_size", "subject_id", "team_id", "category_slug", "category_modality")
+
+
+def _sanitized_logged_value(key: str, value: Any) -> Any | None:
+	"""The value to log for a `_LOGGED_ARG_NAMES` key, or None to omit it.
+
+	ServerMiddleware runs *before* schema validation (see the class
+	docstring), so this reads the client's raw, unvalidated argument — a
+	malformed or malicious client could send free text in a field the
+	schema would otherwise reject for having the wrong type (e.g.
+	`category_slug: "<arbitrary text>"`), and that text would reach this
+	stdout stream by value before validation ever ran. A basic type/format
+	check here, not trust in the client's claimed type, is what keeps
+	`_LOGGED_ARG_NAMES` honestly limited to "public, low-cardinality" data.
+	"""
+	if key in ("page", "page_size", "subject_id", "team_id"):
+		return value if isinstance(value, int) and not isinstance(value, bool) else None
+	if key == "category_slug":
+		if isinstance(value, str) and len(value) <= _MAX_SLUG_LENGTH and _SLUG_RE.fullmatch(value):
+			return value
+		return None
+	if key == "category_modality":
+		return value if value in _CATEGORY_MODALITY_VALUES else None
+	return None  # pragma: no cover — exhaustive over _LOGGED_ARG_NAMES above
 
 
 @dataclass
@@ -95,7 +126,8 @@ def record_truncation_error() -> None:
 
 
 def record_cache_status(status: str) -> None:
-	"""Called by CatalogCache.get_or_fetch() with 'hit', 'miss', or 'wait'."""
+	"""Called by CatalogCache.get_or_fetch() with 'hit', 'miss', or
+	'single-flight-wait' — matching MCP-TELEMETRY-PLAN.md's documented taxonomy."""
 	acc = _accumulator.get()
 	if acc is not None:
 		acc.cache_status = status
@@ -229,7 +261,7 @@ class TelemetryMiddleware(ServerMiddleware[Any]):
 			if isinstance(arguments, dict):
 				event["params_used"] = sorted(k for k, v in arguments.items() if v is not None)
 				for key in _LOGGED_ARG_NAMES:
-					value = arguments.get(key)
+					value = _sanitized_logged_value(key, arguments.get(key))
 					if value is not None:
 						event[key] = value
 				await _annotate_query_shape(event, tool_name, arguments)
@@ -248,7 +280,7 @@ class TelemetryMiddleware(ServerMiddleware[Any]):
 		except MCPError as exc:
 			event["outcome"] = "error"
 			event["error_kind"] = "protocol_error"
-			event["status_code"] = str(exc.error.code)
+			event["status_code"] = exc.error.code
 			_emit(event, start, accumulator)
 			_accumulator.reset(token)
 			raise

--- a/mcp-server/gregory_mcp/tools/articles.py
+++ b/mcp-server/gregory_mcp/tools/articles.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .. import intent as intent_module
 from ..client import get_client
 from ..compact import compact_article
 from ..enums import CategoryModality
@@ -32,6 +33,7 @@ async def search_articles(
 	published_date_before: str | None = None,
 	last_days: float | None = None,
 	ordering: str | None = None,
+	intent: str | None = None,
 	page: int = 1,
 	page_size: int = DEFAULT_PAGE_SIZE,
 ) -> dict:
@@ -56,7 +58,14 @@ async def search_articles(
 	A zero-hit response adds a `guidance` key: which filters were applied
 	and ranked suggestions for what's most likely over-constraining the
 	search — check that before trying a completely different query.
+
+	Args:
+		intent: One short phrase describing the information need. Recorded
+			separately to identify gaps in the corpus. Do not include
+			personal or identifying details.
 	"""
+	if intent:
+		await intent_module.record("search_articles", intent)
 	clamped_page = clamp_page(page)
 	params = {
 		"search": search,

--- a/mcp-server/gregory_mcp/tools/articles.py
+++ b/mcp-server/gregory_mcp/tools/articles.py
@@ -6,6 +6,7 @@ from ..client import get_client
 from ..compact import compact_article
 from ..enums import CategoryModality
 from ..pagination import clamp_page, clamp_page_size
+from ..zero_result import guidance_for
 
 DEFAULT_PAGE_SIZE = 10
 MAX_PAGE_SIZE = 25
@@ -51,6 +52,10 @@ async def search_articles(
 	older papers Gregory only just ingested. `ordering` accepts
 	discovery_date, published_date, title, article_id, ml_score (prefix `-`
 	for descending).
+
+	A zero-hit response adds a `guidance` key: which filters were applied
+	and ranked suggestions for what's most likely over-constraining the
+	search — check that before trying a completely different query.
 	"""
 	clamped_page = clamp_page(page)
 	params = {
@@ -78,11 +83,15 @@ async def search_articles(
 	}
 	data = await get_client().get("/articles/", params)
 	results = data.get("results", [])
-	return {
-		"count": data.get("count", len(results)),
+	count = data.get("count", len(results))
+	response = {
+		"count": count,
 		"next_page": clamped_page + 1 if data.get("next") else None,
 		"articles": [compact_article(a) for a in results],
 	}
+	if count == 0:
+		response["guidance"] = guidance_for(params)
+	return response
 
 
 async def get_article(article_id: int) -> dict:

--- a/mcp-server/gregory_mcp/tools/trials.py
+++ b/mcp-server/gregory_mcp/tools/trials.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
+from .. import intent as intent_module
 from ..client import get_client
 from ..compact import compact_trial
 from ..enums import CategoryModality
@@ -48,6 +49,7 @@ async def search_trials(
 	has_results: bool | None = None,
 	therapeutic_areas: str | None = None,
 	ordering: str | None = None,
+	intent: str | None = None,
 	page: int = 1,
 	page_size: int = DEFAULT_PAGE_SIZE,
 ) -> dict:
@@ -70,7 +72,14 @@ async def search_trials(
 	A zero-hit response adds a `guidance` key: which filters were applied
 	and ranked suggestions for what's most likely over-constraining the
 	search — check that before trying a completely different query.
+
+	Args:
+		intent: One short phrase describing the information need. Recorded
+			separately to identify gaps in the corpus. Do not include
+			personal or identifying details.
 	"""
+	if intent:
+		await intent_module.record("search_trials", intent)
 	clamped_page = clamp_page(page)
 	params = {
 		"search": search,

--- a/mcp-server/gregory_mcp/tools/trials.py
+++ b/mcp-server/gregory_mcp/tools/trials.py
@@ -8,6 +8,7 @@ from ..client import get_client
 from ..compact import compact_trial
 from ..enums import CategoryModality
 from ..pagination import clamp_page, clamp_page_size
+from ..zero_result import guidance_for
 
 SexEligibility = Literal["all", "female", "male"]
 StudyType = Literal["basic_science", "expanded_access", "interventional", "observational", "other"]
@@ -65,6 +66,10 @@ async def search_trials(
 	Information System number). A European trial commonly only has
 	euct/eudract/ctis, not an nct — use whichever registry the caller
 	already has an ID from.
+
+	A zero-hit response adds a `guidance` key: which filters were applied
+	and ranked suggestions for what's most likely over-constraining the
+	search — check that before trying a completely different query.
 	"""
 	clamped_page = clamp_page(page)
 	params = {
@@ -102,11 +107,15 @@ async def search_trials(
 	}
 	data = await get_client().get("/trials/", params)
 	results = data.get("results", [])
-	return {
-		"count": data.get("count", len(results)),
+	count = data.get("count", len(results))
+	response = {
+		"count": count,
 		"next_page": clamped_page + 1 if data.get("next") else None,
 		"trials": [compact_trial(t) for t in results],
 	}
+	if count == 0:
+		response["guidance"] = guidance_for(params)
+	return response
 
 
 async def get_trial(trial_id: int) -> dict:

--- a/mcp-server/gregory_mcp/zero_result.py
+++ b/mcp-server/gregory_mcp/zero_result.py
@@ -1,0 +1,68 @@
+"""Guidance attached to zero-hit search_articles/search_trials responses.
+
+Phase 3 of MCP-TELEMETRY-PLAN.md. A product change independent of the
+telemetry work: `{"count": 0, "articles": []}` is a dead end for the model
+calling the tool, so a zero-hit response gets a `guidance` key naming which
+filters were applied and ranking suggestions for what's most likely
+over-constraining the search — never the filter *values*, only which
+filter names were set, the same boundary telemetry.py holds for
+`params_used`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Pagination/ordering controls aren't filters that can cause a zero-hit
+# result on their own — excluded from the "applied filters" list so it
+# only ever names things that narrow the result set.
+_NON_FILTER_ARGS = frozenset({"page", "page_size", "ordering"})
+
+# (matching arg names, suggestion). Checked in order, so the categories
+# most likely to silently zero out an otherwise-good search come first.
+# Every arg name here is shared by search_articles and/or search_trials —
+# see their param lists in tools/articles.py and tools/trials.py.
+_RULES: tuple[tuple[tuple[str, ...], str], ...] = (
+	(
+		("relevant", "ml_threshold"),
+		"Drop `relevant`/`ml_threshold` — ML relevance predictions don't cover every "
+		"row, and a high threshold can exclude rows that would otherwise match.",
+	),
+	(
+		("published_date_after", "published_date_before", "last_days",
+		 "date_registration_after", "date_registration_before"),
+		"Widen or drop the date filter — a narrow or recent-only window is the most "
+		"common cause of an empty page.",
+	),
+	(
+		("subject_id", "category_id", "category_slug", "category_modality", "team_id"),
+		"Call list_subjects/list_categories first to confirm the ID or slug is "
+		"correct — a typo'd or stale one silently returns zero rows rather than an error.",
+	),
+	(
+		("nct", "euct", "eudract", "ctis", "acronym", "sponsor_id", "sponsor_slug"),
+		"Double-check the registry ID or sponsor — an unrecognized one returns zero "
+		"rows rather than an error.",
+	),
+	(
+		("search",),
+		"If `search` uses AND/parentheses, try loosening it — an OR, a narrower single "
+		"term, or title=/summary= instead.",
+	),
+)
+
+_FALLBACK_SUGGESTION = "Try a broader search term, or drop optional filters one at a time to see which is excluding everything."
+
+
+def guidance_for(params: dict[str, Any]) -> dict[str, Any]:
+	"""(applied filter names, ranked suggestions) for a zero-hit response.
+
+	`params` is the tool's own param dict before None-pruning — only the
+	*names* of the non-None entries matter here, never their values.
+	"""
+	applied = sorted(k for k, v in params.items() if v is not None and k not in _NON_FILTER_ARGS)
+	applied_set = set(applied)
+	suggestions = [text for arg_names, text in _RULES if applied_set.intersection(arg_names)]
+	if not suggestions:
+		suggestions = [_FALLBACK_SUGGESTION]
+	return {"applied_filters": applied, "suggestions": suggestions}

--- a/mcp-server/tests/test_intent.py
+++ b/mcp-server/tests/test_intent.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import inspect
+import logging
+
+import pytest
+
+import gregory_mcp.intent as intent
+import gregory_mcp.query_shape as query_shape
+from gregory_mcp.logging_config import INTENT_LOGGER_NAME, IntentJsonFormatter
+from gregory_mcp.tools.articles import search_articles
+from gregory_mcp.tools.authors import search_authors
+from gregory_mcp.tools.trials import search_trials
+
+
+def test_intent_is_offered_on_search_articles_and_search_trials_only():
+	assert "intent" in inspect.signature(search_articles).parameters
+	assert "intent" in inspect.signature(search_trials).parameters
+	# An intent phrased around a named person would reintroduce exactly what
+	# search_authors' own carve-out removes — see MCP-TELEMETRY-PLAN.md.
+	assert "intent" not in inspect.signature(search_authors).parameters
+
+
+class _CollectingHandler(logging.Handler):
+	"""Attached directly to the `gregory_mcp.intent` logger rather than via
+	caplog: that logger is configured with propagate=False in production
+	(see logging_config.configure_logging), so a handler that only listens
+	on the root logger — which is how caplog's own capture works — would
+	never see these records regardless of propagate, since a handler
+	attached straight to a logger fires independently of that setting.
+	"""
+
+	def __init__(self):
+		super().__init__()
+		self.records: list[logging.LogRecord] = []
+
+	def emit(self, record):
+		self.records.append(record)
+
+
+@pytest.fixture
+def intent_records():
+	handler = _CollectingHandler()
+	logger = logging.getLogger(INTENT_LOGGER_NAME)
+	logger.addHandler(handler)
+	logger.setLevel(logging.INFO)
+	yield handler.records
+	logger.removeHandler(handler)
+
+
+def _patch_categories(monkeypatch, categories):
+	async def fake_get_all_pages_cached(path, params=None):
+		return categories
+
+	monkeypatch.setattr(query_shape, "get_all_pages_cached", fake_get_all_pages_cached)
+
+
+# --- scan_for_pii -----------------------------------------------------------
+
+
+async def test_email_is_flagged():
+	assert "email" in await intent.scan_for_pii("contact me at jane@example.com")
+
+
+async def test_long_digit_run_is_flagged():
+	assert "long_digit_run" in await intent.scan_for_pii("call 5551234567 please")
+
+
+async def test_short_digit_run_is_not_flagged():
+	flags = await intent.scan_for_pii("trial phase 2026")
+	assert "long_digit_run" not in flags
+
+
+@pytest.mark.parametrize(
+	"phrase",
+	[
+		"treatment options for my son with encephalitis",
+		"our daughter was recently diagnosed",
+		"what helps my wife's condition",
+		"I was diagnosed with a rare disease last year",
+		"I'm being treated for a chronic illness",
+	],
+)
+async def test_first_person_medical_is_flagged(phrase):
+	assert "first_person_medical" in await intent.scan_for_pii(phrase)
+
+
+async def test_third_person_medical_language_is_not_flagged():
+	flags = await intent.scan_for_pii("treatment options for paediatric encephalitis")
+	assert "first_person_medical" not in flags
+
+
+@pytest.mark.parametrize("phrase", ["a 7-year-old with encephalitis", "outcomes in patients aged 7"])
+async def test_age_specificity_is_flagged(phrase):
+	assert "age_specificity" in await intent.scan_for_pii(phrase)
+
+
+async def test_no_flags_for_a_benign_query(monkeypatch):
+	_patch_categories(monkeypatch, [])
+	flags = await intent.scan_for_pii("recent treatment options for multiple sclerosis")
+	assert flags == []
+
+
+async def test_specificity_co_occurrence_needs_both_a_specificity_token_and_a_category_match(monkeypatch):
+	categories = [{"category_slug": "encephalitis", "category_name": "Encephalitis", "category_terms": []}]
+	_patch_categories(monkeypatch, categories)
+
+	# age + matching category term -> co-occurrence flag
+	flags = await intent.scan_for_pii("a 7-year-old with encephalitis")
+	assert "specificity_co_occurrence" in flags
+
+	# age alone, no category match -> no co-occurrence flag (age_specificity still fires)
+	flags2 = await intent.scan_for_pii("a 7-year-old patient")
+	assert "specificity_co_occurrence" not in flags2
+	assert "age_specificity" in flags2
+
+	# category match alone, no age/geography token -> no co-occurrence flag
+	flags3 = await intent.scan_for_pii("treatment for encephalitis")
+	assert "specificity_co_occurrence" not in flags3
+
+
+async def test_geography_token_with_category_match_triggers_co_occurrence(monkeypatch):
+	categories = [{"category_slug": "encephalitis", "category_name": "Encephalitis", "category_terms": []}]
+	_patch_categories(monkeypatch, categories)
+
+	flags = await intent.scan_for_pii("encephalitis cases at the hospital")
+	assert "specificity_co_occurrence" in flags
+
+
+async def test_co_occurrence_check_degrades_gracefully_when_taxonomy_fetch_fails(monkeypatch):
+	async def failing_fetch(path, params=None):
+		raise RuntimeError("upstream unreachable")
+
+	monkeypatch.setattr(query_shape, "get_all_pages_cached", failing_fetch)
+
+	flags = await intent.scan_for_pii("a 7-year-old with encephalitis")
+	assert "specificity_co_occurrence" not in flags
+	assert "age_specificity" in flags  # the other flags still fire
+
+
+# --- record -------------------------------------------------------------
+
+
+async def test_record_emits_exactly_one_event_with_the_expected_fields(intent_records, monkeypatch):
+	_patch_categories(monkeypatch, [])
+
+	await intent.record("search_articles", "treatment options for multiple sclerosis")
+
+	assert len(intent_records) == 1
+	record = intent_records[0]
+	assert record.tool == "search_articles"
+	assert record.intent == "treatment options for multiple sclerosis"
+	assert record.pii_flags == []
+
+
+async def test_record_includes_flags_when_present(intent_records, monkeypatch):
+	_patch_categories(monkeypatch, [])
+
+	await intent.record("search_trials", "contact jane@example.com about this")
+
+	assert intent_records[0].pii_flags == ["email"]
+
+
+async def test_record_is_a_no_op_for_blank_text(intent_records):
+	await intent.record("search_articles", "")
+	await intent.record("search_articles", "   ")
+	assert intent_records == []
+
+
+async def test_record_never_raises_when_the_pii_scan_fails(intent_records, monkeypatch):
+	async def failing_scan(text):
+		raise RuntimeError("scan exploded")
+
+	monkeypatch.setattr(intent, "scan_for_pii", failing_scan)
+
+	await intent.record("search_articles", "some intent text")  # must not raise
+
+	# A warning about the failed scan lands on the same logger too — filter
+	# down to the actual mcp_intent event.
+	events = [r for r in intent_records if r.getMessage() == "mcp_intent"]
+	assert len(events) == 1
+	assert events[0].pii_flags == []
+
+
+async def test_record_never_includes_telemetry_fields():
+	"""No shared correlation key with telemetry.py's mcp_request events —
+	assert at the call site that record() only ever passes the intent
+	stream's own three fields, never a request id or anything else.
+	"""
+	import logging as _logging
+
+	captured = {}
+	original_makeRecord = _logging.Logger.makeRecord
+
+	def spy(self, *args, **kwargs):
+		rec = original_makeRecord(self, *args, **kwargs)
+		if self.name == "gregory_mcp.intent":
+			captured.update(rec.__dict__)
+		return rec
+
+	_logging.Logger.makeRecord = spy
+	try:
+		await intent.record("search_articles", "benign query about a rare disease")
+	finally:
+		_logging.Logger.makeRecord = original_makeRecord
+
+	standard_attrs = {
+		"name", "msg", "args", "levelname", "levelno", "pathname", "filename", "module",
+		"exc_info", "exc_text", "stack_info", "lineno", "funcName", "created", "msecs",
+		"relativeCreated", "thread", "threadName", "processName", "process", "message", "taskName",
+	}
+	extra_fields = {k for k in captured if k not in standard_attrs}
+	assert extra_fields == {"tool", "intent", "pii_flags"}
+
+
+# --- IntentJsonFormatter -------------------------------------------------
+
+
+def test_intent_formatter_only_emits_its_own_tiny_allowlist():
+	formatter = IntentJsonFormatter()
+	logger = logging.getLogger("test.intent.formatter")
+	record = logger.makeRecord(
+		logger.name,
+		logging.INFO,
+		__file__,
+		0,
+		"mcp_intent",
+		(),
+		None,
+		extra={
+			"tool": "search_articles",
+			"intent": "some intent text",
+			"pii_flags": ["email"],
+			# Fields that belong to the *other* stream — must never leak through here.
+			"duration_ms": 12.3,
+			"upstream_ms": 5.0,
+			"params_used": ["search"],
+		},
+	)
+	import json
+
+	payload = json.loads(formatter.format(record))
+	assert payload["tool"] == "search_articles"
+	assert payload["intent"] == "some intent text"
+	assert payload["pii_flags"] == ["email"]
+	assert "duration_ms" not in payload
+	assert "upstream_ms" not in payload
+	assert "params_used" not in payload

--- a/mcp-server/tests/test_logging_config.py
+++ b/mcp-server/tests/test_logging_config.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import logging
+import sys
+
+from gregory_mcp.logging_config import IntentJsonFormatter, JsonFormatter
+
+
+def _make_record_with_exc_info(logger_name: str, exc_message: str) -> logging.LogRecord:
+	logger = logging.getLogger(logger_name)
+	try:
+		raise ValueError(exc_message)
+	except ValueError:
+		return logger.makeRecord(logger.name, logging.WARNING, __file__, 0, "something_failed", (), sys.exc_info())
+
+
+def test_json_formatter_logs_exception_type_never_a_traceback():
+	record = _make_record_with_exc_info("gregory_mcp.client", "GET https://gregory.test/articles/?search=SENSITIVE-marker failed")
+
+	payload = json.loads(JsonFormatter().format(record))
+
+	assert payload["exc_type"] == "ValueError"
+	assert "exc_info" not in payload
+	assert "SENSITIVE-marker" not in json.dumps(payload)
+	assert "Traceback" not in json.dumps(payload)
+
+
+def test_intent_json_formatter_logs_exception_type_never_a_traceback():
+	record = _make_record_with_exc_info("gregory_mcp.intent", "taxonomy fetch failed for SENSITIVE-intent-text")
+
+	payload = json.loads(IntentJsonFormatter().format(record))
+
+	assert payload["exc_type"] == "ValueError"
+	assert "exc_info" not in payload
+	assert "SENSITIVE-intent-text" not in json.dumps(payload)
+
+
+def test_json_formatter_omits_exc_type_when_there_is_no_exception():
+	record = logging.getLogger("gregory_mcp.telemetry").makeRecord(
+		"gregory_mcp.telemetry", logging.INFO, __file__, 0, "mcp_request", (), None
+	)
+	payload = json.loads(JsonFormatter().format(record))
+	assert "exc_type" not in payload

--- a/mcp-server/tests/test_query_shape.py
+++ b/mcp-server/tests/test_query_shape.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import gregory_mcp.query_shape as query_shape
+
+_CATEGORIES = [
+	{
+		"category_slug": "encephalitis",
+		"category_name": "Encephalitis",
+		"category_terms": ["encephalitis", "brain inflammation"],
+	},
+	{
+		"category_slug": "rituximab-therapy",
+		"category_name": "Rituximab Therapy",
+		"category_terms": ["rituximab", "anti-cd20"],
+	},
+	{
+		# No slug — a category_slug can be blank per the model (SlugField(blank=True)) — must be skipped.
+		"category_slug": None,
+		"category_name": "Unslugged",
+		"category_terms": ["orphanterm"],
+	},
+]
+
+
+def _patch_categories(monkeypatch, categories=_CATEGORIES):
+	async def fake_get_all_pages_cached(path, params=None):
+		assert path == "/categories/"
+		return categories
+
+	monkeypatch.setattr(query_shape, "get_all_pages_cached", fake_get_all_pages_cached)
+
+
+async def test_blank_text_returns_none(monkeypatch):
+	_patch_categories(monkeypatch)
+	assert await query_shape.analyze("") is None
+	assert await query_shape.analyze("   ") is None
+
+
+async def test_email_guardrail_returns_none(monkeypatch):
+	_patch_categories(monkeypatch)
+	assert await query_shape.analyze("contact jane@example.com about encephalitis") is None
+
+
+async def test_long_digit_run_guardrail_returns_none(monkeypatch):
+	_patch_categories(monkeypatch)
+	assert await query_shape.analyze("phone 5551234567 encephalitis") is None
+
+
+async def test_short_digit_run_is_not_guarded(monkeypatch):
+	_patch_categories(monkeypatch)
+	# 6 digits (e.g. a year range or short code) stays under the 7-digit guardrail.
+	shape = await query_shape.analyze("study 202601 encephalitis")
+	assert shape is not None
+
+
+async def test_over_length_guardrail_returns_none(monkeypatch):
+	_patch_categories(monkeypatch)
+	assert await query_shape.analyze("x" * 401) is None
+
+
+async def test_term_count_drops_stopwords_and_short_tokens(monkeypatch):
+	_patch_categories(monkeypatch)
+	shape = await query_shape.analyze("the of a rituximab and encephalitis")
+	assert shape is not None
+	# "the", "of", "a", "and" are stopwords/too short; "rituximab" and "encephalitis" remain.
+	assert shape.term_count == 2
+
+
+async def test_has_boolean_ops_detects_uppercase_operators(monkeypatch):
+	_patch_categories(monkeypatch)
+	shape = await query_shape.analyze("encephalitis AND rituximab")
+	assert shape.has_boolean_ops is True
+
+
+async def test_has_boolean_ops_false_for_lowercase(monkeypatch):
+	_patch_categories(monkeypatch)
+	shape = await query_shape.analyze("encephalitis and rituximab")
+	assert shape.has_boolean_ops is False
+
+
+async def test_has_quoted_phrase(monkeypatch):
+	_patch_categories(monkeypatch)
+	shape = await query_shape.analyze('"acute encephalitis"')
+	assert shape.has_quoted_phrase is True
+
+	shape2 = await query_shape.analyze("acute encephalitis")
+	assert shape2.has_quoted_phrase is False
+
+
+async def test_length_bucket_boundaries(monkeypatch):
+	_patch_categories(monkeypatch)
+	assert (await query_shape.analyze("x" * 20)).length_bucket == "1-20"
+	assert (await query_shape.analyze("x" * 21)).length_bucket == "21-50"
+	assert (await query_shape.analyze("x" * 50)).length_bucket == "21-50"
+	assert (await query_shape.analyze("x" * 51)).length_bucket == "51-100"
+	assert (await query_shape.analyze("x" * 100)).length_bucket == "51-100"
+	assert (await query_shape.analyze("x" * 101)).length_bucket == "101-400"
+	assert (await query_shape.analyze("x" * 400)).length_bucket == "101-400"
+
+
+async def test_taxonomy_match_returns_slugs_and_unmatched_count(monkeypatch):
+	_patch_categories(monkeypatch)
+	shape = await query_shape.analyze("encephalitis rituximab paediatric")
+	assert shape.matched_category_slugs == ["encephalitis", "rituximab-therapy"]
+	# "paediatric" doesn't match any category term/name.
+	assert shape.unmatched_term_count == 1
+
+
+async def test_category_without_a_slug_is_excluded_from_the_index(monkeypatch):
+	_patch_categories(monkeypatch)
+	shape = await query_shape.analyze("orphanterm")
+	assert shape.matched_category_slugs == []
+	assert shape.unmatched_term_count == 1
+
+
+async def test_a_term_matching_two_categories_reports_both_slugs(monkeypatch):
+	categories = [
+		{"category_slug": "a", "category_name": "Group A", "category_terms": ["shared"]},
+		{"category_slug": "b", "category_name": "Group B", "category_terms": ["shared"]},
+	]
+	_patch_categories(monkeypatch, categories)
+	shape = await query_shape.analyze("shared")
+	assert shape.matched_category_slugs == ["a", "b"]
+	assert shape.unmatched_term_count == 0
+
+
+async def test_no_categories_matches_nothing(monkeypatch):
+	_patch_categories(monkeypatch, categories=[])
+	shape = await query_shape.analyze("encephalitis")
+	assert shape.matched_category_slugs == []
+	assert shape.unmatched_term_count == 1

--- a/mcp-server/tests/test_schema_contract.py
+++ b/mcp-server/tests/test_schema_contract.py
@@ -38,8 +38,10 @@ def schema_params() -> dict[str, set[str]]:
 # (tool function, endpoint path, arg names that are NOT query filters — path
 # params, tool-only dispatch flags, etc.)
 TOOL_ENDPOINTS = [
-	(articles.search_articles, "/articles/", set()),
-	(trials.search_trials, "/trials/", set()),
+	# `intent` (MCP-TELEMETRY-PLAN.md Phase 4) is model-authored telemetry,
+	# never forwarded to Django as a query param — a tool-only dispatch flag.
+	(articles.search_articles, "/articles/", {"intent"}),
+	(trials.search_trials, "/trials/", {"intent"}),
 	(authors.search_authors, "/authors/", set()),
 	(catalog.list_subjects, "/subjects/", set()),
 	(catalog.list_categories, "/categories/", set()),

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -47,11 +47,14 @@ async def test_server_registers_three_prompts(server):
 	}
 
 
-def test_every_cacheable_list_method_carries_a_hint():
+def test_every_cacheable_method_carries_a_hint():
 	"""A missing cache hint means ttlMs=0 — "never cache" — which is the SDK
 	default and therefore fails silently. tools/list is ~17 KB of schemas that
 	lands in the model's system prompt, so losing this hint quietly reintroduces
 	a refetch on every reconnect. Assert the wiring rather than trusting it.
+
+	Not only *list* methods: resources/read and server/discover are cacheable
+	too, and are covered here for the same reason.
 
 	Asserts the dict we pass in, not the server: MCPServer exposes no accessor
 	for the hints it was constructed with. That the SDK honours them was verified
@@ -59,7 +62,13 @@ def test_every_cacheable_list_method_carries_a_hint():
 	"""
 	from gregory_mcp.server import CACHE_HINTS as hints
 
-	for method in ("tools/list", "prompts/list", "resources/list", "resources/read"):
+	for method in (
+		"tools/list",
+		"prompts/list",
+		"resources/list",
+		"resources/read",
+		"server/discover",
+	):
 		assert method in hints, f"{method} has no cache hint — clients will refetch it every time"
 		assert hints[method].ttl_ms > 0, f"{method} hint is ttl_ms=0, same as no hint at all"
 		assert hints[method].scope == "public", (

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -47,6 +47,27 @@ async def test_server_registers_three_prompts(server):
 	}
 
 
+def test_every_cacheable_list_method_carries_a_hint():
+	"""A missing cache hint means ttlMs=0 — "never cache" — which is the SDK
+	default and therefore fails silently. tools/list is ~17 KB of schemas that
+	lands in the model's system prompt, so losing this hint quietly reintroduces
+	a refetch on every reconnect. Assert the wiring rather than trusting it.
+
+	Asserts the dict we pass in, not the server: MCPServer exposes no accessor
+	for the hints it was constructed with. That the SDK honours them was verified
+	on the wire (tools/list -> ttlMs 1800000, scope public).
+	"""
+	from gregory_mcp.server import CACHE_HINTS as hints
+
+	for method in ("tools/list", "prompts/list", "resources/list", "resources/read"):
+		assert method in hints, f"{method} has no cache hint — clients will refetch it every time"
+		assert hints[method].ttl_ms > 0, f"{method} hint is ttl_ms=0, same as no hint at all"
+		assert hints[method].scope == "public", (
+			f"{method} is identical for every caller (this server has no auth), "
+			"so a shared cache should be allowed to serve it"
+		)
+
+
 def test_client_exposes_no_write_methods():
 	"""The server issues GET only — assert the client has no write verbs at all."""
 	for verb in ("post", "put", "patch", "delete"):

--- a/mcp-server/tests/test_telemetry.py
+++ b/mcp-server/tests/test_telemetry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import httpx2
@@ -102,6 +103,74 @@ async def test_emits_one_record_for_a_successful_tool_call(caplog):
 	assert "duration_ms" in fields
 
 
+def test_sanitized_logged_value_rejects_wrong_types_and_bad_formats():
+	# int-typed fields: only real, non-bool ints pass.
+	assert telemetry._sanitized_logged_value("subject_id", 3) == 3
+	assert telemetry._sanitized_logged_value("subject_id", "3") is None
+	assert telemetry._sanitized_logged_value("page", True) is None  # bool is an int subclass
+
+	# category_slug: Django's SlugField alphabet only, length-capped.
+	assert telemetry._sanitized_logged_value("category_slug", "encephalitis-2026") == "encephalitis-2026"
+	assert telemetry._sanitized_logged_value("category_slug", "not a slug!") is None
+	assert telemetry._sanitized_logged_value("category_slug", "x" * 101) is None
+	assert telemetry._sanitized_logged_value("category_slug", 123) is None
+
+	# category_modality: must be one of the declared literal values.
+	assert telemetry._sanitized_logged_value("category_modality", "small_molecule") == "small_molecule"
+	assert telemetry._sanitized_logged_value("category_modality", "made-up-value") is None
+
+
+async def test_pre_validation_free_text_in_a_logged_arg_is_never_logged_by_value(caplog):
+	"""ServerMiddleware runs before schema validation, so a malformed or
+	malicious client can send a string where the schema expects an int, or
+	free text where it expects a slug — this must never reach the log by
+	value just because the field name is on _LOGGED_ARG_NAMES.
+	"""
+
+	async def call_next(ctx):
+		return CallToolResult(content=[], structured_content={"count": 0, "articles": []})
+
+	ctx = _make_ctx(
+		params={
+			"name": "search_articles",
+			"arguments": {
+				"subject_id": "contact me at jane@example.com",  # schema expects int
+				"category_slug": "not a real slug; DROP TABLE articles",
+				"category_modality": "totally-made-up-modality",
+				"page": "1 OR 1=1",
+			},
+		}
+	)
+	await TelemetryMiddleware()(ctx, call_next)
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
+	fields = _record_fields(records[0])
+	# Names still show up in params_used (that's names-only, always safe)...
+	assert fields["params_used"] == ["category_modality", "category_slug", "page", "subject_id"]
+	# ...but none of the malformed values were logged by value.
+	assert "subject_id" not in fields
+	assert "category_slug" not in fields
+	assert "category_modality" not in fields
+	assert "page" not in fields
+	assert "jane@example.com" not in repr(fields)
+	assert "DROP TABLE" not in repr(fields)
+
+
+async def test_a_well_formed_category_slug_is_still_logged_by_value(caplog):
+	async def call_next(ctx):
+		return CallToolResult(content=[], structured_content={"count": 0, "articles": []})
+
+	ctx = _make_ctx(
+		params={"name": "search_articles", "arguments": {"category_slug": "encephalitis-2026", "category_modality": "small_molecule"}}
+	)
+	await TelemetryMiddleware()(ctx, call_next)
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
+	fields = _record_fields(records[0])
+	assert fields["category_slug"] == "encephalitis-2026"
+	assert fields["category_modality"] == "small_molecule"
+
+
 async def test_result_shape_falls_back_to_the_text_content_block(caplog):
 	"""None of our tools declare an output schema (they return plain dict),
 	so structured_content is unset on the real wire — confirmed by driving
@@ -182,6 +251,11 @@ async def test_raising_tool_call_still_emits_an_event(caplog):
 	fields = _record_fields(records[0])
 	assert fields["outcome"] == "error"
 	assert fields["error_kind"] == "protocol_error"
+	# Numeric like every other status_code this middleware emits (upstream_error,
+	# tool_error), not a str — keeps downstream aggregation (ranges, histograms)
+	# from needing a special case for the protocol_error path.
+	assert fields["status_code"] == INTERNAL_ERROR
+	assert isinstance(fields["status_code"], int)
 
 
 async def test_tool_error_result_is_recorded_as_error_outcome(caplog):
@@ -432,6 +506,39 @@ async def test_cache_status_hit_then_miss_recorded_on_accumulator():
 		assert accumulator.cache_status == "hit"
 	finally:
 		telemetry._accumulator.reset(token)
+
+
+async def test_cache_status_single_flight_wait_recorded_on_accumulator():
+	"""A concurrent caller that waits on the lock and finds another caller's
+	fetch already landed should record 'single-flight-wait' — matching
+	MCP-TELEMETRY-PLAN.md's documented taxonomy of hit / miss /
+	single-flight-wait exactly (not the older, undocumented 'wait').
+	"""
+	cache = CatalogCache()
+	release = asyncio.Event()
+
+	async def slow_fetch():
+		await release.wait()
+		return ["row"]
+
+	async def call_with_accumulator():
+		accumulator = _UpstreamAccumulator()
+		token = telemetry._accumulator.set(accumulator)
+		try:
+			await cache.get_or_fetch("/categories/", None, slow_fetch)
+			return accumulator.cache_status
+		finally:
+			telemetry._accumulator.reset(token)
+
+	winner_task = asyncio.create_task(call_with_accumulator())
+	await asyncio.sleep(0.01)  # let the winner reach the fetch/lock first
+	waiter_task = asyncio.create_task(call_with_accumulator())
+	await asyncio.sleep(0.01)  # let the waiter block on the lock
+	release.set()
+
+	winner_status, waiter_status = await asyncio.gather(winner_task, waiter_task)
+	assert winner_status == "miss"
+	assert waiter_status == "single-flight-wait"
 
 
 async def test_no_accumulator_active_is_a_silent_no_op():

--- a/mcp-server/tests/test_telemetry.py
+++ b/mcp-server/tests/test_telemetry.py
@@ -86,7 +86,7 @@ async def test_emits_one_record_for_a_successful_tool_call(caplog):
 	result = await TelemetryMiddleware()(ctx, call_next)
 
 	assert result.structured_content["articles"] == [1, 2, 3]
-	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
 	assert len(records) == 1
 
 	fields = _record_fields(records[0])
@@ -118,7 +118,7 @@ async def test_result_shape_falls_back_to_the_text_content_block(caplog):
 	ctx = _make_ctx(params={"name": "search_articles", "arguments": {"subject_id": 3}})
 	await TelemetryMiddleware()(ctx, call_next)
 
-	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
 	assert len(records) == 1
 	fields = _record_fields(records[0])
 	assert fields["result_count"] == 2
@@ -141,7 +141,7 @@ async def test_params_used_lists_names_never_values(caplog):
 	)
 	await TelemetryMiddleware()(ctx, call_next)
 
-	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
 	assert len(records) == 1
 	fields = _record_fields(records[0])
 	assert fields["params_used"] == ["search", "subject_id"]
@@ -156,7 +156,7 @@ async def test_sensitive_fields_never_appear_in_any_emitted_field(caplog):
 	ctx = _make_ctx(params={"name": "search_authors", "arguments": arguments})
 	await TelemetryMiddleware()(ctx, call_next)
 
-	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
 	assert len(records) == 1
 	fields = _record_fields(records[0])
 
@@ -177,7 +177,7 @@ async def test_raising_tool_call_still_emits_an_event(caplog):
 	with pytest.raises(MCPError):
 		await TelemetryMiddleware()(ctx, call_next)
 
-	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
 	assert len(records) == 1
 	fields = _record_fields(records[0])
 	assert fields["outcome"] == "error"
@@ -199,11 +199,129 @@ async def test_tool_error_result_is_recorded_as_error_outcome(caplog):
 	result = await TelemetryMiddleware()(ctx, call_next)
 	assert result.is_error
 
-	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
 	assert len(records) == 1
 	fields = _record_fields(records[0])
 	assert fields["outcome"] == "error"
 	assert fields["error_kind"] == "tool_error"
+
+
+_QUERY_SHAPE_CATEGORIES = [
+	{"category_slug": "encephalitis", "category_name": "Encephalitis", "category_terms": ["encephalitis"]},
+]
+
+
+def _patch_categories(monkeypatch, categories=_QUERY_SHAPE_CATEGORIES):
+	import gregory_mcp.query_shape as query_shape
+
+	async def fake_get_all_pages_cached(path, params=None):
+		return categories
+
+	monkeypatch.setattr(query_shape, "get_all_pages_cached", fake_get_all_pages_cached)
+
+
+async def test_search_articles_gets_query_shape_fields(caplog, monkeypatch):
+	_patch_categories(monkeypatch)
+
+	async def call_next(ctx):
+		return CallToolResult(content=[], structured_content={"count": 0, "articles": []})
+
+	ctx = _make_ctx(params={"name": "search_articles", "arguments": {"search": "encephalitis outcomes"}})
+	await TelemetryMiddleware()(ctx, call_next)
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
+	assert len(records) == 1
+	fields = _record_fields(records[0])
+	assert fields["term_count"] == 2
+	assert fields["matched_category_slugs"] == ["encephalitis"]
+	assert fields["unmatched_term_count"] == 1
+	assert fields["has_boolean_ops"] is False
+	assert fields["has_quoted_phrase"] is False
+	assert "length_bucket" in fields
+	assert "encephalitis outcomes" not in repr(fields)
+
+
+async def test_search_trials_falls_back_to_title_when_search_is_absent(caplog, monkeypatch):
+	_patch_categories(monkeypatch)
+
+	async def call_next(ctx):
+		return CallToolResult(content=[], structured_content={"count": 0, "trials": []})
+
+	ctx = _make_ctx(params={"name": "search_trials", "arguments": {"title": "encephalitis"}})
+	await TelemetryMiddleware()(ctx, call_next)
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
+	fields = _record_fields(records[0])
+	assert fields["matched_category_slugs"] == ["encephalitis"]
+
+
+async def test_list_categories_uses_its_own_search_argument(caplog, monkeypatch):
+	_patch_categories(monkeypatch)
+
+	async def call_next(ctx):
+		return CallToolResult(content=[], structured_content={"count": 0, "categories": []})
+
+	ctx = _make_ctx(params={"name": "list_categories", "arguments": {"search": "encephalitis"}})
+	await TelemetryMiddleware()(ctx, call_next)
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
+	fields = _record_fields(records[0])
+	assert fields["matched_category_slugs"] == ["encephalitis"]
+
+
+async def test_tools_outside_the_query_shape_allowlist_get_no_shape_fields(caplog, monkeypatch):
+	_patch_categories(monkeypatch)
+
+	async def call_next(ctx):
+		return CallToolResult(content=[], structured_content={"id": 1})
+
+	ctx = _make_ctx(params={"name": "get_article", "arguments": {"article_id": 1}})
+	await TelemetryMiddleware()(ctx, call_next)
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
+	fields = _record_fields(records[0])
+	assert "term_count" not in fields
+	assert "matched_category_slugs" not in fields
+
+
+async def test_query_shape_guardrail_hit_means_no_shape_fields_at_all(caplog, monkeypatch):
+	_patch_categories(monkeypatch)
+
+	async def call_next(ctx):
+		return CallToolResult(content=[], structured_content={"count": 0, "articles": []})
+
+	ctx = _make_ctx(params={"name": "search_articles", "arguments": {"search": "contact jane@example.com"}})
+	await TelemetryMiddleware()(ctx, call_next)
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
+	fields = _record_fields(records[0])
+	assert "term_count" not in fields
+	assert "jane@example.com" not in repr(fields)
+
+
+async def test_query_shape_fetch_failure_does_not_break_the_request(caplog, monkeypatch):
+	"""The Gregory API being unreachable for the taxonomy fetch must not
+	fail the tool call telemetry is describing — it's a best-effort
+	annotation, not a requirement."""
+	import gregory_mcp.query_shape as query_shape
+
+	async def failing_fetch(path, params=None):
+		raise RuntimeError("upstream unreachable")
+
+	monkeypatch.setattr(query_shape, "get_all_pages_cached", failing_fetch)
+
+	async def call_next(ctx):
+		return CallToolResult(content=[], structured_content={"count": 0, "articles": []})
+
+	ctx = _make_ctx(params={"name": "search_articles", "arguments": {"search": "encephalitis"}})
+	result = await TelemetryMiddleware()(ctx, call_next)
+	assert not result.is_error
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
+	assert len(records) == 1
+	fields = _record_fields(records[0])
+	assert fields["outcome"] == "ok"
+	assert "term_count" not in fields
 
 
 async def test_notifications_are_not_logged(caplog):
@@ -213,7 +331,7 @@ async def test_notifications_are_not_logged(caplog):
 	ctx = _make_ctx(method="notifications/cancelled", params={}, request_id=None)
 	await TelemetryMiddleware()(ctx, call_next)
 
-	assert [r for r in caplog.records if r.name == "gregory_mcp.telemetry"] == []
+	assert [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"] == []
 
 
 async def test_non_tool_method_gets_ok_outcome_without_a_tool_field(caplog):
@@ -223,7 +341,7 @@ async def test_non_tool_method_gets_ok_outcome_without_a_tool_field(caplog):
 	ctx = _make_ctx(method="tools/list", params=None)
 	await TelemetryMiddleware()(ctx, call_next)
 
-	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
 	assert len(records) == 1
 	fields = _record_fields(records[0])
 	assert fields["method"] == "tools/list"
@@ -242,7 +360,7 @@ async def test_client_name_version_and_protocol_version_captured(caplog):
 	)
 	await TelemetryMiddleware()(ctx, call_next)
 
-	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry" and r.getMessage() == "mcp_request"]
 	fields = _record_fields(records[0])
 	assert fields["client_name"] == "some-client"
 	assert fields["client_version"] == "1.2.3"

--- a/mcp-server/tests/test_telemetry.py
+++ b/mcp-server/tests/test_telemetry.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import logging
+
+import httpx2
+import pytest
+from mcp.server.context import ServerRequestContext
+from mcp.shared.exceptions import MCPError
+from mcp_types import CLIENT_INFO_META_KEY, INTERNAL_ERROR, CallToolResult, TextContent
+
+from gregory_mcp import telemetry
+from gregory_mcp.cache import CatalogCache
+from gregory_mcp.client import GregoryAPIError, GregoryClient
+from gregory_mcp.telemetry import TelemetryMiddleware, _UpstreamAccumulator
+from tests.conftest import TEST_SETTINGS
+
+# Distinctive marker strings for the fields that must never reach a log
+# line, however the field arrived (as an argument value, inside an error
+# message, anywhere). If one of these ever appears in an emitted record it
+# is a privacy regression, not a formatting nit.
+_SENSITIVE_MARKERS = {
+	"search": "encephalitis AND rituximab paediatric",
+	"full_name": "Jane Q. Researcher",
+	"given_name": "Jane",
+	"family_name": "Researcher",
+	"orcid": "0000-0002-1111-2222",
+	"doi": "10.1234/secret.paper",
+}
+
+
+def _make_ctx(*, method="tools/call", params=None, meta=None, request_id="req-1", protocol_version="2026-07-28"):
+	return ServerRequestContext(
+		session=None,
+		lifespan_context={},
+		protocol_version=protocol_version,
+		method=method,
+		params=params,
+		request_id=request_id,
+		meta=meta,
+	)
+
+
+def _record_fields(record: logging.LogRecord) -> dict:
+	"""Every attribute TelemetryMiddleware could plausibly have set via `extra`."""
+	skip = {
+		"name",
+		"msg",
+		"args",
+		"levelname",
+		"levelno",
+		"pathname",
+		"filename",
+		"module",
+		"exc_info",
+		"exc_text",
+		"stack_info",
+		"lineno",
+		"funcName",
+		"created",
+		"msecs",
+		"relativeCreated",
+		"thread",
+		"threadName",
+		"processName",
+		"process",
+		"message",
+		"taskName",
+	}
+	return {k: v for k, v in record.__dict__.items() if k not in skip}
+
+
+@pytest.fixture(autouse=True)
+def _telemetry_caplog(caplog):
+	caplog.set_level(logging.INFO, logger="gregory_mcp.telemetry")
+	yield caplog
+
+
+async def test_emits_one_record_for_a_successful_tool_call(caplog):
+	async def call_next(ctx):
+		return CallToolResult(
+			content=[TextContent(type="text", text="ok")],
+			structured_content={"count": 5, "next_page": 2, "articles": [1, 2, 3]},
+		)
+
+	ctx = _make_ctx(params={"name": "search_articles", "arguments": {"subject_id": 3, "page": 1}})
+	result = await TelemetryMiddleware()(ctx, call_next)
+
+	assert result.structured_content["articles"] == [1, 2, 3]
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	assert len(records) == 1
+
+	fields = _record_fields(records[0])
+	assert fields["method"] == "tools/call"
+	assert fields["tool"] == "search_articles"
+	assert fields["outcome"] == "ok"
+	assert fields["result_count"] == 3
+	assert fields["total_count"] == 5
+	assert fields["has_next"] is True
+	assert fields["params_used"] == ["page", "subject_id"]
+	assert fields["subject_id"] == 3
+	assert fields["page"] == 1
+	assert "duration_ms" in fields
+
+
+async def test_result_shape_falls_back_to_the_text_content_block(caplog):
+	"""None of our tools declare an output schema (they return plain dict),
+	so structured_content is unset on the real wire — confirmed by driving
+	search_articles through the actual server stack. The payload MCPServer
+	actually sends is JSON inside content[0].text; that's what telemetry
+	must read result_count/total_count/has_next from in production.
+	"""
+	import json as _json
+
+	async def call_next(ctx):
+		payload = {"count": 42, "next_page": None, "articles": [{"id": 1}, {"id": 2}]}
+		return CallToolResult(content=[TextContent(type="text", text=_json.dumps(payload))])
+
+	ctx = _make_ctx(params={"name": "search_articles", "arguments": {"subject_id": 3}})
+	await TelemetryMiddleware()(ctx, call_next)
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	assert len(records) == 1
+	fields = _record_fields(records[0])
+	assert fields["result_count"] == 2
+	assert fields["total_count"] == 42
+	assert fields["has_next"] is False
+
+
+async def test_params_used_lists_names_never_values(caplog):
+	async def call_next(ctx):
+		return CallToolResult(content=[], structured_content={"count": 0, "articles": []})
+
+	ctx = _make_ctx(
+		params={
+			"name": "search_articles",
+			# team_id is explicitly None (an omitted-optional-arg shape some
+			# clients send) and must be excluded from params_used just like a
+			# truly absent key would be.
+			"arguments": {"search": "stem cells", "team_id": None, "subject_id": 7},
+		}
+	)
+	await TelemetryMiddleware()(ctx, call_next)
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	assert len(records) == 1
+	fields = _record_fields(records[0])
+	assert fields["params_used"] == ["search", "subject_id"]
+	assert "stem cells" not in repr(fields)
+
+
+async def test_sensitive_fields_never_appear_in_any_emitted_field(caplog):
+	async def call_next(ctx):
+		return CallToolResult(content=[], structured_content={"count": 0, "authors": []})
+
+	arguments = {**_SENSITIVE_MARKERS, "team_id": 9}
+	ctx = _make_ctx(params={"name": "search_authors", "arguments": arguments})
+	await TelemetryMiddleware()(ctx, call_next)
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	assert len(records) == 1
+	fields = _record_fields(records[0])
+
+	# params_used may name the fields, but must never carry their values.
+	assert fields["params_used"] == sorted(["team_id", *_SENSITIVE_MARKERS.keys()])
+
+	serialized = repr(fields)
+	for marker_value in _SENSITIVE_MARKERS.values():
+		assert marker_value not in serialized
+
+
+async def test_raising_tool_call_still_emits_an_event(caplog):
+	async def call_next(ctx):
+		raise MCPError(code=INTERNAL_ERROR, message="handler exploded")
+
+	ctx = _make_ctx(params={"name": "search_articles", "arguments": {}})
+
+	with pytest.raises(MCPError):
+		await TelemetryMiddleware()(ctx, call_next)
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	assert len(records) == 1
+	fields = _record_fields(records[0])
+	assert fields["outcome"] == "error"
+	assert fields["error_kind"] == "protocol_error"
+
+
+async def test_tool_error_result_is_recorded_as_error_outcome(caplog):
+	"""The SDK's own tool-call handler catches exceptions raised by the tool
+	function (e.g. search_authors' `ValueError: subject_id requires team_id`)
+	and converts them into a CallToolResult(is_error=True) before our
+	middleware ever sees them — so no exception reaches or leaves
+	TelemetryMiddleware here; only the is_error result does.
+	"""
+
+	async def call_next(ctx):
+		return CallToolResult(content=[TextContent(type="text", text="boom")], is_error=True)
+
+	ctx = _make_ctx(params={"name": "search_authors", "arguments": {"subject_id": 1, "team_id": None}})
+	result = await TelemetryMiddleware()(ctx, call_next)
+	assert result.is_error
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	assert len(records) == 1
+	fields = _record_fields(records[0])
+	assert fields["outcome"] == "error"
+	assert fields["error_kind"] == "tool_error"
+
+
+async def test_notifications_are_not_logged(caplog):
+	async def call_next(ctx):
+		return None
+
+	ctx = _make_ctx(method="notifications/cancelled", params={}, request_id=None)
+	await TelemetryMiddleware()(ctx, call_next)
+
+	assert [r for r in caplog.records if r.name == "gregory_mcp.telemetry"] == []
+
+
+async def test_non_tool_method_gets_ok_outcome_without_a_tool_field(caplog):
+	async def call_next(ctx):
+		return {"tools": []}
+
+	ctx = _make_ctx(method="tools/list", params=None)
+	await TelemetryMiddleware()(ctx, call_next)
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	assert len(records) == 1
+	fields = _record_fields(records[0])
+	assert fields["method"] == "tools/list"
+	assert fields["outcome"] == "ok"
+	assert "tool" not in fields
+
+
+async def test_client_name_version_and_protocol_version_captured(caplog):
+	async def call_next(ctx):
+		return CallToolResult(content=[], structured_content={"count": 0, "articles": []})
+
+	ctx = _make_ctx(
+		params={"name": "search_articles", "arguments": {}},
+		meta={CLIENT_INFO_META_KEY: {"name": "some-client", "version": "1.2.3"}},
+		protocol_version="2026-07-28",
+	)
+	await TelemetryMiddleware()(ctx, call_next)
+
+	records = [r for r in caplog.records if r.name == "gregory_mcp.telemetry"]
+	fields = _record_fields(records[0])
+	assert fields["client_name"] == "some-client"
+	assert fields["client_version"] == "1.2.3"
+	assert fields["protocol_version"] == "2026-07-28"
+
+
+async def test_upstream_accounting_survives_retries():
+	accumulator = _UpstreamAccumulator()
+	token = telemetry._accumulator.set(accumulator)
+	try:
+		settings = TEST_SETTINGS
+		from dataclasses import replace
+
+		settings = replace(settings, max_retries=2)
+
+		async def no_delay(seconds):
+			return None
+
+		client = GregoryClient(settings, sleep=no_delay)
+		attempts = []
+
+		def handler(request):
+			attempts.append(1)
+			if len(attempts) < 2:
+				return httpx2.Response(500, json={"detail": "boom"})
+			return httpx2.Response(200, json={"ok": True})
+
+		client._client._transport = httpx2.MockTransport(handler)
+		result = await client.get("/articles/")
+
+		assert result == {"ok": True}
+		assert accumulator.upstream_calls == 2
+		assert accumulator.upstream_ms >= 0
+		assert accumulator.error_kind is None
+	finally:
+		telemetry._accumulator.reset(token)
+
+
+async def test_upstream_error_status_recorded_before_exception_is_raised():
+	accumulator = _UpstreamAccumulator()
+	token = telemetry._accumulator.set(accumulator)
+	try:
+		client = GregoryClient(TEST_SETTINGS)
+		client._client._transport = httpx2.MockTransport(lambda r: httpx2.Response(404, text="nope"))
+
+		with pytest.raises(GregoryAPIError):
+			await client.get("/articles/999/")
+
+		assert accumulator.error_kind == "upstream_error"
+		assert accumulator.error_status == 404
+	finally:
+		telemetry._accumulator.reset(token)
+
+
+async def test_cache_status_hit_then_miss_recorded_on_accumulator():
+	cache = CatalogCache()
+
+	async def fetch():
+		return ["row"]
+
+	accumulator = _UpstreamAccumulator()
+	token = telemetry._accumulator.set(accumulator)
+	try:
+		await cache.get_or_fetch("/subjects/", {"team_id": 1}, fetch)
+		assert accumulator.cache_status == "miss"
+
+		accumulator.cache_status = None
+		await cache.get_or_fetch("/subjects/", {"team_id": 1}, fetch)
+		assert accumulator.cache_status == "hit"
+	finally:
+		telemetry._accumulator.reset(token)
+
+
+async def test_no_accumulator_active_is_a_silent_no_op():
+	"""Outside a tracked request (e.g. every other test file in this suite,
+	which calls client/cache code directly) recording must not raise."""
+	client = GregoryClient(TEST_SETTINGS)
+	client._client._transport = httpx2.MockTransport(lambda r: httpx2.Response(200, json={"ok": True}))
+	assert await client.get("/articles/") == {"ok": True}
+
+	cache = CatalogCache()
+	assert await cache.get_or_fetch("/subjects/", None, lambda: _identity(["row"])) == ["row"]
+
+
+async def _identity(value):
+	return value

--- a/mcp-server/tests/test_tools_articles.py
+++ b/mcp-server/tests/test_tools_articles.py
@@ -95,6 +95,25 @@ async def test_search_articles_last_days(mock_gregory):
 	assert mock_gregory.requests[0].url.params["last_days"] == "30"
 
 
+async def test_search_articles_zero_hits_adds_guidance(mock_gregory):
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "next": None, "results": []}))
+
+	result = await search_articles(search="x", relevant=True, subject_id=3)
+
+	assert result["guidance"]["applied_filters"] == ["relevant", "search", "subject_id"]
+	assert len(result["guidance"]["suggestions"]) >= 1
+
+
+async def test_search_articles_nonzero_hits_has_no_guidance_key(mock_gregory):
+	mock_gregory.set_handler(
+		lambda request: httpx2.Response(200, json={"count": 1, "next": None, "results": [{"article_id": 1}]})
+	)
+
+	result = await search_articles(search="x")
+
+	assert "guidance" not in result
+
+
 async def test_get_article_returns_full_record(mock_gregory):
 	mock_gregory.set_handler(
 		lambda request: httpx2.Response(200, json={"article_id": 42, "authors": [{"full_name": "A"}]})

--- a/mcp-server/tests/test_tools_articles.py
+++ b/mcp-server/tests/test_tools_articles.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import httpx2
 
+import gregory_mcp.tools.articles as articles_module
 from gregory_mcp.tools.articles import get_article, search_articles
 
 
@@ -112,6 +113,37 @@ async def test_search_articles_nonzero_hits_has_no_guidance_key(mock_gregory):
 	result = await search_articles(search="x")
 
 	assert "guidance" not in result
+
+
+async def test_search_articles_records_intent_but_never_sends_it_upstream(mock_gregory, monkeypatch):
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "next": None, "results": []}))
+
+	calls = []
+
+	async def fake_record(tool, text):
+		calls.append((tool, text))
+
+	monkeypatch.setattr(articles_module.intent_module, "record", fake_record)
+
+	await search_articles(search="x", intent="looking for MS treatment trials")
+
+	assert calls == [("search_articles", "looking for MS treatment trials")]
+	assert "intent" not in mock_gregory.requests[0].url.params
+
+
+async def test_search_articles_does_not_record_intent_when_absent(mock_gregory, monkeypatch):
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "next": None, "results": []}))
+
+	calls = []
+
+	async def fake_record(tool, text):
+		calls.append(1)
+
+	monkeypatch.setattr(articles_module.intent_module, "record", fake_record)
+
+	await search_articles(search="x")
+
+	assert calls == []
 
 
 async def test_get_article_returns_full_record(mock_gregory):

--- a/mcp-server/tests/test_tools_trials.py
+++ b/mcp-server/tests/test_tools_trials.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import httpx2
 
+import gregory_mcp.tools.trials as trials_module
 from gregory_mcp.tools.trials import get_trial, search_trials
 
 
@@ -114,6 +115,22 @@ async def test_search_trials_nonzero_hits_has_no_guidance_key(mock_gregory):
 	result = await search_trials()
 
 	assert "guidance" not in result
+
+
+async def test_search_trials_records_intent_but_never_sends_it_upstream(mock_gregory, monkeypatch):
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "next": None, "results": []}))
+
+	calls = []
+
+	async def fake_record(tool, text):
+		calls.append((tool, text))
+
+	monkeypatch.setattr(trials_module.intent_module, "record", fake_record)
+
+	await search_trials(nct="NCT00000000", intent="phase 2 trials for encephalitis")
+
+	assert calls == [("search_trials", "phase 2 trials for encephalitis")]
+	assert "intent" not in mock_gregory.requests[0].url.params
 
 
 async def test_get_trial_returns_full_record(mock_gregory):

--- a/mcp-server/tests/test_tools_trials.py
+++ b/mcp-server/tests/test_tools_trials.py
@@ -97,6 +97,25 @@ async def test_search_trials_eu_registry_ids_and_new_filters(mock_gregory):
 	assert params["therapeutic_areas"] == "oncology"
 
 
+async def test_search_trials_zero_hits_adds_guidance(mock_gregory):
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"count": 0, "next": None, "results": []}))
+
+	result = await search_trials(nct="NCT00000000", date_registration_after="2026-01-01")
+
+	assert result["guidance"]["applied_filters"] == ["date_registration_after", "nct"]
+	assert len(result["guidance"]["suggestions"]) >= 1
+
+
+async def test_search_trials_nonzero_hits_has_no_guidance_key(mock_gregory):
+	mock_gregory.set_handler(
+		lambda request: httpx2.Response(200, json={"count": 1, "next": None, "results": [{"trial_id": 1}]})
+	)
+
+	result = await search_trials()
+
+	assert "guidance" not in result
+
+
 async def test_get_trial_returns_full_record(mock_gregory):
 	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"trial_id": 7, "trial_sites": []}))
 

--- a/mcp-server/tests/test_zero_result.py
+++ b/mcp-server/tests/test_zero_result.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from gregory_mcp.zero_result import guidance_for
+
+
+def test_applied_filters_excludes_pagination_and_ordering():
+	guidance = guidance_for({"search": "x", "page": 1, "page_size": 10, "ordering": "-published_date"})
+	assert guidance["applied_filters"] == ["search"]
+
+
+def test_applied_filters_excludes_none_values():
+	guidance = guidance_for({"search": "x", "team_id": None, "subject_id": 3})
+	assert guidance["applied_filters"] == ["search", "subject_id"]
+
+
+def test_applied_filters_sorted():
+	guidance = guidance_for({"subject_id": 1, "doi": "10.1/x", "search": "x"})
+	assert guidance["applied_filters"] == ["doi", "search", "subject_id"]
+
+
+def test_relevant_or_ml_threshold_triggers_relevance_suggestion():
+	guidance = guidance_for({"relevant": True})
+	assert any("relevant" in s.lower() for s in guidance["suggestions"])
+
+	guidance2 = guidance_for({"ml_threshold": 0.9})
+	assert guidance["suggestions"] == guidance2["suggestions"]
+
+
+def test_date_filters_trigger_date_range_suggestion():
+	for key in ("published_date_after", "published_date_before", "last_days", "date_registration_after"):
+		guidance = guidance_for({key: "2026-01-01"})
+		assert any("date" in s.lower() for s in guidance["suggestions"])
+
+
+def test_taxonomy_id_filters_trigger_taxonomy_suggestion():
+	for key in ("subject_id", "category_id", "category_slug", "category_modality", "team_id"):
+		guidance = guidance_for({key: "x"})
+		assert any("list_subjects" in s or "list_categories" in s for s in guidance["suggestions"])
+
+
+def test_registry_id_filters_trigger_registry_suggestion():
+	for key in ("nct", "euct", "eudract", "ctis", "acronym", "sponsor_id", "sponsor_slug"):
+		guidance = guidance_for({key: "x"})
+		assert any("registry" in s.lower() or "sponsor" in s.lower() for s in guidance["suggestions"])
+
+
+def test_search_filter_triggers_boolean_search_suggestion():
+	guidance = guidance_for({"search": "a AND b"})
+	assert any("AND" in s or "loosen" in s.lower() for s in guidance["suggestions"])
+
+
+def test_multiple_rules_can_fire_together_and_stay_ranked():
+	guidance = guidance_for({"relevant": True, "subject_id": 1, "search": "x"})
+	# relevance, then taxonomy_id, then search — in the plan's stated priority order.
+	assert len(guidance["suggestions"]) == 3
+	assert "relevant" in guidance["suggestions"][0].lower()
+
+
+def test_no_filters_falls_back_to_generic_suggestion():
+	guidance = guidance_for({"page": 1, "page_size": 10})
+	assert guidance["applied_filters"] == []
+	assert len(guidance["suggestions"]) == 1
+
+
+def test_suggestions_never_contain_filter_values():
+	guidance = guidance_for({"search": "SENSITIVE-marker-value", "subject_id": 42})
+	assert "SENSITIVE-marker-value" not in repr(guidance)
+	assert "42" not in repr(guidance["suggestions"])


### PR DESCRIPTION
## Summary

Implements Phases 1-4 of `MCP-TELEMETRY-PLAN.md` — instrumentation for `mcp-server/` to learn which tools/parameters earn their place, where searches come back empty, and what people are asking for that Gregory doesn't yet cover, without building a record of what any individual person researched.

- **Phase 1 — request telemetry** (`gregory_mcp/telemetry.py`): one JSON log line per inbound MCP request (method/tool, timing, outcome, selectivity, upstream/cache timing). No query content — `params_used` records argument *names* only, never values.
- **Phase 2 — query shape & taxonomy match** (`gregory_mcp/query_shape.py`): `search_articles`/`search_trials`/`list_categories` query text is tokenized, bagged (no term co-occurrence logged), and matched against Gregory's own public category vocabulary. A query is dropped from analysis entirely (not redacted) if it looks like it carries an email or a long digit run.
- **Phase 3 — zero-result guidance** (`gregory_mcp/zero_result.py`): a zero-hit `search_articles`/`search_trials` response now carries a `guidance` key — which filters were applied and ranked suggestions for what's likely over-constraining — instead of a dead-end `{"count": 0, "articles": []}`.
- **Phase 4 — intent capture** (`gregory_mcp/intent.py`): optional `intent` param on `search_articles`/`search_trials` (not `search_authors`). Unlike Phases 1-2, this is full text — the protection is a genuinely separate log stream (stderr, `propagate=False`, its own tiny formatter allowlist) plus a heuristic PII scan that flags without blocking, feeding a scheduled review (plan Phase 5, gated on real traffic).

Two real bugs were caught by driving requests through the actual built server (`modern_on_request` + `DirectDispatcher`), not just mocked unit tests:
- our tools return plain `dict` with no declared output schema, so `CallToolResult.structured_content` is unset on the real wire — `result_count`/`total_count`/`has_next` now fall back to parsing the same payload out of `content[0].text`.
- `telemetry.py` importing `query_shape` at module scope created an import cycle (`telemetry -> query_shape -> cache -> client -> telemetry`) — fixed with a lazy import.

Full design/reasoning, the anonymity model, and remaining phases are in [`MCP-TELEMETRY-PLAN.md`](../blob/fix/mcp-cache-tool-catalog/MCP-TELEMETRY-PLAN.md).

**Not in this PR:** Phase 5 (scheduled PII review — can't run until there's real traffic), Phase 5b (k-anon unmatched terms, may never ship), Phase 6 (retention/rotation config, docs). Nothing here is deployed to House — Bruno deploys separately per the plan's deployment boundary.

## Test plan

- [x] `uv run python -m pytest` — 156 passed
- [x] End-to-end smoke tests driving real `tools/call` requests through `build_server()` (not just mocks) for each phase, confirming: no query/intent text ever reaches the telemetry (stdout) stream, intent text only reaches the separate stderr stream, zero-hit guidance composes cleanly with telemetry extraction, taxonomy matching works against a real categories fixture
- [x] `test_schema_contract.py` still passes — `intent` correctly excluded as a non-Django-forwarded param

🤖 Generated with [Claude Code](https://claude.com/claude-code)