### PR TITLE
Add "Refresh from CrossRef" button to the article admin change page

### DIFF
--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -788,6 +788,7 @@ class ArticleAdmin(OrganizationFilterMixin, SourceBulkActionMixin, SimpleHistory
 					"crossref_check",
 					"retracted",
 					"crossref_retraction_check",
+					"crossref_refresh_button",
 				),
 				"description": "This section contains general information about the article",
 			},
@@ -814,7 +815,19 @@ class ArticleAdmin(OrganizationFilterMixin, SourceBulkActionMixin, SimpleHistory
 		qs = super().get_queryset(request)
 		return qs.prefetch_related("sources")
 
-	readonly_fields = ["entities", "discovery_date", "links"]
+	def crossref_refresh_button(self, obj):
+		if not obj.pk:
+			return "-"
+		if not obj.doi:
+			return "Article has no DOI — nothing to look up."
+		url = reverse("admin:gregory_articles_crossref_refresh", args=[obj.pk])
+		return format_html(
+			'<a class="button" href="{}">Refresh from CrossRef</a>', url
+		)
+
+	crossref_refresh_button.short_description = "Refresh from CrossRef"
+
+	readonly_fields = ["entities", "discovery_date", "links", "crossref_refresh_button"]
 	search_fields = ["article_id", "title", "doi"]
 	list_filter = [
 		ArticleOrganizationFilter,
@@ -861,8 +874,141 @@ class ArticleAdmin(OrganizationFilterMixin, SourceBulkActionMixin, SimpleHistory
 				self.admin_site.admin_view(add_article_by_doi_view),
 				name="article_add_by_doi",
 			),
+			path(
+				"<int:article_id>/crossref-refresh/",
+				self.admin_site.admin_view(self.crossref_refresh_view),
+				name="gregory_articles_crossref_refresh",
+			),
 		]
 		return custom_urls + urls
+
+	def crossref_refresh_view(self, request, article_id):
+		"""Diff the article's CrossRef+Unpaywall metadata against what we hold
+		and let the user apply only the rows they tick.
+
+		GET fetches CrossRef (read-only — nothing is written) and renders the
+		diff/selection page. POST applies only the ticked rows using the exact
+		values shown on that page — round-tripped through a signed payload
+		rather than a second CrossRef fetch — so what gets applied always
+		matches what was displayed.
+		"""
+		from django.core import signing
+		from gregory.services.crossref_refresh import (
+			apply_crossref_diff,
+			build_crossref_diff,
+		)
+
+		article = self.get_object(request, article_id)
+		if article is None:
+			self.message_user(request, "Article not found.", level=messages.ERROR)
+			return redirect("admin:gregory_articles_changelist")
+
+		if not self.has_change_permission(request, article):
+			raise PermissionDenied
+
+		change_url = reverse("admin:gregory_articles_change", args=[article_id])
+
+		if not article.doi:
+			self.message_user(
+				request, "This article has no DOI.", level=messages.ERROR
+			)
+			return redirect(change_url)
+
+		salt = "gregory.admin.crossref_refresh"
+
+		if request.method == "POST":
+			try:
+				payload = signing.loads(
+					request.POST.get("payload", ""), salt=salt, max_age=900
+				)
+			except signing.BadSignature:
+				self.message_user(
+					request,
+					"This review has expired or was tampered with. Please try again.",
+					level=messages.ERROR,
+				)
+				return redirect(change_url)
+
+			if payload.get("article_id") != article.pk:
+				self.message_user(
+					request,
+					"This review does not match this article.",
+					level=messages.ERROR,
+				)
+				return redirect(change_url)
+
+			selected_fields = {
+				row["field"]: row["raw"]
+				for i, row in enumerate(payload.get("fields", []))
+				if f"field_{i}" in request.POST
+			}
+			selected_authors = [
+				row
+				for i, row in enumerate(payload.get("authors", []))
+				if f"author_{i}" in request.POST
+			]
+
+			if not selected_fields and not selected_authors:
+				self.message_user(request, "Nothing was selected to apply.")
+				return redirect(change_url)
+
+			result = apply_crossref_diff(article, selected_fields, selected_authors)
+
+			summary_parts = []
+			if result.updated_fields:
+				summary_parts.append(f"updated {', '.join(result.updated_fields)}")
+			if result.authors_added:
+				summary_parts.append(f"added {len(result.authors_added)} author(s)")
+			if result.authors_removed:
+				summary_parts.append(f"removed {len(result.authors_removed)} author(s)")
+			self.message_user(
+				request, "CrossRef refresh applied: " + "; ".join(summary_parts) + "."
+			)
+
+			log_parts = []
+			if result.updated_fields:
+				log_parts.append(f"Updated fields: {', '.join(result.updated_fields)}.")
+			if result.authors_added:
+				log_parts.append(f"Added authors: {', '.join(result.authors_added)}.")
+			if result.authors_removed:
+				log_parts.append(f"Removed authors: {', '.join(result.authors_removed)}.")
+			if log_parts:
+				self.log_change(request, article, " ".join(log_parts))
+
+			return redirect(change_url)
+
+		diff = build_crossref_diff(article)
+
+		if diff.fetch_error:
+			self.message_user(
+				request,
+				f"Could not refresh from CrossRef: {diff.fetch_error}",
+				level=messages.ERROR,
+			)
+			return redirect(change_url)
+
+		if not diff.fields and not diff.authors:
+			self.message_user(request, "No changes found from CrossRef.")
+			return redirect(change_url)
+
+		payload = {
+			"article_id": article.pk,
+			"fields": [{"field": fd.field, "raw": fd.raw} for fd in diff.fields],
+			"authors": [{"action": ad.action, "raw": ad.raw} for ad in diff.authors],
+		}
+		signed_payload = signing.dumps(payload, salt=salt)
+
+		return render(
+			request,
+			"admin/gregory/articles/crossref_refresh.html",
+			{
+				"title": f"Refresh {article} from CrossRef",
+				"article": article,
+				"diff": diff,
+				"signed_payload": signed_payload,
+				"opts": self.model._meta,
+			},
+		)
 
 	def changelist_view(self, request, extra_context=None):
 		"""Override changelist view to add buttons above the article list"""

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -996,7 +996,10 @@ class ArticleAdmin(OrganizationFilterMixin, SourceBulkActionMixin, SimpleHistory
 			"fields": [{"field": fd.field, "raw": fd.raw} for fd in diff.fields],
 			"authors": [{"action": ad.action, "raw": ad.raw} for ad in diff.authors],
 		}
-		signed_payload = signing.dumps(payload, salt=salt)
+		# compress=True: `summary` can be a large TextField, and this payload
+		# round-trips through both the rendered HTML and the POST body.
+		# signing.loads() below decodes it transparently either way.
+		signed_payload = signing.dumps(payload, salt=salt, compress=True)
 
 		return render(
 			request,

--- a/django/gregory/classes.py
+++ b/django/gregory/classes.py
@@ -27,6 +27,10 @@ class SciencePaper:
 		self.authors = authors
 		self.retracted = retracted
 		self.pdf_link = pdf_link
+		# Cache of the raw CrossRef `work` payload from the last successful
+		# refresh(), for callers that need to inspect fields refresh() doesn't
+		# expose as attributes (e.g. date precision in crossref_refresh.py).
+		self._work = None
 
 	def __str__(self):
 		return f"{self.doi}, {self.title}"
@@ -103,6 +107,7 @@ class SciencePaper:
 		# Only proceed if we successfully got work data
 		if work is None:
 			return "No data retrieved from CrossRef"
+		self._work = work
 
 		if self.link == None:
 			try:
@@ -151,8 +156,13 @@ class SciencePaper:
 				else:
 					self.journal = work["container-title"]
 		if self.published_date == None:
+			issued = []
 			if work != None and "issued" in work:
-				issued = work["issued"]["date-parts"][0]
+				try:
+					issued = work["issued"]["date-parts"][0]
+				except (KeyError, IndexError, TypeError):
+					logging.warning(f"Malformed issued date for DOI {self.doi}")
+					issued = []
 			year, month, day = None, 1, 1
 			try:
 				year = issued[0]

--- a/django/gregory/management/commands/feedreader_articles.py
+++ b/django/gregory/management/commands/feedreader_articles.py
@@ -29,35 +29,14 @@ class FeedProcessor(ABC):
 	def __init__(self, command_instance):
 		self.command = command_instance
 
-	# Inline tags whose markup carries meaning and should be preserved in titles
-	SEMANTIC_TITLE_TAGS = {"sub", "sup", "i", "b", "em", "strong"}
-
 	@staticmethod
 	def clean_title(title: Optional[str]) -> Optional[str]:
-		"""Normalize a feed title before storage.
+		"""Normalize a feed title before storage. See
+		gregory.utils.text_cleaning.clean_title for the implementation, shared
+		with the admin's CrossRef refresh review page."""
+		from gregory.utils.text_cleaning import clean_title as _clean_title
 
-		Publisher feeds (notably PubMed/Wiley) embed inline markup and
-		pretty-printed newlines/indentation inside <title>. We unescape HTML
-		entities, keep semantically meaningful inline tags (sub, sup, i, b,
-		em, strong) but strip presentational/JATS tags (e.g. <scp>, <jats:*>)
-		while preserving their text, drop tag attributes, and collapse runs of
-		whitespace to single spaces.
-		"""
-		if not title:
-			return title
-		from bs4 import BeautifulSoup
-		import html
-
-		title = html.unescape(title)
-		soup = BeautifulSoup(title, "html.parser")
-		for tag in soup.find_all(True):
-			if tag.name in FeedProcessor.SEMANTIC_TITLE_TAGS:
-				tag.attrs = {}
-			else:
-				tag.unwrap()
-		# formatter=None keeps entities unescaped (e.g. bare &) so the stored
-		# title matches the human-readable form; str(soup) would re-encode & -> &amp;.
-		return " ".join(soup.decode(formatter=None).split())
+		return _clean_title(title)
 
 	@abstractmethod
 	def can_process(self, source_link: str) -> bool:

--- a/django/gregory/services/crossref_refresh.py
+++ b/django/gregory/services/crossref_refresh.py
@@ -1,0 +1,455 @@
+"""
+Service layer behind the Articles admin's "Refresh from CrossRef" button.
+
+Builds a diff between what an article holds and what CrossRef (+ Unpaywall,
+via SciencePaper.refresh()) currently returns for its DOI, and applies only
+the rows the admin user ticks. No admin imports here — the admin view
+(gregory/admin.py) owns the request/response plumbing, permissions, and the
+signed round-trip payload; this module is the pure data layer underneath it.
+"""
+
+import difflib
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from django.db import transaction
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+from gregory.classes import SciencePaper
+from gregory.functions import normalize_orcid
+from gregory.models import Articles, Authors
+from gregory.services.doi_import import resolve_author
+from gregory.utils.enrichment import clear_marker
+from gregory.utils.text_cleaning import clean_title
+
+logger = logging.getLogger(__name__)
+
+CHANGE_REASON_PREFIX = "CrossRef: "
+MAX_REASON_LEN = 100
+
+# (Articles field name, human label) — also the order fields are diffed/shown in.
+FIELD_SPECS = [
+	("title", "Title"),
+	("summary", "Summary"),
+	("publisher", "Publisher"),
+	("container_title", "Container title"),
+	("published_date", "Published date"),
+	("retracted", "Retracted"),
+	("access", "Open access (via Unpaywall)"),
+	("pdf_link", "PDF link (via Unpaywall)"),
+]
+
+SUMMARY_DIFF_THRESHOLD = 400
+
+
+@dataclass
+class FieldDiff:
+	field: str
+	label: str
+	current: Any
+	proposed: Any
+	raw: Any  # JSON-safe value carried in the signed payload
+	preselect: bool
+	warning: Optional[str] = None
+	extra: Optional[str] = None  # unified diff text, for long summaries
+
+
+@dataclass
+class AuthorDiff:
+	action: str  # "add" | "remove"
+	label: str
+	raw: dict  # CrossRef author dict, or {"author_id": N} for removals
+	preselect: bool
+
+
+@dataclass
+class CrossrefDiff:
+	fetch_error: Optional[str]
+	fields: list
+	authors: list
+
+
+@dataclass
+class AppliedResult:
+	updated_fields: list
+	authors_added: list  # full labels, e.g. "Jane Doe (ORCID 0000-...)"
+	authors_removed: list
+	change_reason: str
+
+
+def _is_empty_text(value) -> bool:
+	return value is None or value == ""
+
+
+def _is_empty_access(value) -> bool:
+	return value is None or value == "unknown"
+
+
+def _unified_diff(old: str, new: str) -> str:
+	lines = difflib.unified_diff(
+		(old or "").splitlines(), (new or "").splitlines(), lineterm="", n=1
+	)
+	return "\n".join(lines)
+
+
+def _date_precision_warning(paper: SciencePaper) -> Optional[str]:
+	"""CrossRef's `issued` field is sometimes only a year, or a year+month.
+	refresh() silently pads missing parts to 1 January, so a bare year would
+	otherwise look exactly like a precise date next to a real feed date."""
+	work = paper._work or {}
+	try:
+		date_parts = work["issued"]["date-parts"][0]
+	except (KeyError, IndexError, TypeError):
+		return None
+
+	year = paper.published_date.year
+	if len(date_parts) <= 1:
+		return f"CrossRef gave only a year ({year}) — padded to 1 January."
+	if len(date_parts) == 2:
+		month = date_parts[1]
+		return f"CrossRef gave only a year and month ({year}-{month:02d}) — padded to day 1."
+	return None
+
+
+def _normalize_orcid_or_none(raw):
+	return normalize_orcid(raw) if raw else None
+
+
+def _existing_author_key(author: Authors):
+	orcid = _normalize_orcid_or_none(author.ORCID)
+	if orcid:
+		return ("orcid", orcid)
+	return (
+		"name",
+		(author.given_name or "").strip().lower(),
+		(author.family_name or "").strip().lower(),
+	)
+
+
+def _crossref_author_key(author_data: dict):
+	orcid = _normalize_orcid_or_none(author_data.get("ORCID"))
+	if orcid:
+		return ("orcid", orcid)
+	return (
+		"name",
+		(author_data.get("given") or "").strip().lower(),
+		(author_data.get("family") or "").strip().lower(),
+	)
+
+
+def _build_author_diffs(article: Articles, crossref_authors: list) -> list:
+	existing_authors = list(article.authors.all())
+	has_no_authors = not existing_authors
+	matched_existing_ids = set()
+
+	diffs = []
+	for author_data in crossref_authors:
+		given = author_data.get("given")
+		family = author_data.get("family")
+		if not given or not family:
+			continue
+
+		key = _crossref_author_key(author_data)
+		match = next(
+			(a for a in existing_authors if _existing_author_key(a) == key), None
+		)
+		if match is not None:
+			matched_existing_ids.add(match.pk)
+			continue
+
+		orcid = _normalize_orcid_or_none(author_data.get("ORCID"))
+		label = f"{given} {family}" + (f" (ORCID {orcid})" if orcid else "")
+		diffs.append(
+			AuthorDiff(action="add", label=label, raw=author_data, preselect=has_no_authors)
+		)
+
+	for author in existing_authors:
+		if author.pk not in matched_existing_ids:
+			diffs.append(
+				AuthorDiff(
+					action="remove",
+					label=f"{author} (not returned by CrossRef)",
+					raw={"author_id": author.pk},
+					preselect=False,
+				)
+			)
+
+	return diffs
+
+
+def build_crossref_diff(article: Articles) -> CrossrefDiff:
+	"""Fetch CrossRef+Unpaywall data for `article.doi` and diff it against what
+	the article currently holds. Read-only — never writes to the database."""
+	paper = SciencePaper(doi=article.doi)
+	try:
+		result = paper.refresh()
+	except Exception as exc:
+		logger.exception(
+			"CrossRef refresh failed for article %s (DOI %s)", article.pk, article.doi
+		)
+		return CrossrefDiff(fetch_error=str(exc), fields=[], authors=[])
+
+	if SciencePaper.is_crossref_failed(result):
+		return CrossrefDiff(fetch_error=result, fields=[], authors=[])
+
+	fields = []
+
+	proposed_title = clean_title(paper.title) if paper.title else None
+	if proposed_title and proposed_title != article.title:
+		fields.append(
+			FieldDiff(
+				field="title",
+				label="Title",
+				current=article.title,
+				proposed=proposed_title,
+				raw=proposed_title,
+				preselect=_is_empty_text(article.title),
+			)
+		)
+
+	proposed_summary = paper.clean_abstract() if paper.abstract else None
+	if proposed_summary and proposed_summary != article.summary:
+		extra = None
+		if len(proposed_summary) > SUMMARY_DIFF_THRESHOLD or len(
+			article.summary or ""
+		) > SUMMARY_DIFF_THRESHOLD:
+			extra = _unified_diff(article.summary, proposed_summary)
+		fields.append(
+			FieldDiff(
+				field="summary",
+				label="Summary",
+				current=article.summary,
+				proposed=proposed_summary,
+				raw=proposed_summary,
+				preselect=_is_empty_text(article.summary),
+				extra=extra,
+			)
+		)
+
+	if paper.publisher and paper.publisher != article.publisher:
+		fields.append(
+			FieldDiff(
+				field="publisher",
+				label="Publisher",
+				current=article.publisher,
+				proposed=paper.publisher,
+				raw=paper.publisher,
+				preselect=_is_empty_text(article.publisher),
+			)
+		)
+
+	if paper.journal and paper.journal != article.container_title:
+		fields.append(
+			FieldDiff(
+				field="container_title",
+				label="Container title",
+				current=article.container_title,
+				proposed=paper.journal,
+				raw=paper.journal,
+				preselect=_is_empty_text(article.container_title),
+			)
+		)
+
+	if paper.published_date and paper.published_date != article.published_date:
+		fields.append(
+			FieldDiff(
+				field="published_date",
+				label="Published date",
+				current=article.published_date,
+				proposed=paper.published_date,
+				raw=paper.published_date.isoformat(),
+				preselect=article.published_date is None,
+				warning=_date_precision_warning(paper),
+			)
+		)
+
+	if paper.retracted and not article.retracted:
+		fields.append(
+			FieldDiff(
+				field="retracted",
+				label="Retracted",
+				current=article.retracted,
+				proposed=True,
+				raw=True,
+				preselect=True,
+			)
+		)
+
+	if paper.access and paper.access != article.access:
+		fields.append(
+			FieldDiff(
+				field="access",
+				label="Open access (via Unpaywall)",
+				current=article.access,
+				proposed=paper.access,
+				raw=paper.access,
+				preselect=_is_empty_access(article.access),
+			)
+		)
+
+	if paper.pdf_link and paper.pdf_link != article.pdf_link:
+		fields.append(
+			FieldDiff(
+				field="pdf_link",
+				label="PDF link (via Unpaywall)",
+				current=article.pdf_link,
+				proposed=paper.pdf_link,
+				raw=paper.pdf_link,
+				preselect=_is_empty_text(article.pdf_link),
+			)
+		)
+
+	authors = _build_author_diffs(article, paper.authors or [])
+
+	return CrossrefDiff(fetch_error=None, fields=fields, authors=authors)
+
+
+FIELD_DESERIALIZERS = {
+	"published_date": lambda raw: parse_datetime(raw) if raw else None,
+}
+
+
+def _deserialize_field(field_name: str, raw):
+	deserializer = FIELD_DESERIALIZERS.get(field_name)
+	return deserializer(raw) if deserializer else raw
+
+
+def _author_family_name(author: Authors) -> str:
+	return author.family_name or str(author)
+
+
+def _author_full_label(author: Authors) -> str:
+	if author.ORCID:
+		return f"{author.given_name} {author.family_name} (ORCID {author.ORCID})"
+	return f"{author.given_name} {author.family_name}"
+
+
+def build_change_reason(
+	changed_fields: list, added_authors: list, removed_authors: list
+) -> str:
+	"""Compose the simple_history change reason within the 100-char column
+	budget (history_change_reason is a CharField — Postgres errors, doesn't
+	truncate, on overflow). Degrades deterministically when too long: drop
+	author names into "+N more" one at a time (added first, then removed),
+	then collapse the scalar field list to "N fields"."""
+	if not changed_fields and not added_authors and not removed_authors:
+		return ""
+
+	added = list(added_authors)
+	removed = list(removed_authors)
+	added_dropped = 0
+	removed_dropped = 0
+	fields_text = ", ".join(changed_fields)
+
+	def render() -> str:
+		segments = []
+		if fields_text:
+			segments.append(fields_text)
+		if added or added_dropped:
+			if added:
+				text = "+authors " + ", ".join(added)
+				if added_dropped:
+					text += f" +{added_dropped} more"
+			else:
+				text = f"+{added_dropped} authors"
+			segments.append(text)
+		if removed or removed_dropped:
+			if removed:
+				text = "-authors " + ", ".join(removed)
+				if removed_dropped:
+					text += f" +{removed_dropped} more"
+			else:
+				text = f"-{removed_dropped} authors"
+			segments.append(text)
+		return CHANGE_REASON_PREFIX + "; ".join(segments)
+
+	reason = render()
+
+	while len(reason) > MAX_REASON_LEN and (added or removed):
+		if added:
+			added.pop()
+			added_dropped += 1
+		else:
+			removed.pop()
+			removed_dropped += 1
+		reason = render()
+
+	if len(reason) > MAX_REASON_LEN and changed_fields:
+		fields_text = f"{len(changed_fields)} fields"
+		reason = render()
+
+	if len(reason) > MAX_REASON_LEN:
+		reason = reason[: MAX_REASON_LEN - 1] + "…"
+
+	return reason
+
+
+def apply_crossref_diff(
+	article: Articles, selected_fields: dict, selected_authors: list
+) -> AppliedResult:
+	"""Apply exactly the ticked rows from a CrossrefDiff.
+
+	`selected_fields` maps Articles field name -> raw value, and
+	`selected_authors` is the subset of author rows the user ticked — both as
+	carried in the signed diff payload built from `build_crossref_diff`'s
+	output. Never re-fetches CrossRef: the caller is responsible for
+	round-tripping the exact values that were shown on the review page, so
+	what's applied always matches what was displayed.
+	"""
+	update_fields = []
+	changed_field_names = []
+	for field_name, raw in selected_fields.items():
+		setattr(article, field_name, _deserialize_field(field_name, raw))
+		update_fields.append(field_name)
+		changed_field_names.append(field_name)
+
+	article.crossref_check = timezone.now()
+	update_fields.append("crossref_check")
+	if "retracted" in changed_field_names:
+		article.crossref_retraction_check = timezone.now()
+		update_fields.append("crossref_retraction_check")
+
+	added_family, added_full = [], []
+	removed_family, removed_full = [], []
+
+	with transaction.atomic():
+		for row in selected_authors:
+			action = row.get("action")
+			raw = row.get("raw") or {}
+			if action == "add":
+				author_obj = resolve_author(raw)
+				if author_obj is None:
+					continue
+				article.authors.add(author_obj)
+				added_family.append(_author_family_name(author_obj))
+				added_full.append(_author_full_label(author_obj))
+			elif action == "remove":
+				author_obj = Authors.objects.filter(pk=raw.get("author_id")).first()
+				if author_obj is None:
+					continue
+				article.authors.remove(author_obj)
+				removed_family.append(_author_family_name(author_obj))
+				removed_full.append(_author_full_label(author_obj))
+
+		reason = build_change_reason(changed_field_names, added_family, removed_family)
+		if reason:
+			article._change_reason = reason
+
+		if changed_field_names or added_family or removed_family:
+			# save=False: fold this into the single save() below rather than a
+			# second one, which would otherwise write a duplicate history row
+			# carrying the same change reason (every save() creates one,
+			# regardless of update_fields — see build_change_reason's docstring).
+			clear_marker(article, "details", save=False)
+			update_fields += ["details_attempts", "details_next_check"]
+
+		article.save(update_fields=update_fields)
+
+	return AppliedResult(
+		updated_fields=changed_field_names,
+		authors_added=added_full,
+		authors_removed=removed_full,
+		change_reason=reason,
+	)

--- a/django/gregory/services/crossref_refresh.py
+++ b/django/gregory/services/crossref_refresh.py
@@ -277,7 +277,16 @@ def build_crossref_diff(article: Articles) -> CrossrefDiff:
 			)
 		)
 
-	if paper.access and paper.access != article.access:
+	# "unknown" just means Unpaywall had nothing to say — never propose it as a
+	# downgrade over an already-determined "open"/"restricted" value.
+	access_is_real_downgrade = paper.access == "unknown" and not _is_empty_access(
+		article.access
+	)
+	if (
+		paper.access
+		and paper.access != article.access
+		and not access_is_real_downgrade
+	):
 		fields.append(
 			FieldDiff(
 				field="access",

--- a/django/gregory/services/doi_import.py
+++ b/django/gregory/services/doi_import.py
@@ -51,47 +51,54 @@ def normalize_doi(doi: str) -> str:
 	return doi.strip()
 
 
+def resolve_author(author_data: dict) -> Authors | None:
+	"""Get-or-create the Authors row matching a CrossRef author dict, without
+	attaching it to any article. ORCID (when present) takes priority over name
+	matching; falls back to exact given/family name lookup. Returns None when
+	the author data is unusable (missing name) or ambiguous (multiple existing
+	authors share the same name).
+	"""
+	given_name = author_data.get("given")
+	family_name = author_data.get("family")
+	raw_orcid = author_data.get("ORCID")
+	orcid = normalize_orcid(raw_orcid) if raw_orcid else None
+
+	if not given_name or not family_name:
+		logger.warning("Skipping author with missing name: %s", author_data)
+		return None
+
+	if orcid:
+		author_obj, created = Authors.objects.get_or_create(
+			ORCID=orcid,
+			defaults={"given_name": given_name, "family_name": family_name},
+		)
+		if not created and (
+			author_obj.given_name != given_name
+			or author_obj.family_name != family_name
+		):
+			author_obj.given_name = given_name
+			author_obj.family_name = family_name
+			author_obj.save()
+		return author_obj
+
+	try:
+		return Authors.objects.get(given_name=given_name, family_name=family_name)
+	except Authors.DoesNotExist:
+		return Authors.objects.create(
+			given_name=given_name, family_name=family_name, ORCID=orcid
+		)
+	except Authors.MultipleObjectsReturned:
+		logger.warning(
+			"Multiple authors for %s %s — skipping", given_name, family_name
+		)
+		return None
+
+
 def _process_authors(article: Articles, authors_data: list) -> int:
 	"""Attach authors from CrossRef data to an article. Returns count added."""
 	added = 0
 	for author_data in authors_data:
-		given_name = author_data.get("given")
-		family_name = author_data.get("family")
-		raw_orcid = author_data.get("ORCID")
-		orcid = normalize_orcid(raw_orcid) if raw_orcid else None
-
-		if not given_name or not family_name:
-			logger.warning("Skipping author with missing name: %s", author_data)
-			continue
-
-		author_obj = None
-		if orcid:
-			author_obj, created = Authors.objects.get_or_create(
-				ORCID=orcid,
-				defaults={"given_name": given_name, "family_name": family_name},
-			)
-			if not created and (
-				author_obj.given_name != given_name
-				or author_obj.family_name != family_name
-			):
-				author_obj.given_name = given_name
-				author_obj.family_name = family_name
-				author_obj.save()
-		else:
-			try:
-				author_obj = Authors.objects.get(
-					given_name=given_name, family_name=family_name
-				)
-			except Authors.DoesNotExist:
-				author_obj = Authors.objects.create(
-					given_name=given_name, family_name=family_name, ORCID=orcid
-				)
-			except Authors.MultipleObjectsReturned:
-				logger.warning(
-					"Multiple authors for %s %s — skipping", given_name, family_name
-				)
-				continue
-
+		author_obj = resolve_author(author_data)
 		if author_obj:
 			article.authors.add(author_obj)
 			added += 1

--- a/django/gregory/tests/test_admin_article_crossref_refresh.py
+++ b/django/gregory/tests/test_admin_article_crossref_refresh.py
@@ -193,6 +193,26 @@ class ArticleCrossrefRefreshViewTest(TestCase):
 		self.assertFalse(access_row.preselect)
 
 	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_access_unknown_from_unpaywall_never_downgrades_determined_value(
+		self, MockSciencePaper
+	):
+		# SciencePaper.refresh() sets access="unknown" when Unpaywall has
+		# nothing — that must never be proposed as a downgrade over an
+		# already-determined "open"/"restricted" value.
+		self.article.access = "open"
+		self.article.save()
+		self._patch_paper(MockSciencePaper, _mock_paper(access="unknown"))
+		self.client.force_login(self.superuser)
+
+		# access="unknown" is the only thing CrossRef/Unpaywall returned, and
+		# it must not be proposed at all — so there's nothing left to review.
+		response = self.client.get(self.url)
+
+		self.assertRedirects(response, self.change_url)
+		self.article.refresh_from_db()
+		self.assertEqual(self.article.access, "open")
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
 	def test_year_only_issued_warns_and_is_not_preselected_over_existing_date(
 		self, MockSciencePaper
 	):

--- a/django/gregory/tests/test_admin_article_crossref_refresh.py
+++ b/django/gregory/tests/test_admin_article_crossref_refresh.py
@@ -1,0 +1,434 @@
+"""
+Tests for the Articles admin's "Refresh from CrossRef" button/view
+(gregory.admin.ArticleAdmin.crossref_refresh_view) and the
+gregory.services.crossref_refresh service layer.
+
+Run with:
+    docker exec gregory python manage.py test gregory.tests.test_admin_article_crossref_refresh
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytz
+from django.contrib.auth import get_user_model
+from django.core import signing
+from django.test import SimpleTestCase, TestCase
+from django.urls import reverse
+from organizations.models import Organization
+
+from gregory.classes import SciencePaper
+from gregory.models import Articles, Authors, Team
+from gregory.services.crossref_refresh import build_change_reason
+
+User = get_user_model()
+
+
+def _mock_paper(doi="10.1000/xyz", **kwargs):
+	"""Build a SciencePaper mock with sensible "nothing new" defaults, the way
+	test_doi_import_service.py does for the sibling import service."""
+	paper = MagicMock()
+	paper.doi = doi
+	paper.title = None
+	paper.abstract = None
+	paper.published_date = None
+	paper.access = None
+	paper.publisher = None
+	paper.journal = None
+	paper.pdf_link = None
+	paper.authors = []
+	paper.retracted = None
+	paper._work = {"issued": {"date-parts": [[2024, 3, 5]]}}
+	paper.clean_abstract.side_effect = lambda: paper.abstract
+	paper.refresh.return_value = None
+	for k, v in kwargs.items():
+		setattr(paper, k, v)
+	return paper
+
+
+class ArticleCrossrefRefreshViewTest(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(name="Org", slug="crossref-org")
+		self.team = Team.objects.create(
+			organization=self.org, name="Team", slug="crossref-team"
+		)
+		self.article = Articles.objects.create(
+			title="Old title",
+			link="https://example.com/a",
+			doi="10.1000/xyz",
+		)
+		self.article.teams.add(self.team)
+
+		self.superuser = User.objects.create_superuser(
+			username="admin", email="admin@example.com", password="pw"
+		)
+		self.url = reverse(
+			"admin:gregory_articles_crossref_refresh", args=[self.article.pk]
+		)
+		self.change_url = reverse(
+			"admin:gregory_articles_change", args=[self.article.pk]
+		)
+
+	def _patch_paper(self, MockSciencePaper, paper):
+		MockSciencePaper.return_value = paper
+		# Use the real (static) failure-detection logic against whatever
+		# refresh() "returned", instead of a mock that's truthy by default.
+		MockSciencePaper.is_crossref_failed = SciencePaper.is_crossref_failed
+
+	def _get_diff(self):
+		response = self.client.get(self.url)
+		return response, response.context["diff"], response.context.get("signed_payload")
+
+	def _field_index(self, diff, field_name):
+		return next(i for i, fd in enumerate(diff.fields) if fd.field == field_name)
+
+	# ------------------------------------------------------------------
+	# GET
+	# ------------------------------------------------------------------
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_get_renders_diff_without_mutating(self, MockSciencePaper):
+		self._patch_paper(
+			MockSciencePaper, _mock_paper(title="New Title", publisher="Acme")
+		)
+		self.client.force_login(self.superuser)
+
+		response, diff, payload = self._get_diff()
+
+		self.assertEqual(response.status_code, 200)
+		self.article.refresh_from_db()
+		self.assertEqual(self.article.title, "Old title")
+		self.assertIsNone(self.article.crossref_check)
+		self.assertTrue(payload)
+		self.assertEqual({fd.field for fd in diff.fields}, {"title", "publisher"})
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_get_no_changes_found_redirects(self, MockSciencePaper):
+		self.article.title = "Same Title"
+		self.article.save()
+		self._patch_paper(MockSciencePaper, _mock_paper(title="Same Title"))
+		self.client.force_login(self.superuser)
+
+		response = self.client.get(self.url)
+
+		self.assertRedirects(response, self.change_url)
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_get_crossref_failure_shows_error_and_does_not_write(
+		self, MockSciencePaper
+	):
+		paper = _mock_paper()
+		paper.refresh.return_value = "DOI not found"
+		self._patch_paper(MockSciencePaper, paper)
+		self.client.force_login(self.superuser)
+
+		response = self.client.get(self.url)
+
+		self.assertRedirects(response, self.change_url)
+		self.article.refresh_from_db()
+		self.assertIsNone(self.article.crossref_check)
+
+	def test_article_without_doi_button_hidden_and_view_refuses(self):
+		article = Articles.objects.create(title="No DOI", link="https://example.com/b")
+		article.teams.add(self.team)
+		self.client.force_login(self.superuser)
+
+		change_response = self.client.get(
+			reverse("admin:gregory_articles_change", args=[article.pk])
+		)
+		self.assertIn(b"nothing to look up", change_response.content)
+
+		url = reverse("admin:gregory_articles_crossref_refresh", args=[article.pk])
+		response = self.client.get(url)
+
+		self.assertRedirects(
+			response, reverse("admin:gregory_articles_change", args=[article.pk])
+		)
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_title_diff_is_cleaned_like_feed_titles(self, MockSciencePaper):
+		self._patch_paper(
+			MockSciencePaper, _mock_paper(title="<scp>ABC</scp> Title")
+		)
+		self.client.force_login(self.superuser)
+
+		_, diff, _ = self._get_diff()
+		title_row = next(fd for fd in diff.fields if fd.field == "title")
+
+		self.assertEqual(title_row.proposed, "ABC Title")
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_crossref_none_never_blanks_populated_field(self, MockSciencePaper):
+		self.article.publisher = "Existing Publisher"
+		self.article.save()
+		self._patch_paper(MockSciencePaper, _mock_paper(title="New Title"))
+		self.client.force_login(self.superuser)
+
+		_, diff, _ = self._get_diff()
+
+		self.assertNotIn("publisher", [fd.field for fd in diff.fields])
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_access_unknown_current_counts_as_empty_and_preselects(
+		self, MockSciencePaper
+	):
+		self._patch_paper(MockSciencePaper, _mock_paper(access="open"))
+		self.client.force_login(self.superuser)
+
+		_, diff, _ = self._get_diff()
+		access_row = next(fd for fd in diff.fields if fd.field == "access")
+
+		self.assertTrue(access_row.preselect)
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_access_already_determined_does_not_preselect(self, MockSciencePaper):
+		self.article.access = "open"
+		self.article.save()
+		self._patch_paper(MockSciencePaper, _mock_paper(access="restricted"))
+		self.client.force_login(self.superuser)
+
+		_, diff, _ = self._get_diff()
+		access_row = next(fd for fd in diff.fields if fd.field == "access")
+
+		self.assertFalse(access_row.preselect)
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_year_only_issued_warns_and_is_not_preselected_over_existing_date(
+		self, MockSciencePaper
+	):
+		self.article.published_date = datetime(2020, 5, 5, tzinfo=pytz.UTC)
+		self.article.save()
+		paper = _mock_paper(
+			published_date=datetime(2024, 1, 1, tzinfo=pytz.UTC),
+		)
+		paper._work = {"issued": {"date-parts": [[2024]]}}
+		self._patch_paper(MockSciencePaper, paper)
+		self.client.force_login(self.superuser)
+
+		_, diff, _ = self._get_diff()
+		date_row = next(fd for fd in diff.fields if fd.field == "published_date")
+
+		self.assertIn("only a year", date_row.warning)
+		self.assertFalse(date_row.preselect)
+
+	# ------------------------------------------------------------------
+	# POST
+	# ------------------------------------------------------------------
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_post_applies_only_ticked_fields(self, MockSciencePaper):
+		self._patch_paper(
+			MockSciencePaper, _mock_paper(title="New Title", publisher="Acme")
+		)
+		self.client.force_login(self.superuser)
+		_, diff, payload = self._get_diff()
+		title_index = self._field_index(diff, "title")
+
+		response = self.client.post(
+			self.url, {"payload": payload, f"field_{title_index}": "on"}
+		)
+
+		self.assertRedirects(response, self.change_url)
+		self.article.refresh_from_db()
+		self.assertEqual(self.article.title, "New Title")
+		self.assertIsNone(self.article.publisher)
+		self.assertIsNotNone(self.article.crossref_check)
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_post_writes_history_row_with_change_reason(self, MockSciencePaper):
+		self._patch_paper(MockSciencePaper, _mock_paper(title="New Title"))
+		self.client.force_login(self.superuser)
+		_, diff, payload = self._get_diff()
+		title_index = self._field_index(diff, "title")
+
+		self.client.post(self.url, {"payload": payload, f"field_{title_index}": "on"})
+
+		self.article.refresh_from_db()
+		latest_history = self.article.history.first()
+		self.assertEqual(latest_history.history_change_reason, "CrossRef: title")
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_post_writes_exactly_one_history_row_per_apply(self, MockSciencePaper):
+		# Regression guard: clear_marker() used to do its own save() after the
+		# main article.save(), and since simple_history writes a history row on
+		# every save() regardless of update_fields, that produced a duplicate
+		# row carrying the same (still-set) change reason.
+		self._patch_paper(MockSciencePaper, _mock_paper(title="New Title"))
+		self.client.force_login(self.superuser)
+		history_count_before = self.article.history.count()
+		_, diff, payload = self._get_diff()
+		title_index = self._field_index(diff, "title")
+
+		self.client.post(self.url, {"payload": payload, f"field_{title_index}": "on"})
+
+		self.article.refresh_from_db()
+		self.assertEqual(self.article.history.count(), history_count_before + 1)
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_authors_add_reuses_existing_orcid_match(self, MockSciencePaper):
+		existing = Authors.objects.create(
+			given_name="Jane", family_name="Doe", ORCID="0000-0001-2345-6789"
+		)
+		self._patch_paper(
+			MockSciencePaper,
+			_mock_paper(
+				authors=[
+					{"given": "Jane", "family": "Doe", "ORCID": "0000-0001-2345-6789"}
+				]
+			),
+		)
+		self.client.force_login(self.superuser)
+		_, diff, payload = self._get_diff()
+		self.assertEqual(len(diff.authors), 1)
+		self.assertEqual(diff.authors[0].action, "add")
+		self.assertTrue(diff.authors[0].preselect)  # article currently has no authors
+
+		self.client.post(self.url, {"payload": payload, "author_0": "on"})
+
+		self.article.refresh_from_db()
+		self.assertEqual(list(self.article.authors.all()), [existing])
+		self.assertEqual(Authors.objects.filter(family_name="Doe").count(), 1)
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_authors_only_apply_still_writes_history_naming_added_author(
+		self, MockSciencePaper
+	):
+		self._patch_paper(
+			MockSciencePaper,
+			_mock_paper(authors=[{"given": "Jane", "family": "Doe"}]),
+		)
+		self.client.force_login(self.superuser)
+		_, diff, payload = self._get_diff()
+
+		self.client.post(self.url, {"payload": payload, "author_0": "on"})
+
+		self.article.refresh_from_db()
+		self.assertEqual(self.article.authors.count(), 1)
+		latest_history = self.article.history.first()
+		self.assertIn("Doe", latest_history.history_change_reason)
+
+	@patch("gregory.services.crossref_refresh.SciencePaper")
+	def test_unticked_author_removal_leaves_m2m_alone(self, MockSciencePaper):
+		existing = Authors.objects.create(given_name="John", family_name="Smith")
+		self.article.authors.add(existing)
+		self._patch_paper(MockSciencePaper, _mock_paper(authors=[]))
+		self.client.force_login(self.superuser)
+
+		_, diff, payload = self._get_diff()
+		self.assertEqual(len(diff.authors), 1)
+		self.assertEqual(diff.authors[0].action, "remove")
+		self.assertFalse(diff.authors[0].preselect)
+
+		# Nothing ticked: the view should refuse and change nothing.
+		response = self.client.post(self.url, {"payload": payload})
+
+		self.assertRedirects(response, self.change_url)
+		self.article.refresh_from_db()
+		self.assertEqual(list(self.article.authors.all()), [existing])
+
+	def test_tampered_payload_rejected(self):
+		self.client.force_login(self.superuser)
+		bad_payload = signing.dumps(
+			{
+				"article_id": self.article.pk,
+				"fields": [{"field": "title", "raw": "Hacked"}],
+				"authors": [],
+			},
+			salt="not-the-right-salt",
+		)
+
+		response = self.client.post(
+			self.url, {"payload": bad_payload, "field_0": "on"}
+		)
+
+		self.assertRedirects(response, self.change_url)
+		self.article.refresh_from_db()
+		self.assertEqual(self.article.title, "Old title")
+
+	def test_expired_payload_rejected(self):
+		import time
+
+		salt = "gregory.admin.crossref_refresh"
+		data = {
+			"article_id": self.article.pk,
+			"fields": [{"field": "title", "raw": "Hacked"}],
+			"authors": [],
+		}
+		serialized = signing.JSONSerializer().dumps(data)
+		base64d = signing.b64_encode(serialized).decode()
+		old_timestamp = signing.b62_encode(int(time.time()) - 1000)
+		value_with_old_timestamp = f"{base64d}:{old_timestamp}"
+		# A validly-signed payload whose embedded timestamp is already outside
+		# the view's max_age=900 window — forged the same way TimestampSigner
+		# itself would have signed it 1000 seconds ago.
+		expired_payload = signing.Signer(salt=salt).sign(value_with_old_timestamp)
+
+		self.client.force_login(self.superuser)
+		response = self.client.post(
+			self.url, {"payload": expired_payload, "field_0": "on"}
+		)
+
+		self.assertRedirects(response, self.change_url)
+		self.article.refresh_from_db()
+		self.assertEqual(self.article.title, "Old title")
+
+	def test_anonymous_user_cannot_trigger_apply(self):
+		response = self.client.post(self.url)
+
+		self.assertNotEqual(response.status_code, 200)
+		self.article.refresh_from_db()
+		self.assertIsNone(self.article.crossref_check)
+
+	def test_staff_without_change_permission_is_forbidden(self):
+		from organizations.models import OrganizationUser
+
+		# Belongs to the article's org (so OrganizationFilterMixin's scoped
+		# get_object() finds it) but has no Django model permission — the
+		# has_change_permission() check inside the view is what must fire.
+		staff = User.objects.create_user(
+			username="staff-no-perm", password="pw", is_staff=True
+		)
+		OrganizationUser.objects.create(user=staff, organization=self.org)
+		self.client.force_login(staff)
+
+		response = self.client.post(self.url)
+
+		self.assertEqual(response.status_code, 403)
+		self.article.refresh_from_db()
+		self.assertIsNone(self.article.crossref_check)
+
+
+class ChangeReasonBuilderTest(SimpleTestCase):
+	def test_empty_when_nothing_changed(self):
+		self.assertEqual(build_change_reason([], [], []), "")
+
+	def test_simple_case_fits_verbatim(self):
+		reason = build_change_reason(["title", "summary"], [], [])
+		self.assertEqual(reason, "CrossRef: title, summary")
+
+	def test_never_exceeds_100_chars_with_30_authors(self):
+		added = [f"VeryLongFamilyName{i}" for i in range(30)]
+		reason = build_change_reason([], added, [])
+		self.assertLessEqual(len(reason), 100)
+		self.assertTrue(reason.startswith("CrossRef: "))
+
+	def test_never_exceeds_100_chars_with_very_long_family_names(self):
+		added = ["A" * 60, "B" * 60, "C" * 60]
+		reason = build_change_reason([], added, [])
+		self.assertLessEqual(len(reason), 100)
+
+	def test_never_exceeds_100_chars_with_every_scalar_field_and_authors(self):
+		fields = [
+			"title",
+			"summary",
+			"publisher",
+			"container_title",
+			"published_date",
+			"retracted",
+			"access",
+			"pdf_link",
+		]
+		added = [f"AddedFamilyName{i}" for i in range(10)]
+		removed = [f"RemovedFamilyName{i}" for i in range(10)]
+		reason = build_change_reason(fields, added, removed)
+		self.assertLessEqual(len(reason), 100)

--- a/django/gregory/utils/text_cleaning.py
+++ b/django/gregory/utils/text_cleaning.py
@@ -1,0 +1,35 @@
+"""Shared text-cleaning helpers used both when ingesting feed entries and
+when reviewing upstream (CrossRef) metadata in the admin.
+"""
+
+from typing import Optional
+
+# Inline tags whose markup carries meaning and should be preserved in titles
+SEMANTIC_TITLE_TAGS = {"sub", "sup", "i", "b", "em", "strong"}
+
+
+def clean_title(title: Optional[str]) -> Optional[str]:
+	"""Normalize a title before storage.
+
+	Publisher feeds (notably PubMed/Wiley) and CrossRef embed inline markup
+	and pretty-printed newlines/indentation inside titles. We unescape HTML
+	entities, keep semantically meaningful inline tags (sub, sup, i, b, em,
+	strong) but strip presentational/JATS tags (e.g. <scp>, <jats:*>) while
+	preserving their text, drop tag attributes, and collapse runs of
+	whitespace to single spaces.
+	"""
+	if not title:
+		return title
+	from bs4 import BeautifulSoup
+	import html
+
+	title = html.unescape(title)
+	soup = BeautifulSoup(title, "html.parser")
+	for tag in soup.find_all(True):
+		if tag.name in SEMANTIC_TITLE_TAGS:
+			tag.attrs = {}
+		else:
+			tag.unwrap()
+	# formatter=None keeps entities unescaped (e.g. bare &) so the stored
+	# title matches the human-readable form; str(soup) would re-encode & -> &amp;.
+	return " ".join(soup.decode(formatter=None).split())

--- a/django/templates/admin/gregory/articles/crossref_refresh.html
+++ b/django/templates/admin/gregory/articles/crossref_refresh.html
@@ -1,0 +1,87 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<h1>{{ title }}</h1>
+
+<p>
+	This is the current CrossRef{% if diff.authors %} and author{% endif %} data for
+	<strong>{{ article }}</strong> (DOI: {{ article.doi }}), compared against what we
+	hold. Nothing is changed until you tick the rows you want and submit.
+</p>
+
+<form method="post">
+	{% csrf_token %}
+	<input type="hidden" name="payload" value="{{ signed_payload }}">
+
+	{% if diff.fields %}
+	<fieldset class="module aligned">
+		<h2>Fields</h2>
+		<table>
+			<thead>
+				<tr>
+					<th></th>
+					<th>Field</th>
+					<th>Current</th>
+					<th>Proposed</th>
+				</tr>
+			</thead>
+			<tbody>
+				{% for row in diff.fields %}
+				<tr>
+					<td>
+						<input type="checkbox" name="field_{{ forloop.counter0 }}" {% if row.preselect %}checked{% endif %}>
+					</td>
+					<td>{{ row.label }}</td>
+					<td>{{ row.current }}</td>
+					<td>
+						{{ row.proposed }}
+						{% if row.warning %}
+						<div class="help">{{ row.warning }}</div>
+						{% endif %}
+						{% if row.extra %}
+						<details>
+							<summary>Show diff</summary>
+							<pre>{{ row.extra }}</pre>
+						</details>
+						{% endif %}
+					</td>
+				</tr>
+				{% endfor %}
+			</tbody>
+		</table>
+	</fieldset>
+	{% endif %}
+
+	{% if diff.authors %}
+	<fieldset class="module aligned">
+		<h2>Authors</h2>
+		<table>
+			<thead>
+				<tr>
+					<th></th>
+					<th>Action</th>
+					<th>Author</th>
+				</tr>
+			</thead>
+			<tbody>
+				{% for row in diff.authors %}
+				<tr>
+					<td>
+						<input type="checkbox" name="author_{{ forloop.counter0 }}" {% if row.preselect %}checked{% endif %}>
+					</td>
+					<td>{% if row.action == "add" %}Add{% else %}Remove{% endif %}</td>
+					<td>{{ row.label }}</td>
+				</tr>
+				{% endfor %}
+			</tbody>
+		</table>
+	</fieldset>
+	{% endif %}
+
+	<div class="submit-row">
+		<input type="submit" value="Apply selected changes" class="default">
+		<a href="{% url 'admin:gregory_articles_change' article.pk %}" class="button cancel-link">Cancel</a>
+	</div>
+</form>
+{% endblock %}

--- a/docs/02-sources-and-articles.md
+++ b/docs/02-sources-and-articles.md
@@ -67,6 +67,26 @@ keys: `medicalCondition`, `sponsor`, `number`, `containAll`, `status`. Run via
 | `doi` | Digital Object Identifier, used for de-duplication and CrossRef enrichment |
 | `kind` | One of: `science paper`, `news`, `trial` |
 
+### Refreshing metadata from CrossRef in the admin
+
+Articles with a `doi` show a **Refresh from CrossRef** button on their admin
+change page (articles without a DOI show an inert message instead). It fetches
+current CrossRef metadata — plus Unpaywall's `access`/`pdf_link` — and renders a
+field-by-field diff against what the article currently holds, alongside any
+authors CrossRef lists that aren't attached yet (and any attached authors
+CrossRef no longer lists, as opt-in, never pre-ticked, removals). Nothing is
+written until you tick the rows you want and submit; only those rows are
+applied. A CrossRef value of `None` never blanks a populated field, and a
+year-only or year+month `issued` date is flagged with a precision warning
+rather than silently applied as a padded 1 January date. Scalar changes are
+recorded in the article's History tab; author additions/removals are recorded
+as a change-reason note (family names only, to fit the 100-character column)
+plus a full detail entry in the admin's own log.
+
+This uses the same `SciencePaper.refresh()` CrossRef/Unpaywall client as the
+`update_articles_info` pipeline command — see
+[gregory/services/crossref_refresh.py](../django/gregory/services/crossref_refresh.py).
+
 ---
 
 ## Endpoints by subject and category


### PR DESCRIPTION
## Summary

Adds a per-article **Refresh from CrossRef** button at `/admin/gregory/articles/<id>/change/` (next to the existing "Recheck ORCID now" button on Authors, same shape):

- **GET** fetches current CrossRef metadata + Unpaywall `access`/`pdf_link`, diffs it against what the article holds (title, summary, publisher, container_title, published_date, retracted, access, pdf_link, plus attached-author additions/removals), and renders a review page with a checkbox per row. Nothing is written on GET.
- Only rows where we currently hold **nothing** start ticked; a `None` from CrossRef never blanks a populated field; a year-only or year+month `issued` date gets a precision warning instead of silently applying a padded 1‑January date; author removals are opt-in and never pre-ticked.
- **POST** applies only the ticked rows, using the *exact* values shown on the review page — round-tripped through a `django.core.signing` payload (salted, `max_age=900`) rather than a second CrossRef call, so what's applied can never drift from what was displayed. Tampered/expired payloads are rejected.
- Scalar changes land in the article's History tab (simple_history change reason, family-names-only to fit the 100-char column, with a deterministic degrade for many/long author names); the full detail (given+family+ORCID, removals) goes into the admin's own `LogEntry`.
- Articles with no DOI show an inert message instead of the button, and the view itself refuses even via a hand-typed URL.

Also, while wiring this up:
- Fixed a latent `NameError` in `SciencePaper.refresh()` (`classes.py`) that crashed when a CrossRef `work` had no `"issued"` key — previously silently swallowed by callers that skip the whole row on any exception, so it never surfaced, but the admin view needed a hard fix rather than a wrap.
- Extracted `FeedProcessor.clean_title` into `gregory/utils/text_cleaning.py` (kept as a thin delegate) so both the feedreader and the CrossRef review page normalize titles identically.
- Extracted `resolve_author()` out of `doi_import._process_authors` so the review page can get-or-create a *subset* of authors with identical ORCID/name-matching semantics, without duplicating that logic.

No model changes, no migration, no API/serializer/filter change — no `schema.yml` regeneration needed.

## Test plan

- [x] New test suite `gregory/tests/test_admin_article_crossref_refresh.py` (24 tests): GET renders diff without mutating, no-changes-found redirect, CrossRef failure handling, no-DOI button/view refusal, title cleaning applied, `None` never blanks a populated field, `access="unknown"` vs `"open"` pre-selection, date-precision warning, POST applies only ticked fields, history row + change reason (including the exactly-one-row regression guard below), author add reuses existing ORCID match, authors-only apply still writes history, unticked author removal leaves M2M alone, tampered/expired payload rejection, anonymous/permission-denied cases, and a dedicated `build_change_reason` unit-test class covering the 100-char budget (30 authors, very long names, all 8 scalar fields at once).
- [x] Existing suites unaffected: `test_doi_import_service`, `test_feed_title_cleaning`, `test_admin_authors_recheck_orcid` all still pass.
- [x] Full `gregory` app suite: 1279 tests, all passing.
- [x] `python manage.py check`: no issues.
- [x] Manually verified end-to-end in a browser against **live CrossRef + Unpaywall** for a real DOI (`10.1371/journal.pone.0000001`): button renders, diff shows correct pre-selection (title unticked since already populated; empty fields + all 4 authors pre-ticked since article had none), applying writes exactly one history row with the expected `CrossRef: publisher, container_title, published_date, access, pdf_link; +authors Almeida +3 more` change reason. This manual pass caught and fixed a real bug: `clear_marker()`'s own internal `save()` was producing a duplicate history row sharing the same change reason — fixed by using `clear_marker(..., save=False)` and folding those fields into the single `article.save()` call, with a regression test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)