### PR TITLE
Persist MCP telemetry/intent logs to rotated files on disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ postgres-data_old/
 # Database backups
 backups/
 
+# MCP server telemetry/intent logs
+mcp-server/logs/
+
 # Metabase
 metabase-data/
 metabase/db-data/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -72,11 +72,14 @@ services:
     build: ./mcp-server
     ports:
       - 127.0.0.1:8001:8001
+    volumes:
+      - ./mcp-server/logs:/var/log/gregory-mcp  # telemetry + intent logs (persist, rotated in-app)
     environment:
       # Base URL of the GregoryAI instance this server proxies. Defaults to
       # the sibling `gregory` container for local dev; point it at a public
       # instance (e.g. https://api.brain-regeneration.com) in production.
       - GREGORY_API_URL=${GREGORY_MCP_API_URL:-http://gregory:8000}
+      - MCP_LOG_DIR=/var/log/gregory-mcp
     networks:
       - gregory_network
     depends_on:

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -144,18 +144,29 @@ question — tune them from what this log actually shows, not speculatively.
 `gregory_mcp`'s own two log streams (`mcp_request` telemetry on stdout, `mcp_intent` on
 stderr — see `mcp-server/gregory_mcp/logging_config.py`) are, by default, only readable
 via `docker logs`, with no rotation and retention entirely at the mercy of Docker's log
-driver. Setting `MCP_LOG_DIR` (wired up in `docker-compose.yaml` as
-`/var/log/gregory-mcp`, bind-mounted to `./mcp-server/logs/` on the host) additionally
-writes each stream to its own file — `telemetry.log` and `intent.log` — rotated in-app at
-10 MB × 5 backups, no `logrotate` needed. `docker logs` keeps showing the same events
-either way; the files are additive, not a replacement. Leaving `MCP_LOG_DIR` unset (the
-default for local dev) keeps today's stdout/stderr-only behavior.
+driver. `docker-compose.yaml` sets `MCP_LOG_DIR=/var/log/gregory-mcp` for the
+`gregory-mcp` service (bind-mounted to `./mcp-server/logs/` on the host), which
+additionally writes each stream to its own file — `telemetry.log` and `intent.log` —
+rotated in-app at 10 MB × 5 backups, no `logrotate` needed. `docker logs` keeps showing
+the same events either way; the files are additive, not a replacement. `MCP_LOG_DIR` is
+only unset when running the server directly (`python -m gregory_mcp`, e.g. in tests),
+which keeps that path stdout/stderr-only.
 
-Audit directly from the files instead of `docker logs` once deployed:
+The container runs as non-root `appuser` (UID 1000, see `mcp-server/Dockerfile`), so
+`./mcp-server/logs/` must exist and be writable by that UID before the container starts
+— `mkdir -p mcp-server/logs && chown 1000:1000 mcp-server/logs` on the host, or Docker
+will create it as root on first `up` and the container won't be able to write to it. If
+the directory isn't writable, `configure_logging()` catches the error, logs one warning,
+and falls back to stdout/stderr-only rather than crashing the server — so a permissions
+mistake here silently loses the on-disk mirror rather than taking the server down.
+
+Audit directly from the files instead of `docker logs` once deployed — use `tail -F`
+(capital F), not `-f`: rotation renames the current file out from under a plain `-f`,
+which then stops following:
 
 ```bash
-tail -f mcp-server/logs/telemetry.log | jq
-tail -f mcp-server/logs/intent.log | jq
+tail -F mcp-server/logs/telemetry.log | jq
+tail -F mcp-server/logs/intent.log | jq
 ```
 
 This ships persistence and rotation only. The 90-day `intent` hard-delete retention

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -139,6 +139,28 @@ awk '$9 == 429' /var/log/nginx/mcp-access.log | grep -o 'mcp_name="[^"]*"' | sor
 Whether 30 r/m per (client, tool) and 120 r/m per client are the right numbers is an open
 question — tune them from what this log actually shows, not speculatively.
 
+### Telemetry and intent logs on disk
+
+`gregory_mcp`'s own two log streams (`mcp_request` telemetry on stdout, `mcp_intent` on
+stderr — see `mcp-server/gregory_mcp/logging_config.py`) are, by default, only readable
+via `docker logs`, with no rotation and retention entirely at the mercy of Docker's log
+driver. Setting `MCP_LOG_DIR` (wired up in `docker-compose.yaml` as
+`/var/log/gregory-mcp`, bind-mounted to `./mcp-server/logs/` on the host) additionally
+writes each stream to its own file — `telemetry.log` and `intent.log` — rotated in-app at
+10 MB × 5 backups, no `logrotate` needed. `docker logs` keeps showing the same events
+either way; the files are additive, not a replacement. Leaving `MCP_LOG_DIR` unset (the
+default for local dev) keeps today's stdout/stderr-only behavior.
+
+Audit directly from the files instead of `docker logs` once deployed:
+
+```bash
+tail -f mcp-server/logs/telemetry.log | jq
+tail -f mcp-server/logs/intent.log | jq
+```
+
+This ships persistence and rotation only. The 90-day `intent` hard-delete retention
+policy from `MCP-TELEMETRY-PLAN.md`'s Phase 6 is still separate, not-yet-built work.
+
 ## Deployment
 
 The image is `amaralbruno/gregory-mcp`, built and pushed by

--- a/mcp-server/gregory_mcp/__main__.py
+++ b/mcp-server/gregory_mcp/__main__.py
@@ -19,7 +19,7 @@ logger = logging.getLogger("gregory_mcp")
 
 def main() -> None:
 	settings = load_settings()
-	configure_logging(settings.log_level)
+	configure_logging(settings.log_level, settings.log_dir)
 	init_client(settings)
 
 	logger.info("gregory_mcp_starting", extra={"path": settings.api_base})

--- a/mcp-server/gregory_mcp/config.py
+++ b/mcp-server/gregory_mcp/config.py
@@ -15,6 +15,7 @@ class Settings:
 	connect_timeout: float
 	max_retries: int
 	log_level: str
+	log_dir: str | None
 
 	@property
 	def api_base(self) -> str:
@@ -39,4 +40,5 @@ def load_settings() -> Settings:
 		# all and every call fails immediately without ever hitting the network.
 		max_retries=max(0, int(os.environ.get("GREGORY_MAX_RETRIES", "2"))),
 		log_level=os.environ.get("MCP_LOG_LEVEL", "INFO").upper(),
+		log_dir=os.environ.get("MCP_LOG_DIR", "").strip() or None,
 	)

--- a/mcp-server/gregory_mcp/logging_config.py
+++ b/mcp-server/gregory_mcp/logging_config.py
@@ -132,24 +132,34 @@ def configure_logging(level: str, log_dir: str | None = None) -> None:
 
 	# Optional on-disk mirror of both streams, additive to stdout/stderr
 	# above rather than a replacement — `docker logs` keeps working exactly
-	# as before whether or not this is configured. Unset in local dev; set
-	# via MCP_LOG_DIR in production so the files land on a mounted volume
-	# and survive container restarts.
+	# as before whether or not this is configured. Best-effort: the
+	# container runs as non-root `appuser` (UID 1000, see Dockerfile), so a
+	# bind-mounted host directory that hasn't been created/chowned for that
+	# UID makes this raise OSError. That must not crash the server — fall
+	# back to stdout/stderr-only logging instead. Both handlers are built
+	# before either is attached, so a failure never leaves one stream
+	# mirrored to disk and the other not.
 	if log_dir:
-		os.makedirs(log_dir, exist_ok=True)
+		try:
+			os.makedirs(log_dir, exist_ok=True)
 
-		telemetry_file_handler = RotatingFileHandler(
-			os.path.join(log_dir, "telemetry.log"),
-			maxBytes=_LOG_MAX_BYTES,
-			backupCount=_LOG_BACKUP_COUNT,
-		)
-		telemetry_file_handler.setFormatter(JsonFormatter())
-		root.handlers.append(telemetry_file_handler)
+			telemetry_file_handler = RotatingFileHandler(
+				os.path.join(log_dir, "telemetry.log"),
+				maxBytes=_LOG_MAX_BYTES,
+				backupCount=_LOG_BACKUP_COUNT,
+				encoding="utf-8",
+			)
+			telemetry_file_handler.setFormatter(JsonFormatter())
 
-		intent_file_handler = RotatingFileHandler(
-			os.path.join(log_dir, "intent.log"),
-			maxBytes=_LOG_MAX_BYTES,
-			backupCount=_LOG_BACKUP_COUNT,
-		)
-		intent_file_handler.setFormatter(IntentJsonFormatter())
-		intent_logger.handlers.append(intent_file_handler)
+			intent_file_handler = RotatingFileHandler(
+				os.path.join(log_dir, "intent.log"),
+				maxBytes=_LOG_MAX_BYTES,
+				backupCount=_LOG_BACKUP_COUNT,
+				encoding="utf-8",
+			)
+			intent_file_handler.setFormatter(IntentJsonFormatter())
+		except OSError:
+			logging.getLogger(__name__).warning("mcp_log_dir_unwritable", exc_info=True)
+		else:
+			root.handlers.append(telemetry_file_handler)
+			intent_logger.handlers.append(intent_file_handler)

--- a/mcp-server/gregory_mcp/logging_config.py
+++ b/mcp-server/gregory_mcp/logging_config.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 import time
+from logging.handlers import RotatingFileHandler
+
+# 10 MB x 5 backups per file: generous enough that low-traffic instances never
+# rotate for weeks, capped so an unattended instance can't fill the disk.
+_LOG_MAX_BYTES = 10_000_000
+_LOG_BACKUP_COUNT = 5
 
 
 # Explicit allowlist, not "every extra field": this is the boundary that
@@ -102,7 +109,7 @@ class IntentJsonFormatter(logging.Formatter):
 		return json.dumps(payload)
 
 
-def configure_logging(level: str) -> None:
+def configure_logging(level: str, log_dir: str | None = None) -> None:
 	handler = logging.StreamHandler(sys.stdout)
 	handler.setFormatter(JsonFormatter())
 	root = logging.getLogger()
@@ -122,3 +129,27 @@ def configure_logging(level: str) -> None:
 	intent_logger.handlers = [intent_handler]
 	intent_logger.propagate = False
 	intent_logger.setLevel(level)
+
+	# Optional on-disk mirror of both streams, additive to stdout/stderr
+	# above rather than a replacement — `docker logs` keeps working exactly
+	# as before whether or not this is configured. Unset in local dev; set
+	# via MCP_LOG_DIR in production so the files land on a mounted volume
+	# and survive container restarts.
+	if log_dir:
+		os.makedirs(log_dir, exist_ok=True)
+
+		telemetry_file_handler = RotatingFileHandler(
+			os.path.join(log_dir, "telemetry.log"),
+			maxBytes=_LOG_MAX_BYTES,
+			backupCount=_LOG_BACKUP_COUNT,
+		)
+		telemetry_file_handler.setFormatter(JsonFormatter())
+		root.handlers.append(telemetry_file_handler)
+
+		intent_file_handler = RotatingFileHandler(
+			os.path.join(log_dir, "intent.log"),
+			maxBytes=_LOG_MAX_BYTES,
+			backupCount=_LOG_BACKUP_COUNT,
+		)
+		intent_file_handler.setFormatter(IntentJsonFormatter())
+		intent_logger.handlers.append(intent_file_handler)

--- a/mcp-server/tests/conftest.py
+++ b/mcp-server/tests/conftest.py
@@ -18,6 +18,7 @@ TEST_SETTINGS = Settings(
 	connect_timeout=2,
 	max_retries=0,
 	log_level="ERROR",
+	log_dir=None,
 )
 
 

--- a/mcp-server/tests/test_config.py
+++ b/mcp-server/tests/test_config.py
@@ -27,3 +27,21 @@ def test_positive_max_retries_passes_through(monkeypatch):
 	settings = load_settings()
 
 	assert settings.max_retries == 5
+
+
+def test_log_dir_defaults_to_none(monkeypatch):
+	monkeypatch.setenv("GREGORY_API_URL", "https://gregory.test")
+	monkeypatch.delenv("MCP_LOG_DIR", raising=False)
+
+	settings = load_settings()
+
+	assert settings.log_dir is None
+
+
+def test_log_dir_passes_through(monkeypatch):
+	monkeypatch.setenv("GREGORY_API_URL", "https://gregory.test")
+	monkeypatch.setenv("MCP_LOG_DIR", "/var/log/gregory-mcp")
+
+	settings = load_settings()
+
+	assert settings.log_dir == "/var/log/gregory-mcp"

--- a/mcp-server/tests/test_logging_config.py
+++ b/mcp-server/tests/test_logging_config.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 import json
 import logging
 import sys
+from logging.handlers import RotatingFileHandler
 
-from gregory_mcp.logging_config import IntentJsonFormatter, JsonFormatter
+from gregory_mcp.logging_config import (
+	INTENT_LOGGER_NAME,
+	IntentJsonFormatter,
+	JsonFormatter,
+	configure_logging,
+)
 
 
 def _make_record_with_exc_info(logger_name: str, exc_message: str) -> logging.LogRecord:
@@ -42,3 +48,41 @@ def test_json_formatter_omits_exc_type_when_there_is_no_exception():
 	)
 	payload = json.loads(JsonFormatter().format(record))
 	assert "exc_type" not in payload
+
+
+def test_configure_logging_without_log_dir_only_attaches_stream_handlers():
+	configure_logging("INFO")
+
+	root_handlers = logging.getLogger().handlers
+	intent_handlers = logging.getLogger(INTENT_LOGGER_NAME).handlers
+
+	assert len(root_handlers) == 1 and isinstance(root_handlers[0], logging.StreamHandler)
+	assert not isinstance(root_handlers[0], RotatingFileHandler)
+	assert len(intent_handlers) == 1 and isinstance(intent_handlers[0], logging.StreamHandler)
+	assert not isinstance(intent_handlers[0], RotatingFileHandler)
+
+
+def test_configure_logging_with_log_dir_writes_rotated_files(tmp_path):
+	configure_logging("INFO", log_dir=str(tmp_path))
+
+	logging.getLogger("gregory_mcp.telemetry").info("mcp_request", extra={"tool": "search_articles"})
+	logging.getLogger(INTENT_LOGGER_NAME).info("mcp_intent", extra={"tool": "search_articles", "intent": "test"})
+
+	telemetry_path = tmp_path / "telemetry.log"
+	intent_path = tmp_path / "intent.log"
+	assert telemetry_path.exists()
+	assert intent_path.exists()
+
+	telemetry_payload = json.loads(telemetry_path.read_text().splitlines()[-1])
+	assert telemetry_payload["tool"] == "search_articles"
+
+	intent_payload = json.loads(intent_path.read_text().splitlines()[-1])
+	assert intent_payload["intent"] == "test"
+
+	# Additive, not a replacement: the stdout/stderr handlers are still there.
+	root_handler_types = [type(h) for h in logging.getLogger().handlers]
+	intent_handler_types = [type(h) for h in logging.getLogger(INTENT_LOGGER_NAME).handlers]
+	assert root_handler_types.count(logging.StreamHandler) == 1
+	assert root_handler_types.count(RotatingFileHandler) == 1
+	assert intent_handler_types.count(logging.StreamHandler) == 1
+	assert intent_handler_types.count(RotatingFileHandler) == 1

--- a/mcp-server/tests/test_logging_config.py
+++ b/mcp-server/tests/test_logging_config.py
@@ -86,3 +86,21 @@ def test_configure_logging_with_log_dir_writes_rotated_files(tmp_path):
 	assert root_handler_types.count(RotatingFileHandler) == 1
 	assert intent_handler_types.count(logging.StreamHandler) == 1
 	assert intent_handler_types.count(RotatingFileHandler) == 1
+
+
+def test_configure_logging_falls_back_when_log_dir_is_unwritable(tmp_path):
+	# A regular file where a directory is expected makes os.makedirs(...,
+	# exist_ok=True) raise FileExistsError (an OSError subclass) — the same
+	# failure shape as a bind-mounted host directory the container's
+	# non-root user can't create/write into.
+	blocked_path = tmp_path / "not-a-directory"
+	blocked_path.write_text("occupied")
+
+	configure_logging("INFO", log_dir=str(blocked_path))
+
+	root_handlers = logging.getLogger().handlers
+	intent_handlers = logging.getLogger(INTENT_LOGGER_NAME).handlers
+	assert len(root_handlers) == 1 and isinstance(root_handlers[0], logging.StreamHandler)
+	assert not isinstance(root_handlers[0], RotatingFileHandler)
+	assert len(intent_handlers) == 1 and isinstance(intent_handlers[0], logging.StreamHandler)
+	assert not isinstance(intent_handlers[0], RotatingFileHandler)


### PR DESCRIPTION
## Summary
- Adds an optional `MCP_LOG_DIR` env var that mirrors the existing stdout (`mcp_request` telemetry) and stderr (`mcp_intent`) log streams to rotated files (`telemetry.log`/`intent.log`, 10MB x 5 backups) — additive to the current `docker logs` behavior, not a replacement.
- `docker-compose.yaml` wires this up for `gregory-mcp` with `MCP_LOG_DIR=/var/log/gregory-mcp` and a bind mount to `./mcp-server/logs`, matching the existing pattern used for the `gregory` service's persisted volumes.
- `docs/07-mcp-server.md` documents the new files, rotation behavior, and updated audit commands (`tail -f mcp-server/logs/telemetry.log | jq`).
- Closes the persistence/rotation half of `MCP-TELEMETRY-PLAN.md`'s Phase 6 (the 90-day intent retention/deletion policy is still separate, not-yet-built follow-up work).

## Test plan
- [x] `cd mcp-server && uv run pytest` — 167 passed (163 existing + 4 new: `test_config.py::test_log_dir_defaults_to_none`/`test_log_dir_passes_through`, `test_logging_config.py::test_configure_logging_without_log_dir_only_attaches_stream_handlers`/`test_configure_logging_with_log_dir_writes_rotated_files`)
- [x] `docker compose config --quiet` validates cleanly
- [ ] After deploy: confirm `mcp-server/logs/telemetry.log` and `intent.log` appear on House and survive a container restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)